### PR TITLE
Fixed some FindBugs warnings in the quorum tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
@@ -49,11 +49,6 @@ public class ClientMapReadQuorumTest extends HazelcastTestSupport {
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
-    static IMap<Object, Object> map1;
-    static IMap<Object, Object> map2;
-    static IMap<Object, Object> map3;
-    static IMap<Object, Object> map4;
-    static IMap<Object, Object> map5;
 
     static HazelcastInstance c1;
     static HazelcastInstance c2;
@@ -62,6 +57,12 @@ public class ClientMapReadQuorumTest extends HazelcastTestSupport {
     static HazelcastInstance c5;
 
     private static TestHazelcastFactory factory;
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+    IMap<Object, Object> map3;
+    IMap<Object, Object> map4;
+    IMap<Object, Object> map5;
 
     @BeforeClass
     public static void initialize() throws Exception {
@@ -118,14 +119,14 @@ public class ClientMapReadQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.getAsync("foo");
-        foo.get();
+        Future<Object> future = map1.getAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.getAsync("foo");
-        foo.get();
+        Future<Object> future = map4.getAsync("foo");
+        future.get();
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -53,11 +53,6 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
-    static IMap<Object, Object> map1;
-    static IMap<Object, Object> map2;
-    static IMap<Object, Object> map3;
-    static IMap<Object, Object> map4;
-    static IMap<Object, Object> map5;
 
     static HazelcastInstance c1;
     static HazelcastInstance c2;
@@ -66,6 +61,12 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
     static HazelcastInstance c5;
 
     private static TestHazelcastFactory factory;
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+    IMap<Object, Object> map3;
+    IMap<Object, Object> map4;
+    IMap<Object, Object> map5;
 
     @BeforeClass
     public static void initialize() throws Exception {
@@ -152,14 +153,14 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map1.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map4.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test
@@ -188,14 +189,14 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.getAsync("foo");
-        foo.get();
+        Future<Object> future = map1.getAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.getAsync("foo");
-        foo.get();
+        Future<Object> future = map4.getAsync("foo");
+        future.get();
     }
 
     @Test
@@ -244,14 +245,14 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map1.removeAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map4.removeAsync("foo");
+        future.get();
     }
 
     @Test
@@ -460,13 +461,13 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testSubmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future foo = map1.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map1.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testSubmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future foo = map4.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map4.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
@@ -51,13 +51,8 @@ public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME_PREFIX = "quorum";
     private static final String QUORUM_ID = "threeNodeQuorumRule";
-    static PartitionedCluster cluster;
 
-    static IMap<Object, Object> map1;
-    static IMap<Object, Object> map2;
-    static IMap<Object, Object> map3;
-    static IMap<Object, Object> map4;
-    static IMap<Object, Object> map5;
+    static PartitionedCluster cluster;
 
     static HazelcastInstance c1;
     static HazelcastInstance c2;
@@ -66,6 +61,12 @@ public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
     static HazelcastInstance c5;
 
     private static TestHazelcastFactory factory;
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+    IMap<Object, Object> map3;
+    IMap<Object, Object> map4;
+    IMap<Object, Object> map5;
 
     @BeforeClass
     public static void initialize() throws Exception {
@@ -152,14 +153,14 @@ public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map1.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map4.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test
@@ -198,14 +199,14 @@ public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map1.removeAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map4.removeAsync("foo");
+        future.get();
     }
 
     @Test
@@ -364,13 +365,13 @@ public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testSubmmtToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future foo = map1.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map1.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testSubmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future foo = map4.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map4.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -56,6 +56,7 @@ public class ClientTransactionalMapQuorumTest extends HazelcastTestSupport {
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
+
     static HazelcastInstance c1;
     static HazelcastInstance c2;
     static HazelcastInstance c3;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadQuorumTest.java
@@ -48,18 +48,14 @@ public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
-    static PartitionedCluster cluster;
+    private static PartitionedCluster cluster;
 
-    private static HazelcastClientCachingProvider cachingProvider1;
-    private static HazelcastClientCachingProvider cachingProvider2;
-    private static HazelcastClientCachingProvider cachingProvider3;
-    private static HazelcastClientCachingProvider cachingProvider4;
-    private static HazelcastClientCachingProvider cachingProvider5;
     private static HazelcastInstance c1;
     private static HazelcastInstance c2;
     private static HazelcastInstance c3;
     private static HazelcastInstance c4;
     private static HazelcastInstance c5;
+
     private static ICache<Integer, String> cache1;
     private static ICache<Integer, String> cache2;
     private static ICache<Integer, String> cache3;
@@ -69,7 +65,7 @@ public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
     private static TestHazelcastFactory factory;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
         quorumConfig.setType(QuorumType.READ);
@@ -96,18 +92,18 @@ public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
     }
 
     private static void initializeCaches() {
-        cachingProvider1 = HazelcastClientCachingProvider.createCachingProvider(c1);
-        cachingProvider2 = HazelcastClientCachingProvider.createCachingProvider(c2);
-        cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(c3);
-        cachingProvider4 = HazelcastClientCachingProvider.createCachingProvider(c4);
-        cachingProvider5 = HazelcastClientCachingProvider.createCachingProvider(c5);
+        HazelcastClientCachingProvider cachingProvider1 = HazelcastClientCachingProvider.createCachingProvider(c1);
+        HazelcastClientCachingProvider cachingProvider2 = HazelcastClientCachingProvider.createCachingProvider(c2);
+        HazelcastClientCachingProvider cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(c3);
+        HazelcastClientCachingProvider cachingProvider4 = HazelcastClientCachingProvider.createCachingProvider(c4);
+        HazelcastClientCachingProvider cachingProvider5 = HazelcastClientCachingProvider.createCachingProvider(c5);
 
         String cacheName = CACHE_NAME_PREFIX + randomString();
-        cache1 = (ICache) cachingProvider1.getCacheManager().getCache(cacheName);
-        cache2 = (ICache) cachingProvider2.getCacheManager().getCache(cacheName);
-        cache3 = (ICache) cachingProvider3.getCacheManager().getCache(cacheName);
-        cache4 = (ICache) cachingProvider4.getCacheManager().getCache(cacheName);
-        cache5 = (ICache) cachingProvider5.getCacheManager().getCache(cacheName);
+        cache1 = (ICache<Integer, String>) cachingProvider1.getCacheManager().<Integer, String>getCache(cacheName);
+        cache2 = (ICache<Integer, String>) cachingProvider2.getCacheManager().<Integer, String>getCache(cacheName);
+        cache3 = (ICache<Integer, String>) cachingProvider3.getCacheManager().<Integer, String>getCache(cacheName);
+        cache4 = (ICache<Integer, String>) cachingProvider4.getCacheManager().<Integer, String>getCache(cacheName);
+        cache5 = (ICache<Integer, String>) cachingProvider5.getCacheManager().<Integer, String>getCache(cacheName);
     }
 
     private static void verifyClients() {
@@ -166,13 +162,13 @@ public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAsync(1);
+        future.get();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadWriteQuorumTest.java
@@ -55,18 +55,14 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
-    static PartitionedCluster cluster;
+    private static PartitionedCluster cluster;
 
-    private static HazelcastClientCachingProvider cachingProvider1;
-    private static HazelcastClientCachingProvider cachingProvider2;
-    private static HazelcastClientCachingProvider cachingProvider3;
-    private static HazelcastClientCachingProvider cachingProvider4;
-    private static HazelcastClientCachingProvider cachingProvider5;
     private static HazelcastInstance c1;
     private static HazelcastInstance c2;
     private static HazelcastInstance c3;
     private static HazelcastInstance c4;
     private static HazelcastInstance c5;
+
     private static ICache<Integer, String> cache1;
     private static ICache<Integer, String> cache2;
     private static ICache<Integer, String> cache3;
@@ -76,7 +72,7 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
     private static TestHazelcastFactory factory;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
         quorumConfig.setType(QuorumType.READ_WRITE);
@@ -103,18 +99,18 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
     }
 
     private static void initializeCaches() {
-        cachingProvider1 = HazelcastClientCachingProvider.createCachingProvider(c1);
-        cachingProvider2 = HazelcastClientCachingProvider.createCachingProvider(c2);
-        cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(c3);
-        cachingProvider4 = HazelcastClientCachingProvider.createCachingProvider(c4);
-        cachingProvider5 = HazelcastClientCachingProvider.createCachingProvider(c5);
+        HazelcastClientCachingProvider cachingProvider1 = HazelcastClientCachingProvider.createCachingProvider(c1);
+        HazelcastClientCachingProvider cachingProvider2 = HazelcastClientCachingProvider.createCachingProvider(c2);
+        HazelcastClientCachingProvider cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(c3);
+        HazelcastClientCachingProvider cachingProvider4 = HazelcastClientCachingProvider.createCachingProvider(c4);
+        HazelcastClientCachingProvider cachingProvider5 = HazelcastClientCachingProvider.createCachingProvider(c5);
 
         String cacheName = CACHE_NAME_PREFIX + randomString();
-        cache1 = (ICache) cachingProvider1.getCacheManager().getCache(cacheName);
-        cache2 = (ICache) cachingProvider2.getCacheManager().getCache(cacheName);
-        cache3 = (ICache) cachingProvider3.getCacheManager().getCache(cacheName);
-        cache4 = (ICache) cachingProvider4.getCacheManager().getCache(cacheName);
-        cache5 = (ICache) cachingProvider5.getCacheManager().getCache(cacheName);
+        cache1 = (ICache<Integer, String>) cachingProvider1.getCacheManager().<Integer, String>getCache(cacheName);
+        cache2 = (ICache<Integer, String>) cachingProvider2.getCacheManager().<Integer, String>getCache(cacheName);
+        cache3 = (ICache<Integer, String>) cachingProvider3.getCacheManager().<Integer, String>getCache(cacheName);
+        cache4 = (ICache<Integer, String>) cachingProvider4.getCacheManager().<Integer, String>getCache(cacheName);
+        cache5 = (ICache<Integer, String>) cachingProvider5.getCacheManager().<Integer, String>getCache(cacheName);
     }
 
     private static void verifyClients() {
@@ -277,14 +273,14 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAsync(1);
+        future.get();
     }
 
     @Test
@@ -294,80 +290,80 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test(expected = ExecutionException.class)
     public void testGetAndPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndPutAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndPutAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testGetAndRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test
     public void testGetAndReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache1.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Void> foo = cache1.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache1.putAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Void> foo = cache4.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache4.putAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testPutIfAbsentAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutIfAbsentAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache1.removeAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache4.removeAsync(1);
+        future.get();
     }
 
     @Test
     public void testReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.replaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.replaceAsync(1, "");
+        future.get();
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheWriteQuorumTest.java
@@ -55,18 +55,14 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
-    static PartitionedCluster cluster;
+    private static PartitionedCluster cluster;
 
-    private static HazelcastClientCachingProvider cachingProvider1;
-    private static HazelcastClientCachingProvider cachingProvider2;
-    private static HazelcastClientCachingProvider cachingProvider3;
-    private static HazelcastClientCachingProvider cachingProvider4;
-    private static HazelcastClientCachingProvider cachingProvider5;
-    private static HazelcastInstance c1;
-    private static HazelcastInstance c2;
-    private static HazelcastInstance c3;
-    private static HazelcastInstance c4;
-    private static HazelcastInstance c5;
+    private static HazelcastInstance hz1;
+    private static HazelcastInstance hz2;
+    private static HazelcastInstance hz3;
+    private static HazelcastInstance hz4;
+    private static HazelcastInstance hz5;
+
     private static ICache<Integer, String> cache1;
     private static ICache<Integer, String> cache2;
     private static ICache<Integer, String> cache3;
@@ -76,7 +72,7 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
     private static TestHazelcastFactory factory;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
         quorumConfig.setType(QuorumType.WRITE);
@@ -95,31 +91,31 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
     }
 
     private static void initializeClients() {
-        c1 = factory.newHazelcastClient(getClientConfig(cluster.h1));
-        c2 = factory.newHazelcastClient(getClientConfig(cluster.h2));
-        c3 = factory.newHazelcastClient(getClientConfig(cluster.h3));
-        c4 = factory.newHazelcastClient(getClientConfig(cluster.h4));
-        c5 = factory.newHazelcastClient(getClientConfig(cluster.h5));
+        hz1 = factory.newHazelcastClient(getClientConfig(cluster.h1));
+        hz2 = factory.newHazelcastClient(getClientConfig(cluster.h2));
+        hz3 = factory.newHazelcastClient(getClientConfig(cluster.h3));
+        hz4 = factory.newHazelcastClient(getClientConfig(cluster.h4));
+        hz5 = factory.newHazelcastClient(getClientConfig(cluster.h5));
     }
 
     private static void initializeCaches() {
-        cachingProvider1 = HazelcastClientCachingProvider.createCachingProvider(c1);
-        cachingProvider2 = HazelcastClientCachingProvider.createCachingProvider(c2);
-        cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(c3);
-        cachingProvider4 = HazelcastClientCachingProvider.createCachingProvider(c4);
-        cachingProvider5 = HazelcastClientCachingProvider.createCachingProvider(c5);
+        HazelcastClientCachingProvider cachingProvider1 = HazelcastClientCachingProvider.createCachingProvider(hz1);
+        HazelcastClientCachingProvider cachingProvider2 = HazelcastClientCachingProvider.createCachingProvider(hz2);
+        HazelcastClientCachingProvider cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(hz3);
+        HazelcastClientCachingProvider cachingProvider4 = HazelcastClientCachingProvider.createCachingProvider(hz4);
+        HazelcastClientCachingProvider cachingProvider5 = HazelcastClientCachingProvider.createCachingProvider(hz5);
 
         final String cacheName = CACHE_NAME_PREFIX + randomString();
-        cache1 = (ICache) cachingProvider1.getCacheManager().getCache(cacheName);
-        cache2 = (ICache) cachingProvider2.getCacheManager().getCache(cacheName);
-        cache3 = (ICache) cachingProvider3.getCacheManager().getCache(cacheName);
-        cache4 = (ICache) cachingProvider4.getCacheManager().getCache(cacheName);
-        cache5 = (ICache) cachingProvider5.getCacheManager().getCache(cacheName);
+        cache1 = (ICache<Integer, String>) cachingProvider1.getCacheManager().<Integer, String>getCache(cacheName);
+        cache2 = (ICache<Integer, String>) cachingProvider2.getCacheManager().<Integer, String>getCache(cacheName);
+        cache3 = (ICache<Integer, String>) cachingProvider3.getCacheManager().<Integer, String>getCache(cacheName);
+        cache4 = (ICache<Integer, String>) cachingProvider4.getCacheManager().<Integer, String>getCache(cacheName);
+        cache5 = (ICache<Integer, String>) cachingProvider5.getCacheManager().<Integer, String>getCache(cacheName);
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1, c2, c3);
-        assertClusterSizeEventually(2, c4, c5);
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+        assertClusterSizeEventually(2, hz4, hz5);
     }
 
     @AfterClass
