### PR TITLE
Apply minor fixes in the new clustering design

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -160,7 +160,13 @@ public class ClusterHeartbeatManager {
 
         try {
             if (!clusterService.isJoined()) {
-                logger.fine("Ignoring heartbeat of sender: " + senderMembersViewMetadata + ", because node is not joined!");
+                if (clusterService.getThisUuid().equals(receiverUuid)) {
+                    logger.fine("Ignoring heartbeat of sender: " + senderMembersViewMetadata + ", because node is not joined!");
+                } else {
+                    logger.fine("Sending explicit suspicion to " + senderAddress + " for heartbeat " + senderMembersViewMetadata
+                            + ", because this node has received an invalid heartbeat before it joins to the cluster");
+                    clusterService.sendExplicitSuspicion(senderMembersViewMetadata);
+                }
                 return;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -427,6 +427,11 @@ public class MembershipManager {
 
         clusterServiceLock.lock();
         try {
+            if (!clusterService.isJoined()) {
+                logger.fine("Cannot handle suspect of " + suspectedMember + " because this node is not joined...");
+                return;
+            }
+
             ClusterJoinManager clusterJoinManager = clusterService.getClusterJoinManager();
             if (clusterService.isMaster() && !clusterJoinManager.isMastershipClaimInProgress()) {
                 removeMember(suspectedMember, reason, shouldCloseConn);
@@ -697,7 +702,7 @@ public class MembershipManager {
             futures.put(member.getAddress(), invokeFetchMembersViewOp(member.getAddress(), member.getUuid()));
         }
 
-        while (true) {
+        while (clusterService.isJoined()) {
             boolean done = true;
 
             for (Entry<Address, Future<MembersView>> e : new ArrayList<Entry<Address, Future<MembersView>>>(futures.entrySet())) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManagerCompat.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManagerCompat.java
@@ -67,6 +67,11 @@ public class MembershipManagerCompat {
 
         clusterServiceLock.lock();
         try {
+            if (!clusterService.isJoined()) {
+                logger.fine("Cannot remove " + deadAddress + " with uuid: " + uuid + " because this node is not joined...");
+                return;
+            }
+
             MemberImpl member = membershipManager.getMember(deadAddress);
             if (member == null || (uuid != null && !uuid.equals(member.getUuid()))) {
                 if (logger.isFineEnabled()) {


### PR DESCRIPTION
1) A node should not perform any cluster-related tasks, such as mastership claim, if the cluster service is already reset during shutdown. Otherwise, if the current master and another member leaves the cluster simultaneously, the current master may think that it has just became the master and can start the mastership claim process by mistake.
2) If a node restarts with the same address and a new uuid, it should respond (i.e., explicit suspicions) to incoming heartbeats that include its previous uuid, even before it joins to the cluster.

Fixes #10526