### PR TITLE
Event journal for map and cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -36,6 +36,9 @@ import com.hazelcast.client.impl.protocol.codec.MapDeleteCodec;
 import com.hazelcast.client.impl.protocol.codec.MapEntriesWithPagingPredicateCodec;
 import com.hazelcast.client.impl.protocol.codec.MapEntriesWithPredicateCodec;
 import com.hazelcast.client.impl.protocol.codec.MapEntrySetCodec;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalReadCodec;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalSubscribeCodec;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalSubscribeCodec.ResponseParameters;
 import com.hazelcast.client.impl.protocol.codec.MapEvictAllCodec;
 import com.hazelcast.client.impl.protocol.codec.MapEvictCodec;
 import com.hazelcast.client.impl.protocol.codec.MapExecuteOnAllKeysCodec;
@@ -103,6 +106,7 @@ import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
@@ -112,6 +116,7 @@ import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.map.impl.SimpleEntryView;
+import com.hazelcast.map.impl.journal.EventJournalMapEvent;
 import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
@@ -135,7 +140,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.ringbuffer.impl.client.PortableReadResultSet;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.IterationType;
@@ -152,6 +160,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -221,6 +230,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         }
     };
 
+    private ClientMessageDecoder eventJournalReadResponseDecoder;
     private ClientLockReferenceIdGenerator lockReferenceIdGenerator;
     private ClientQueryCacheContext queryCacheContext;
 
@@ -234,6 +244,16 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
         lockReferenceIdGenerator = getClient().getLockReferenceIdGenerator();
         queryCacheContext = getContext().getQueryCacheContext();
+        eventJournalReadResponseDecoder = new ClientMessageDecoder() {
+            @Override
+            public ReadResultSet<?> decodeClientMessage(ClientMessage message) {
+                final MapEventJournalReadCodec.ResponseParameters params = MapEventJournalReadCodec.decodeResponse(message);
+                final PortableReadResultSet<?> resultSet
+                        = new PortableReadResultSet<Object>(params.readCount, params.items, params.itemSeqs);
+                resultSet.setSerializationService(getSerializationService());
+                return resultSet;
+            }
+        };
     }
 
     @Override
@@ -1536,6 +1556,61 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     // used for testing
     public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
         return new ClientMapPartitionIterator<K, V>(this, getContext(), fetchSize, partitionId, prefetchValues);
+    }
+
+    /**
+     * Subscribe to the event journal for this map and a specific partition ID.
+     * The method will register the subscription so that the event journal knows which
+     * items have been read by this subscriber. It will return the subscription ID and
+     * the newest and oldest event journal sequence.
+     *
+     * @param partitionId the partition ID of the entries to which we are subscribing
+     * @return the initial subscriber state containing the subscription ID, newest and oldest event journal sequence
+     * @throws UnsupportedOperationException if the cluster version is lower than 3.9 or there is no event journal
+     *                                       configured for this map
+     * @since 3.9
+     */
+    public EventJournalInitialSubscriberState subscribeToEventJournal(int partitionId) {
+        final ClientMessage request = MapEventJournalSubscribeCodec.encodeRequest(name);
+        final ClientInvocationFuture invocation = new ClientInvocation(getClient(), request, partitionId).invoke();
+        try {
+            final ClientMessage msg = invocation.get();
+            final ResponseParameters resp = MapEventJournalSubscribeCodec.decodeResponse(msg);
+            return new EventJournalInitialSubscriberState(resp.oldestSequence, resp.newestSequence);
+        } catch (InterruptedException e) {
+            throw rethrow(e);
+        } catch (ExecutionException e) {
+            throw rethrow(e);
+        }
+    }
+
+    /**
+     * Reads from the event journal. The returned future may throw {@link UnsupportedOperationException}
+     * if the cluster version is lower than 3.9 or there is no event journal configured for this map.
+     *
+     * @param startSequence the sequence of the first item to read
+     * @param maxSize       the maximum number of items to read
+     * @param partitionId   the partition ID of the entries in the journal
+     * @param predicate     the predicate which the events must pass to be included in the response.
+     *                      May be {@code null} in which case all events pass the predicate
+     * @param projection    the projection which is applied to the events before returning.
+     *                      May be {@code null} in which case the event is returned without being projected
+     * @param <T>           the return type of the projection. It is equal to the journal event type
+     *                      if the projection is {@code null} or it is the identity projection
+     * @return the future with the filtered and projected journal items
+     * @since 3.9
+     */
+    public <T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
+            Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        final SerializationService ss = getSerializationService();
+        final ClientMessage request = MapEventJournalReadCodec.encodeRequest(
+                name, startSequence, 1, maxSize, ss.toData(predicate), ss.toData(projection));
+        final ClientInvocationFuture fut = new ClientInvocation(getClient(), request, partitionId).invoke();
+        return new ClientDelegatingFuture<ReadResultSet<T>>(fut, ss, eventJournalReadResponseDecoder);
     }
 
     // used for testing

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -93,10 +93,9 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         readManyAsyncResponseDecoder = new ClientMessageDecoder() {
             @Override
             public PortableReadResultSet decodeClientMessage(ClientMessage clientMessage) {
-                final RingbufferReadManyCodec.ResponseParameters responseParameters
-                        = RingbufferReadManyCodec.decodeResponse(clientMessage);
-                PortableReadResultSet readResultSet = new PortableReadResultSet(responseParameters.readCount,
-                        responseParameters.items);
+                final RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(clientMessage);
+                final PortableReadResultSet readResultSet
+                        = new PortableReadResultSet(params.readCount, params.items, params.itemSeqs);
                 readResultSet.setSerializationService(getSerializationService());
                 return readResultSet;
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientBasicCacheJournalTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientBasicCacheJournalTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.journal.BasicCacheJournalTest;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
+import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.util.function.Predicate;
+import org.junit.After;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+
+public class ClientBasicCacheJournalTest extends BasicCacheJournalTest {
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance client;
+
+    @Override
+    protected HazelcastInstance getRandomInstance() {
+        return client;
+    }
+
+    @Override
+    protected HazelcastInstance[] createInstances() {
+        factory = new TestHazelcastFactory();
+        final HazelcastInstance[] instances = factory.newInstances(getConfig(), 2);
+        client = factory.newHazelcastClient();
+        return instances;
+    }
+
+    @Override
+    protected CacheManager createCacheManager() {
+        final HazelcastClientCachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
+        return provider.getCacheManager();
+    }
+
+    @Override
+    protected <K, V> ICache<K, V> getCache(String cacheName) {
+        return (ICache<K, V>) cacheManager.getCache(cacheName);
+    }
+
+    @Override
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(Cache<K, V> cache, int partitionId) {
+        return ((ClientCacheProxy<K, V>) cache).subscribeToEventJournal(partitionId);
+    }
+
+    @Override
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(Cache<K, V> cache,
+                                                                                  long startSequence,
+                                                                                  int maxSize,
+                                                                                  int partitionId,
+                                                                                  Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+                                                                                  Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        return ((ClientCacheProxy<K, V>) cache).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+    @After
+    public final void terminate() {
+        factory.terminateAll();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientBasicMapJournalTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientBasicMapJournalTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.journal.BasicMapJournalTest;
+import com.hazelcast.map.impl.journal.EventJournalMapEvent;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.util.function.Predicate;
+import org.junit.After;
+
+public class ClientBasicMapJournalTest extends BasicMapJournalTest {
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance client;
+
+    @Override
+    protected HazelcastInstance getRandomInstance() {
+        return client;
+    }
+
+    @Override
+    protected HazelcastInstance[] createInstances() {
+        factory = new TestHazelcastFactory();
+        final HazelcastInstance[] instances = factory.newInstances(getConfig(), 2);
+        client = factory.newHazelcastClient();
+        return instances;
+    }
+
+    @Override
+    protected <K, V> IMap<K, V> getMap(String mapName) {
+        return client.getMap(mapName);
+    }
+
+    @Override
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(IMap<K, V> map, int partitionId) {
+        return ((ClientMapProxy<K, V>) map).subscribeToEventJournal(partitionId);
+    }
+
+    @Override
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(IMap<K, V> map,
+                                                                                  long startSequence,
+                                                                                  int maxSize,
+                                                                                  int partitionId,
+                                                                                  Predicate<? super EventJournalMapEvent<K, V>> predicate,
+                                                                                  Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        return ((ClientMapProxy<K, V>) map).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+    @After
+    public final void terminate() {
+        factory.terminateAll();
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.HotRestartConfig;
@@ -165,6 +166,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> executorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> durableExecutorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> scheduledExecutorManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> mapEventJournalManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> cacheEventJournalManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> cardinalityEstimatorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> wanReplicationManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> jobTrackerManagedMap;
@@ -188,6 +191,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.executorManagedMap = createManagedMap("executorConfigs");
             this.durableExecutorManagedMap = createManagedMap("durableExecutorConfigs");
             this.scheduledExecutorManagedMap = createManagedMap("scheduledExecutorConfigs");
+            this.mapEventJournalManagedMap = createManagedMap("mapEventJournalConfigs");
+            this.cacheEventJournalManagedMap = createManagedMap("cacheEventJournalConfigs");
             this.cardinalityEstimatorManagedMap = createManagedMap("cardinalityEstimatorConfigs");
             this.wanReplicationManagedMap = createManagedMap("wanReplicationConfigs");
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
@@ -222,6 +227,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleDurableExecutor(node);
                     } else if ("scheduled-executor-service".equals(nodeName)) {
                         handleScheduledExecutor(node);
+                    } else if ("event-journal".equals(nodeName)) {
+                        handleEventJournal(node);
                     } else if ("cardinality-estimator".equals(nodeName)) {
                         handleCardinalityEstimator(node);
                     } else if ("queue".equals(nodeName)) {
@@ -561,7 +568,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             for (Node n : childElements(node)) {
                 String name = cleanNodeName(n);
                 if ("trusted-interfaces".equals(name)) {
-                    for (Node i: childElements(n)) {
+                    for (Node i : childElements(n)) {
                         name = cleanNodeName(i);
                         if ("interface".equals(name)) {
                             String value = getTextContent(i);
@@ -622,6 +629,19 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 }
             }
             lockManagedMap.put(getAttribute(node, "name"), lockConfigBuilder.getBeanDefinition());
+        }
+
+        public void handleEventJournal(Node node) {
+            final BeanDefinitionBuilder eventJournalBuilder = createBeanBuilder(EventJournalConfig.class);
+            fillAttributeValues(node, eventJournalBuilder);
+            final String mapName = getAttribute(node, "map-name");
+            final String cacheName = getAttribute(node, "cache-name");
+            if (!StringUtil.isNullOrEmpty(mapName)) {
+                mapEventJournalManagedMap.put(mapName, eventJournalBuilder.getBeanDefinition());
+            }
+            if (!StringUtil.isNullOrEmpty(cacheName)) {
+                cacheEventJournalManagedMap.put(cacheName, eventJournalBuilder.getBeanDefinition());
+            }
         }
 
         public void handleRingbuffer(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -977,6 +977,58 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element name="event-journal" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Configuration for an event journal. The event journal keeps events related
+                                        to a specific partition and data structure. For instance, it could keep
+                                        map add, update, remove, merge events along with the key, old value, new value and so on.
+                                        This configuration is not tied to a specific data structure and can be reused.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:attribute name="map-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the map to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the cache to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="enabled" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            True if the event journal is enabled, false otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="capacity" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of items in the event journal. If no time-to-live-seconds
+                                            is set, the size will always be equal to capacity after the event
+                                            journal has been filled. This is because no items are getting retired.
+                                            The default value is 10000.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="time-to-live-seconds" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum number of seconds for each entry to stay in the event journal.
+                                            Entries that are older than &lt;time-to-live-seconds&gt; are evicted from the journal.
+                                            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="multimap" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
@@ -1042,4 +1043,23 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         assertEquals(expectedComparatorClassName, mapConfig.getMapEvictionPolicy().getClass().getName());
     }
+
+    @Test
+    public void testMapEventJournalConfigIsWellParsed() {
+        final EventJournalConfig journalConfig = config.getMapEventJournalConfig("mapName");
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(123, journalConfig.getCapacity());
+        assertEquals(321, journalConfig.getTimeToLiveSeconds());
+    }
+
+    @Test
+    public void testCacheEventJournalConfigIsWellParsed() {
+        final EventJournalConfig journalConfig = config.getCacheEventJournalConfig("cacheName");
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(123, journalConfig.getCapacity());
+        assertEquals(321, journalConfig.getTimeToLiveSeconds());
+    }
+
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd
+		hazelcast-spring-3.9.xsd
 		http://www.hazelcast.com/schema/sample
 		hazelcast-sample-service.xsd">
 
@@ -409,6 +409,9 @@
                 </hz:wan-replication-ref>
                 <hz:hot-restart enabled="true" fsync="true" />
             </hz:cache>
+
+            <hz:event-journal map-name="mapName" cache-name="cacheName" enabled="true"
+                              capacity="123" time-to-live-seconds="321"/>
 
             <hz:multimap name="testMultimap"
                          value-collection-type="LIST" binary="false" statistics-enabled="false">

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -19,6 +19,8 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
+import com.hazelcast.cache.impl.journal.CacheEventJournal;
+import com.hazelcast.cache.impl.journal.RingbufferCacheEventJournalImpl;
 import com.hazelcast.cache.impl.operation.PostJoinCacheOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -105,6 +107,7 @@ public abstract class AbstractCacheService implements ICacheService, PostJoinAwa
     protected CachePartitionSegment[] segments;
     protected CacheEventHandler cacheEventHandler;
     protected CacheSplitBrainHandler cacheSplitBrainHandler;
+    protected RingbufferCacheEventJournalImpl eventJournal;
     protected ILogger logger;
 
     @Override
@@ -118,6 +121,7 @@ public abstract class AbstractCacheService implements ICacheService, PostJoinAwa
         this.cacheEventHandler = new CacheEventHandler(nodeEngine);
         this.cacheSplitBrainHandler = new CacheSplitBrainHandler(nodeEngine, configs, segments);
         this.logger = nodeEngine.getLogger(getClass());
+        this.eventJournal = new RingbufferCacheEventJournalImpl(nodeEngine);
         postInit(nodeEngine, properties);
     }
 
@@ -702,5 +706,10 @@ public abstract class AbstractCacheService implements ICacheService, PostJoinAwa
 
     public CacheEventHandler getCacheEventHandler() {
         return cacheEventHandler;
+    }
+
+    @Override
+    public CacheEventJournal getEventJournal() {
+        return eventJournal;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -18,6 +18,9 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
+import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
+import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
+import com.hazelcast.cache.impl.journal.DeserialisingEventJournalCacheEvent;
 import com.hazelcast.cache.impl.merge.entry.DefaultCacheEntryView;
 import com.hazelcast.cache.impl.operation.CacheBackupEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheClearBackupOperation;
@@ -137,8 +140,11 @@ public final class CacheDataSerializerHook
     public static final short CACHE_ASSIGN_AND_GET_UUIDS_FACTORY = 53;
     public static final short CACHE_NEAR_CACHE_STATE_HOLDER = 54;
     public static final short CACHE_EVENT_LISTENER_ADAPTOR = 55;
+    public static final short EVENT_JOURNAL_CACHE_EVENT = 56;
+    public static final short EVENT_JOURNAL_SUBSCRIBE_OPERATION = 57;
+    public static final short EVENT_JOURNAL_READ_OPERATION = 58;
 
-    private static final int LEN = CACHE_EVENT_LISTENER_ADAPTOR + 1;
+    private static final int LEN = EVENT_JOURNAL_READ_OPERATION + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -412,6 +418,21 @@ public final class CacheDataSerializerHook
         constructors[CACHE_EVENT_LISTENER_ADAPTOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheEventListenerAdaptor();
+            }
+        };
+        constructors[EVENT_JOURNAL_CACHE_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DeserialisingEventJournalCacheEvent<Object, Object>();
+            }
+        };
+        constructors[EVENT_JOURNAL_SUBSCRIBE_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEventJournalSubscribeOperation();
+            }
+        };
+        constructors[EVENT_JOURNAL_READ_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEventJournalReadOperation<Object, Object, Object>();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.cache.impl.event.CacheWanEventPublisher;
+import com.hazelcast.cache.impl.journal.CacheEventJournal;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.nio.serialization.Data;
@@ -41,8 +42,23 @@ public interface ICacheService
 
     String SERVICE_NAME = "hz:impl:cacheService";
 
+    /**
+     * Gets or creates a cache record store with the prefixed {@code name}
+     * and partition ID.
+     *
+     * @param name        the full cache name containing the prefix
+     * @param partitionId the record store partition ID
+     * @return the cache partition record store
+     */
     ICacheRecordStore getOrCreateRecordStore(String name, int partitionId);
 
+    /**
+     * Gets a cache record store with the prefixed {@code name} and partition ID.
+     *
+     * @param name        the full cache name containing the prefix
+     * @param partitionId the record store partition ID
+     * @return the cache partition record store
+     */
     ICacheRecordStore getRecordStore(String name, int partitionId);
 
     CachePartitionSegment getSegment(int partitionId);
@@ -97,4 +113,6 @@ public interface ICacheService
     boolean isWanReplicationEnabled(String cacheName);
 
     CacheWanEventPublisher getCacheWanEventPublisher();
+
+    CacheEventJournal getEventJournal();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ObjectNamespace;
+
+/**
+ * The event journal is a container for events related to a data structure.
+ * This interface provides methods for cache event journals. This includes
+ * events such as add, update, remove, evict and others. Each cache and
+ * partition has it's own event journal.
+ * <p>
+ * If a cache is destroyed or the migrated, the related event journal will be destroyed or
+ * migrated as well. In this sense, the event journal is co-located with the cache partition
+ * and it's replicas.
+ *
+ * @since 3.9
+ */
+public interface CacheEventJournal extends EventJournal<InternalEventJournalCacheEvent> {
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#UPDATED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param oldValue    the old value
+     * @param newValue    the new value
+     */
+    void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#CREATED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeCreatedEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#REMOVED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#EVICTED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#EXPIRED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeExpiredEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.journal.EventJournalReadOperation;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.util.function.Predicate;
+
+import java.io.IOException;
+
+/**
+ * Reads from the cache event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @since 3.9
+ */
+public class CacheEventJournalReadOperation<K, V, T> extends EventJournalReadOperation<T, InternalEventJournalCacheEvent> {
+    protected Predicate<? super EventJournalCacheEvent<K, V>> predicate;
+    protected Projection<? super EventJournalCacheEvent<K, V>, T> projection;
+
+    public CacheEventJournalReadOperation() {
+    }
+
+    public CacheEventJournalReadOperation(String cacheName, long startSequence, int minSize, int maxSize,
+                                          Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+                                          Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        super(cacheName, startSequence, minSize, maxSize);
+        this.predicate = predicate;
+        this.projection = projection;
+    }
+
+    @Override
+    protected EventJournal<InternalEventJournalCacheEvent> getJournal() {
+        final CacheService service = getService();
+        return service.getEventJournal();
+    }
+
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_READ_OPERATION;
+    }
+
+    @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(predicate);
+        out.writeObject(projection);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        predicate = in.readObject();
+        projection = in.readObject();
+    }
+
+    @Override
+    protected ReadResultSetImpl<InternalEventJournalCacheEvent, T> createResultSet() {
+        return new CacheEventJournalReadResultSetImpl<K, V, T>(
+                minSize, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Predicate;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class CacheEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetImpl<InternalEventJournalCacheEvent, T> {
+
+    CacheEventJournalReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
+                                       final Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+                                       final Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        super(minSize, maxSize, serializationService,
+                predicate == null ? null : new Predicate<InternalEventJournalCacheEvent>() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+                    public boolean test(InternalEventJournalCacheEvent e) {
+                        return predicate.test((DeserialisingEventJournalCacheEvent<K, V>) e);
+                    }
+                },
+                projection == null ? null : new Projection<InternalEventJournalCacheEvent, T>() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+                    public T transform(InternalEventJournalCacheEvent input) {
+                        return projection.transform((DeserialisingEventJournalCacheEvent<K, V>) input);
+                    }
+                });
+    }
+
+    @Override
+    public void addItem(long seq, Object item) {
+        final InternalEventJournalCacheEvent e = serializationService.toObject(item);
+        final DeserialisingEventJournalCacheEvent<K, V> deserialisingEvent
+                = new DeserialisingEventJournalCacheEvent<K, V>(serializationService, e);
+        super.addItem(seq, deserialisingEvent);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.version.Version;
+
+/**
+ * Performs the initial subscription to the cache event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @since 3.9
+ */
+public class CacheEventJournalSubscribeOperation
+        extends AbstractNamedOperation
+        implements PartitionAwareOperation, IdentifiedDataSerializable, ReadonlyOperation {
+    private EventJournalInitialSubscriberState response;
+    private DistributedObjectNamespace namespace;
+
+    public CacheEventJournalSubscribeOperation() {
+    }
+
+    public CacheEventJournalSubscribeOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        super.beforeRun();
+
+        final Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        if (clusterVersion.isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is " + clusterVersion);
+        }
+
+        namespace = new DistributedObjectNamespace(CacheService.SERVICE_NAME, name);
+        final CacheService service = getService();
+        if (!service.getEventJournal().hasEventJournal(namespace)) {
+            throw new UnsupportedOperationException(
+                    "Cannot subscribe to event journal because it is either not configured or disabled for cache " + name);
+        }
+    }
+
+    @Override
+    public void run() {
+        final CacheService service = getService();
+        final CacheEventJournal eventJournal = service.getEventJournal();
+        final long newestSequence = eventJournal.newestSequence(namespace, getPartitionId());
+        final long oldestSequence = eventJournal.oldestSequence(namespace, getPartitionId());
+        response = new EventJournalInitialSubscriberState(oldestSequence, newestSequence);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_SUBSCRIBE_OPERATION;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ICacheService.SERVICE_NAME;
+    }
+
+
+    @Override
+    public EventJournalInitialSubscriberState getResponse() {
+        return response;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserialisingEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserialisingEventJournalCacheEvent.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.io.IOException;
+
+public class DeserialisingEventJournalCacheEvent<K, V>
+        extends InternalEventJournalCacheEvent
+        implements IdentifiedDataSerializable, EventJournalCacheEvent<K, V>, HazelcastInstanceAware {
+    private SerializationService serializationService;
+
+    private K objectKey;
+    private V objectNewValue;
+    private V objectOldValue;
+
+    public DeserialisingEventJournalCacheEvent() {
+    }
+
+    public DeserialisingEventJournalCacheEvent(SerializationService serializationService, InternalEventJournalCacheEvent je) {
+        super(je.getDataKey(), je.getDataNewValue(), je.getDataOldValue(), je.getEventType());
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_CACHE_EVENT;
+    }
+
+    @Override
+    public K getKey() {
+        if (objectKey == null && dataKey != null) {
+            objectKey = serializationService.toObject(dataKey);
+        }
+        return objectKey;
+    }
+
+    @Override
+    public V getNewValue() {
+        if (objectNewValue == null && dataNewValue != null) {
+            objectNewValue = serializationService.toObject(dataNewValue);
+        }
+        return objectNewValue;
+    }
+
+    @Override
+    public V getOldValue() {
+        if (objectOldValue == null && dataOldValue != null) {
+            objectOldValue = serializationService.toObject(dataOldValue);
+        }
+        return objectOldValue;
+    }
+
+    @Override
+    public CacheEventType getType() {
+        return CacheEventType.getByType(eventType);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        out.writeData(toData(dataKey, objectKey));
+        out.writeData(toData(dataNewValue, objectNewValue));
+        out.writeData(toData(dataOldValue, objectOldValue));
+    }
+
+    private Data toData(Data data, Object o) {
+        return o != null ? serializationService.toData(o) : data;
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        eventType = in.readInt();
+        dataKey = in.readData();
+        dataNewValue = in.readData();
+        dataOldValue = in.readData();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/EventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/EventJournalCacheEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheEventType;
+
+/**
+ * The event for the cache event journal.
+ *
+ * @param <K> the entry key type
+ * @param <V> the entry value type
+ */
+public interface EventJournalCacheEvent<K, V> {
+    /**
+     * Returns the key for the event entry.
+     *
+     * @return the entry key
+     */
+    K getKey();
+
+    /**
+     * Returns the new value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link CacheEventType#CREATED}, the new
+     * value is non-{@code null} but when it is of type {@link CacheEventType#REMOVED},
+     * the value is {@code null}.
+     *
+     * @return the entry new value
+     */
+    V getNewValue();
+
+    /**
+     * Returns the old value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link CacheEventType#CREATED}, the old
+     * value is {@code null} but when it is of type {@link CacheEventType#REMOVED},
+     * the value is non-{@code null}.
+     *
+     * @return the entry old value
+     */
+    V getOldValue();
+
+    /**
+     * Returns the event type.
+     *
+     * @return the event type
+     */
+    CacheEventType getType();
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.nio.serialization.Data;
+
+/**
+ * The event journal item for map events. It contains serialized
+ * values for key and all values included in map mutations as well as
+ * the event type.
+ */
+public class InternalEventJournalCacheEvent {
+    protected Data dataKey;
+    protected Data dataNewValue;
+    protected Data dataOldValue;
+    protected int eventType;
+
+    public InternalEventJournalCacheEvent() {
+    }
+
+    public InternalEventJournalCacheEvent(Data dataKey, Data dataNewValue, Data dataOldValue, int eventType) {
+        this.eventType = eventType;
+        this.dataKey = dataKey;
+        this.dataNewValue = dataNewValue;
+        this.dataOldValue = dataOldValue;
+    }
+
+    public Data getDataKey() {
+        return dataKey;
+    }
+
+    public Data getDataNewValue() {
+        return dataNewValue;
+    }
+
+    public Data getDataOldValue() {
+        return dataOldValue;
+    }
+
+    /**
+     * Return the integer defining the event type. It can be turned into an
+     * enum value by calling {@link com.hazelcast.cache.impl.CacheEventType#getByType(int)}.
+     *
+     * @return the integer defining the event type
+     */
+    public int getEventType() {
+        return eventType;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.CacheNotExistsException;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.ringbuffer.impl.RingbufferWaitNotifyKey;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationparker.OperationParker;
+
+import static com.hazelcast.cache.impl.CacheEventType.CREATED;
+import static com.hazelcast.cache.impl.CacheEventType.EVICTED;
+import static com.hazelcast.cache.impl.CacheEventType.EXPIRED;
+import static com.hazelcast.cache.impl.CacheEventType.REMOVED;
+import static com.hazelcast.cache.impl.CacheEventType.UPDATED;
+
+
+/**
+ * The cache event journal implementation based on the {@link com.hazelcast.ringbuffer.Ringbuffer}.
+ * It will add all journal events into a {@link RingbufferContainer} with the provided namespace
+ * and partition ID and allows checking if the cache has a configured event journal.
+ * Adapts the {@link EventJournalConfig} to the {@link RingbufferConfig} when creating the ringbuffer.
+ */
+public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
+    private final NodeEngineImpl nodeEngine;
+
+    public RingbufferCacheEventJournalImpl(NodeEngine engine) {
+        this.nodeEngine = (NodeEngineImpl) engine;
+    }
+
+    @Override
+    public void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue) {
+        addToEventRingbuffer(namespace, partitionId, UPDATED, key, oldValue, newValue);
+    }
+
+    @Override
+    public void writeCreatedEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, CREATED, key, null, value);
+    }
+
+    @Override
+    public void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, REMOVED, key, value, null);
+    }
+
+    @Override
+    public void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, EVICTED, key, value, null);
+    }
+
+    @Override
+    public void writeExpiredEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, EXPIRED, key, value, null);
+    }
+
+    @Override
+    public long newestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).tailSequence();
+    }
+
+    @Override
+    public long oldestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).headSequence();
+    }
+
+    @Override
+    public void destroy(ObjectNamespace namespace, int partitionId) {
+        getRingbufferService().destroyContainer(partitionId, namespace);
+    }
+
+    @Override
+    public void isAvailableOrNextSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        getRingbufferOrFail(namespace, partitionId).checkBlockableReadSequence(sequence);
+    }
+
+    @Override
+    public boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        return getRingbufferOrFail(namespace, partitionId).shouldWait(sequence);
+    }
+
+    @Override
+    public WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
+        return new RingbufferWaitNotifyKey(namespace);
+    }
+
+    @Override
+    public <T> long readMany(ObjectNamespace namespace, int partitionId, long beginSequence,
+                             ReadResultSetImpl<InternalEventJournalCacheEvent, T> resultSet) {
+        return getRingbufferOrFail(namespace, partitionId).readMany(beginSequence, resultSet);
+    }
+
+    @Override
+    public void cleanup(ObjectNamespace namespace, int partitionId) {
+        getRingbufferOrFail(namespace, partitionId).cleanup();
+    }
+
+    /**
+     * {@inheritDoc}
+     * NOTE: The cache config should have already been created in the cache service before
+     * invoking this method.
+     *
+     * @param namespace the cache namespace, containing the full prefixed cache name
+     * @return {@code true} if the object has a configured and enabled event journal, {@code false} otherwise
+     */
+    @Override
+    public boolean hasEventJournal(ObjectNamespace namespace) {
+        return getEventJournalConfig(namespace) != null;
+    }
+
+    private void addToEventRingbuffer(ObjectNamespace namespace, int partitionId, CacheEventType eventType,
+                                      Data key, Object oldValue, Object newValue) {
+        final RingbufferContainer<InternalEventJournalCacheEvent> eventContainer = getRingbufferOrNull(namespace, partitionId);
+        if (eventContainer == null) {
+            return;
+        }
+        final InternalEventJournalCacheEvent event
+                = new InternalEventJournalCacheEvent(toData(key), toData(newValue), toData(oldValue), eventType.getType());
+        eventContainer.add(event);
+        getOperationParker().unpark(eventContainer);
+    }
+
+    protected Data toData(Object val) {
+        return getSerializationService().toData(val, DataType.HEAP);
+    }
+
+    /**
+     * Gets or creates a ringbuffer for an event journal or throws an exception if no
+     * event journal is configured. The caller should call
+     * {@link #hasEventJournal(ObjectNamespace)} before invoking this method to avoid getting
+     * the exception. This method can be used to get the ringbuffer on which future events
+     * will be added once the cache has been created.
+     * <p>
+     * NOTE: The cache config should have already been created in the cache service before
+     * invoking this method.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the cache partition ID
+     * @return the cache partition event journal
+     * @throws IllegalStateException if there is no event journal configured for this cache
+     */
+    private RingbufferContainer<InternalEventJournalCacheEvent> getRingbufferOrFail(ObjectNamespace namespace, int partitionId) {
+        final RingbufferService ringbufferService = getRingbufferService();
+        if (ringbufferService.hasContainer(partitionId, namespace)) {
+            return ringbufferService.getContainer(partitionId, namespace, null);
+        }
+
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        if (config == null) {
+            throw new IllegalStateException("There is no event journal configured for cache with name: "
+                    + namespace.getObjectName());
+        }
+        return getOrCreateRingbufferContainer(namespace, partitionId, config);
+    }
+
+    /**
+     * Gets or creates a ringbuffer for an event journal or returns {@link null} if no
+     * event journal is configured. The cache record store should have been already created
+     * at the point when this method is invoked.
+     * This method can be used to get the ringbuffer when we already know that the cache record
+     * store has been created.
+     * <p>
+     * NOTE: The cache config should have already been created in the cache service before
+     * invoking this method.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the cache partition ID
+     * @return the cache partition event journal or {@code null} if no journal is configured for this cache
+     * @throws CacheNotExistsException if the cache hasn't been already created
+     */
+    private RingbufferContainer<InternalEventJournalCacheEvent> getRingbufferOrNull(ObjectNamespace namespace, int partitionId) {
+        final RingbufferService ringbufferService = getRingbufferService();
+        if (ringbufferService.hasContainer(partitionId, namespace)) {
+            return ringbufferService.getContainer(partitionId, namespace, null);
+        }
+
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        return config != null ? getOrCreateRingbufferContainer(namespace, partitionId, config) : null;
+    }
+
+    private EventJournalConfig getEventJournalConfig(ObjectNamespace namespace) {
+        final String name = namespace.getObjectName();
+        final CacheConfig cacheConfig = getCacheService().getCacheConfig(name);
+        if (cacheConfig == null) {
+            throw new CacheNotExistsException("Cache " + name + " is already destroyed or not created yet, on "
+                    + nodeEngine.getLocalMember());
+        }
+        final String cacheSimpleName = cacheConfig.getName();
+        final EventJournalConfig config = nodeEngine.getConfig().getCacheEventJournalConfig(cacheSimpleName);
+        if (config == null || !config.isEnabled()) {
+            return null;
+        }
+        return config;
+    }
+
+    private RingbufferContainer<InternalEventJournalCacheEvent> getOrCreateRingbufferContainer(ObjectNamespace namespace,
+                                                                                               int partitionId,
+                                                                                               EventJournalConfig config) {
+        final RingbufferConfig ringbufferConfig = new RingbufferConfig()
+                .setAsyncBackupCount(0)
+                .setBackupCount(0)
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setCapacity(config.getCapacity())
+                .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
+        return getRingbufferService().getContainer(partitionId, namespace, ringbufferConfig);
+    }
+
+    private RingbufferService getRingbufferService() {
+        return nodeEngine.getService(RingbufferService.SERVICE_NAME);
+    }
+
+    private OperationParker getOperationParker() {
+        return nodeEngine.getOperationParker();
+    }
+
+    private InternalSerializationService getSerializationService() {
+        return (InternalSerializationService) nodeEngine.getSerializationService();
+    }
+
+    private CacheService getCacheService() {
+        return nodeEngine.getService(CacheService.SERVICE_NAME);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * Base Cache Operation. Cache operations are named operations. Key based operations are subclasses of this base
  * class providing a cacheRecordStore access and partial backup support.
  */
-abstract class AbstractCacheOperation
+public abstract class AbstractCacheOperation
         extends AbstractNamedOperation
         implements PartitionAwareOperation, ServiceNamespaceAware, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.impl.protocol;
 
 import com.hazelcast.client.impl.protocol.task.MessageTask;
+import com.hazelcast.client.impl.protocol.task.cache.CacheEventJournalReadTask;
+import com.hazelcast.client.impl.protocol.task.cache.CacheEventJournalSubscribeTask;
 import com.hazelcast.client.impl.protocol.task.cache.Pre38CacheAddInvalidationListenerTask;
 import com.hazelcast.client.impl.protocol.task.cardinality.CardinalityEstimatorAddMessageTask;
 import com.hazelcast.client.impl.protocol.task.cardinality.CardinalityEstimatorEstimateMessageTask;
@@ -25,6 +27,8 @@ import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableEx
 import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableExecutorRetrieveResultMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapAggregateMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapAggregateWithPredicateMessageTask;
+import com.hazelcast.client.impl.protocol.task.map.MapEventJournalReadTask;
+import com.hazelcast.client.impl.protocol.task.map.MapEventJournalSubscribeTask;
 import com.hazelcast.client.impl.protocol.task.map.MapProjectionMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapProjectionWithPredicateMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.Pre38MapAddNearCacheEntryListenerMessageTask;
@@ -384,6 +388,16 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.CacheIterateEntriesCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new com.hazelcast.client.impl.protocol.task.cache.CacheIterateEntriesMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.CacheEventJournalSubscribeCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new CacheEventJournalSubscribeTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.CacheEventJournalReadCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new CacheEventJournalReadTask<Object, Object, Object>(clientMessage, node, connection);
             }
         };
 