@@ -238,32 +234,32 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
 
     @Test(expected = ExecutionException.class)
     public void testGetAndPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndPutAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndPutAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testGetAndRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test
     public void testGetAndReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache1.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test
@@ -282,7 +278,6 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
         hashSet.add(123);
         EntryProcessorResult epr = cache1.invokeAll(hashSet, new SimpleEntryProcessor()).get(123);
         assertNull(epr);
-
     }
 
     @Test(expected = EntryProcessorException.class)
@@ -294,50 +289,50 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Void> foo = cache1.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache1.putAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Void> foo = cache4.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache4.putAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testPutIfAbsentAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutIfAbsentAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache1.removeAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache4.removeAsync(1);
+        future.get();
     }
 
     @Test
     public void testReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.replaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.replaceAsync(1, "");
+        future.get();
     }
 
     public static class SimpleEntryProcessor implements EntryProcessor<Integer, String, Void>, Serializable {
@@ -345,9 +340,7 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
         private static final long serialVersionUID = -396575576353368113L;
 
         @Override
-        public Void process(MutableEntry<Integer, String> entry, Object... arguments)
-                throws EntryProcessorException {
-
+        public Void process(MutableEntry<Integer, String> entry, Object... arguments) throws EntryProcessorException {
             entry.setValue("Foo");
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -32,17 +32,15 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
-
 import static com.hazelcast.test.HazelcastTestSupport.suspectMember;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class PartitionedCluster {
 
@@ -60,18 +58,17 @@ public class PartitionedCluster {
         this.factory = factory;
     }
 
-    public PartitionedCluster partitionFiveMembersThreeAndTwo(MapConfig mapConfig, QuorumConfig quorumConfig) throws Exception {
+    public PartitionedCluster partitionFiveMembersThreeAndTwo(MapConfig mapConfig, QuorumConfig quorumConfig) {
         createFiveMemberCluster(mapConfig, quorumConfig);
         return splitFiveMembersThreeAndTwo();
     }
 
-    public PartitionedCluster partitionFiveMembersThreeAndTwo(CacheSimpleConfig cacheSimpleConfig, QuorumConfig quorumConfig)
-            throws Exception {
+    public PartitionedCluster partitionFiveMembersThreeAndTwo(CacheSimpleConfig cacheSimpleConfig, QuorumConfig quorumConfig) {
         createFiveMemberCluster(cacheSimpleConfig, quorumConfig);
         return splitFiveMembersThreeAndTwo();
     }
 
-    public PartitionedCluster partitionFiveMembersThreeAndTwo(QueueConfig qConfig, QuorumConfig quorumConfig) throws Exception {
+    public PartitionedCluster partitionFiveMembersThreeAndTwo(QueueConfig qConfig, QuorumConfig quorumConfig) {
         createFiveMemberCluster(qConfig, quorumConfig);
         return splitFiveMembersThreeAndTwo();
     }
@@ -117,7 +114,7 @@ public class PartitionedCluster {
         return config;
     }
 
-    public PartitionedCluster splitFiveMembersThreeAndTwo() throws Exception {
+    public PartitionedCluster splitFiveMembersThreeAndTwo() {
         final CountDownLatch splitLatch = new CountDownLatch(6);
         h4.getCluster().addMembershipListener(new MembershipAdapter() {
             @Override
@@ -134,13 +131,12 @@ public class PartitionedCluster {
 
         splitCluster();
 
-        assertTrue(splitLatch.await(30, TimeUnit.SECONDS));
+        assertOpenEventually(splitLatch, 30);
         assertClusterSizeEventually(3, h1, h2, h3);
         assertClusterSizeEventually(2, h4, h5);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 assertFalse(h4.getQuorumService().getQuorum(SUCCESSFUL_SPLIT_TEST_QUORUM_NAME).isPresent());
                 assertFalse(h5.getQuorumService().getQuorum(SUCCESSFUL_SPLIT_TEST_QUORUM_NAME).isPresent());
             }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadQuorumTest.java
@@ -63,7 +63,7 @@ public class CacheReadQuorumTest {
     private ICache<Integer, String> cache5;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
         cacheConfig.setName(CACHE_NAME_PREFIX + "*");
         cacheConfig.setQuorumName(QUORUM_ID);
@@ -144,14 +144,14 @@ public class CacheReadQuorumTest {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAsync(1);
+        future.get();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadWriteQuorumTest.java
@@ -69,7 +69,7 @@ public class CacheReadWriteQuorumTest extends HazelcastTestSupport {
     private ICache<Integer, String> cache5;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
         cacheConfig.setName(CACHE_NAME_PREFIX + "*");
         cacheConfig.setQuorumName(QUORUM_ID);
@@ -254,14 +254,14 @@ public class CacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAsync(1);
+        future.get();
     }
 
     @Test
@@ -271,80 +271,80 @@ public class CacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     @Test(expected = ExecutionException.class)
     public void testGetAndPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndPutAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndPutAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testGetAndRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test
     public void testGetAndReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache1.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Void> foo = cache1.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache1.putAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Void> foo = cache4.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache4.putAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testPutIfAbsentAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutIfAbsentAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache1.removeAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache4.removeAsync(1);
+        future.get();
     }
 
     @Test
     public void testReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.replaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.replaceAsync(1, "");
+        future.get();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheWriteQuorumTest.java
@@ -61,6 +61,7 @@ public class CacheWriteQuorumTest {
     private static HazelcastServerCachingProvider cachingProvider3;
     private static HazelcastServerCachingProvider cachingProvider4;
     private static HazelcastServerCachingProvider cachingProvider5;
+
     private ICache<Integer, String> cache1;
     private ICache<Integer, String> cache2;
     private ICache<Integer, String> cache3;
@@ -68,7 +69,7 @@ public class CacheWriteQuorumTest {
     private ICache<Integer, String> cache5;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
         cacheConfig.setName(CACHE_NAME_PREFIX + "*");
         cacheConfig.setQuorumName(QUORUM_ID);
@@ -214,32 +215,32 @@ public class CacheWriteQuorumTest {
 
     @Test(expected = ExecutionException.class)
     public void testGetAndPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndPutAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndPutAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testGetAndRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache1.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndRemoveAsync(1);
-        foo.get();
+        Future<String> future = cache4.getAndRemoveAsync(1);
+        future.get();
     }
 
     @Test
     public void testGetAndReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<String> foo = cache1.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache1.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAndReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<String> foo = cache4.getAndReplaceAsync(1, "");
-        foo.get();
+        Future<String> future = cache4.getAndReplaceAsync(1, "");
+        future.get();
     }
 
     @Test
@@ -269,50 +270,50 @@ public class CacheWriteQuorumTest {
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Void> foo = cache1.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache1.putAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Void> foo = cache4.putAsync(1, "");
-        foo.get();
+        Future<Void> future = cache4.putAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testPutIfAbsentAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutIfAbsentAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.putIfAbsentAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.putIfAbsentAsync(1, "");
+        future.get();
     }
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache1.removeAsync(1);
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.removeAsync(1);
-        foo.get();
+        Future<Boolean> future = cache4.removeAsync(1);
+        future.get();
     }
 
     @Test
     public void testReplaceAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Boolean> foo = cache1.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache1.replaceAsync(1, "");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testReplaceAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Boolean> foo = cache4.replaceAsync(1, "");
-        foo.get();
+        Future<Boolean> future = cache4.replaceAsync(1, "");
+        future.get();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadQuorumTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 public class LockReadQuorumTest extends AbstractLockQuorumTest {
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ, 3);
         cluster.splitFiveMembersThreeAndTwo();
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadWriteQuorumTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 public class LockReadWriteQuorumTest extends AbstractLockQuorumTest {
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
         cluster.splitFiveMembersThreeAndTwo();
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockWriteQuorumTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 public class LockWriteQuorumTest extends AbstractLockQuorumTest {
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.WRITE, 3);
         cluster.splitFiveMembersThreeAndTwo();
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadQuorumTest.java
@@ -48,14 +48,15 @@ public class MapReadQuorumTest {
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
-    static IMap<Object, Object> map1;
-    static IMap<Object, Object> map2;
-    static IMap<Object, Object> map3;
-    static IMap<Object, Object> map4;
-    static IMap<Object, Object> map5;
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+    IMap<Object, Object> map3;
+    IMap<Object, Object> map4;
+    IMap<Object, Object> map5;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
         quorumConfig.setType(QuorumType.READ);
@@ -63,7 +64,8 @@ public class MapReadQuorumTest {
         quorumConfig.setSize(3);
         MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
         mapConfig.setQuorumName(QUORUM_ID);
-        cluster = new PartitionedCluster(new TestHazelcastInstanceFactory()).partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        cluster = new PartitionedCluster(new TestHazelcastInstanceFactory())
+                .partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
     }
 
     @Before
@@ -93,14 +95,14 @@ public class MapReadQuorumTest {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.getAsync("foo");
-        foo.get();
+        Future<Object> future = map1.getAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.getAsync("foo");
-        foo.get();
+        Future<Object> future = map4.getAsync("foo");
+        future.get();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
@@ -51,21 +51,23 @@ public class MapReadWriteQuorumTest {
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
-    static IMap<Object, Object> map1;
-    static IMap<Object, Object> map2;
-    static IMap<Object, Object> map3;
-    static IMap<Object, Object> map4;
-    static IMap<Object, Object> map5;
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+    IMap<Object, Object> map3;
+    IMap<Object, Object> map5;
+    IMap<Object, Object> map4;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
         quorumConfig.setEnabled(true);
         quorumConfig.setSize(3);
         MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
         mapConfig.setQuorumName(QUORUM_ID);
-        cluster = new PartitionedCluster(new TestHazelcastInstanceFactory()).partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        cluster = new PartitionedCluster(new TestHazelcastInstanceFactory())
+                .partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
     }
 
     @Before
@@ -125,14 +127,14 @@ public class MapReadWriteQuorumTest {
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map1.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map4.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test
@@ -161,14 +163,14 @@ public class MapReadWriteQuorumTest {
 
     @Test
     public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.getAsync("foo");
-        foo.get();
+        Future<Object> future = map1.getAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.getAsync("foo");
-        foo.get();
+        Future<Object> future = map4.getAsync("foo");
+        future.get();
     }
 
     @Test
@@ -217,14 +219,14 @@ public class MapReadWriteQuorumTest {
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map1.removeAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map4.removeAsync("foo");
+        future.get();
     }
 
     @Test
@@ -443,13 +445,13 @@ public class MapReadWriteQuorumTest {
 
     @Test
     public void testSubmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future foo = map1.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map1.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testSubmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future foo = map4.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map4.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapWriteQuorumTest.java
@@ -52,14 +52,15 @@ public class MapWriteQuorumTest {
     private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
-    static IMap<Object, Object> map1;
-    static IMap<Object, Object> map2;
-    static IMap<Object, Object> map3;
-    static IMap<Object, Object> map4;
-    static IMap<Object, Object> map5;
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+    IMap<Object, Object> map3;
+    IMap<Object, Object> map4;
+    IMap<Object, Object> map5;
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
         quorumConfig.setEnabled(true);
@@ -127,14 +128,14 @@ public class MapWriteQuorumTest {
 
     @Test
     public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map1.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.putAsync("foo", "bar");
-        foo.get();
+        Future<Object> future = map4.putAsync("foo", "bar");
+        future.get();
     }
 
     @Test
@@ -173,14 +174,14 @@ public class MapWriteQuorumTest {
 
     @Test
     public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future<Object> foo = map1.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map1.removeAsync("foo");
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future<Object> foo = map4.removeAsync("foo");
-        foo.get();
+        Future<Object> future = map4.removeAsync("foo");
+        future.get();
     }
 
     @Test
@@ -339,13 +340,13 @@ public class MapWriteQuorumTest {
 
     @Test
     public void testSubmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
-        Future foo = map1.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map1.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 
     @Test(expected = ExecutionException.class)
     public void testSubmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
-        Future foo = map4.submitToKey("foo", new TestLoggingEntryProcessor());
-        foo.get();
+        Future future = map4.submitToKey("foo", new TestLoggingEntryProcessor());
+        future.get();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadQuorumTest.java
@@ -57,7 +57,6 @@ public class TransactionalMapReadQuorumTest {
     @Parameterized.Parameter(0)
     public TransactionOptions options;
 
-
     @Parameterized.Parameters(name = "Executing: {0}")
     public static Collection<Object[]> parameters() {
 
@@ -74,7 +73,7 @@ public class TransactionalMapReadQuorumTest {
     }
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setEnabled(true);
         quorumConfig.setSize(3);

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
@@ -74,7 +74,7 @@ public class TransactionalMapReadWriteQuorumTest {
     }
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setEnabled(true);
         quorumConfig.setSize(3);

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapWriteQuorumTest.java
@@ -72,7 +72,7 @@ public class TransactionalMapWriteQuorumTest {
     }
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setEnabled(true);
         quorumConfig.setSize(3);

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadQuorumTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 public class QueueReadQuorumTest extends AbstractQueueQuorumTest {
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ, 3);
         addQueueData(q4);
         cluster.splitFiveMembersThreeAndTwo();

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadWriteQuorumTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 public class QueueReadWriteQuorumTest extends AbstractQueueQuorumTest {
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
         addQueueData(q4);
         cluster.splitFiveMembersThreeAndTwo();

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueWriteQuorumTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 public class QueueWriteQuorumTest extends AbstractQueueQuorumTest {
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.WRITE, 3);
         addQueueData(q4);
         cluster.splitFiveMembersThreeAndTwo();

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumTest.java
@@ -31,31 +31,34 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class TransactionalQueueQuorumTest extends AbstractQueueQuorumTest {
 
-    @Parameterized.Parameter(0)
+    @Parameter
     public TransactionOptions options;
 
-    @Parameterized.Parameters(name = "Executing: {0}")
+    @Parameters(name = "Executing: {0}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(
+        return asList(
                 new Object[]{TransactionOptions.getDefault().setTransactionType(ONE_PHASE)},
                 new Object[]{TransactionOptions.getDefault().setTransactionType(TWO_PHASE)}
         );
     }
 
     @BeforeClass
-    public static void initialize() throws Exception {
+    public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
         q4.add("foo");
         addQueueData(q4);


### PR DESCRIPTION
All map fields are used in instance methods, so FindBugs think its suspicious that they are static. Renamed `foo` to `future`. Got rid of a lot of `throws Exception`. Changed some fields to local variables and added missing generics.

It's actually not much of a change, but due to the massive code duplication in the quorum tests, it's a big PR :(