@@ -1593,6 +1607,16 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.MapProjectWithPredicateCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new MapProjectionWithPredicateMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.MapEventJournalSubscribeCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new MapEventJournalSubscribeTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.MapEventJournalReadCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new MapEventJournalReadTask<Object, Object, Object>(clientMessage, node, connection);
             }
         };
 //endregion

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.cache;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheEventJournalReadCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.function.Predicate;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads from the cache event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <K> cache key type
+ * @param <V> cache value type
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @see CacheEventJournalReadOperation
+ * @since 3.9
+ */
+public class CacheEventJournalReadTask<K, V, T>
+        extends AbstractCacheMessageTask<CacheEventJournalReadCodec.RequestParameters> {
+
+    public CacheEventJournalReadTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        final Projection<? super EventJournalCacheEvent<K, V>, T> projection
+                = serializationService.toObject(parameters.projection);
+        final Predicate<? super EventJournalCacheEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);
+        return new CacheEventJournalReadOperation<K, V, T>(parameters.name,
+                parameters.startSequence, parameters.minSize, parameters.maxSize, predicate, projection);
+    }
+
+    @Override
+    protected CacheEventJournalReadCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return CacheEventJournalReadCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
+        final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
+        final List<Data> items = new ArrayList<Data>(resultSet.size());
+        final long[] seqs = new long[resultSet.size()];
+        final Data[] dataItems = resultSet.getDataItems();
+
+        for (int k = 0; k < resultSet.size(); k++) {
+            items.add(dataItems[k]);
+            seqs[k] = resultSet.getSequence(k);
+        }
+
+        return CacheEventJournalReadCodec.encodeResponse(resultSet.readCount(), items, seqs);
+    }
+
+    @Override
+    public final String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.name, parameters.predicate, parameters.projection};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalSubscribeTask.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.cache;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheEventJournalSubscribeCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
+import com.hazelcast.spi.Operation;
+
+import java.security.Permission;
+
+
+/**
+ * Performs the initial subscription to the cache event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @see com.hazelcast.cache.impl.CacheProxy#subscribeToEventJournal
+ * @see CacheEventJournalSubscribeOperation
+ * @since 3.9
+ */
+public class CacheEventJournalSubscribeTask
+        extends AbstractCacheMessageTask<CacheEventJournalSubscribeCodec.RequestParameters> {
+
+    public CacheEventJournalSubscribeTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        return new CacheEventJournalSubscribeOperation(parameters.name);
+    }
+
+    @Override
+    protected CacheEventJournalSubscribeCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return CacheEventJournalSubscribeCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        final EventJournalInitialSubscriberState state = (EventJournalInitialSubscriberState) response;
+        return CacheEventJournalSubscribeCodec.encodeResponse(state.getOldestSequence(), state.getNewestSequence());
+    }
+
+    @Override
+    public final String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.name};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalReadCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.journal.EventJournalMapEvent;
+import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.MapPermission;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.function.Predicate;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads from the map event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @see MapEventJournalReadOperation
+ * @since 3.9
+ */
+public class MapEventJournalReadTask<K, V, T>
+        extends AbstractMapPartitionMessageTask<MapEventJournalReadCodec.RequestParameters> {
+
+    public MapEventJournalReadTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        final Projection<? super EventJournalMapEvent<K, V>, T> projection = serializationService.toObject(parameters.projection);
+        final Predicate<? super EventJournalMapEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);
+        return new MapEventJournalReadOperation<K, V, T>(parameters.name,
+                parameters.startSequence, parameters.minSize, parameters.maxSize, predicate, projection);
+    }
+
+    @Override
+    protected MapEventJournalReadCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapEventJournalReadCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
+        final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
+        final List<Data> items = new ArrayList<Data>(resultSet.size());
+        final long[] seqs = new long[resultSet.size()];
+        final Data[] dataItems = resultSet.getDataItems();
+
+        for (int k = 0; k < resultSet.size(); k++) {
+            items.add(dataItems[k]);
+            seqs[k] = resultSet.getSequence(k);
+        }
+
+        return MapEventJournalReadCodec.encodeResponse(resultSet.readCount(), items, seqs);
+    }
+
+    @Override
+    public final String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new MapPermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.name, parameters.predicate, parameters.projection};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalSubscribeCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.MapPermission;
+import com.hazelcast.spi.Operation;
+
+import java.security.Permission;
+
+/**
+ * Performs the initial subscription to the map event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @see com.hazelcast.map.impl.proxy.MapProxyImpl#subscribeToEventJournal
+ * @see com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation
+ * @since 3.9
+ */
+public class MapEventJournalSubscribeTask
+        extends AbstractMapPartitionMessageTask<MapEventJournalSubscribeCodec.RequestParameters> {
+
+    public MapEventJournalSubscribeTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        return new MapEventJournalSubscribeOperation(parameters.name);
+    }
+
+    @Override
+    protected MapEventJournalSubscribeCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapEventJournalSubscribeCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        final EventJournalInitialSubscriberState state = (EventJournalInitialSubscriberState) response;
+        return MapEventJournalSubscribeCodec.encodeResponse(state.getOldestSequence(), state.getNewestSequence());
+    }
+
+    @Override
+    public final String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new MapPermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.name};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
@@ -59,13 +59,17 @@ public class RingbufferReadManyMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
-        ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
-        List<Data> items = new ArrayList<Data>(resultSet.size());
+        final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
+        final List<Data> items = new ArrayList<Data>(resultSet.size());
+        final long[] seqs = new long[resultSet.size()];
+        final Data[] dataItems = resultSet.getDataItems();
+
         for (int k = 0; k < resultSet.size(); k++) {
-            items.add(resultSet.getDataItems()[k]);
+            items.add(dataItems[k]);
+            seqs[k] = resultSet.getSequence(k);
         }
 
-        return RingbufferReadManyCodec.encodeResponse(resultSet.readCount(), items);
+        return RingbufferReadManyCodec.encodeResponse(resultSet.readCount(), items, seqs);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.util.StringUtil;
 
 import java.io.File;
 import java.net.URL;
@@ -103,6 +104,10 @@ public class Config {
 
     private final Map<String, CardinalityEstimatorConfig> cardinalityEstimatorConfigs =
             new ConcurrentHashMap<String, CardinalityEstimatorConfig>();
+
+    private final Map<String, EventJournalConfig> mapEventJournalConfigs = new ConcurrentHashMap<String, EventJournalConfig>();
+
+    private final Map<String, EventJournalConfig> cacheEventJournalConfigs = new ConcurrentHashMap<String, EventJournalConfig>();
 
     private ServicesConfig servicesConfig = new ServicesConfig();
 
@@ -1196,6 +1201,97 @@ public class Config {
         return this;
     }
 
+    public EventJournalConfig findMapEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        final EventJournalConfig config = lookupByPattern(mapEventJournalConfigs, baseName);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getMapEventJournalConfig("default").getAsReadOnly();
+    }
+
+    public EventJournalConfig findCacheEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        final EventJournalConfig config = lookupByPattern(cacheEventJournalConfigs, baseName);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getCacheEventJournalConfig("default").getAsReadOnly();
+    }
+
+    public EventJournalConfig getMapEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        EventJournalConfig config = lookupByPattern(mapEventJournalConfigs, baseName);
+        if (config != null) {
+            return config;
+        }
+        EventJournalConfig defConfig = mapEventJournalConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new EventJournalConfig().setMapName("default");
+            addEventJournalConfig(defConfig);
+        }
+        config = new EventJournalConfig(defConfig).setMapName(name);
+        addEventJournalConfig(config);
+        return config;
+    }
+
+    public EventJournalConfig getCacheEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        EventJournalConfig config = lookupByPattern(cacheEventJournalConfigs, baseName);
+        if (config != null) {
+            return config;
+        }
+        EventJournalConfig defConfig = cacheEventJournalConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new EventJournalConfig().setCacheName("default");
+            addEventJournalConfig(defConfig);
+        }
+        config = new EventJournalConfig(defConfig).setCacheName(name);
+        addEventJournalConfig(config);
+        return config;
+    }
+
+    public Config addEventJournalConfig(EventJournalConfig eventJournalConfig) {
+        final String mapName = eventJournalConfig.getMapName();
+        final String cacheName = eventJournalConfig.getCacheName();
+        if (StringUtil.isNullOrEmpty(mapName) && StringUtil.isNullOrEmpty(cacheName)) {
+            throw new IllegalArgumentException("Event journal config should have non-empty map name and/or cache name");
+        }
+        if (!StringUtil.isNullOrEmpty(mapName)) {
+            mapEventJournalConfigs.put(eventJournalConfig.getMapName(), eventJournalConfig);
+        }
+        if (!StringUtil.isNullOrEmpty(cacheName)) {
+            cacheEventJournalConfigs.put(eventJournalConfig.getCacheName(), eventJournalConfig);
+        }
+        return this;
+    }
+
+    public Map<String, EventJournalConfig> getMapEventJournalConfigs() {
+        return mapEventJournalConfigs;
+    }
+
+    public Map<String, EventJournalConfig> getCacheEventJournalConfigs() {
+        return cacheEventJournalConfigs;
+    }
+
+    public Config setMapEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        this.mapEventJournalConfigs.clear();
+        this.mapEventJournalConfigs.putAll(eventJournalConfigs);
+        for (Entry<String, EventJournalConfig> entry : eventJournalConfigs.entrySet()) {
+            entry.getValue().setMapName(entry.getKey());
+        }
+        return this;
+    }
+
+    public Config setCacheEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        this.cacheEventJournalConfigs.clear();
+        this.cacheEventJournalConfigs.putAll(eventJournalConfigs);
+        for (Entry<String, EventJournalConfig> entry : eventJournalConfigs.entrySet()) {
+            entry.getValue().setCacheName(entry.getKey());
+        }
+        return this;
+    }
+
     public SerializationConfig getSerializationConfig() {
         return serializationConfig;
     }
@@ -1371,6 +1467,8 @@ public class Config {
                 + ", ringbufferConfigs=" + ringbufferConfigs
                 + ", wanReplicationConfigs=" + wanReplicationConfigs
                 + ", listenerConfigs=" + listenerConfigs
+                + ", mapEventJournalConfigs=" + mapEventJournalConfigs
+                + ", cacheEventJournalConfigs=" + cacheEventJournalConfigs
                 + ", partitionGroupConfig=" + partitionGroupConfig
                 + ", managementCenterConfig=" + managementCenterConfig
                 + ", securityConfig=" + securityConfig

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -122,6 +122,7 @@ public class ConfigXmlGenerator {
         executorXmlGenerator(gen, config);
         durableExecutorXmlGenerator(gen, config);
         scheduledExecutorXmlGenerator(gen, config);
+        eventJournalXmlGenerator(gen, config);
         partitionGroupXmlGenerator(gen, config);
         cardinalityEstimatorXmlGenerator(gen, config);
         listenerXmlGenerator(gen, config);
@@ -182,6 +183,25 @@ public class ConfigXmlGenerator {
             gen.node("listener", classNameOrImplClass(lc.getClassName(), lc.getImplementation()));
         }
         gen.close();
+    }
+
+    private static void eventJournalXmlGenerator(XmlGenerator gen, Config config) {
+        final Collection<EventJournalConfig> mapJournalConfigs = config.getMapEventJournalConfigs().values();
+        final Collection<EventJournalConfig> cacheJournalConfigs = config.getCacheEventJournalConfigs().values();
+        for (EventJournalConfig c : mapJournalConfigs) {
+            gen.open("event-journal", "enabled", c.isEnabled())
+               .node("mapName", c.getMapName())
+               .node("capacity", c.getCapacity())
+               .node("time-to-live-seconds", c.getTimeToLiveSeconds())
+               .close();
+        }
+        for (EventJournalConfig c : cacheJournalConfigs) {
+            gen.open("event-journal", "enabled", c.isEnabled())
+               .node("cacheName", c.getCacheName())
+               .node("capacity", c.getCapacity())
+               .node("time-to-live-seconds", c.getTimeToLiveSeconds())
+               .close();
+        }
     }
 
     @SuppressWarnings({"checkstyle:npathcomplexity"})

--- a/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.annotation.Beta;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.Preconditions.checkPositive;
+
+/**
+ * Configuration for an event journal. The event journal keeps events related
+ * to a specific partition and data structure. For instance, it could keep
+ * map add, update, remove, merge events along with the key, old value, new value and so on.
+ * This configuration is not tied to a specific data structure and can be reused.
+ */
+@Beta
+public class EventJournalConfig {
+
+    /**
+     * Default value of capacity of the event journal.
+     */
+    public static final int DEFAULT_CAPACITY = 10 * 1000;
+    /**
+     * Default value for the time to live property.
+     */
+    public static final int DEFAULT_TTL_SECONDS = 0;
+
+    private String mapName;
+    private String cacheName;
+    private boolean enabled = true;
+    private int capacity = DEFAULT_CAPACITY;
+    private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
+
+    public EventJournalConfig() {
+    }
+
+    /**
+     * Clones a {@link EventJournalConfig}.
+     *
+     * @param config the event journal config to clone
+     * @throws NullPointerException if the config is null
+     */
+    public EventJournalConfig(EventJournalConfig config) {
+        checkNotNull(config, "config can't be null");
+        this.enabled = config.enabled;
+        this.mapName = config.mapName;
+        this.cacheName = config.cacheName;
+        this.capacity = config.capacity;
+        this.timeToLiveSeconds = config.timeToLiveSeconds;
+    }
+
+    /**
+     * Gets the capacity of the event journal.
+     * The capacity is the total number of items that the event journal can hold at any moment.
+     * The actual number of items contained in the journal can be lower.
+     *
+     * @return the capacity.
+     */
+    public int getCapacity() {
+        return capacity;
+    }
+
+    /**
+     * Sets the capacity of the event journal.
+     *
+     * @param capacity the capacity.
+     * @return the updated config.
+     * @throws java.lang.IllegalArgumentException if capacity smaller than 1.
+     * @see #getCapacity()
+     */
+    public EventJournalConfig setCapacity(int capacity) {
+        checkPositive(capacity, "capacity can't be smaller than 1");
+        this.capacity = capacity;
+        return this;
+    }
+
+    /**
+     * Gets the time to live in seconds.
+     *
+     * @return the time to live in seconds. Returns 0 the time to live if the items don't expire.
+     */
+    public int getTimeToLiveSeconds() {
+        return timeToLiveSeconds;
+    }
+
+    /**
+     * Sets the time to live in seconds.
+     * Time to live is the time the event journal retains items before removing them from the journal.
+     * The events are removed on journal read and write actions, not while the journal is idle.
+     * <p>
+     * Time to live can be disabled by setting timeToLiveSeconds to 0. This means that the
+     * events never expire but they can be overwritten when the capacity of the journal is exceeed.
+     *
+     * @param timeToLiveSeconds the time to live period in seconds
+     * @return the updated config
+     * @throws IllegalArgumentException if timeToLiveSeconds smaller than 0.
+     */
+    public EventJournalConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
+        this.timeToLiveSeconds = checkNotNegative(timeToLiveSeconds, "timeToLiveSeconds can't be smaller than 0");
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "EventJournalConfig{"
+                + "mapName='" + mapName + '\''
+                + ", cacheName='" + cacheName + '\''
+                + ", enabled=" + enabled
+                + ", capacity=" + capacity
+                + ", timeToLiveSeconds=" + timeToLiveSeconds
+                + '}';
+    }
+
+    /**
+     * Returns an immutable version of this configuration.
+     *
+     * @return immutable version of this configuration
+     * @deprecated this method will be removed in 4.0; it is meant for internal usage only.
+     */
+    public EventJournalConfig getAsReadOnly() {
+        return new EventJournalConfigReadOnly(this);
+    }
+
+    /**
+     * Returns the map name to which this config applies.
+     *
+     * @return the map name
+     */
+    public String getMapName() {
+        return mapName;
+    }
+
+    /**
+     * Sets the map name to which this config applies. Map names
+     * are also matched by pattern and event journal with map name "default"
+     * applies to all maps that do not have more specific event journal configs.
+     *
+     * @param mapName the map name
+     * @return the event journal config
+     */
+    public EventJournalConfig setMapName(String mapName) {
+        this.mapName = mapName;
+        return this;
+    }
+
+    /**
+     * Returns the cache name to which this config applies.
+     *
+     * @return the cache name
+     */
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    /**
+     * Sets the cache name to which this config applies. Cache names
+     * are also matched by pattern and event journal with cache name "default"
+     * applies to all caches that do not have more specific event journal configs.
+     *
+     * @param cacheName the cache name
+     * @return the event journal config
+     */
+    public EventJournalConfig setCacheName(String cacheName) {
+        this.cacheName = checkHasText(cacheName, "name must contain text");
+        return this;
+    }
+
+    /**
+     * Returns if the event journal is enabled.
+     *
+     * @return {@code true} if the event journal is enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+
+    /**
+     * Enables or disables the event journal.
+     *
+     * @param enabled {@code true} if enabled, {@code false} otherwise.
+     * @return the updated config.
+     */
+    public EventJournalConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+
+    @Beta
+    private static class EventJournalConfigReadOnly extends EventJournalConfig {
+        EventJournalConfigReadOnly(EventJournalConfig config) {
+            super(config);
+        }
+
+        @Override
+        public EventJournalConfig setCapacity(int capacity) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setEnabled(boolean enabled) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setMapName(String mapName) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setCacheName(String cacheName) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -63,6 +63,7 @@ import static com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import static com.hazelcast.config.XmlElements.CACHE;
 import static com.hazelcast.config.XmlElements.CARDINALITY_ESTIMATOR;
 import static com.hazelcast.config.XmlElements.DURABLE_EXECUTOR_SERVICE;
+import static com.hazelcast.config.XmlElements.EVENT_JOURNAL;
 import static com.hazelcast.config.XmlElements.EXECUTOR_SERVICE;
 import static com.hazelcast.config.XmlElements.GROUP;
 import static com.hazelcast.config.XmlElements.HOT_RESTART_PERSISTENCE;
@@ -317,6 +318,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleDurableExecutor(node);
         } else if (SCHEDULED_EXECUTOR_SERVICE.isEqual(nodeName)) {
             handleScheduledExecutor(node);
+        } else if (EVENT_JOURNAL.isEqual(nodeName)) {
+            handleEventJournal(node);
         } else if (SERVICES.isEqual(nodeName)) {
             handleServices(node);
         } else if (QUEUE.isEqual(nodeName)) {
@@ -1859,6 +1862,12 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             }
         }
         config.addSemaphoreConfig(sConfig);
+    }
+
+    private void handleEventJournal(Node node) throws Exception {
+        final EventJournalConfig journalConfig = new EventJournalConfig();
+        handleViaReflection(node, config, journalConfig);
+        config.addEventJournalConfig(journalConfig);
     }
 
     private void handleRingbuffer(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -30,6 +30,7 @@ enum XmlElements {
     EXECUTOR_SERVICE("executor-service", true),
     DURABLE_EXECUTOR_SERVICE("durable-executor-service", true),
     SCHEDULED_EXECUTOR_SERVICE("scheduled-executor-service", true),
+    EVENT_JOURNAL("event-journal", true),
     QUEUE("queue", true),
     MAP("map", true),
     CACHE("cache", true),

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.internal.serialization;
 
+import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.Disposable;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -53,6 +55,12 @@ public interface InternalSerializationService extends SerializationService, Disp
      * disabled.
      */
     byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash);
+
+    <B extends Data> B toData(Object obj, DataType type);
+
+    <B extends Data> B toData(Object obj, DataType type, PartitioningStrategy strategy);
+
+    <B extends Data> B convertData(Data data, DataType type);
 
     void writeObject(ObjectDataOutput out, Object obj);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -137,6 +137,9 @@ public final class FactoryIdHelper {
     public static final String ENTERPRISE_SECURITY_DS_FACTORY = "hazelcast.serialization.ds.security";
     public static final int ENTERPRISE_SECURITY_DS_FACTORY_ID = -44;
 
+    public static final String EVENT_JOURNAL_DS_FACTORY = "hazelcast.serialization.ds.event_journal";
+    public static final int EVENT_JOURNAL_DS_FACTORY_ID = -45;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -108,6 +109,30 @@ public class SerializationServiceV1 extends AbstractSerializationService {
                 new JavaDefaultSerializers.ExternalizableSerializer(enableCompression), this);
         registerConstantSerializers();
         registerJavaTypeSerializers();
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type) {
+        if (type == DataType.NATIVE) {
+            throw new IllegalArgumentException("Native data type is not supported");
+        }
+        return toData(obj);
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type, PartitioningStrategy strategy) {
+        if (type == DataType.NATIVE) {
+            throw new IllegalArgumentException("Native data type is not supported");
+        }
+        return toData(obj, strategy);
+    }
+
+    @Override
+    public <B extends Data> B convertData(Data data, DataType type) {
+        if (type == DataType.NATIVE) {
+            throw new IllegalArgumentException("Native data type is not supported");
+        }
+        return (B) data;
     }
 
     public PortableReader createPortableReader(Data data) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
+
+/**
+ * The event journal is a container for events related to a data structure.
+ * This interface provides methods for distributed object event journals.
+ * Each distributed object and partition has it's own event journal.
+ * <p>
+ * If a object is destroyed or the migrated, the related event journal will be destroyed or
+ * migrated as well. In this sense, the event journal is co-located with the object partition
+ * and it's replicas.
+ *
+ * @param <E> journal event type
+ * @since 3.9
+ */
+public interface EventJournal<E> {
+    /**
+     * Returns the sequence of the newest event stored in the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the event journal
+     * @return the sequence of the last stored event
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    long newestSequence(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Returns the sequence of the oldest event stored in the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the event journal
+     * @return the sequence of the oldest stored event
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    long oldestSequence(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Destroys the event journal for the given object and partition ID.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     */
+    void destroy(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Checks if the sequence is of an item that can be read immediately
+     * or is the sequence of the next item to be added into the event journal.
+     * Since this method allows the sequence to be one larger than
+     * the {@link #newestSequence(ObjectNamespace, int)}, the caller can use this method
+     * to check the sequence before performing a possibly blocking read.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @param sequence    the sequence wanting to be read
+     * @throws StaleSequenceException   if the requested sequence is smaller than the
+     *                                  sequence of the oldest event (the sequence has
+     *                                  been overwritten)
+     * @throws IllegalArgumentException if the requested sequence is greater than the
+     *                                  next available sequence + 1
+     * @throws IllegalStateException    if there is no event journal configured for this object
+     */
+    void isAvailableOrNextSequence(ObjectNamespace namespace, int partitionId, long sequence);
+
+    /**
+     * Checks if the {@code sequence} is the sequence of the next event to
+     * be added to the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @param sequence    the sequence to be checked
+     * @return {@code true} if the {@code sequence} is one greater
+     * than the sequence of the last event, {@code false} otherwise
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence);
+
+    /**
+     * Return the {@link WaitNotifyKey} for objects waiting and notifying on the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @return the key for a wait notify object
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Reads events from the journal in batches. It will read up to
+     * the maximum number that the set can hold - see {@link ReadResultSetImpl#isMaxSizeReached()}
+     * or until the journal is exhausted. The {@code resultSet} allows
+     * filtering and projections on journal items so that the caller
+     * can control which data is returned.
+     * <p>
+     * If the set has reached it's max size, the returned sequence
+     * one greater than the sequence of the last item in the set.
+     * In other cases it means that the set hasn't reached it's full
+     * size because we have reached the end of the event journal. In
+     * this case the returned sequence is one greater than the sequence
+     * of the last stored event.
+     *
+     * @param namespace     the object namespace
+     * @param partitionId   the partition ID of the entries in the journal
+     * @param beginSequence the sequence of the first item to read.
+     * @param resultSet     the container for read, filtered and projected events
+     * @param <T>           the return type of the projected events
+     * @return returns the sequenceId of the next item to read
+     * @throws IllegalStateException    if there is no event journal configured for this object
+     * @throws StaleSequenceException   if the requested sequence is smaller than the sequence of the oldest event
+     * @throws IllegalArgumentException if the requested sequence is greater than the sequence of the newest event + 1
+     * @see #isAvailableOrNextSequence(ObjectNamespace, int, long)
+     */
+    <T> long readMany(ObjectNamespace namespace, int partitionId, long beginSequence, ReadResultSetImpl<E, T> resultSet);
+
+    /**
+     * Cleans up the event journal by removing any expired items. Items are considered
+     * expired as according to the configured expiration policy.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    void cleanup(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Returns {@code true} if the object has a configured and enabled event journal.
+     *
+     * @param namespace the object namespace
+     * @return {@code true} if the object has a configured and enabled event journal, {@code false} otherwise
+     */
+    boolean hasEventJournal(ObjectNamespace namespace);
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalDataSerializerHook.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.EVENT_JOURNAL_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.EVENT_JOURNAL_DS_FACTORY_ID;
+
+/**
+ * Data serializer hook for common classes related to the {@link EventJournal}. Data structure specific
+ * (map, cache,...) event journal classes are under the other respective serializer hooks.
+ */
+public final class EventJournalDataSerializerHook implements DataSerializerHook {
+    /**
+     * Factory ID for the event journal {@link IdentifiedDataSerializable} classes
+     */
+    public static final int F_ID = FactoryIdHelper.getFactoryId(EVENT_JOURNAL_DS_FACTORY, EVENT_JOURNAL_DS_FACTORY_ID);
+
+    /**
+     * Type ID for the {@link EventJournalInitialSubscriberState} class
+     */
+    public static final int EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE = 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        return new DataSerializableFactory() {
+            @Override
+            public IdentifiedDataSerializable create(int typeId) {
+                switch (typeId) {
+                    case EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE:
+                        return new EventJournalInitialSubscriberState();
+                    default:
+                        return null;
+                }
+            }
+        };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalInitialSubscriberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalInitialSubscriberState.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * The response for the event journal subcription. This includes
+ * the sequence IDs of the newest and oldest event in the event
+ * journal from which new events can be read.
+ * Keep in mind that these sequence IDs may be overwritten at any point
+ * and may be stale by the time you decide to read them.
+ *
+ * @see com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation
+ * @see com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation
+ * @since 3.9
+ */
+public class EventJournalInitialSubscriberState implements IdentifiedDataSerializable {
+    private long oldestSequence;
+    private long newestSequence;
+
+    public EventJournalInitialSubscriberState() {
+    }
+
+    public EventJournalInitialSubscriberState(long oldestSequence, long newestSequence) {
+        this.oldestSequence = oldestSequence;
+        this.newestSequence = newestSequence;
+    }
+
+    public long getOldestSequence() {
+        return oldestSequence;
+    }
+
+    public long getNewestSequence() {
+        return newestSequence;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return EventJournalDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return EventJournalDataSerializerHook.EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeLong(oldestSequence);
+        out.writeLong(newestSequence);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        oldestSequence = in.readLong();
+        newestSequence = in.readLong();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReadOperation.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.BlockingOperation;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.version.Version;
+
+import java.io.IOException;
+
+/**
+ * Reads from the map event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @param <J> journal event type
+ * @since 3.9
+ */
+public abstract class EventJournalReadOperation<T, J> extends Operation
+        implements IdentifiedDataSerializable, PartitionAwareOperation, BlockingOperation {
+    protected String name;
+    protected int minSize;
+    protected int maxSize;
+    protected long startSequence;
+
+    protected transient ReadResultSetImpl<J, T> resultSet;
+    protected transient long sequence;
+    protected transient DistributedObjectNamespace namespace;
+    private WaitNotifyKey waitNotifyKey;
+
+    public EventJournalReadOperation() {
+    }
+
+    public EventJournalReadOperation(String name, long startSequence, int minSize, int maxSize) {
+        this.name = name;
+        this.minSize = minSize;
+        this.maxSize = maxSize;
+        this.startSequence = startSequence;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Checks the precondition that the start sequence is already
+     * available (in the event journal) or is the sequence of the
+     * next event to be added into the journal.
+     */
+    @Override
+    public void beforeRun() {
+        final Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        if (clusterVersion.isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is " + clusterVersion);
+        }
+
+        namespace = new DistributedObjectNamespace(getServiceName(), name);
+
+        final EventJournal<J> journal = getJournal();
+        if (!journal.hasEventJournal(namespace)) {
+            throw new UnsupportedOperationException(
+                    "Cannot subscribe to event journal because it is either not configured or disabled for " + namespace);
+        }
+
+        final int partitionId = getPartitionId();
+        journal.cleanup(namespace, partitionId);
+        journal.isAvailableOrNextSequence(namespace, partitionId, startSequence);
+        // we'll store the wait notify key because ICache destroys the record store
+        // and the cache config is unavailable at the time operations are being
+        // cancelled. Hence, we cannot create the journal and fetch it's wait notify
+        // key
+        waitNotifyKey = journal.getWaitNotifyKey(namespace, partitionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * On every invocation this method reads from the event journal until
+     * it has collected the minimum required number of response items.
+     * Returns {@code true} if there are currently not enough
+     * elements in the response and the operation should be parked.
+     *
+     * @return if the operation should wait on the wait/notify key
+     */
+    @Override
+    public boolean shouldWait() {
+        if (resultSet == null) {
+            resultSet = createResultSet();
+            sequence = startSequence;
+        }
+
+        final EventJournal<J> journal = getJournal();
+        final int partitionId = getPartitionId();
+        journal.cleanup(namespace, partitionId);
+        if (minSize == 0) {
+            if (!journal.isNextAvailableSequence(namespace, partitionId, sequence)) {
+                sequence = journal.readMany(namespace, partitionId, sequence, resultSet);
+            }
+            return false;
+        }
+
+        if (resultSet.isMinSizeReached()) {
+            // enough items have been read, we are done.
+            return false;
+        }
+
+        if (journal.isNextAvailableSequence(namespace, partitionId, sequence)) {
+            // the sequence is not readable
+            return true;
+        }
+
+        sequence = journal.readMany(namespace, partitionId, sequence, resultSet);
+        return !resultSet.isMinSizeReached();
+    }
+
+    @Override
+    public void run() throws Exception {
+        // no-op; we already did the work in the shouldWait method.
+    }
+
+    @Override
+    public Object getResponse() {
+        return resultSet;
+    }
+
+    @Override
+    public WaitNotifyKey getWaitKey() {
+        return waitNotifyKey;
+    }
+
+    @Override
+    public void onWaitExpire() {
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(name);
+        out.writeInt(minSize);
+        out.writeInt(maxSize);
+        out.writeLong(startSequence);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        name = in.readUTF();
+        minSize = in.readInt();
+        maxSize = in.readInt();
+        startSequence = in.readLong();
+    }
+
+    @Override
+    public void logError(Throwable e) {
+        if (e instanceof StaleSequenceException) {
+            ILogger logger = getLogger();
+            if (logger.isFinestEnabled()) {
+                logger.finest(e.getMessage(), e);
+            } else if (logger.isFineEnabled()) {
+                logger.fine(e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        } else {
+            super.logError(e);
+        }
+    }
+
+    public abstract String getServiceName();
+
+    protected abstract ReadResultSetImpl<J, T> createResultSet();
+
+    protected abstract EventJournal<J> getJournal();
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains supporting classes for data structure specific event journals.
+ * The event journal is a container for events related to a data structure.
+ * This includes events such as add, update, remove, evict and others.
+ * Each distributed object and partition has it's own event journal.
+ *
+ * @since 3.9
+ */
+
+package com.hazelcast.journal;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -25,6 +25,9 @@ import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
+import com.hazelcast.map.impl.journal.DeserialisingEventJournalMapEvent;
+import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
+import com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation;
 import com.hazelcast.map.impl.nearcache.invalidation.UuidFilter;
 import com.hazelcast.map.impl.operation.AccumulatorConsumerOperation;
 import com.hazelcast.map.impl.operation.AddIndexOperation;
@@ -286,8 +289,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int ENTRY_REMOVING_PROCESSOR = 135;
     public static final int ENTRY_OFFLOADABLE_SET_UNLOCK = 136;
     public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 137;
+    public static final int EVENT_JOURNAL_SUBSCRIBE_OPERATION = 138;
+    public static final int EVENT_JOURNAL_READ = 139;
+    public static final int EVENT_JOURNAL_MAP_EVENT = 140;
 
-    private static final int LEN = LOCK_AWARE_LAZY_MAP_ENTRY + 1;
+    private static final int LEN = EVENT_JOURNAL_MAP_EVENT + 1;
 
     @Override
     public int getFactoryId() {
@@ -968,6 +974,22 @@ public final class MapDataSerializerHook implements DataSerializerHook {
                 return new LockAwareLazyMapEntry();
             }
         };
+        constructors[EVENT_JOURNAL_SUBSCRIBE_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapEventJournalSubscribeOperation();
+            }
+        };
+        constructors[EVENT_JOURNAL_READ] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapEventJournalReadOperation<Object, Object, Object>();
+            }
+        };
+        constructors[EVENT_JOURNAL_MAP_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DeserialisingEventJournalMapEvent<Object, Object>();
+            }
+        };
+
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
@@ -132,6 +133,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     MergePolicyProvider getMergePolicyProvider();
 
     MapEventPublisher getMapEventPublisher();
+
+    MapEventJournal getEventJournal();
 
     MapQueryEngine getMapQueryEngine(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -197,6 +197,8 @@ public class PartitionContainer {
     public void clear(boolean onShutdown) {
         for (RecordStore recordStore : maps.values()) {
             recordStore.clearPartition(onShutdown);
+            mapService.getMapServiceContext().getEventJournal().destroy(
+                    recordStore.getMapContainer().getObjectNamespace(), partitionId);
         }
         maps.clear();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -118,5 +118,8 @@ public interface MapEventPublisher {
      */
     void addEventToQueryCache(Object eventData);
 
+    /**
+     * Returns {@code true} if there is at least one listener registered for the specified {@code mapName}.
+     */
     boolean hasEventListener(String mapName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -293,6 +293,9 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         return eventService.getRegistrations(SERVICE_NAME, mapName);
     }
 
+    /**
+     * Returns the hashCode of the {@code key} or -1 if {@code null}
+     */
     private int pickOrderKey(Data key) {
         return key == null ? -1 : key.hashCode();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserialisingEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserialisingEventJournalMapEvent.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.io.IOException;
+
+public class DeserialisingEventJournalMapEvent<K, V>
+        extends InternalEventJournalMapEvent
+        implements IdentifiedDataSerializable, EventJournalMapEvent<K, V>, HazelcastInstanceAware {
+    private SerializationService serializationService;
+    private K objectKey;
+    private V objectNewValue;
+    private V objectOldValue;
+
+    public DeserialisingEventJournalMapEvent() {
+    }
+
+    public DeserialisingEventJournalMapEvent(SerializationService serializationService, InternalEventJournalMapEvent je) {
+        super(je.getDataKey(), je.getDataNewValue(), je.getDataOldValue(), je.getEventType());
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_MAP_EVENT;
+    }
+
+    @Override
+    public K getKey() {
+        if (objectKey == null && dataKey != null) {
+            objectKey = serializationService.toObject(dataKey);
+        }
+        return objectKey;
+    }
+
+    @Override
+    public V getNewValue() {
+        if (objectNewValue == null && dataNewValue != null) {
+            objectNewValue = serializationService.toObject(dataNewValue);
+        }
+        return objectNewValue;
+    }
+
+    @Override
+    public V getOldValue() {
+        if (objectOldValue == null && dataOldValue != null) {
+            objectOldValue = serializationService.toObject(dataOldValue);
+        }
+        return objectOldValue;
+    }
+
+    @Override
+    public EntryEventType getType() {
+        return EntryEventType.getByType(eventType);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        out.writeData(toData(dataKey, objectKey));
+        out.writeData(toData(dataNewValue, objectNewValue));
+        out.writeData(toData(dataOldValue, objectOldValue));
+    }
+
+    private Data toData(Data data, Object o) {
+        return o != null ? serializationService.toData(o) : data;
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        eventType = in.readInt();
+        dataKey = in.readData();
+        dataNewValue = in.readData();
+        dataOldValue = in.readData();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/EventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/EventJournalMapEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.core.EntryEventType;
+
+/**
+ * The event for the map event journal.
+ *
+ * @param <K> the entry key type
+ * @param <V> the entry value type
+ */
+public interface EventJournalMapEvent<K, V> {
+    /**
+     * Returns the key for the event entry.
+     *
+     * @return the entry key
+     */
+    K getKey();
+
+    /**
+     * Returns the new value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link EntryEventType#ADDED}, the new
+     * value is non-{@code null} but when it is of type {@link EntryEventType#REMOVED},
+     * the value is {@code null}.
+     *
+     * @return the entry new value
+     */
+    V getNewValue();
+
+    /**
+     * Returns the old value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link EntryEventType#ADDED}, the old
+     * value is {@code null} but when it is of type {@link EntryEventType#REMOVED},
+     * the value is non-{@code null}.
+     *
+     * @return the entry old value
+     */
+    V getOldValue();
+
+    /**
+     * Returns the event type.
+     *
+     * @return the event type
+     */
+    EntryEventType getType();
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.nio.serialization.Data;
+
+/**
+ * The event journal item for map events. It contains serialized
+ * values for key and all values included in map mutations as well as
+ * the event type.
+ */
+public class InternalEventJournalMapEvent {
+    protected Data dataKey;
+    protected Data dataNewValue;
+    protected Data dataOldValue;
+    protected int eventType;
+
+    public InternalEventJournalMapEvent() {
+    }
+
+    public InternalEventJournalMapEvent(Data dataKey, Data dataNewValue, Data dataOldValue, int eventType) {
+        this.eventType = eventType;
+        this.dataKey = dataKey;
+        this.dataNewValue = dataNewValue;
+        this.dataOldValue = dataOldValue;
+    }
+
+    public Data getDataKey() {
+        return dataKey;
+    }
+
+    public Data getDataNewValue() {
+        return dataNewValue;
+    }
+
+    public Data getDataOldValue() {
+        return dataOldValue;
+    }
+
+    /**
+     * Return the integer defining the event type. It can be turned into an
+     * enum value by calling {@link com.hazelcast.core.EntryEventType#getByType(int)}.
+     *
+     * @return the integer defining the event type
+     */
+    public int getEventType() {
+        return eventType;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ObjectNamespace;
+
+/**
+ * The event journal is a container for events related to a data structure.
+ * This interface provides methods for map event journals. This includes
+ * events such as add, update, remove, evict and others. Each map and
+ * partition has it's own event journal.
+ * <p>
+ * If a map is destroyed or the migrated, the related event journal will be destroyed or
+ * migrated as well. In this sense, the event journal is co-located with the map partition
+ * and it's replicas.
+ *
+ * @since 3.9
+ */
+public interface MapEventJournal extends EventJournal<InternalEventJournalMapEvent> {
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#UPDATED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param oldValue    the old value
+     * @param newValue    the new value
+     */
+    void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue);
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#ADDED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeAddEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#REMOVED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#EVICTED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Returns {@code true} if the object has a configured and enabled event journal.
+     *
+     * @param namespace the object namespace
+     * @return {@code true} if the object has a configured and enabled event journal, {@code false} otherwise
+     */
+    boolean hasEventJournal(ObjectNamespace namespace);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.journal.EventJournalReadOperation;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.util.function.Predicate;
+
+import java.io.IOException;
+
+/**
+ * Reads from the map event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to an implementation of {@link }
+ *            if the projection is {@code null} or it is the identity projection
+ * @since 3.9
+ */
+public class MapEventJournalReadOperation<K, V, T> extends EventJournalReadOperation<T, InternalEventJournalMapEvent> {
+
+    protected Predicate<? super EventJournalMapEvent<K, V>> predicate;
+    protected Projection<? super EventJournalMapEvent<K, V>, T> projection;
+
+    public MapEventJournalReadOperation() {
+    }
+
+    public MapEventJournalReadOperation(String mapName, long startSequence, int minSize, int maxSize,
+                                        Predicate<? super EventJournalMapEvent<K, V>> predicate,
+                                        Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        super(mapName, startSequence, minSize, maxSize);
+        this.predicate = predicate;
+        this.projection = projection;
+    }
+
+    @Override
+    protected ReadResultSetImpl<InternalEventJournalMapEvent, T> createResultSet() {
+        return new MapEventJournalReadResultSetImpl<K, V, T>(
+                minSize, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
+    }
+
+    @Override
+    protected EventJournal<InternalEventJournalMapEvent> getJournal() {
+        final MapService service = getService();
+        return service.getMapServiceContext().getEventJournal();
+    }
+
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_READ;
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(predicate);
+        out.writeObject(projection);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        predicate = in.readObject();
+        projection = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Predicate;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class MapEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetImpl<InternalEventJournalMapEvent, T> {
+
+    MapEventJournalReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
+                                     final Predicate<? super EventJournalMapEvent<K, V>> predicate,
+                                     final Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        super(minSize, maxSize, serializationService,
+                predicate == null ? null : new Predicate<InternalEventJournalMapEvent>() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+                    public boolean test(InternalEventJournalMapEvent e) {
+                        return predicate.test((DeserialisingEventJournalMapEvent<K, V>) e);
+                    }
+                },
+                projection == null ? null : new Projection<InternalEventJournalMapEvent, T>() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+                    public T transform(InternalEventJournalMapEvent input) {
+                        return projection.transform((DeserialisingEventJournalMapEvent<K, V>) input);
+                    }
+                });
+    }
+
+    @Override
+    public void addItem(long seq, Object item) {
+        final InternalEventJournalMapEvent e = serializationService.toObject(item);
+        final DeserialisingEventJournalMapEvent<K, V> deserialisingEvent
+                = new DeserialisingEventJournalMapEvent<K, V>(serializationService, e);
+        super.addItem(seq, deserialisingEvent);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.MapOperation;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.version.Version;
+
+/**
+ * Performs the initial subscription to the map event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @since 3.9
+ */
+public class MapEventJournalSubscribeOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
+    private EventJournalInitialSubscriberState response;
+    private DistributedObjectNamespace namespace;
+
+    public MapEventJournalSubscribeOperation() {
+    }
+
+    public MapEventJournalSubscribeOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        super.beforeRun();
+
+        final Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        if (clusterVersion.isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is " + clusterVersion);
+        }
+        namespace = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
+        if (!mapServiceContext.getEventJournal().hasEventJournal(namespace)) {
+            throw new UnsupportedOperationException(
+                    "Cannot subscribe to event journal because it is either not configured or disabled for map " + name);
+        }
+    }
+
+    @Override
+    public void run() {
+        final MapEventJournal eventJournal = mapServiceContext.getEventJournal();
+        final long newestSequence = eventJournal.newestSequence(namespace, getPartitionId());
+        final long oldestSequence = eventJournal.oldestSequence(namespace, getPartitionId());
+        response = new EventJournalInitialSubscriberState(oldestSequence, newestSequence);
+    }
+
+    @Override
+    public EventJournalInitialSubscriberState getResponse() {
+        return response;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_SUBSCRIBE_OPERATION;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.ringbuffer.impl.RingbufferWaitNotifyKey;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationparker.OperationParker;
+
+import static com.hazelcast.core.EntryEventType.ADDED;
+import static com.hazelcast.core.EntryEventType.EVICTED;
+import static com.hazelcast.core.EntryEventType.REMOVED;
+import static com.hazelcast.core.EntryEventType.UPDATED;
+
+/**
+ * The map event journal implementation based on the {@link com.hazelcast.ringbuffer.Ringbuffer}.
+ * It will add all journal events into a {@link RingbufferContainer} with the provided namespace
+ * and partition ID and allows checking if the map has a configured event journal.
+ * Adapts the {@link EventJournalConfig} to the {@link RingbufferConfig} when creating the ringbuffer.
+ */
+public class RingbufferMapEventJournalImpl implements MapEventJournal {
+    private final NodeEngineImpl nodeEngine;
+
+    public RingbufferMapEventJournalImpl(NodeEngine engine) {
+        this.nodeEngine = (NodeEngineImpl) engine;
+    }
+
+    @Override
+    public void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue) {
+        addToEventRingbuffer(namespace, partitionId, UPDATED, key, oldValue, newValue);
+    }
+
+    @Override
+    public void writeAddEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, ADDED, key, null, value);
+    }
+
+    @Override
+    public void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, REMOVED, key, value, null);
+    }
+
+    @Override
+    public void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, EVICTED, key, value, null);
+    }
+
+    @Override
+    public long newestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).tailSequence();
+    }
+
+    @Override
+    public long oldestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).headSequence();
+    }
+
+    @Override
+    public void destroy(ObjectNamespace namespace, int partitionId) {
+        getRingbufferService().destroyContainer(partitionId, namespace);
+    }
+
+    @Override
+    public void isAvailableOrNextSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        getRingbufferOrFail(namespace, partitionId).checkBlockableReadSequence(sequence);
+    }
+
+    @Override
+    public boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        return getRingbufferOrFail(namespace, partitionId).shouldWait(sequence);
+    }
+
+    @Override
+    public WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
+        return new RingbufferWaitNotifyKey(namespace);
+    }
+
+    @Override
+    public <T> long readMany(ObjectNamespace namespace, int partitionId, long beginSequence,
+                             ReadResultSetImpl<InternalEventJournalMapEvent, T> resultSet) {
+        return getRingbufferOrFail(namespace, partitionId).readMany(beginSequence, resultSet);
+    }
+
+    @Override
+    public void cleanup(ObjectNamespace namespace, int partitionId) {
+        getRingbufferOrFail(namespace, partitionId).cleanup();
+    }
+
+    @Override
+    public boolean hasEventJournal(ObjectNamespace namespace) {
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        return config != null && config.isEnabled();
+    }
+
+    private void addToEventRingbuffer(ObjectNamespace namespace, int partitionId, EntryEventType eventType,
+                                      Data key, Object oldValue, Object newValue) {
+        final RingbufferContainer<InternalEventJournalMapEvent> eventContainer = getRingbufferOrNull(namespace, partitionId);
+        if (eventContainer == null) {
+            return;
+        }
+        final InternalEventJournalMapEvent event
+                = new InternalEventJournalMapEvent(toData(key), toData(newValue), toData(oldValue), eventType.getType());
+        eventContainer.add(event);
+        getOperationParker().unpark(eventContainer);
+    }
+
+    private Data toData(Object val) {
+        return getSerializationService().toData(val, DataType.HEAP);
+    }
+
+    private RingbufferContainer<InternalEventJournalMapEvent> getRingbufferOrFail(ObjectNamespace namespace, int partitionId) {
+        final RingbufferContainer<InternalEventJournalMapEvent> ringbuffer = getRingbufferOrNull(namespace, partitionId);
+        if (ringbuffer == null) {
+            throw new IllegalStateException("There is no event journal configured for map with name: "
+                    + namespace.getObjectName());
+        }
+        return ringbuffer;
+    }
+
+    private RingbufferContainer<InternalEventJournalMapEvent> getRingbufferOrNull(ObjectNamespace namespace, int partitionId) {
+        final RingbufferService service = getRingbufferService();
+        final RingbufferConfig ringbufferConfig;
+        if (service.hasContainer(partitionId, namespace)) {
+            ringbufferConfig = null;
+        } else {
+            final EventJournalConfig config = getEventJournalConfig(namespace);
+            if (config == null || !config.isEnabled()) {
+                return null;
+            }
+            ringbufferConfig = new RingbufferConfig()
+                    .setAsyncBackupCount(0)
+                    .setBackupCount(0)
+                    .setInMemoryFormat(InMemoryFormat.OBJECT)
+                    .setCapacity(config.getCapacity())
+                    .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
+        }
+        return service.getContainer(partitionId, namespace, ringbufferConfig);
+    }
+
+    private EventJournalConfig getEventJournalConfig(ObjectNamespace namespace) {
+        return nodeEngine.getConfig().getMapEventJournalConfig(namespace.getObjectName());
+    }
+
+    private RingbufferService getRingbufferService() {
+        return nodeEngine.getService(RingbufferService.SERVICE_NAME);
+    }
+
+    private OperationParker getOperationParker() {
+        return nodeEngine.getOperationParker();
+    }
+
+    private InternalSerializationService getSerializationService() {
+        return (InternalSerializationService) nodeEngine.getSerializationService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
@@ -32,7 +32,10 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Removes data from Record store on LoadAllOperation that replaces existing values
+ * Removes keys that are contained in the {@link com.hazelcast.map.impl.recordstore.RecordStore} from the provided list,
+ * leaving only keys which are not contained in the record store.
+ *
+ * @see com.hazelcast.core.IMap#loadAll(java.util.Set, boolean)
  */
 public class RemoveFromLoadAllOperation extends MapOperation implements PartitionAwareOperation, MutatingOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -25,12 +25,16 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.QueryCache;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.map.impl.iterator.MapPartitionIterator;
+import com.hazelcast.map.impl.journal.EventJournalMapEvent;
+import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
+import com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation;
 import com.hazelcast.map.impl.query.AggregationResult;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.Query;
@@ -61,6 +65,7 @@ import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -84,6 +89,7 @@ import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.query.QueryResultUtils.transformToSet;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequests.newQueryCacheRequest;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -882,6 +888,56 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
 
     public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
         return new MapPartitionIterator<K, V>(this, fetchSize, partitionId, prefetchValues);
+    }
+
+    /**
+     * Subscribe to the event journal for this map and a specific partition ID.
+     * The method will return the newest and oldest event journal sequence.
+     *
+     * @param partitionId the partition ID of the entries to which we are subscribing
+     * @return the initial subscriber state containing the newest and oldest event journal sequence
+     * @throws UnsupportedOperationException if the cluster version is lower than 3.9 or there is no event journal
+     *                                       configured for this map
+     * @since 3.9
+     */
+    public EventJournalInitialSubscriberState subscribeToEventJournal(int partitionId) {
+        final MapEventJournalSubscribeOperation op = new MapEventJournalSubscribeOperation(name);
+        op.setPartitionId(partitionId);
+        final InternalCompletableFuture<EventJournalInitialSubscriberState> fut = operationService.invokeOnPartition(op);
+
+        try {
+            return fut.get();
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    /**
+     * Reads from the event journal. The returned future may throw {@link UnsupportedOperationException}
+     * if the cluster version is lower than 3.9 or there is no event journal configured for this map.
+     *
+     * @param startSequence the sequence of the first item to read
+     * @param maxSize       the maximum number of items to read
+     * @param partitionId   the partition ID of the entries in the journal
+     * @param predicate     the predicate which the events must pass to be included in the response.
+     *                      May be {@code null} in which case all events pass the predicate
+     * @param projection    the projection which is applied to the events before returning.
+     *                      May be {@code null} in which case the event is returned without being projected
+     * @param <T>           the return type of the projection. It is equal to the journal event type
+     *                      if the projection is {@code null} or it is the identity projection
+     * @return the future with the filtered and projected journal items
+     * @since 3.9
+     */
+    public <T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
+            Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        final MapEventJournalReadOperation<K, V, T> op = new MapEventJournalReadOperation<K, V, T>(
+                name, startSequence, 1, maxSize, predicate, projection);
+        op.setPartitionId(partitionId);
+        return operationService.invokeOnPartition(op);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -24,6 +24,7 @@ import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.mapstore.MapStoreManager;
@@ -63,6 +64,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     protected final MapStoreContext mapStoreContext;
     protected final InMemoryFormat inMemoryFormat;
     protected final int partitionId;
+    protected final MapEventJournal eventJournal;
 
     protected Storage<Data, Record> storage;
 
@@ -83,6 +85,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         MapStoreManager mapStoreManager = mapStoreContext.getMapStoreManager();
         this.mapDataStore = mapStoreManager.getMapDataStore(name, partitionId);
         this.lockStore = createLockStore();
+        this.eventJournal = mapServiceContext.getEventJournal();
     }
 
     @Override
@@ -133,6 +136,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     protected void updateRecord(Data key, Record record, Object value, long now) {
         updateStatsOnPut(false, now);
         record.onUpdate(now);
+        eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue(), value);
         storage.updateRecordValue(key, record, value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
+
+/**
+ * Defines type of the Data: heap or native.
+ */
+public enum DataType {
+
+    /**
+     * Heap data type.
+     */
+    HEAP,
+
+    /**
+     * Native data type.
+     */
+    NATIVE
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/ReadResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/ReadResultSet.java
@@ -46,4 +46,19 @@ public interface ReadResultSet<E> extends Iterable<E> {
      * @throws IllegalArgumentException if index out of bounds.
      */
     E get(int index);
+
+    /**
+     * Return the sequence number for the item at the given index.
+     *
+     * @param index the index
+     * @return the sequence number for the ringbuffer item
+     */
+    long getSequence(int index);
+
+    /**
+     * Return the result set size.
+     *
+     * @return the result set size
+     */
+    int size();
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -27,16 +27,16 @@ import com.hazelcast.ringbuffer.StaleSequenceException;
  * <p/>
  * The ringItems is the ring that contains the actual items.
  */
-public class ArrayRingbuffer implements Ringbuffer {
+public class ArrayRingbuffer<T> implements Ringbuffer<T> {
     // contains the actual items
-    Object[] ringItems;
+    T[] ringItems;
     private long tailSequence = -1;
     private long headSequence = tailSequence + 1;
     private int capacity;
 
     public ArrayRingbuffer(int capacity) {
         this.capacity = capacity;
-        this.ringItems = new Object[capacity];
+        this.ringItems = (T[]) new Object[capacity];
     }
 
     @Override
@@ -76,7 +76,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
-    public long add(Object item) {
+    public long add(T item) {
         tailSequence++;
 
         if (tailSequence - capacity == headSequence) {
@@ -91,7 +91,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
-    public Object read(long sequence) {
+    public T read(long sequence) {
         checkReadSequence(sequence);
         return ringItems[toIndex(sequence)];
     }
@@ -132,7 +132,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
-    public void set(long seq, Object data) {
+    public void set(long seq, T data) {
         ringItems[toIndex(seq)] = data;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+import com.hazelcast.spi.ObjectNamespace;
 
 /**
  * A {@link RingbufferStore} that decorates an RingbufferStore with latency tracking instrumentation.
@@ -34,12 +35,13 @@ class LatencyTrackingRingbufferStore<T> implements RingbufferStore<T> {
     private final LatencyProbe storeAllProbe;
     private final RingbufferStore<T> delegate;
 
-    LatencyTrackingRingbufferStore(RingbufferStore<T> delegate, StoreLatencyPlugin plugin, String ringbufferName) {
+    LatencyTrackingRingbufferStore(RingbufferStore<T> delegate, StoreLatencyPlugin plugin, ObjectNamespace namespace) {
+        final String nsDescription = namespace.getServiceName() + ":" + namespace.getObjectName();
         this.delegate = delegate;
-        this.loadProbe = plugin.newProbe(KEY, ringbufferName, "load");
-        this.getLargestSequenceProbe = plugin.newProbe(KEY, ringbufferName, "getLargestSequence");
-        this.storeProbe = plugin.newProbe(KEY, ringbufferName, "store");
-        this.storeAllProbe = plugin.newProbe(KEY, ringbufferName, "storeAll");
+        this.loadProbe = plugin.newProbe(KEY, nsDescription, "load");
+        this.getLargestSequenceProbe = plugin.newProbe(KEY, nsDescription, "getLargestSequence");
+        this.storeProbe = plugin.newProbe(KEY, nsDescription, "store");
+        this.storeAllProbe = plugin.newProbe(KEY, nsDescription, "storeAll");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
@@ -19,13 +19,17 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IFunction;
-import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.projection.Projection;
 import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Predicate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -38,34 +42,50 @@ import static com.hazelcast.util.Preconditions.checkTrue;
 
 /**
  * A list for the {@link com.hazelcast.ringbuffer.impl.operations.ReadManyOperation}.
- *
+ * <p>
  * The problem with a regular list is that if you store Data objects, then on the receiving side you get
  * a list with data objects. If you hand this list out to the caller, you have a problem because he sees
  * data objects instead of deserialized objects.
+ * <p>
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
  *
- * @param <E>
+ * @param <O> deserialized ringbuffer type
+ * @param <E> result set type, is equal to {@code O} if the projection
+ *            is {@code null} or returns the same type as the parameter
  */
-public class ReadResultSetImpl<E> extends AbstractList<E>
-        implements IdentifiedDataSerializable, HazelcastInstanceAware, ReadResultSet<E> {
+public class ReadResultSetImpl<O, E> extends AbstractList<E>
+        implements IdentifiedDataSerializable, HazelcastInstanceAware, ReadResultSet<E>, Versioned {
 
+    protected transient SerializationService serializationService;
     private transient int minSize;
     private transient int maxSize;
-    private transient IFunction<Object, Boolean> filter;
-    private transient HazelcastInstance hz;
+    private transient IFunction<O, Boolean> filter;
+    private transient Predicate<? super O> predicate;
+    private transient Projection<? super O, E> projection;
 
     private Data[] items;
+    private long[] seqs;
     private int size;
     private int readCount;
 
     public ReadResultSetImpl() {
     }
 
-    public ReadResultSetImpl(int minSize, int maxSize, HazelcastInstance hz, IFunction<Object, Boolean> filter) {
+    public ReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService, IFunction<O, Boolean> filter) {
         this.minSize = minSize;
         this.maxSize = maxSize;
         this.items = new Data[maxSize];
-        this.hz = hz;
+        this.seqs = new long[maxSize];
+        this.serializationService = serializationService;
         this.filter = filter;
+    }
+
+    public ReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
+                             Predicate<? super O> predicate, Projection<? super O, E> projection) {
+        this(minSize, maxSize, serializationService, null);
+        this.predicate = predicate;
+        this.projection = projection;
     }
 
     public boolean isMaxSizeReached() {
@@ -88,7 +108,11 @@ public class ReadResultSetImpl<E> extends AbstractList<E>
 
     @Override
     public void setHazelcastInstance(HazelcastInstance hz) {
-        this.hz = hz;
+        setSerializationService(((SerializationServiceSupport) hz).getSerializationService());
+    }
+
+    public void setSerializationService(SerializationService serializationService) {
+        this.serializationService = serializationService;
     }
 
     @Override
@@ -96,38 +120,53 @@ public class ReadResultSetImpl<E> extends AbstractList<E>
         checkNotNegative(index, "index should not be negative");
         checkTrue(index < size, "index should not be equal or larger than size");
 
-        SerializationService serializationService = getSerializationService();
-
-        Data item = items[index];
+        final Data item = items[index];
         return serializationService.toObject(item);
     }
 
-    private SerializationService getSerializationService() {
-        HazelcastInstanceImpl impl = (HazelcastInstanceImpl) hz;
-        return impl.getSerializationService();
+    @Override
+    public long getSequence(int index) {
+        return seqs != null && seqs.length > index ? seqs[index] : -1;
     }
 
-    public void addItem(Object item) {
+    /**
+     * Applies the {@link Projection} and adds an item to this {@link ReadResultSetImpl} if
+     * it passes the {@link Predicate} and {@link IFunction} with which it was constructed.
+     * The {@code item} may be in serialized or deserialized format as this method will
+     * adapt the parameter if necessary before providing it to the predicate and projection.
+     * <p>
+     * If the {@code item} is in {@link Data} format and there is no filter, predicate or projection,
+     * the item is added to the set without any additional serialization or deserialization.
+     *
+     * @param seq  the sequence ID of the item
+     * @param item the item to add to the result set
+     */
+    public void addItem(long seq, Object item) {
         assert size < maxSize;
-
         readCount++;
 
-        if (!acceptable(item)) {
-            return;
+        Data resultItem;
+        if (filter != null || predicate != null || projection != null) {
+            final O objectItem = serializationService.toObject(item);
+            final boolean passesFilter = filter == null || filter.apply(objectItem);
+            final boolean passesPredicate = predicate == null || predicate.test(objectItem);
+            if (!passesFilter || !passesPredicate) {
+                return;
+            }
+            if (projection != null) {
+                resultItem = serializationService.toData(projection.transform(objectItem));
+            } else {
+                resultItem = serializationService.toData(item);
+            }
+        } else {
+            resultItem = serializationService.toData(item);
         }
 
-        items[size] = getSerializationService().toData(item);
+        items[size] = resultItem;
+        seqs[size] = seq;
         size++;
     }
 
-    private boolean acceptable(Object item) {
-        if (filter == null) {
-            return true;
-        }
-
-        Object object = getSerializationService().toObject(item);
-        return filter.apply(object);
-    }
 
     @Override
     public boolean add(Object o) {
@@ -156,6 +195,9 @@ public class ReadResultSetImpl<E> extends AbstractList<E>
         for (int k = 0; k < size; k++) {
             out.writeData(items[k]);
         }
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_9)) {
+            out.writeLongArray(seqs);
+        }
     }
 
     @Override
@@ -165,6 +207,9 @@ public class ReadResultSetImpl<E> extends AbstractList<E>
         items = new Data[size];
         for (int k = 0; k < size; k++) {
             items[k] = in.readData();
+        }
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_9)) {
+            seqs = in.readLongArray();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -19,11 +19,17 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.spi.Notifier;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
@@ -43,12 +49,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * it is null to save space.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class RingbufferContainer implements IdentifiedDataSerializable {
+public class RingbufferContainer<T> implements IdentifiedDataSerializable, Notifier, Versioned {
 
     private static final long TTL_DISABLED = 0;
-    private static final String EMPTY = "empty";
 
-    private String name;
+    private ObjectNamespace namespace;
 
     // a cached version of the wait notify key needed to wait for a change if the ringbuffer is empty
     private RingbufferWaitNotifyKey emptyRingWaitNotifyKey;
@@ -58,11 +63,18 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     private RingbufferStoreWrapper store;
     private SerializationService serializationService;
 
+    /**
+     * The ringbuffer containing the items. The type of contained items depends on the {@link #inMemoryFormat} :
+     * <ul>
+     * <li>{@link InMemoryFormat#OBJECT} - the type is the same as the type {@link T}</li>
+     * <li>{@link InMemoryFormat#BINARY} or {@link InMemoryFormat#NATIVE} - the type is {@link Data}</li>
+     * </ul>
+     */
     private Ringbuffer ringbuffer;
 
     /**
-     * This constructor only supports IdentifiedDataSerializable instance creation. For any other purpose, use other
-     * constructors in this class.
+     * For purposes of {@link IdentifiedDataSerializable} instance creation.
+     * For any other purpose, use other constructors in this class.
      */
     public RingbufferContainer() {
     }
@@ -70,20 +82,20 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     /**
      * Constructs the ring buffer container with only the name and the key for blocking operations. This does not fully
      * prepare the container for usage. The caller must invoke the
-     * {@link #init(String, RingbufferConfig, SerializationService, ClassLoader)} method to complete the initialization before
-     * usage.
+     * {@link #init(RingbufferConfig, SerializationService, ClassLoader)}
+     * method to complete the initialization before usage.
      *
-     * @param name the name of the ring buffer container
+     * @param namespace the namespace of the ring buffer container
      */
-    public RingbufferContainer(String name) {
-        this.name = name;
-        this.emptyRingWaitNotifyKey = new RingbufferWaitNotifyKey(name, EMPTY);
+    public RingbufferContainer(ObjectNamespace namespace) {
+        this.namespace = namespace;
+        this.emptyRingWaitNotifyKey = new RingbufferWaitNotifyKey(namespace);
     }
 
-    public RingbufferContainer(String name, RingbufferConfig config,
+    public RingbufferContainer(ObjectNamespace namespace, RingbufferConfig config,
                                SerializationService serializationService,
                                ClassLoader configClassLoader) {
-        this(name);
+        this(namespace);
 
         this.inMemoryFormat = config.getInMemoryFormat();
         this.ringbuffer = new ArrayRingbuffer(config.getCapacity());
@@ -92,7 +104,7 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
         if (ttlMs != TTL_DISABLED) {
             this.expirationPolicy = new RingbufferExpirationPolicy(ringbuffer.getCapacity(), ttlMs);
         }
-        init(name, config, serializationService, configClassLoader);
+        init(config, serializationService, configClassLoader);
     }
 
     /**
@@ -100,22 +112,21 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
      * on a replication operation the container is only partially constructed. The init method finishes the configuration
      * of the ring buffer container for further usage.
      *
-     * @param name                 the name of the ring buffer
      * @param config               the configuration of the ring buffer
      * @param serializationService the serialization service
      * @param configClassLoader    the class loader for which the ring buffer store classes will be loaded
      */
-    public void init(String name, RingbufferConfig config,
+    public void init(RingbufferConfig config,
                      SerializationService serializationService,
                      ClassLoader configClassLoader) {
         this.config = config;
         this.serializationService = serializationService;
-        initRingbufferStore(name, config, serializationService, configClassLoader);
+        initRingbufferStore(config, serializationService, configClassLoader);
     }
 
-    private void initRingbufferStore(String name, RingbufferConfig config,
-                                     SerializationService serializationService, ClassLoader configClassLoader) {
-        this.store = RingbufferStoreWrapper.create(name,
+    private void initRingbufferStore(RingbufferConfig config, SerializationService serializationService,
+                                     ClassLoader configClassLoader) {
+        this.store = RingbufferStoreWrapper.create(namespace,
                 config.getRingbufferStoreConfig(),
                 config.getInMemoryFormat(),
                 serializationService,
@@ -211,20 +222,21 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
 
     /**
      * Adds one item to the ring buffer. Sets the expiration time if TTL is configured and also attempts to store the item
-     * in the data store if one is configured.
+     * in the data store if one is configured. The provided {@code item} can be {@link Data} or the deserialized object.
+     * The provided item will be transformed to the configured ringbuffer {@link InMemoryFormat} if necessary.
      *
-     * @param item item to be stored in the ring buffer and data store
+     * @param item item to be stored in the ring buffer and data store, can be {@link Data} or an deserialized object
      * @return the sequence id of the item stored in the ring buffer
-     * @throws HazelcastException                                              if there was any exception thrown by the data store
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if the ring buffer is configured to keep items
-     *                                                                         in object format and the item could not be
-     *                                                                         deserialized
+     * @throws HazelcastException              if there was any exception thrown by the data store
+     * @throws HazelcastSerializationException if the ring buffer is configured to keep items
+     *                                         in object format and the item could not be
+     *                                         deserialized
      */
-    public long add(Data item) {
+    public long add(T item) {
         final long sequence = addInternal(item);
         if (store.isEnabled()) {
             try {
-                store.store(sequence, item);
+                store.store(sequence, convertToData(item));
             } catch (Exception e) {
                 throw new HazelcastException(e);
             }
@@ -238,12 +250,12 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
      *
      * @param items items to be stored in the ring buffer and data store
      * @return the sequence id of the last item stored in the ring buffer
-     * @throws HazelcastException                                              if there was any exception thrown by the data store
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if the ring buffer is configured to keep items
-     *                                                                         in object format and the item could not be
-     *                                                                         deserialized
+     * @throws HazelcastException              if there was any exception thrown by the data store
+     * @throws HazelcastSerializationException if the ring buffer is configured to keep items
+     *                                         in object format and the item could not be
+     *                                         deserialized
      */
-    public long addAll(Data[] items) {
+    public long addAll(T[] items) {
         long firstSequence = -1;
         long lastSequence = -1;
 
@@ -255,7 +267,7 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
         }
         if (store.isEnabled() && items.length != 0) {
             try {
-                store.storeAll(firstSequence, items);
+                store.storeAll(firstSequence, convertToData(items));
             } catch (Exception e) {
                 throw new HazelcastException(e);
             }
@@ -264,23 +276,24 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     }
 
     /**
-     * Sets the item at the given sequence ID and updates the expiration time if TTL is configured.  Unlike other methods
-     * for adding items into the ring buffer, does not attempt to store the item in the data store. This method expand the
-     * ring buffer tail and head sequence to accommodate for the sequence. This means that it will move the head or tail
-     * sequence to the target sequence if the target sequence is less than the head sequence or greater than the tail sequence.
+     * Sets the item at the given sequence ID and updates the expiration time if TTL is configured.
+     * Unlike other methods for adding items into the ring buffer, does not attempt to store the
+     * item in the data store. This method expands the ring buffer tail and head sequence to
+     * accommodate for the sequence. This means that it will move the head or tail sequence to
+     * the target sequence if the target sequence is less than the head sequence or greater than the tail sequence.
      *
      * @param sequenceId the sequence ID under which the item is stored
-     * @param dataItem   item to be stored in the ring buffer and data store
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if the ring buffer is configured to keep items
-     *                                                                         in object format and the item could not be
-     *                                                                         deserialized
+     * @param item       item to be stored in the ring buffer and data store
+     * @throws HazelcastSerializationException if the ring buffer is configured to keep items
+     *                                         in object format and the item could not be
+     *                                         deserialized
      */
     @SuppressWarnings("unchecked")
-    public void set(long sequenceId, Data dataItem) {
-        final Object item = getRingbufferFormat(dataItem);
+    public void set(long sequenceId, T item) {
+        final Object rbItem = convertToRingbufferFormat(item);
 
         // first we write the dataItem in the ring.
-        ringbuffer.set(sequenceId, item);
+        ringbuffer.set(sequenceId, rbItem);
 
         if (sequenceId > tailSequence()) {
             ringbuffer.setTailSequence(sequenceId);
@@ -296,7 +309,9 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     }
 
     /**
-     * Reads one item from the ring buffer.
+     * Reads one item from the ring buffer and returns the serialized format.
+     * If the item is not available, it will try and load it from the ringbuffer store.
+     * If the stored format is already serialized, there is no serialization.
      *
      * @param sequence The sequence of the item to be read
      * @return The item read
@@ -304,10 +319,10 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
      *                                1. larger than the tailSequence or
      *                                2. smaller than the headSequence and the data store is disabled
      */
-    public Data read(long sequence) {
+    public Data readAsData(long sequence) {
         checkReadSequence(sequence);
-        Object item = readOrLoadItem(sequence);
-        return serializationService.toData(item);
+        Object rbItem = readOrLoadItem(sequence);
+        return serializationService.toData(rbItem);
     }
 
     /**
@@ -323,7 +338,7 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
 
         long seq = beginSequence;
         while (seq <= ringbuffer.tailSequence()) {
-            result.addItem(readOrLoadItem(seq));
+            result.addItem(seq, readOrLoadItem(seq));
             seq++;
             if (result.isMaxSizeReached()) {
                 // we have found all items we are looking for. We are done.
@@ -341,10 +356,13 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     }
 
     /**
-     * Check if the sequence is of an item that can be read immediately or is the sequence of the next item to be added
-     * into the ringbuffer. Since this method allows the sequence to be one larger than the {@code {@link #tailSequence()}},
-     * the caller can use this method to determine if he is checking the sequence ID before performing a possibly blocking
-     * read.  Also, the requested sequence can be smaller than the head sequence if the data store is enabled.
+     * Check if the sequence is of an item that can be read immediately
+     * or is the sequence of the next item to be added into the ringbuffer.
+     * Since this method allows the sequence to be one larger than
+     * the {@link #tailSequence()}, the caller can use this method
+     * to check the sequence before performing a possibly blocking read.
+     * Also, the requested sequence can be smaller than the head sequence
+     * if the data store is enabled.
      *
      * @param readSequence the sequence wanting to be read
      * @throws StaleSequenceException   if the requested sequence is smaller than the head sequence and the data store is
@@ -392,6 +410,11 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
         }
     }
 
+    /**
+     * Reads the item at the specified sequence or loads it from the ringbuffer
+     * store if one is enabled. The type of the returned object is equal to the
+     * ringbuffer format.
+     */
     private Object readOrLoadItem(long sequence) {
         Object item;
         if (sequence < ringbuffer.headSequence() && store.isEnabled()) {
@@ -403,11 +426,11 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     }
 
     @SuppressWarnings("unchecked")
-    private long addInternal(Data dataItem) {
-        final Object item = getRingbufferFormat(dataItem);
+    private long addInternal(T item) {
+        final Object rbItem = convertToRingbufferFormat(item);
 
         // first we write the dataItem in the ring.
-        final long tailSequence = ringbuffer.add(item);
+        final long tailSequence = ringbuffer.add(rbItem);
 
         // and then we optionally write the expiration.
         if (expirationPolicy != null) {
@@ -417,22 +440,55 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     }
 
     /**
-     * Deserializes the dataItem if the ring buffer configured {@code inMemoryFormat} is set to {@code OBJECT}.
+     * Converts the {@code item} into the ringbuffer {@link InMemoryFormat} or keeps
+     * it unchanged if the supplied argument is already in the ringbuffer format.
      *
-     * @param dataItem the item in binary format
+     * @param item the item
      * @return the binary or deserialized format, depending on the {@link RingbufferContainer#inMemoryFormat}
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if the ring buffer is configured to keep items
-     *                                                                         in object format and the item could not be
-     *                                                                         deserialized
+     * @throws HazelcastSerializationException if the ring buffer is configured to keep items
+     *                                         in object format and the item could not be deserialized
      */
-    private Object getRingbufferFormat(Data dataItem) {
-        return inMemoryFormat == OBJECT ? serializationService.toObject(dataItem) : dataItem;
+    private Object convertToRingbufferFormat(Object item) {
+        return inMemoryFormat == OBJECT
+                ? serializationService.toObject(item)
+                : serializationService.toData(item);
+    }
+
+    /**
+     * Convert the supplied argument into serialized format.
+     *
+     * @throws HazelcastSerializationException when serialization fails.
+     */
+    private Data convertToData(Object item) {
+        return serializationService.toData(item);
+    }
+
+    /**
+     * Convert the supplied argument into serialized format.
+     *
+     * @throws HazelcastSerializationException when serialization fails.
+     */
+    private Data[] convertToData(T[] items) {
+        if (items == null || items.length == 0) {
+            return new Data[0];
+        }
+        if (items[0] instanceof Data) {
+            return (Data[]) items;
+        }
+        final Data[] ret = new Data[items.length];
+        for (int i = 0; i < items.length; i++) {
+            ret[i] = convertToData(items[i]);
+        }
+        return ret;
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        assert !out.getVersion().isUnknown();
         boolean ttlEnabled = expirationPolicy != null;
-        out.writeUTF(name);
+        if (out.getVersion().isLessThan(Versions.V3_9)) {
+            out.writeUTF(namespace.getObjectName());
+        }
         out.writeLong(ringbuffer.tailSequence());
         out.writeLong(ringbuffer.headSequence());
         out.writeInt((int) ringbuffer.getCapacity());
@@ -464,8 +520,11 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     @Override
     @SuppressWarnings("unchecked")
     public void readData(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        emptyRingWaitNotifyKey = new RingbufferWaitNotifyKey(name, EMPTY);
+        assert !in.getVersion().isUnknown();
+        if (in.getVersion().isLessThan(Versions.V3_9)) {
+            // ringbuffer name, it is replaced with namespace in 3.9 which is set in the constructor
+            in.readUTF();
+        }
         final long tailSequence = in.readLong();
         final long headSequence = in.readLong();
         final int capacity = in.readInt();
@@ -496,16 +555,16 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
         }
     }
 
-    String getName() {
-        return name;
-    }
-
     Ringbuffer getRingbuffer() {
         return ringbuffer;
     }
 
     RingbufferExpirationPolicy getExpirationPolicy() {
         return expirationPolicy;
+    }
+
+    public ObjectNamespace getNamespace() {
+        return namespace;
     }
 
     @Override
@@ -516,5 +575,15 @@ public class RingbufferContainer implements IdentifiedDataSerializable {
     @Override
     public int getId() {
         return RingbufferDataSerializerHook.RINGBUFFER_CONTAINER;
+    }
+
+    @Override
+    public boolean shouldNotify() {
+        return true;
+    }
+
+    @Override
+    public WaitNotifyKey getNotifiedKey() {
+        return emptyRingWaitNotifyKey;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
@@ -69,7 +69,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
     public RingbufferProxy(NodeEngine nodeEngine, RingbufferService service, String name, RingbufferConfig config) {
         super(nodeEngine, service);
         this.name = name;
-        this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
+        this.partitionId = service.getRingbufferPartitionId(name);
         this.config = config;
     }
 
@@ -195,7 +195,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
         checkTrue(minCount <= config.getCapacity(), "the minCount should be smaller than or equal to the capacity");
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
-        Operation op = new ReadManyOperation(name, startSequence, minCount, maxCount, filter)
+        Operation op = new ReadManyOperation<E>(name, startSequence, minCount, maxCount, filter)
                 .setPartitionId(partitionId);
         OperationService operationService = getOperationService();
         return operationService.createInvocationBuilder(null, op, partitionId)

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -19,26 +19,34 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.ringbuffer.impl.operations.ReplicationOperation;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.FragmentedMigrationAwareService;
 import com.hazelcast.spi.ManagedService;
-import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
 import static com.hazelcast.spi.partition.MigrationEndpoint.DESTINATION;
 import static com.hazelcast.spi.partition.MigrationEndpoint.SOURCE;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -46,16 +54,27 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 /**
  * The SPI Service that deals with the {@link com.hazelcast.ringbuffer.Ringbuffer}.
  */
-public class RingbufferService implements ManagedService, RemoteService, MigrationAwareService {
-
+public class RingbufferService implements ManagedService, RemoteService, FragmentedMigrationAwareService {
     /**
      * Prefix of ringbuffers that are created for topics. Using a prefix prevents users accidentally retrieving the ringbuffer.
      */
     public static final String TOPIC_RB_PREFIX = "_hz_rb_";
 
+    /**
+     * The ringbuffer service name which defines it in the node engine.
+     */
     public static final String SERVICE_NAME = "hz:impl:ringbufferService";
-    private final ConcurrentMap<String, RingbufferContainer> containers
-            = new ConcurrentHashMap<String, RingbufferContainer>();
+
+    /**
+     * Map from namespace to actual ringbuffer containers. The namespace defines the service and object name which
+     * is the owner of the ringbuffer container.
+     */
+    private final ConcurrentMap<Integer, ConcurrentMap<ObjectNamespace, RingbufferContainer>> containers
+            = new ConcurrentHashMap<Integer, ConcurrentMap<ObjectNamespace, RingbufferContainer>>();
+
+    /**
+     * The node engine for this node.
+     */
     private NodeEngine nodeEngine;
 
     public RingbufferService(NodeEngineImpl nodeEngine) {
@@ -70,20 +89,28 @@ public class RingbufferService implements ManagedService, RemoteService, Migrati
     }
 
     // just for testing.
-    public ConcurrentMap<String, RingbufferContainer> getContainers() {
+    public ConcurrentMap<Integer, ConcurrentMap<ObjectNamespace, RingbufferContainer>> getContainers() {
         return containers;
     }
 
     @Override
     public DistributedObject createDistributedObject(String objectName) {
-        RingbufferConfig ringbufferConfig = getRingbufferConfig(objectName);
+        final RingbufferConfig ringbufferConfig = getRingbufferConfig(objectName);
         return new RingbufferProxy(nodeEngine, this, objectName, ringbufferConfig);
     }
 
     @Override
     public void destroyDistributedObject(String name) {
-        containers.remove(name);
+        destroyContainer(getRingbufferPartitionId(name), getRingbufferNamespace(name));
         nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, name);
+    }
+
+    public void destroyContainer(int partitionId, ObjectNamespace namespace) {
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (partitionContainers == null) {
+            return;
+        }
+        partitionContainers.remove(namespace);
     }
 
     @Override
@@ -101,29 +128,113 @@ public class RingbufferService implements ManagedService, RemoteService, Migrati
         reset();
     }
 
+    /**
+     * Return the ringbuffer containter for the specified {@code namespace}. If there is no ringbuffer container,
+     * create it using the {@code config}.
+     *
+     * @param namespace the ringbuffer container namespace
+     * @param config    the ringbuffer config. Used to create the container when the container doesn't exist
+     * @return the ringbuffer container
+     */
+    @SuppressWarnings("unchecked")
+    public <T> RingbufferContainer<T> getContainer(int partitionId, ObjectNamespace namespace, RingbufferConfig config) {
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = getOrCreateRingbufferContainers(partitionId);
+
+        RingbufferContainer<T> ringbuffer = partitionContainers.get(namespace);
+        if (ringbuffer != null) {
+            return ringbuffer;
+        }
+
+        ringbuffer = new RingbufferContainer<T>(
+                namespace,
+                config,
+                nodeEngine.getSerializationService(),
+                nodeEngine.getConfigClassLoader());
+        ringbuffer.getStore().instrument(nodeEngine);
+        partitionContainers.put(namespace, ringbuffer);
+        return ringbuffer;
+    }
+
+    public boolean hasContainer(int partitionId, ObjectNamespace namespace) {
+        final ConcurrentMap<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        return partitionContainers != null && partitionContainers.get(namespace) != null;
+    }
+
+    private Map<ObjectNamespace, RingbufferContainer> getOrCreateRingbufferContainers(int partitionId) {
+        Map<ObjectNamespace, RingbufferContainer> partitionContainer = containers.get(partitionId);
+        if (partitionContainer == null) {
+            containers.putIfAbsent(partitionId, new ConcurrentHashMap<ObjectNamespace, RingbufferContainer>());
+        }
+        return containers.get(partitionId);
+    }
+
+    public RingbufferConfig getRingbufferConfig(String name) {
+        Config config = nodeEngine.getConfig();
+        return config.getRingbufferConfig(getConfigName(name));
+    }
+
+    public static ObjectNamespace getRingbufferNamespace(String name) {
+        return new DistributedObjectNamespace(SERVICE_NAME, name);
+    }
+
+    public int getRingbufferPartitionId(String ringbufferName) {
+        final Data partitionAwareData =
+                nodeEngine.getSerializationService().toData(ringbufferName, StringPartitioningStrategy.INSTANCE);
+        return nodeEngine.getPartitionService().getPartitionId(partitionAwareData);
+    }
+
+    public void addRingbuffer(int partitionId, RingbufferContainer ringbuffer, RingbufferConfig config) {
+        checkNotNull(ringbuffer, "ringbuffer can't be null");
+        final SerializationService serializationService = nodeEngine.getSerializationService();
+        ringbuffer.init(config, serializationService, nodeEngine.getConfigClassLoader());
+        ringbuffer.getStore().instrument(nodeEngine);
+        getOrCreateRingbufferContainers(partitionId).put(ringbuffer.getNamespace(), ringbuffer);
+    }
+
     @Override
     public void beforeMigration(PartitionMigrationEvent partitionMigrationEvent) {
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Here we will replicate only ringbuffer containers for the ringbuffer service. Other services are responsible
+     * for migrating their ringbuffer containers on migration events. The main reason is because of fine-grained
+     * anti entropy (replication). The partition data might not be migrated in full but rather in part.
+     * For instance, the partition data for a single map might not be in sync between replicas but the ringbuffer
+     * data might be in sync. This means that the map data will be replicated but the ringbuffer data will not be replicated
+     * which can cause differences between ringbuffer data for some services.
+     * In another words, each service is responsible for replicating all of it's data, including data in other services.
+     *
+     * @param event replication event
+     * @return the replication operation
+     */
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
-        Map<String, RingbufferContainer> migrationData = new HashMap<String, RingbufferContainer>();
-        IPartitionService partitionService = nodeEngine.getPartitionService();
-        for (Map.Entry<String, RingbufferContainer> entry : containers.entrySet()) {
-            String name = entry.getKey();
-            int partitionId = partitionService.getPartitionId(getPartitionKey(name));
-            RingbufferContainer container = entry.getValue();
-            int backupCount = container.getConfig().getTotalBackupCount();
-            if (partitionId == event.getPartitionId() && backupCount >= event.getReplicaIndex()) {
-                migrationData.put(name, container);
+        return prepareReplicationOperation(event, getAllServiceNamespaces(event));
+    }
+
+    @Override
+    public Operation prepareReplicationOperation(PartitionReplicationEvent event,
+                                                 Collection<ServiceNamespace> namespaces) {
+        final int partitionId = event.getPartitionId();
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (partitionContainers == null || partitionContainers.isEmpty()) {
+            return null;
+        }
+        final Map<String, RingbufferContainer> migrationData = new HashMap<String, RingbufferContainer>();
+        for (ServiceNamespace namespace : namespaces) {
+            final ObjectNamespace ns = (ObjectNamespace) namespace;
+            final RingbufferContainer container = partitionContainers.get(ns);
+            if (container != null && container.getConfig().getTotalBackupCount() >= event.getReplicaIndex()) {
+                migrationData.put(ns.getObjectName(), container);
             }
         }
-
         if (migrationData.isEmpty()) {
             return null;
         }
-
         return new ReplicationOperation(migrationData, event.getPartitionId(), event.getReplicaIndex());
+
     }
 
     @Override
@@ -141,56 +252,41 @@ public class RingbufferService implements ManagedService, RemoteService, Migrati
     }
 
     private void clearRingbuffersHavingLesserBackupCountThan(int partitionId, int thresholdReplicaIndex) {
-        Iterator<Map.Entry<String, RingbufferContainer>> iterator = containers.entrySet().iterator();
-        IPartitionService partitionService = nodeEngine.getPartitionService();
-        while (iterator.hasNext()) {
-            Map.Entry<String, RingbufferContainer> entry = iterator.next();
-            String name = entry.getKey();
-            int containerPartitionId = partitionService.getPartitionId(getPartitionKey(name));
-            if (containerPartitionId != partitionId) {
-                continue;
-            }
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (partitionContainers == null || partitionContainers.isEmpty()) {
+            return;
+        }
 
-            RingbufferContainer container = entry.getValue();
-            if (thresholdReplicaIndex < 0 || thresholdReplicaIndex > container.getConfig().getTotalBackupCount()) {
+        final Iterator<Entry<ObjectNamespace, RingbufferContainer>> iterator = partitionContainers.entrySet().iterator();
+        while (iterator.hasNext()) {
+            final Entry<ObjectNamespace, RingbufferContainer> entry = iterator.next();
+            final RingbufferContainer container = entry.getValue();
+            if (thresholdReplicaIndex < 0 || container.getConfig().getTotalBackupCount() < thresholdReplicaIndex) {
                 iterator.remove();
             }
         }
     }
 
-    public RingbufferContainer getContainer(String name) {
-        RingbufferContainer ringbuffer = containers.get(name);
-        if (ringbuffer != null) {
-            return ringbuffer;
+
+    @Override
+    public Collection<ServiceNamespace> getAllServiceNamespaces(PartitionReplicationEvent event) {
+        final int partitionId = event.getPartitionId();
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (partitionContainers == null || partitionContainers.isEmpty()) {
+            return Collections.emptyList();
         }
-
-        RingbufferConfig ringbufferConfig = getRingbufferConfig(name);
-        ringbuffer = new RingbufferContainer(
-                name,
-                ringbufferConfig,
-                nodeEngine.getSerializationService(),
-                nodeEngine.getConfigClassLoader());
-        ringbuffer.getStore().instrument(nodeEngine);
-        containers.put(name, ringbuffer);
-        return ringbuffer;
+        final Set<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
+        for (RingbufferContainer container : partitionContainers.values()) {
+            if (container.getConfig().getTotalBackupCount() < event.getReplicaIndex()) {
+                continue;
+            }
+            namespaces.add(container.getNamespace());
+        }
+        return namespaces;
     }
 
-    private RingbufferConfig getRingbufferConfig(String name) {
-        Config config = nodeEngine.getConfig();
-        return config.getRingbufferConfig(getConfigName(name));
-    }
-
-    public void addRingbuffer(String name, RingbufferContainer ringbuffer) {
-        checkNotNull(name, "name can't be null");
-        checkNotNull(ringbuffer, "ringbuffer can't be null");
-        final RingbufferConfig config = nodeEngine.getConfig().getRingbufferConfig(name);
-        final SerializationService serializationService = nodeEngine.getSerializationService();
-        ringbuffer.init(
-                name,
-                config,
-                serializationService,
-                nodeEngine.getConfigClassLoader());
-        ringbuffer.getStore().instrument(nodeEngine);
-        containers.put(name, ringbuffer);
+    @Override
+    public boolean isKnownServiceNamespace(ServiceNamespace namespace) {
+        return namespace instanceof ObjectNamespace;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
@@ -16,20 +16,21 @@
 
 package com.hazelcast.ringbuffer.impl;
 
-import com.hazelcast.spi.AbstractWaitNotifyKey;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
 
-import static com.hazelcast.ringbuffer.impl.RingbufferService.SERVICE_NAME;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * A {@link com.hazelcast.spi.AbstractWaitNotifyKey} to make it possible to wait for an item to be published in the ringbuffer.
  */
-public class RingbufferWaitNotifyKey extends AbstractWaitNotifyKey {
+public class RingbufferWaitNotifyKey implements WaitNotifyKey {
 
-    private final String type;
+    private final ObjectNamespace namespace;
 
-    public RingbufferWaitNotifyKey(String name, String type) {
-        super(SERVICE_NAME, name);
-        this.type = type;
+    public RingbufferWaitNotifyKey(ObjectNamespace namespace) {
+        checkNotNull(namespace);
+        this.namespace = namespace;
     }
 
     @Override
@@ -40,19 +41,25 @@ public class RingbufferWaitNotifyKey extends AbstractWaitNotifyKey {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
 
         RingbufferWaitNotifyKey that = (RingbufferWaitNotifyKey) o;
-        return type.equals(that.type);
+
+        return namespace.equals(that.namespace);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + type.hashCode();
-        return result;
+        return namespace.hashCode();
+    }
+
+    @Override
+    public String getServiceName() {
+        return namespace.getServiceName();
+    }
+
+    @Override
+    public String getObjectName() {
+        return namespace.getObjectName();
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -36,8 +36,7 @@ import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_OPE
  * the backup operation will put the item under the sequence ID that the master generated. This is to avoid differences
  * in ring buffer data structures.
  */
-public class AddOperation extends AbstractRingBufferOperation
-        implements Notifier, BackupAwareOperation {
+public class AddOperation extends AbstractRingBufferOperation implements Notifier, BackupAwareOperation {
 
     private Data item;
     private long resultSequence;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -55,7 +55,7 @@ public class ReadOneOperation extends AbstractRingBufferOperation implements Blo
     @Override
     public void run() throws Exception {
         RingbufferContainer ringbuffer = getRingBufferContainer();
-        result = ringbuffer.read(sequence);
+        result = ringbuffer.readAsData(sequence);
     }
 
     @Override

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -30,3 +30,4 @@ com.hazelcast.internal.usercodedeployment.impl.UserCodeDeploymentSerializerHook
 com.hazelcast.aggregation.impl.AggregatorDataSerializerHook
 com.hazelcast.projection.impl.ProjectionDataSerializerHook
 com.hazelcast.config.ConfigDataSerializerHook
+com.hazelcast.journal.EventJournalDataSerializerHook

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -43,6 +43,7 @@
                 <xs:element name="durable-executor-service" type="durable-executor-service" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="scheduled-executor-service" type="scheduled-executor-service" minOccurs="0"
                             maxOccurs="unbounded"/>
+                <xs:element name="event-journal" type="event-journal" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="queue" type="queue" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="map" type="map" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="multimap" type="multimap" minOccurs="0" maxOccurs="unbounded"/>
@@ -3123,6 +3124,60 @@
             <xs:annotation>
                 <xs:documentation>
                     True if Hot Restart Persistence is enabled, false otherwise. Only available on Hazelcast Enterprise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="event-journal">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for an event journal. The event journal keeps events related
+                to a specific partition and data structure. For instance, it could keep
+                map or cache add, update, remove, merge events along with the key, old value,
+                new value and so on.
+                This configuration is not tied to a specific data structure and can be reused.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="mapName" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the map to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cacheName" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the cache to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of items in the event journal. If no time-to-live-seconds
+                        is set, the size will always be equal to capacity after the event
+                        journal has been filled. This is because no items are getting retired.
+                        The default value is 10000.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay in the event journal.
+                        Entries that are older than &lt;time-to-live-seconds&gt; are evicted from the journal.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    True if the event journal is enabled, false otherwise.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -206,6 +206,23 @@
 
     </map>
 
+    <!--
+           Configuration for an event journal. The event journal keeps events related
+           to a specific partition and data structure. For instance, it could keep
+           map add, update, remove, merge events along with the key, old value, new value and so on.
+        -->
+    <event-journal enabled="false">
+        <mapName>mapName</mapName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
+
+    <event-journal enabled="false">
+        <cacheName>cacheName</cacheName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
+
     <multimap name="default">
         <backup-count>1</backup-count>
         <value-collection-type>SET</value-collection-type>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -870,8 +870,8 @@ It has the following sub-elements:
     	Adds the partition lost listeners that you created by implementing Hazelcast's PartitionLostListener interface. 
     * <quorum-ref>:
 	Adds the quorum for this map which you configure using the <quorum> element. You should set the <quorum-ref>'s value
-	as the <quorum>'s name. 
- -->    
+	as the <quorum>'s name.
+ -->
     <map name="default">
         <in-memory-format>BINARY</in-memory-format>
         <statistics-enabled>true</statistics-enabled>
@@ -888,54 +888,54 @@ It has the following sub-elements:
         <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
         <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
         <read-backup-data>false</read-backup-data>
-	<hot-restart enabled="false">
-		<fsync>false</fsync>
-	</hot-restart>
-	<map-store enabled="true" initial-mode="LAZY">
-		<class-name>com.hazelcast.examples.DummyStore</class-name>
-		<write-delay-seconds>60</write-delay-seconds>
-		<write-batch-size>1000</write-batch-size>
-		<write-coalescing>true</write-coalescing>
-		<properties>
-    			<property name="jdbc_url">my.jdbc.com</property>
-		</properties>
-	</map-store>
-	<near-cache>
-		<max-size>5000</max-size>
-		<time-to-live-seconds>0</time-to-live-seconds>
-		<max-idle-seconds>60</max-idle-seconds>
-		<eviction-policy>LRU</eviction-policy>
-		<invalidate-on-change>true</invalidate-on-change>
-		<in-memory-format>BINARY</in-memory-format>
-		<cache-local-entries>false</cache-local-entries>
-		<eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
-	</near-cache>
-	<wan-replication-ref name="my-wan-cluster-batch">
-		<merge-policy>com.hazelcast.map.merge.PassThroughMergePolicy</merge-policy>
-		<filters>
-			<filter-impl>com.example.SampleFilter</filter-impl>
-			<filter-impl>com.example.SampleFilter2</filter-impl>
-		</filters>
-		<republishing-enabled>false</republishing-enabled>
-	</wan-replication-ref>
-	<indexes>
-		<index ordered="false">name</index>
-		<index ordered="true">age</index>
-	</indexes>
-	<attributes>
-		<attribute extractor="com.bank.CurrencyExtractor">currency</attribute>
-	</attributes>
-	<entry-listeners>
-		<entry-listener include-value="false" local="false">
-			com.your-package.MyEntryListener
-		</entry-listener>
-	</entry-listeners>
-	<partition-lost-listeners>
-		<partition-lost-listener>
-			com.your-package.YourPartitionLostListener
-		</partition-lost-listener>
-	</partition-lost-listeners>
-	<quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
+        <hot-restart enabled="false">
+            <fsync>false</fsync>
+        </hot-restart>
+        <map-store enabled="true" initial-mode="LAZY">
+            <class-name>com.hazelcast.examples.DummyStore</class-name>
+            <write-delay-seconds>60</write-delay-seconds>
+            <write-batch-size>1000</write-batch-size>
+            <write-coalescing>true</write-coalescing>
+            <properties>
+                <property name="jdbc_url">my.jdbc.com</property>
+            </properties>
+        </map-store>
+        <near-cache>
+            <max-size>5000</max-size>
+            <time-to-live-seconds>0</time-to-live-seconds>
+            <max-idle-seconds>60</max-idle-seconds>
+            <eviction-policy>LRU</eviction-policy>
+            <invalidate-on-change>true</invalidate-on-change>
+            <in-memory-format>BINARY</in-memory-format>
+            <cache-local-entries>false</cache-local-entries>
+            <eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
+        </near-cache>
+        <wan-replication-ref name="my-wan-cluster-batch">
+            <merge-policy>com.hazelcast.map.merge.PassThroughMergePolicy</merge-policy>
+            <filters>
+                <filter-impl>com.example.SampleFilter</filter-impl>
+                <filter-impl>com.example.SampleFilter2</filter-impl>
+            </filters>
+            <republishing-enabled>false</republishing-enabled>
+        </wan-replication-ref>
+        <indexes>
+            <index ordered="false">name</index>
+            <index ordered="true">age</index>
+        </indexes>
+        <attributes>
+            <attribute extractor="com.bank.CurrencyExtractor">currency</attribute>
+        </attributes>
+        <entry-listeners>
+            <entry-listener include-value="false" local="false">
+                com.your-package.MyEntryListener
+            </entry-listener>
+        </entry-listeners>
+        <partition-lost-listeners>
+            <partition-lost-listener>
+                com.your-package.YourPartitionLostListener
+            </partition-lost-listener>
+        </partition-lost-listeners>
+        <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
     </map>
 <!--
     ===== HAZELCAST CONTINUOUS QUERY CACHE CONFIGURATION =====
@@ -1201,25 +1201,68 @@ It has the following sub-elements:
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>
         <eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
-	<wan-replication-ref name="my-wan-cluster-batch">
-	    <merge-policy>com.hazelcast.cache.merge.PassThroughCacheMergePolicy</merge-policy>
-	    <republishing-enabled>true</republishing-enabled>
-	    <filters>
-		<filter-impl>com.example.SampleFilter</filter-impl>
-	    </filters>
-	</wan-replication-ref>
+        <wan-replication-ref name="my-wan-cluster-batch">
+            <merge-policy>com.hazelcast.cache.merge.PassThroughCacheMergePolicy</merge-policy>
+            <republishing-enabled>true</republishing-enabled>
+            <filters>
+                <filter-impl>com.example.SampleFilter</filter-impl>
+            </filters>
+        </wan-replication-ref>
         <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
-	<partition-lost-listeners>
-		<partition-lost-listener>
-			com.your-package.YourPartitionLostListener
-		</partition-lost-listener>
-	</partition-lost-listeners>
+        <partition-lost-listeners>
+            <partition-lost-listener>
+                com.your-package.YourPartitionLostListener
+            </partition-lost-listener>
+        </partition-lost-listeners>
         <merge-policy>com.hazelcast.cache.merge.LatestAccessCacheMergePolicy</merge-policy>
-	<hot-restart enabled="false">
-		<fsync>false</fsync>
-	</hot-restart>
-	<disable-per-entry-invalidation-events>true</disable-per-entry-invalidation-events>
+        <hot-restart enabled="false">
+            <fsync>false</fsync>
+        </hot-restart>
+        <disable-per-entry-invalidation-events>true</disable-per-entry-invalidation-events>
     </cache>
+    <!--
+    ===== HAZELCAST EVENT JOURNAL CONFIGURATION =====
+
+    Configuration element's name is <event-journal>.
+    It has the following attributes and sub-elements:
+    * enabled:
+    	Specifies whether the event journal is enabled.
+    * <mapName>:
+    	Map name to which this configuration applies. This attribute's default value is "default".
+    	Configuration for the event journal with name "default" applies to all maps without
+    	configuration for a specific named map. In another words, if you specify the default
+    	event journal config as enabled then all maps which don't have specific event journal
+    	will be also enabled.
+    * <cacheName>:
+    	Cache name to which this configuration applies. This attribute's default value is "default".
+    	Configuration for the event journal with name "default" applies to all caches without
+    	configuration for a specific named cache. In another words, if you specify the default
+    	event journal config as enabled then all caches which don't have specific event journal
+    	will be also enabled.
+    * <capacity>:
+    * Gets the capacity of the event journal.
+    * The capacity is the total number of items that the event journal can hold at any moment.
+    * The actual number of items contained in the journal can be lower. Its default value is 10000.
+    * <time-to-live-seconds>:
+    * Sets the time to live in seconds.
+    * Time to live is the time the event journal retains items before removing them from the journal.
+    * The events are removed on journal read and write actions, not while the journal is idle.
+    * Time to live can be disabled by setting timeToLiveSeconds to 0. This means that the
+    * events never expire but they can be overwritten when the capacity of the journal is exceeed.
+    * Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Its default value is 0.
+-->
+
+    <event-journal enabled="false">
+        <mapName>default</mapName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
+
+    <event-journal enabled="false">
+        <cacheName>default</cacheName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
 
 <!--
     ===== HAZELCAST LIST CONFIGURATION =====

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.function.Predicate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BasicCacheJournalTest extends HazelcastTestSupport {
+    protected HazelcastInstance[] instances;
+    protected CacheManager cacheManager;
+    private static final Random RANDOM = new Random();
+    private static final TruePredicate<EventJournalCacheEvent<String, Integer>> TRUE_PREDICATE = truePredicate();
+    private static final IdentityProjection<EventJournalCacheEvent<String, Integer>> IDENTITY_PROJECTION = identityProjection();
+    private int partitionId;
+
+    @Before
+    public void init() {
+        instances = createInstances();
+        partitionId = 1;
+        cacheManager = createCacheManager();
+        warmUpPartitions(instances);
+    }
+
+    protected CacheManager createCacheManager() {
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(getRandomInstance());
+        return cachingProvider.getCacheManager();
+    }
+
+    protected HazelcastInstance getRandomInstance() {
+        return instances[RANDOM.nextInt(instances.length)];
+    }
+
+    protected HazelcastInstance[] createInstances() {
+        return createHazelcastInstanceFactory(2).newInstances(getConfig());
+    }
+
+    @Override
+    protected Config getConfig() {
+        final Config config = super.getConfig();
+        config.addEventJournalConfig(new EventJournalConfig().setCacheName("default").setEnabled(true));
+        final CacheSimpleConfig nonEvictingCache = new CacheSimpleConfig().setName("cache");
+        nonEvictingCache.getEvictionConfig().setSize(Integer.MAX_VALUE);
+
+        return config.addCacheConfig(nonEvictingCache)
+                     .addCacheConfig(new CacheSimpleConfig().setName("evicting"));
+    }
+
+
+    @Test
+    public void unparkReadOperation() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        assertJournalSize(c, 0);
+
+        final String key = randomPartitionKey();
+        final Integer value = RANDOM.nextInt();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        readFromEventJournal(c, 0, 100, partitionId, TRUE_PREDICATE, IDENTITY_PROJECTION)
+                .andThen(new ExecutionCallback<ReadResultSet<EventJournalCacheEvent<String, Integer>>>() {
+                    @Override
+                    public void onResponse(ReadResultSet<EventJournalCacheEvent<String, Integer>> response) {
+                        assertEquals(1, response.size());
+                        final EventJournalCacheEvent<String, Integer> e = response.get(0);
+
+                        assertEquals(CacheEventType.CREATED, e.getType());
+                        assertEquals(e.getKey(), key);
+                        assertEquals(e.getNewValue(), value);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        t.printStackTrace();
+                    }
+                });
+
+        c.put(key, value);
+        latch.await();
+        assertJournalSize(c, 1);
+    }
+
+    @Test
+    public void receiveAddedEventsWhenPut() throws Exception {
+        final ICache<String, Integer> c = getCache();
+
+        final int count = 100;
+        assertJournalSize(c, 0);
+
+        for (int i = 0; i < count; i++) {
+            c.put(randomPartitionKey(), i);
+        }
+
+        assertJournalSize(c, count);
+        final ReadResultSet<EventJournalCacheEvent<String, Integer>> events = getAllEvents(c, null, null);
+        assertEquals(count, events.size());
+
+        final HashMap<String, Integer> received = new HashMap<String, Integer>();
+        for (EventJournalCacheEvent<String, Integer> e : events) {
+            assertEquals(CacheEventType.CREATED, e.getType());
+            assertNull(e.getOldValue());
+            received.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(getEntries(c), received.entrySet());
+    }
+
+    @Test
+    public void receiveRemoveEventsWhenRemove() throws Exception {
+        final ICache<String, Integer> c = getCache();
+
+        final int count = 100;
+        assertJournalSize(c, 0);
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(count);
+        for (int i = 0; i < count; i++) {
+            final String k = randomPartitionKey();
+            c.put(k, i);
+            initialMap.put(k, i);
+        }
+        assertJournalSize(c, count);
+
+        for (Map.Entry<String, Integer> e : getEntries(c)) {
+            final String key = e.getKey();
+            c.getAndRemove(key);
+        }
+
+        final HashMap<String, Integer> added = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> removed = new HashMap<String, Integer>(count);
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case CREATED:
+                    added.put(e.getKey(), e.getNewValue());
+                    break;
+                case REMOVED:
+                    removed.put(e.getKey(), e.getOldValue());
+                    break;
+            }
+        }
+
+
+        assertEquals(0, c.size());
+        assertJournalSize(c, count * 2);
+        assertEquals(initialMap, added);
+        assertEquals(initialMap, removed);
+    }
+
+    @Test
+    public void receiveUpdateEventsOnMapPut() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        final int count = 100;
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(count);
+        assertJournalSize(c, 0);
+        for (int i = 0; i < count; i++) {
+            final String k = randomPartitionKey();
+            c.put(k, i);
+            initialMap.put(k, i);
+        }
+        assertJournalSize(c, count);
+
+        for (Map.Entry<String, Integer> e : getEntries(c)) {
+            final String key = e.getKey();
+            final Integer newVal = initialMap.get(key) + 100;
+            c.getAndPut(key, newVal);
+        }
+
+        assertJournalSize(c, count * 2);
+
+        final HashMap<String, Integer> updatedFrom = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> updatedTo = new HashMap<String, Integer>(count);
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case UPDATED:
+                    updatedFrom.put(e.getKey(), e.getOldValue());
+                    updatedTo.put(e.getKey(), e.getNewValue());
+                    break;
+            }
+        }
+
+        assertEquals(initialMap, updatedFrom);
+        assertEquals(getEntries(c), updatedTo.entrySet());
+    }
+
+    @Test
+    public void testPredicates() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        final int count = 50;
+        assertJournalSize(c, 0);
+
+        for (int i = 0; i < count; i++) {
+            c.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(c, count);
+
+        final HashMap<String, Integer> evenMap = new HashMap<String, Integer>();
+        final HashMap<String, Integer> oddMap = new HashMap<String, Integer>();
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, new NewValueParityPredicate(0), IDENTITY_PROJECTION)) {
+            assertEquals(CacheEventType.CREATED, e.getType());
+            evenMap.put(e.getKey(), e.getNewValue());
+        }
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, new NewValueParityPredicate(1), IDENTITY_PROJECTION)) {
+            assertEquals(CacheEventType.CREATED, e.getType());
+            oddMap.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(count / 2, evenMap.size());
+        assertEquals(count / 2, oddMap.size());
+
+        for (Entry<String, Integer> e : evenMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 0);
+            assertEquals(c.get(e.getKey()), v);
+        }
+        for (Entry<String, Integer> e : oddMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 1);
+            assertEquals(c.get(e.getKey()), v);
+        }
+    }
+
+    @Test
+    public void testProjection() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        final int count = 50;
+        assertJournalSize(c, 0);
+        for (int i = 0; i < count; i++) {
+            c.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(c, count);
+
+
+        final ReadResultSet<Integer> resultSet = getAllEvents(c, TRUE_PREDICATE, new NewValueIncrementingProjection(100));
+        final ArrayList<Integer> ints = new ArrayList<Integer>(count);
+        for (Integer i : resultSet) {
+            ints.add(i);
+        }
+
+        assertEquals(count, ints.size());
+        for (Entry<String, Integer> e : getEntries(c)) {
+            assertTrue(ints.contains(e.getValue() + 100));
+        }
+    }
+
+    private <K, V> Set<Map.Entry<K, V>> getEntries(ICache<K, V> cache) {
+        final Iterator<Cache.Entry<K, V>> it = cache.iterator();
+        final HashSet<Entry<K, V>> entries = new HashSet<Map.Entry<K, V>>(cache.size());
+        while (it.hasNext()) {
+            final Cache.Entry<K, V> e = it.next();
+            entries.add(new SimpleImmutableEntry<K, V>(e.getKey(), e.getValue()));
+        }
+        return entries;
+    }
+
+    public static class NewValueParityPredicate implements Predicate<EventJournalCacheEvent<String, Integer>>, Serializable {
+        private final int remainder;
+
+        NewValueParityPredicate(int remainder) {
+            this.remainder = remainder;
+        }
+
+        @Override
+        public boolean test(EventJournalCacheEvent<String, Integer> e) {
+            return e.getNewValue() % 2 == remainder;
+        }
+    }
+
+    private static class NewValueIncrementingProjection extends Projection<EventJournalCacheEvent<String, Integer>, Integer> {
+        private final int delta;
+
+        NewValueIncrementingProjection(int delta) {
+            this.delta = delta;
+        }
+
+        @Override
+        public Integer transform(EventJournalCacheEvent<String, Integer> input) {
+            return input.getNewValue() + delta;
+        }
+    }
+
+    private <T> ReadResultSet<T> getAllEvents(ICache<String, Integer> c,
+                                              Predicate<? super EventJournalCacheEvent<String, Integer>> predicate,
+                                              Projection<? super EventJournalCacheEvent<String, Integer>, T> projection) throws Exception {
+        final EventJournalInitialSubscriberState state = subscribeToEventJournal(c, partitionId);
+        return readFromEventJournal(
+                c, state.getOldestSequence(), (int) (state.getNewestSequence() - state.getOldestSequence() + 1),
+                partitionId, predicate, projection).get();
+    }
+
+    private static class TruePredicate<T> implements Predicate<T>, Serializable {
+        @Override
+        public boolean test(T t) {
+            return true;
+        }
+    }
+
+    private static class IdentityProjection<I> extends Projection<I, I> implements Serializable {
+        @Override
+        public I transform(I input) {
+            return input;
+        }
+    }
+
+    private String randomPartitionKey() {
+        return generateKeyForPartition(instances[0], partitionId);
+    }
+
+    private void assertJournalSize(ICache<?, ?> cache, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(cache.getServiceName(), cache.getPrefixedName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, ICache<?, ?> cache, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(cache.getServiceName(), cache.getName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, ObjectNamespace namespace, int size) {
+        HazelcastInstance partitionOwner = null;
+        for (HazelcastInstance instance : instances) {
+            if (getNode(instance).partitionService.getPartition(partitionId).isLocal()) {
+                partitionOwner = instance;
+                break;
+            }
+        }
+
+        final NodeEngineImpl nodeEngine = getNode(partitionOwner).nodeEngine;
+        final RingbufferService rbService = nodeEngine.getService(RingbufferService.SERVICE_NAME);
+        final ConcurrentMap<Integer, ConcurrentMap<ObjectNamespace, RingbufferContainer>> containers = rbService.getContainers();
+        final ConcurrentMap<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (size == 0 && partitionContainers == null) {
+            return;
+        }
+        assertNotNull(partitionContainers);
+        final RingbufferContainer container = partitionContainers.get(namespace);
+        if (size == 0 && container == null) {
+            return;
+        }
+        assertNotNull(container);
+        assertEquals(size, container.size());
+    }
+
+    private <K, V> ICache<K, V> getCache() {
+        return getCache("cache");
+    }
+
+    protected <K, V> ICache<K, V> getCache(String cacheName) {
+        return (ICache<K, V>) cacheManager.getCache(cacheName);
+    }
+
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(Cache<K, V> cache, int partitionId) {
+        return ((CacheProxy<K, V>) cache).subscribeToEventJournal(partitionId);
+    }
+
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            Cache<K, V> cache,
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+            Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        return ((CacheProxy<K, V>) cache).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+    private static <T> TruePredicate<T> truePredicate() {
+        return new TruePredicate<T>();
+    }
+
+    private static <T> IdentityProjection<T> identityProjection() {
+        return new IdentityProjection<T>();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
@@ -248,6 +248,30 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(    aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(    aListOfStringToByteArrEntry   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -1095,6 +1119,30 @@ public class BinaryCompatibilityFileGenerator {
         outputStream.writeInt(clientMessage.getFrameLength());
         outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
      }
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(    aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 
 
@@ -3914,6 +3962,30 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(    aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -4219,7 +4291,7 @@ public class BinaryCompatibilityFileGenerator {
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     outputStream.writeInt(clientMessage.getFrameLength());
     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
@@ -248,6 +248,30 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(   aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(   aListOfStringToByteArrEntry   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -1095,6 +1119,30 @@ public class BinaryCompatibilityNullFileGenerator {
         outputStream.writeInt(clientMessage.getFrameLength());
         outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
      }
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(   aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(   aLong ,   aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(   aString ,   aLong ,   anInt ,   anInt ,   null ,   null   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(   anInt ,   datas ,   arrLongs   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 
 
@@ -3914,6 +3962,30 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(   aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(   aLong ,   aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(   aString ,   aLong ,   anInt ,   anInt ,   null ,   null   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(   anInt ,   datas ,   arrLongs   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(   anXid   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -4219,7 +4291,7 @@ public class BinaryCompatibilityNullFileGenerator {
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(   anInt ,   datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(   anInt ,   datas ,   arrLongs   );
     outputStream.writeInt(clientMessage.getFrameLength());
     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
@@ -384,6 +384,10 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1448,6 +1452,10 @@ public class ClientCompatibilityNullTest_1_0 {
     inputStream.read(bytes);
     MapClearNearCacheCodec.ResponseParameters params = MapClearNearCacheCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
 }
+
+
+
+
 
 
 
@@ -5402,6 +5410,10 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5826,6 +5838,7 @@ public class ClientCompatibilityNullTest_1_0 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
@@ -384,6 +384,10 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1482,6 +1486,10 @@ public class ClientCompatibilityNullTest_1_1 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
 
 
 
@@ -5447,6 +5455,10 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5871,6 +5883,7 @@ public class ClientCompatibilityNullTest_1_1 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
@@ -384,6 +384,10 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1462,6 +1466,10 @@ public class ClientCompatibilityNullTest_1_2 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
 
 
 
@@ -5377,6 +5385,10 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5801,6 +5813,7 @@ public class ClientCompatibilityNullTest_1_2 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
@@ -374,6 +374,10 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1452,6 +1456,10 @@ public class ClientCompatibilityNullTest_1_3 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
 
 
 
@@ -5367,6 +5375,10 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5791,6 +5803,7 @@ public class ClientCompatibilityNullTest_1_3 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
@@ -374,6 +374,10 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1616,6 +1620,10 @@ public class ClientCompatibilityNullTest_1_4 {
         handler.handle(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
      }
 }
+
+
+
+
 
 
 
@@ -5596,6 +5604,10 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6020,6 +6032,7 @@ public class ClientCompatibilityNullTest_1_4 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
@@ -396,6 +396,10 @@ public class ClientCompatibilityTest_1_0 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1516,6 +1520,10 @@ public class ClientCompatibilityTest_1_0 {
     inputStream.read(bytes);
     MapClearNearCacheCodec.ResponseParameters params = MapClearNearCacheCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
 }
+
+
+
+
 
 
 
@@ -5670,6 +5678,10 @@ public class ClientCompatibilityTest_1_0 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6116,6 +6128,7 @@ public class ClientCompatibilityTest_1_0 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
@@ -396,6 +396,10 @@ public class ClientCompatibilityTest_1_1 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1552,6 +1556,10 @@ public class ClientCompatibilityTest_1_1 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
 
 
 
@@ -5718,6 +5726,10 @@ public class ClientCompatibilityTest_1_1 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6164,6 +6176,7 @@ public class ClientCompatibilityTest_1_1 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
@@ -396,6 +396,10 @@ public class ClientCompatibilityTest_1_2 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1532,6 +1536,10 @@ public class ClientCompatibilityTest_1_2 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
 
 
 
@@ -5648,6 +5656,10 @@ public class ClientCompatibilityTest_1_2 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6094,6 +6106,7 @@ public class ClientCompatibilityTest_1_2 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
@@ -386,6 +386,10 @@ public class ClientCompatibilityTest_1_3 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1522,6 +1526,10 @@ public class ClientCompatibilityTest_1_3 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
 
 
 
@@ -5638,6 +5646,10 @@ public class ClientCompatibilityTest_1_3 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6084,6 +6096,7 @@ public class ClientCompatibilityTest_1_3 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
@@ -386,6 +386,10 @@ public class ClientCompatibilityTest_1_4 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1694,6 +1698,10 @@ public class ClientCompatibilityTest_1_4 {
         handler.handle(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
      }
 }
+
+
+
+
 
 
 {
@@ -5878,6 +5886,10 @@ public class ClientCompatibilityTest_1_4 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6324,6 +6336,7 @@ public class ClientCompatibilityTest_1_4 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
@@ -287,6 +287,24 @@ public class EncodeDecodeCompatibilityNullTest {
     ClientPingCodec.ResponseParameters params = ClientPingCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(    aString   );
+    ClientStatisticsCodec.RequestParameters params = ClientStatisticsCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.stats));
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    ClientStatisticsCodec.ResponseParameters params = ClientStatisticsCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(    aListOfStringToByteArrEntry   );
+    ClientDeployClassesCodec.RequestParameters params = ClientDeployClassesCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aListOfStringToByteArrEntry, params.classDefinitions));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    ClientDeployClassesCodec.ResponseParameters params = ClientDeployClassesCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     MapPutCodec.RequestParameters params = MapPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
@@ -1239,6 +1257,34 @@ public class EncodeDecodeCompatibilityNullTest {
         ClientMessage clientMessage = MapAddNearCacheInvalidationListenerCodec.encodeIMapBatchInvalidationEvent( datas ,  strings ,  uuids ,  longs   );
         handler.handle(ClientMessage.createForDecode(clientMessage.buffer(), 0));
      }
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(    aString   );
+    MapEventJournalSubscribeCodec.RequestParameters params = MapEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    MapEventJournalSubscribeCodec.ResponseParameters params = MapEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null ,    null   );
+    MapEventJournalReadCodec.RequestParameters params = MapEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(null, params.predicate));
+            assertTrue(isEqual(null, params.projection));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    MapEventJournalReadCodec.ResponseParameters params = MapEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = MultiMapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong   );
@@ -4194,6 +4240,34 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(aPartitionUuidList, params.partitionUuidList));
 }
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(    aString   );
+    CacheEventJournalSubscribeCodec.RequestParameters params = CacheEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    CacheEventJournalSubscribeCodec.ResponseParameters params = CacheEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null ,    null   );
+    CacheEventJournalReadCodec.RequestParameters params = CacheEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(null, params.predicate));
+            assertTrue(isEqual(null, params.projection));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    CacheEventJournalReadCodec.ResponseParameters params = CacheEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
+}
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     XATransactionClearRemoteCodec.RequestParameters params = XATransactionClearRemoteCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anXid, params.xid));
@@ -4493,10 +4567,11 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anInt, params.readCount));
             assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = DurableExecutorShutdownCodec.encodeRequest(    aString   );

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
@@ -287,6 +287,24 @@ public class EncodeDecodeCompatibilityTest {
     ClientPingCodec.ResponseParameters params = ClientPingCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(    aString   );
+    ClientStatisticsCodec.RequestParameters params = ClientStatisticsCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.stats));
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    ClientStatisticsCodec.ResponseParameters params = ClientStatisticsCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(    aListOfStringToByteArrEntry   );
+    ClientDeployClassesCodec.RequestParameters params = ClientDeployClassesCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aListOfStringToByteArrEntry, params.classDefinitions));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    ClientDeployClassesCodec.ResponseParameters params = ClientDeployClassesCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     MapPutCodec.RequestParameters params = MapPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
@@ -1239,6 +1257,34 @@ public class EncodeDecodeCompatibilityTest {
         ClientMessage clientMessage = MapAddNearCacheInvalidationListenerCodec.encodeIMapBatchInvalidationEvent( datas ,  strings ,  uuids ,  longs   );
         handler.handle(ClientMessage.createForDecode(clientMessage.buffer(), 0));
      }
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(    aString   );
+    MapEventJournalSubscribeCodec.RequestParameters params = MapEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    MapEventJournalSubscribeCodec.ResponseParameters params = MapEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+    MapEventJournalReadCodec.RequestParameters params = MapEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(aData, params.predicate));
+            assertTrue(isEqual(aData, params.projection));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    MapEventJournalReadCodec.ResponseParameters params = MapEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = MultiMapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong   );
@@ -4194,6 +4240,34 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aPartitionUuidList, params.partitionUuidList));
 }
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(    aString   );
+    CacheEventJournalSubscribeCodec.RequestParameters params = CacheEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    CacheEventJournalSubscribeCodec.ResponseParameters params = CacheEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+    CacheEventJournalReadCodec.RequestParameters params = CacheEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(aData, params.predicate));
+            assertTrue(isEqual(aData, params.projection));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    CacheEventJournalReadCodec.ResponseParameters params = CacheEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
+}
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     XATransactionClearRemoteCodec.RequestParameters params = XATransactionClearRemoteCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anXid, params.xid));
@@ -4493,10 +4567,11 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anInt, params.readCount));
             assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = DurableExecutorShutdownCodec.encodeRequest(    aString   );

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
@@ -5369,7 +5369,7 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
@@ -5420,7 +5420,7 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
@@ -5350,7 +5350,7 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
@@ -5340,7 +5340,7 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
@@ -5506,7 +5506,7 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
@@ -5398,7 +5398,7 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
@@ -5449,7 +5449,7 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
@@ -5379,7 +5379,7 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
@@ -5369,7 +5369,7 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
@@ -5539,7 +5539,7 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
     byte[] bytes = new byte[length];
     inputStream.read(bytes);

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -81,6 +81,8 @@ class ConfigCompatibilityChecker {
         checkCompatibleConfigs("executor", c1, c2, c1.getExecutorConfigs(), c2.getExecutorConfigs(), new ExecutorConfigChecker());
         checkCompatibleConfigs("durable executor", c1, c2, c1.getDurableExecutorConfigs(), c2.getDurableExecutorConfigs(), new DurableExecutorConfigChecker());
         checkCompatibleConfigs("scheduled executor", c1, c2, c1.getScheduledExecutorConfigs(), c2.getScheduledExecutorConfigs(), new ScheduledExecutorConfigChecker());
+        checkCompatibleConfigs("map event journal", c1, c2, c1.getMapEventJournalConfigs(), c2.getMapEventJournalConfigs(), new MapEventJournalConfigChecker());
+        checkCompatibleConfigs("cache event journal", c1, c2, c1.getCacheEventJournalConfigs(), c2.getCacheEventJournalConfigs(), new CacheEventJournalConfigChecker());
         checkCompatibleConfigs("multimap", c1, c2, c1.getMultiMapConfigs(), c2.getMultiMapConfigs(), new MultimapConfigChecker());
         checkCompatibleConfigs("list", c1, c2, c1.getListConfigs(), c2.getListConfigs(), new ListConfigChecker());
         checkCompatibleConfigs("set", c1, c2, c1.getSetConfigs(), c2.getSetConfigs(), new SetConfigChecker());
@@ -203,6 +205,34 @@ class ConfigCompatibilityChecker {
         @Override
         RingbufferConfig getDefault(Config c) {
             return c.getRingbufferConfig("default");
+        }
+    }
+
+    public static class EventJournalConfigChecker extends ConfigChecker<EventJournalConfig> {
+        @Override
+        boolean check(EventJournalConfig c1, EventJournalConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getMapName(), c2.getMapName())
+                            && nullSafeEqual(c1.getCacheName(), c2.getCacheName())
+                            && nullSafeEqual(c1.getCapacity(), c2.getCapacity())
+                            && nullSafeEqual(c1.getTimeToLiveSeconds(), c2.getTimeToLiveSeconds()));
+        }
+    }
+
+    public static class MapEventJournalConfigChecker extends EventJournalConfigChecker {
+        @Override
+        EventJournalConfig getDefault(Config c) {
+            return c.getMapEventJournalConfig("default");
+        }
+    }
+
+    public static class CacheEventJournalConfigChecker extends EventJournalConfigChecker {
+        @Override
+        EventJournalConfig getDefault(Config c) {
+            return c.getCacheEventJournalConfig("default");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.ConfigCompatibilityChecker.EventJournalConfigChecker;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -208,6 +209,38 @@ public class ConfigXmlGeneratorTest {
         final Config xmlConfig = getNewConfigViaXMLGenerator(config);
 
         ConfigCompatibilityChecker.checkWanConfigs(config.getWanReplicationConfigs(), xmlConfig.getWanReplicationConfigs());
+    }
+
+    @Test
+    public void testMapEventJournal() {
+        final String mapName = "mapName";
+        final EventJournalConfig journalConfig = new EventJournalConfig()
+                .setMapName(mapName)
+                .setEnabled(true)
+                .setCapacity(123)
+                .setTimeToLiveSeconds(321);
+        final Config config = new Config().addEventJournalConfig(journalConfig);
+        final Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        assertTrue(new EventJournalConfigChecker().check(
+                journalConfig,
+                xmlConfig.getMapEventJournalConfig(mapName)));
+    }
+
+    @Test
+    public void testCacheEventJournal() {
+        final String cacheName = "cacheName";
+        final EventJournalConfig journalConfig = new EventJournalConfig()
+                .setCacheName(cacheName)
+                .setEnabled(true)
+                .setCapacity(123)
+                .setTimeToLiveSeconds(321);
+        final Config config = new Config().addEventJournalConfig(journalConfig);
+        final Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        assertTrue(new EventJournalConfigChecker().check(
+                journalConfig,
+                xmlConfig.getCacheEventJournalConfig(cacheName)));
     }
 
     private DiscoveryConfig getDummyDiscoveryConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.core.RingbufferStoreFactory;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.ringbuffer.impl.RingbufferStoreWrapper;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -57,7 +58,9 @@ public class RingbufferStoreConfigTest {
     @Test
     public void setStoreImplementation() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        RingbufferStore<Data> store = RingbufferStoreWrapper.create("name", config, OBJECT, serializationService, null);
+        RingbufferStore<Data> store = RingbufferStoreWrapper.create(
+                RingbufferService.getRingbufferNamespace("name"),
+                config, OBJECT, serializationService, null);
 
         config.setStoreImplementation(store);
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -902,6 +902,44 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
     }
 
+    @Test
+    public void testMapEventJournalConfig() {
+        final String journalName = "mapName";
+        final String xml = HAZELCAST_START_TAG
+                + "  <event-journal enabled=\"true\">\n" +
+                "        <mapName>" + journalName + "</mapName>\n" +
+                "        <capacity>120</capacity>\n" +
+                "        <time-to-live-seconds>20</time-to-live-seconds>\n" +
+                "    </event-journal>"
+                + HAZELCAST_END_TAG;
+
+        final Config config = buildConfig(xml);
+        final EventJournalConfig journalConfig = config.getMapEventJournalConfig(journalName);
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(120, journalConfig.getCapacity());
+        assertEquals(20, journalConfig.getTimeToLiveSeconds());
+    }
+
+    @Test
+    public void testCacheEventJournalConfig() {
+        final String journalName = "cacheName";
+        final String xml = HAZELCAST_START_TAG
+                + "  <event-journal enabled=\"true\">\n" +
+                "        <cacheName>" + journalName + "</cacheName>\n" +
+                "        <capacity>120</capacity>\n" +
+                "        <time-to-live-seconds>20</time-to-live-seconds>\n" +
+                "    </event-journal>"
+                + HAZELCAST_END_TAG;
+
+        final Config config = buildConfig(xml);
+        final EventJournalConfig journalConfig = config.getCacheEventJournalConfig(journalName);
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(120, journalConfig.getCapacity());
+        assertEquals(20, journalConfig.getTimeToLiveSeconds());
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void testParseExceptionIsNotSwallowed() {
         String invalidXml = HAZELCAST_START_TAG + "</hazelcast";

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.function.BiConsumer;
+import com.hazelcast.util.function.Predicate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BasicMapJournalTest extends HazelcastTestSupport {
+    protected HazelcastInstance[] instances;
+    private static final Random RANDOM = new Random();
+    private static final TruePredicate<EventJournalMapEvent<String, Integer>> TRUE_PREDICATE = truePredicate();
+    private static final IdentityProjection<EventJournalMapEvent<String, Integer>> IDENTITY_PROJECTION = identityProjection();
+    private int partitionId;
+
+    @Before
+    public void init() {
+        instances = createInstances();
+        partitionId = 1;
+        warmUpPartitions(instances);
+    }
+
+    protected HazelcastInstance getRandomInstance() {
+        return instances[RANDOM.nextInt(instances.length)];
+    }
+
+    protected HazelcastInstance[] createInstances() {
+        return createHazelcastInstanceFactory(2).newInstances(getConfig());
+    }
+
+    protected <K, V> IMap<K, V> getMap(String mapName) {
+        return getRandomInstance().getMap(mapName);
+    }
+
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(IMap<K, V> map, int partitionId) {
+        return ((MapProxyImpl<K, V>) map).subscribeToEventJournal(partitionId);
+    }
+
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            IMap<K, V> map,
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            Predicate<? super EventJournalMapEvent<K, V>> predicate,
+            Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        return ((MapProxyImpl<K, V>) map).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+
+    @Override
+    protected Config getConfig() {
+        final Config config = super.getConfig();
+        config.addEventJournalConfig(new EventJournalConfig().setMapName("default").setEnabled(true));
+
+        final MapConfig mapConfig = new MapConfig("mappy");
+        final MapConfig expiringMap = new MapConfig("expiring").setTimeToLiveSeconds(1);
+        return config.addMapConfig(mapConfig).addMapConfig(expiringMap);
+    }
+
+    @Test
+    public void unparkReadOperation() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        assertJournalSize(m, 0);
+
+        final String key = randomPartitionKey();
+        final Integer value = RANDOM.nextInt();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        readFromEventJournal(m, 0, 100, partitionId, TRUE_PREDICATE, IDENTITY_PROJECTION)
+                .andThen(new ExecutionCallback<ReadResultSet<EventJournalMapEvent<String, Integer>>>() {
+                    @Override
+                    public void onResponse(ReadResultSet<EventJournalMapEvent<String, Integer>> response) {
+                        assertEquals(1, response.size());
+                        final EventJournalMapEvent<String, Integer> e = response.get(0);
+
+                        assertEquals(EntryEventType.ADDED, e.getType());
+                        assertEquals(e.getKey(), key);
+                        assertEquals(e.getNewValue(), value);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        t.printStackTrace();
+                    }
+                });
+
+        m.put(key, value);
+        latch.await();
+        assertJournalSize(m, 1);
+    }
+
+    @Test
+    public void receiveAddedEventsWhenPut() throws Exception {
+        final IMap<String, Integer> m = getMap();
+
+        final int count = 100;
+        assertJournalSize(m, 0);
+
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+
+        assertJournalSize(m, count);
+        final ReadResultSet<EventJournalMapEvent<String, Integer>> events = getAllEvents(m, null, null);
+        assertEquals(count, events.size());
+
+        final HashMap<String, Integer> received = new HashMap<String, Integer>();
+        for (EventJournalMapEvent<String, Integer> e : events) {
+            assertEquals(EntryEventType.ADDED, e.getType());
+            assertNull(e.getOldValue());
+            received.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(m.entrySet(), received.entrySet());
+    }
+
+    @Test
+    public void receiveExpirationEventsWhenPutWithTtl() throws Exception {
+        final String mapName = "mappy";
+        final IMap<String, Integer> m = getMap(mapName);
+        testExpiration(mapName, new BiConsumer<String, Integer>() {
+            @Override
+            public void accept(String k, Integer i) {
+                m.put(k, i, 1, TimeUnit.SECONDS);
+            }
+        });
+    }
+
+    @Test
+    public void receiveExpirationEventsWhenPutOnExpiringMap() throws Exception {
+        final String mapName = "expiring";
+        final IMap<String, Integer> m = getMap(mapName);
+        testExpiration(mapName, new BiConsumer<String, Integer>() {
+            @Override
+            public void accept(String k, Integer i) {
+                m.put(k, i);
+            }
+        });
+    }
+
+    @Test
+    public void receiveRemoveEventsWhenRemove() throws Exception {
+        final IMap<String, Integer> m = getMap();
+
+        final int count = 100;
+        assertJournalSize(m, 0);
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(m, count);
+
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(m);
+        for (String key : m.keySet()) {
+            m.remove(key);
+        }
+
+        final HashMap<String, Integer> added = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> removed = new HashMap<String, Integer>(count);
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case ADDED:
+                    added.put(e.getKey(), e.getNewValue());
+                    break;
+                case REMOVED:
+                    removed.put(e.getKey(), e.getOldValue());
+                    break;
+            }
+        }
+
+
+        assertEquals(0, m.size());
+        assertJournalSize(m, count * 2);
+        assertEquals(initialMap, added);
+        assertEquals(initialMap, removed);
+    }
+
+    @Test
+    public void receiveUpdateEventsOnMapPut() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        final int count = 100;
+        assertJournalSize(m, 0);
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(m);
+        assertJournalSize(m, count);
+
+        for (String key : m.keySet()) {
+            final Integer newVal = initialMap.get(key) + 100;
+            m.put(key, newVal);
+        }
+        assertJournalSize(m, count * 2);
+
+        final HashMap<String, Integer> updatedFrom = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> updatedTo = new HashMap<String, Integer>(count);
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case UPDATED:
+                    updatedFrom.put(e.getKey(), e.getOldValue());
+                    updatedTo.put(e.getKey(), e.getNewValue());
+                    break;
+            }
+        }
+
+        assertEquals(initialMap, updatedFrom);
+        assertEquals(m.entrySet(), updatedTo.entrySet());
+    }
+
+    @Test
+    public void testPredicates() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        final int count = 50;
+        assertJournalSize(m, 0);
+
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(m, count);
+
+        final HashMap<String, Integer> evenMap = new HashMap<String, Integer>();
+        final HashMap<String, Integer> oddMap = new HashMap<String, Integer>();
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, new NewValueParityPredicate(0), IDENTITY_PROJECTION)) {
+            assertEquals(EntryEventType.ADDED, e.getType());
+            evenMap.put(e.getKey(), e.getNewValue());
+        }
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, new NewValueParityPredicate(1), IDENTITY_PROJECTION)) {
+            assertEquals(EntryEventType.ADDED, e.getType());
+            oddMap.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(count / 2, evenMap.size());
+        assertEquals(count / 2, oddMap.size());
+
+        for (Entry<String, Integer> e : evenMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 0);
+            assertEquals(m.get(e.getKey()), v);
+        }
+        for (Entry<String, Integer> e : oddMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 1);
+            assertEquals(m.get(e.getKey()), v);
+        }
+    }
+
+    @Test
+    public void testProjection() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        final int count = 50;
+        assertJournalSize(m, 0);
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(m, count);
+
+
+        final ReadResultSet<Integer> ints = getAllEvents(m, TRUE_PREDICATE, new NewValueIncrementingProjection(100));
+        assertEquals(count, ints.size());
+        final Collection<Integer> values = m.values();
+        for (Integer v : ints) {
+            assertTrue(values.contains(v - 100));
+        }
+    }
+
+    private static class NewValueIncrementingProjection extends Projection<EventJournalMapEvent<String, Integer>, Integer> {
+        private final int delta;
+
+        NewValueIncrementingProjection(int delta) {
+            this.delta = delta;
+        }
+
+        @Override
+        public Integer transform(EventJournalMapEvent<String, Integer> input) {
+            return input.getNewValue() + delta;
+        }
+    }
+
+    public static class NewValueParityPredicate implements Predicate<EventJournalMapEvent<String, Integer>>, Serializable {
+        private final int remainder;
+
+        NewValueParityPredicate(int remainder) {
+            this.remainder = remainder;
+        }
+
+        @Override
+        public boolean test(EventJournalMapEvent<String, Integer> e) {
+            return e.getNewValue() % 2 == remainder;
+        }
+    }
+
+    private void testExpiration(String mapName, BiConsumer<String, Integer> mutationFn) throws Exception {
+        final IMap<String, Integer> m = getMap(mapName);
+        final int count = 2;
+        assertJournalSize(m, 0);
+
+        for (int i = 0; i < count; i++) {
+            final String k = randomPartitionKey();
+            mutationFn.accept(k, i);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertJournalSize(partitionId, m, count * 2);
+                final ReadResultSet<EventJournalMapEvent<String, Integer>> set = getAllEvents(m, null, null);
+                assertEquals(count * 2, set.size());
+                final HashMap<String, Integer> added = new HashMap<String, Integer>();
+                final HashMap<String, Integer> evicted = new HashMap<String, Integer>();
+                for (EventJournalMapEvent<String, Integer> e : set) {
+                    if (EntryEventType.ADDED.equals(e.getType())) {
+                        added.put(e.getKey(), e.getNewValue());
+                    } else if (EntryEventType.EVICTED.equals(e.getType())) {
+                        evicted.put(e.getKey(), e.getOldValue());
+                    }
+                }
+                assertEquals(added, evicted);
+            }
+        });
+    }
+
+    private <T> ReadResultSet<T> getAllEvents(IMap<String, Integer> m,
+                                              Predicate<? super EventJournalMapEvent<String, Integer>> predicate,
+                                              Projection<? super EventJournalMapEvent<String, Integer>, T> projection) throws Exception {
+        final EventJournalInitialSubscriberState state = subscribeToEventJournal(m, partitionId);
+        return readFromEventJournal(
+                m, state.getOldestSequence(), (int) (state.getNewestSequence() - state.getOldestSequence() + 1),
+                partitionId, predicate, projection).get();
+    }
+
+
+    private static class TruePredicate<T> implements Predicate<T>, Serializable {
+        @Override
+        public boolean test(T t) {
+            return true;
+        }
+    }
+
+    private static class IdentityProjection<I> extends Projection<I, I> implements Serializable {
+        @Override
+        public I transform(I input) {
+            return input;
+        }
+    }
+
+    private String randomPartitionKey() {
+        return generateKeyForPartition(instances[0], partitionId);
+    }
+
+    private void assertJournalSize(DistributedObject object, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(object.getServiceName(), object.getName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, DistributedObject object, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(object.getServiceName(), object.getName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, ObjectNamespace namespace, int size) {
+        HazelcastInstance partitionOwner = null;
+        for (HazelcastInstance instance : instances) {
+            if (getNode(instance).partitionService.getPartition(partitionId).isLocal()) {
+                partitionOwner = instance;
+                break;
+            }
+        }
+
+        final Node node = getNode(partitionOwner);
+        final NodeEngineImpl nodeEngine = node.nodeEngine;
+        final RingbufferService rbService = nodeEngine.getService(RingbufferService.SERVICE_NAME);
+        final ConcurrentMap<Integer, ConcurrentMap<ObjectNamespace, RingbufferContainer>> containers = rbService.getContainers();
+        final ConcurrentMap<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (size == 0 && partitionContainers == null) {
+            return;
+        }
+        assertNotNull(partitionContainers);
+        final RingbufferContainer container = partitionContainers.get(namespace);
+        if (size == 0 && container == null) {
+            return;
+        }
+        assertNotNull(container);
+        assertEquals(size, container.size());
+    }
+
+    private <K, V> IMap<K, V> getMap() {
+        return getMap("mappy");
+    }
+
+    private static <T> TruePredicate<T> truePredicate() {
+        return new TruePredicate<T>();
+    }
+
+    private static <T> IdentityProjection<T> identityProjection() {
+        return new IdentityProjection<T>();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.when;
 @Category({QuickTest.class, ParallelTest.class})
 public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
     private static final String NAME = "somerb";
+    private static final ObjectNamespace NAMESPACE = RingbufferService.getRingbufferNamespace(NAME);
 
     private HazelcastInstance hz;
     private StoreLatencyPlugin plugin;
@@ -48,7 +50,8 @@ public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
         hz = createHazelcastInstance();
         plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
         delegate = mock(RingbufferStore.class);
-        ringbufferStore = new LatencyTrackingRingbufferStore<String>(delegate, plugin, NAME);
+        ringbufferStore = new LatencyTrackingRingbufferStore<String>(delegate, plugin,
+                NAMESPACE);
     }
 
     @Test
@@ -97,7 +100,7 @@ public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
     }
 
     public void assertProbeCalledOnce(String methodName) {
-        assertEquals(1, plugin.count(LatencyTrackingRingbufferStore.KEY, NAME, methodName));
+        assertEquals(1, plugin.count(LatencyTrackingRingbufferStore.KEY,
+                NAMESPACE.getServiceName() + ":" + NAMESPACE.getObjectName(), methodName));
     }
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
@@ -98,8 +98,7 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
                 .setInMemoryFormat(inMemoryFormat)
                 .setTimeToLiveSeconds(ttlSeconds);
 
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
         testSerialization(rbContainer);
 
         for (int k = 0; k < config.getCapacity() * 2; k++) {
@@ -119,6 +118,12 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
             ringbuffer.setHeadSequence(ringbuffer.headSequence() + 1);
             testSerialization(rbContainer);
         }
+    }
+
+    private RingbufferContainer getRingbufferContainer(RingbufferConfig config) {
+        return new RingbufferContainer(
+                RingbufferService.getRingbufferNamespace(config.getName()), config,
+                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
     }
 
     private void testSerialization(RingbufferContainer original) {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -65,8 +66,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void constructionNoTTL() {
         final RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(0);
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), rbContainer.getCapacity());
         final ArrayRingbuffer ringbuffer = (ArrayRingbuffer) rbContainer.getRingbuffer();
@@ -81,8 +81,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void constructionWithTTL() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(30);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), ringbuffer.getCapacity());
         assertNotNull(ringbuffer.getExpirationPolicy());
@@ -95,8 +94,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void remainingCapacity_whenTTLDisabled() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(0);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), ringbuffer.remainingCapacity());
 
@@ -105,11 +103,16 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
         assertEquals(config.getCapacity(), ringbuffer.remainingCapacity());
     }
 
+    private RingbufferContainer getRingbufferContainer(RingbufferConfig config) {
+        return new RingbufferContainer(
+                RingbufferService.getRingbufferNamespace(config.getName()), config,
+                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+    }
+
     @Test
     public void remainingCapacity_whenTTLEnabled() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(1);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), ringbuffer.remainingCapacity());
 
@@ -125,8 +128,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void size_whenEmpty() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(0, ringbuffer.size());
         assertTrue(ringbuffer.isEmpty());
@@ -135,8 +137,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void size_whenAddingManyItems() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         for (int k = 0; k < config.getCapacity(); k++) {
             ringbuffer.add(toData(""));
@@ -157,8 +158,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void add() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(10);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
         ringbuffer.add(toData("foo"));
         ringbuffer.add(toData("bar"));
 
@@ -169,47 +169,45 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void add_whenWrapped() {
         RingbufferConfig config = new RingbufferConfig("foo").setInMemoryFormat(InMemoryFormat.OBJECT).setCapacity(3);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         ringbuffer.add(toData("1"));
         assertEquals(0, ringbuffer.headSequence());
         assertEquals(0, ringbuffer.tailSequence());
-        assertEquals(toData("1"), ringbuffer.read(0));
+        assertEquals(toData("1"), ringbuffer.readAsData(0));
 
         ringbuffer.add(toData("2"));
         assertEquals(1, ringbuffer.tailSequence());
         assertEquals(0, ringbuffer.headSequence());
-        assertEquals(toData("1"), ringbuffer.read(0));
-        assertEquals(toData("2"), ringbuffer.read(1));
+        assertEquals(toData("1"), ringbuffer.readAsData(0));
+        assertEquals(toData("2"), ringbuffer.readAsData(1));
 
         ringbuffer.add(toData("3"));
         assertEquals(2, ringbuffer.tailSequence());
         assertEquals(0, ringbuffer.headSequence());
-        assertEquals(toData("1"), ringbuffer.read(0));
-        assertEquals(toData("2"), ringbuffer.read(1));
-        assertEquals(toData("3"), ringbuffer.read(2));
+        assertEquals(toData("1"), ringbuffer.readAsData(0));
+        assertEquals(toData("2"), ringbuffer.readAsData(1));
+        assertEquals(toData("3"), ringbuffer.readAsData(2));
 
         ringbuffer.add(toData("4"));
         assertEquals(3, ringbuffer.tailSequence());
         assertEquals(1, ringbuffer.headSequence());
-        assertEquals(toData("2"), ringbuffer.read(1));
-        assertEquals(toData("3"), ringbuffer.read(2));
-        assertEquals(toData("4"), ringbuffer.read(3));
+        assertEquals(toData("2"), ringbuffer.readAsData(1));
+        assertEquals(toData("3"), ringbuffer.readAsData(2));
+        assertEquals(toData("4"), ringbuffer.readAsData(3));
 
         ringbuffer.add(toData("5"));
         assertEquals(4, ringbuffer.tailSequence());
         assertEquals(2, ringbuffer.headSequence());
-        assertEquals(toData("3"), ringbuffer.read(2));
-        assertEquals(toData("4"), ringbuffer.read(3));
-        assertEquals(toData("5"), ringbuffer.read(4));
+        assertEquals(toData("3"), ringbuffer.readAsData(2));
+        assertEquals(toData("4"), ringbuffer.readAsData(3));
+        assertEquals(toData("5"), ringbuffer.readAsData(4));
     }
 
     @Test(expected = StaleSequenceException.class)
     public void read_whenStaleSequence() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(3);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer<Data> ringbuffer = getRingbufferContainer(config);
 
         ringbuffer.add(toData("1"));
         ringbuffer.add(toData("2"));
@@ -217,14 +215,13 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
         // this one will overwrite the first item
         ringbuffer.add(toData("4"));
 
-        ringbuffer.read(0);
+        ringbuffer.readAsData(0);
     }
 
     @Test
     public void add_whenBinaryInMemoryFormat() {
         final RingbufferConfig config = new RingbufferConfig("foo").setInMemoryFormat(InMemoryFormat.BINARY);
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
         final ArrayRingbuffer ringbuffer = (ArrayRingbuffer) rbContainer.getRingbuffer();
 
         rbContainer.add(toData("foo"));
@@ -234,8 +231,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void add_inObjectInMemoryFormat() {
         final RingbufferConfig config = new RingbufferConfig("foo").setInMemoryFormat(InMemoryFormat.OBJECT);
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
         final ArrayRingbuffer ringbuffer = (ArrayRingbuffer) rbContainer.getRingbuffer();
 
         rbContainer.add(toData("foo"));

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
@@ -57,8 +57,16 @@ public class RingbufferServiceTest extends HazelcastTestSupport {
 
     @Test
     public void reset() {
-        service.getContainer("foo");
-        service.getContainer("bar");
+        final String foo = "foo";
+        final String bar = "bar";
+        service.getContainer(
+                service.getRingbufferPartitionId(foo),
+                RingbufferService.getRingbufferNamespace(foo),
+                service.getRingbufferConfig(foo));
+        service.getContainer(
+                service.getRingbufferPartitionId(bar),
+                RingbufferService.getRingbufferNamespace(bar),
+                service.getRingbufferConfig(bar));
 
         service.reset();
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
@@ -45,10 +45,14 @@ public class RingbufferTTLTest extends HazelcastTestSupport {
         Config config = new Config();
         config.addRingBufferConfig(ringbufferConfig);
         hz = createHazelcastInstance(config);
-        ringbuffer = hz.getRingbuffer(ringbufferConfig.getName());
+        final String name = ringbufferConfig.getName();
+        ringbuffer = hz.getRingbuffer(name);
 
         RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(ringbufferConfig.getName());
+        ringbufferContainer = ringbufferService.getContainer(
+                ringbufferService.getRingbufferPartitionId(name),
+                RingbufferService.getRingbufferNamespace(name),
+                ringbufferConfig);
         arrayRingbuffer = (ArrayRingbuffer) ringbufferContainer.getRingbuffer();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.ringbuffer.impl;
 
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,21 +34,27 @@ public class RingbufferWaitNotifyKeyTest {
 
     @Test
     public void test_equals() {
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("peter", "java"), true);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("peter", "c#"), false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("talip", "java"), false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("talip", "c#"), false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                "", false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                null, false);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), true);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "talip"), false);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(MapService.SERVICE_NAME, "peter"), false);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(MapService.SERVICE_NAME, "talip"), false);
+        test_equals(waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), "", false);
+        test_equals(waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), null, false);
 
-        RingbufferWaitNotifyKey key = new RingbufferWaitNotifyKey("peter", "java");
+        RingbufferWaitNotifyKey key = waitNotifyKey(RingbufferService.SERVICE_NAME, "peter");
         test_equals(key, key, true);
+    }
+
+    private RingbufferWaitNotifyKey waitNotifyKey(String service, String object) {
+        return new RingbufferWaitNotifyKey(new DistributedObjectNamespace(service, object));
     }
 
     public void test_equals(Object key1, Object key2, boolean equals) {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperationTest.java
@@ -20,7 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -45,6 +47,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
     private NodeEngineImpl nodeEngine;
     private SerializationService serializationService;
     private Ringbuffer<Object> ringbuffer;
+    private RingbufferService ringbufferService;
 
     @Before
     public void setup() {
@@ -56,6 +59,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
         nodeEngine = getNodeEngineImpl(hz);
         serializationService = getSerializationService(hz);
         ringbuffer = hz.getRingbuffer(rbConfig.getName());
+        ringbufferService = nodeEngine.getService(RingbufferService.SERVICE_NAME);
     }
 
     @Test
@@ -66,8 +70,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, FAIL);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, FAIL);
         addOperation.run();
 
         assertFalse(addOperation.shouldNotify());
@@ -83,8 +86,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, FAIL);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, FAIL);
         addOperation.run();
 
         assertTrue(addOperation.shouldNotify());
@@ -100,8 +102,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, OVERWRITE);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, OVERWRITE);
         addOperation.run();
 
         assertTrue(addOperation.shouldNotify());
@@ -117,12 +118,18 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, OVERWRITE);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, OVERWRITE);
         addOperation.run();
 
         assertTrue(addOperation.shouldNotify());
         assertTrue(addOperation.shouldBackup());
         assertEquals(ringbuffer.tailSequence(), addOperation.getResponse());
+    }
+
+    private AddAllOperation getAddAllOperation(Data[] items, OverflowPolicy policy) {
+        AddAllOperation op = new AddAllOperation(ringbuffer.getName(), items, policy);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        op.setNodeEngine(nodeEngine);
+        return op;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
@@ -52,6 +52,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
     private Ringbuffer<Object> ringbuffer;
     private RingbufferContainer ringbufferContainer;
     private SerializationService serializationService;
+    private RingbufferService ringbufferService;
 
     @Before
     public void setup() {
@@ -64,10 +65,14 @@ public class GenericOperationTest extends HazelcastTestSupport {
         hz = createHazelcastInstance(config);
         nodeEngine = getNodeEngineImpl(hz);
         serializationService = nodeEngine.getSerializationService();
-        ringbuffer = hz.getRingbuffer(rbConfig.getName());
+        final String name = rbConfig.getName();
+        ringbuffer = hz.getRingbuffer(name);
 
-        RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(rbConfig.getName());
+        ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
+        ringbufferContainer = ringbufferService.getContainer(
+                ringbufferService.getRingbufferPartitionId(name),
+                RingbufferService.getRingbufferNamespace(name),
+                rbConfig);
     }
 
     @Test
@@ -75,8 +80,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_SIZE);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_SIZE);
 
         op.run();
         Long result = op.getResponse();
@@ -88,8 +92,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_CAPACITY);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_CAPACITY);
 
         op.run();
         Long result = op.getResponse();
@@ -101,8 +104,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_REMAINING_CAPACITY);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_REMAINING_CAPACITY);
 
         op.run();
         Long result = op.getResponse();
@@ -114,8 +116,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_TAIL);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_TAIL);
 
         op.run();
         Long result = op.getResponse();
@@ -128,12 +129,18 @@ public class GenericOperationTest extends HazelcastTestSupport {
             ringbuffer.add("a");
         }
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_HEAD);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_HEAD);
 
         op.run();
         Long result = op.getResponse();
         assertEquals(new Long(ringbufferContainer.headSequence()), result);
+    }
+
+    private GenericOperation getGenericOperation(byte operation) {
+        GenericOperation op = new GenericOperation(ringbuffer.getName(), operation);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        op.setNodeEngine(nodeEngine);
+        return op;
     }
 
     public void serialize() {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -51,6 +51,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     private Ringbuffer<Object> ringbuffer;
     private RingbufferContainer ringbufferContainer;
     private SerializationService serializationService;
+    private RingbufferService ringbufferService;
 
     @Before
     public void setup() {
@@ -61,17 +62,21 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         hz = createHazelcastInstance(config);
         nodeEngine = getNodeEngineImpl(hz);
         serializationService = nodeEngine.getSerializationService();
-        ringbuffer = hz.getRingbuffer(rbConfig.getName());
+        final String name = rbConfig.getName();
+        ringbuffer = hz.getRingbuffer(name);
 
-        RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(rbConfig.getName());
+        ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
+        ringbufferContainer = ringbufferService.getContainer(
+                ringbufferService.getRingbufferPartitionId(name),
+                RingbufferService.getRingbufferNamespace(name),
+                rbConfig);
     }
 
     @Test
     public void whenAtTail() throws Exception {
         ringbuffer.add("tail");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence(), 1, 1, null);
+        ReadManyOperation<String> op = getReadManyOperation(ringbuffer.tailSequence(), 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -89,7 +94,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     public void whenOneAfterTail() throws Exception {
         ringbuffer.add("tail");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() + 1, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 1, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -104,7 +109,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     public void whenTooFarAfterTail() throws Exception {
         ringbuffer.add("tail");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() + 2, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 2, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -113,7 +118,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
     @Test
     public void whenOneAfterTailAndBufferEmpty() throws Exception {
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() + 1, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 1, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -127,7 +132,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
     @Test(expected = StaleSequenceException.class)
     public void whenOnTailAndBufferEmpty() throws Exception {
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence(), 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence(), 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -140,7 +145,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer.add("item2");
         ringbuffer.add("item3");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() - 1, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() - 1, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -161,7 +166,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer.add("item2");
         ringbuffer.add("item3");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.headSequence(), 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.headSequence(), 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -185,7 +190,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         long oldhead = ringbuffer.headSequence();
         ringbufferContainer.setHeadSequence(ringbufferContainer.tailSequence());
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), oldhead, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(oldhead, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         op.shouldWait();
@@ -194,7 +199,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenMinimumNumberOfItemsNotAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
         op.setNodeEngine(nodeEngine);
 
         assertTrue(op.shouldWait());
@@ -220,7 +225,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenBelowMinimumAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -239,7 +244,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenMinimumNumberOfItemsAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -254,7 +259,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenEnoughItemsAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 1, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 1, 3, null);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -274,7 +279,8 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenEnoughItemsAvailableAndReturnPortable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 1, 3, null, true);
+        final ReadManyOperation<String> op = new ReadManyOperation<String>(ringbuffer.getName(), startSequence, 1, 3, null, true);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -308,7 +314,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
             }
         };
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, filter);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, filter);
         op.setNodeEngine(nodeEngine);
 
         assertTrue(op.shouldWait());
@@ -365,7 +371,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
             }
         };
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, filter);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, filter);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("bad1");
@@ -378,5 +384,12 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         assertFalse(op.shouldWait());
         assertEquals(startSequence + 6, op.sequence);
         assertEquals(asList("good1", "good2", "good3"), op.getResponse());
+    }
+
+    private <T> ReadManyOperation<T> getReadManyOperation(long start, int min, int max, IFunction<T, Boolean> filter) {
+        final ReadManyOperation<T> op = new ReadManyOperation<T>(ringbuffer.getName(), start, min, max, filter);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        op.setNodeEngine(nodeEngine);
+        return op;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.test.TestEnvironment;
 
@@ -115,6 +116,21 @@ public class SamplingSerializationService implements InternalSerializationServic
         byte[] bytes =  delegate.toBytes(obj, leftPadding, insertPartitionHash);
         sampleObject(obj, bytes);
         return bytes;
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type) {
+        return toData(obj);
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type, PartitioningStrategy strategy) {
+        return toData(obj, strategy);
+    }
+
+    @Override
+    public <B extends Data> B convertData(Data data, DataType type) {
+        return (B) data;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicCreateTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.core.ITopic;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -57,7 +58,8 @@ public class ReliableTopicCreateTest extends HazelcastTestSupport {
 
         ReliableTopicProxy<String> topic = (ReliableTopicProxy<String>) hz.<String>getReliableTopic("foo");
 
-        Ringbuffer ringbuffer = hz.getRingbuffer(RingbufferService.TOPIC_RB_PREFIX + "foo");
+        final String name = RingbufferService.TOPIC_RB_PREFIX + "foo";
+        Ringbuffer ringbuffer = hz.getRingbuffer(name);
         assertSame(ringbuffer, topic.ringbuffer);
 
         // make sure the ringbuffer and topic are hooked up correctly
@@ -66,9 +68,11 @@ public class ReliableTopicCreateTest extends HazelcastTestSupport {
 
         assertEquals(0, ringbuffer.headSequence());
         assertEquals(1, ringbuffer.tailSequence());
-        ConcurrentMap<String, RingbufferContainer> containers = ringbufferService.getContainers();
+        final ConcurrentMap<ObjectNamespace, RingbufferContainer> containers =
+                ringbufferService.getContainers().get(ringbufferService.getRingbufferPartitionId(name));
+        final ObjectNamespace ns = RingbufferService.getRingbufferNamespace(ringbuffer.getName());
         assertEquals(1, containers.size());
-        assertTrue(containers.containsKey(ringbuffer.getName()));
+        assertTrue(containers.containsKey(ns));
     }
 
     @Test
@@ -89,11 +93,13 @@ public class ReliableTopicCreateTest extends HazelcastTestSupport {
         // triggers the creation
         ringbuffer.size();
 
-        ConcurrentMap<String, RingbufferContainer> containers = ringbufferService.getContainers();
+        final ConcurrentMap<ObjectNamespace, RingbufferContainer> containers =
+                ringbufferService.getContainers().get(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        final ObjectNamespace ns = RingbufferService.getRingbufferNamespace(ringbuffer.getName());
         assertEquals(1, containers.size());
-        assertTrue(containers.containsKey(ringbuffer.getName()));
+        assertTrue(containers.containsKey(ns));
 
-        RingbufferContainer container = containers.get(ringbuffer.getName());
+        RingbufferContainer container = containers.get(ns);
         assertEquals(rbConfig.getCapacity(), container.getConfig().getCapacity());
     }
 
@@ -113,8 +119,14 @@ public class ReliableTopicCreateTest extends HazelcastTestSupport {
 
         ReliableTopicProxy proxy = assertInstanceOf(ReliableTopicProxy.class, topic);
         assertEquals(proxy.overloadPolicy, TopicOverloadPolicy.DISCARD_NEWEST);
-        assertEquals(1, ringbufferService.getContainers().size());
-        assertTrue(ringbufferService.getContainers().containsKey(ringbuffer.getName()));
+
+        final ConcurrentMap<Integer, ConcurrentMap<ObjectNamespace, RingbufferContainer>> containers = ringbufferService.getContainers();
+        assertEquals(1, containers.size());
+        final ConcurrentMap<ObjectNamespace, RingbufferContainer> partitionContainers =
+                containers.get(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        final ObjectNamespace ns = RingbufferService.getRingbufferNamespace(ringbuffer.getName());
+
+        assertTrue(partitionContainers.containsKey(ns));
         assertEquals(0, ringbuffer.headSequence());
         assertEquals(0, ringbuffer.tailSequence());
         assertEquals(10, ringbuffer.capacity());

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.topic.impl.reliable;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -33,6 +34,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -81,8 +83,11 @@ public class ReliableTopicDestroyTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                ConcurrentMap<String, RingbufferContainer> containers = ringbufferService.getContainers();
-                assertFalse(containers.containsKey(topic.ringbuffer.getName()));
+                final String name = topic.ringbuffer.getName();
+                final ConcurrentMap<ObjectNamespace, RingbufferContainer> partitionContainers =
+                        ringbufferService.getContainers().get(ringbufferService.getRingbufferPartitionId(name));
+                assertTrue(partitionContainers != null);
+                assertFalse(partitionContainers.containsKey(RingbufferService.getRingbufferNamespace(name)));
             }
         });
     }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -419,6 +419,18 @@
 
     </map>
 
+    <event-journal enabled="true">
+        <mapName>mapName</mapName>
+        <capacity>120</capacity>
+        <time-to-live-seconds>20</time-to-live-seconds>
+    </event-journal>
+
+    <event-journal enabled="true">
+        <cacheName>cacheName</cacheName>
+        <capacity>120</capacity>
+        <time-to-live-seconds>20</time-to-live-seconds>
+    </event-journal>
+
     <multimap name="default">
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.5.0-1</client.protocol.version>
+        <client.protocol.version>1.5.0-2</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
https://hazelcast.atlassian.net/wiki/display/PM/Core+Part+-+Stream+Source+from+Map+and+Cache

https://hazelcast.atlassian.net/wiki/display/EN/Core+Part+-+Stream+Source+from+Map+and+Cache+-+Design

Gotchas : 
- the event journal config is outside of map and cache config and is matched to a specific map or cache by name. In the case of cache, the simple cache name is used but the configuration needs to be created on all nodes before subscribing
- the event journal config is public but the subscribe/unsubscribe is not public (they are public methods on an internal class - `MapProxyImpl`, `ClientMapProxy`, `CacheProxy` and `ClientCacheProxy`)
- the journal is destroyed if the map is destroyed. This includes migrations (when a member is no longer a replica). The event journal should be colocated with the replicas. If the map is destroyed, the listeners should fail as well. Sorry, the map is no more.

Depends on : https://github.com/hazelcast/hazelcast-client-protocol/pull/80
EE : https://github.com/hazelcast/hazelcast-enterprise/pull/1501