### PR TITLE
Fixed some FindBugs warnings in the client tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientListenersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientListenersTest.java
@@ -59,6 +59,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertTrue;
 
@@ -218,17 +219,16 @@ public class ClientListenersTest extends HazelcastTestSupport {
 
     @Test
     public void testLifecycleListener_registeredViaClassName() {
-        assertTrue(StaticListener.calledAtLeastOnce);
+        assertTrue(StaticListener.CALLED_AT_LEAST_ONCE.get());
     }
 
     public static class StaticListener implements LifecycleListener {
-        private static volatile boolean calledAtLeastOnce;
+
+        private static final AtomicBoolean CALLED_AT_LEAST_ONCE = new AtomicBoolean();
 
         @Override
         public void stateChanged(LifecycleEvent event) {
-            calledAtLeastOnce = true;
+            CALLED_AT_LEAST_ONCE.set(true);
         }
     }
-
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -120,7 +119,6 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         JoinConfig join = c.getNetworkConfig().getJoin();
         join.getTcpIpConfig().addMember("127.0.0.1").setEnabled(true);
         join.getMulticastConfig().setEnabled(false);
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(c);
         Member m1 = h1.getCluster().getLocalMember();
@@ -153,7 +151,6 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         }
 
         assertTrue(found);
-
     }
 
     @Test(timeout = 120000)

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -57,7 +57,7 @@ public class ClientRegressionWithRealNetworkTest extends HazelcastTestSupport {
         final Config config2 = new Config();
         config2.getGroupConfig().setName("bar");
         config2.getNetworkConfig().setPort(5702);
-        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config2);
+        Hazelcast.newHazelcastInstance(config2);
 
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.getGroupConfig().setName("bar");
@@ -84,7 +84,7 @@ public class ClientRegressionWithRealNetworkTest extends HazelcastTestSupport {
             public void run() {
                 ClientConfig config = new ClientConfig();
                 config.getNetworkConfig().setConnectionAttemptLimit(10);
-                HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
+                HazelcastClient.newHazelcastClient(config);
                 clientLatch.countDown();
             }
         });

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
-import com.hazelcast.core.IList;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -55,7 +54,7 @@ public class ClientTimeoutTest {
         clientConfig.getGroupConfig().setName("dev").setPassword("dev-pass");
         clientConfig.getNetworkConfig().addAddress("8.8.8.8:5701");
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-        IList<Object> list = client.getList("test");
+        client.getList("test");
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -23,7 +23,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.spi.properties.GroupProperty;
 import org.junit.Ignore;
 
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
@@ -37,12 +36,6 @@ public class SimpleMapTestFromClient {
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         GroupProperty.PHONE_HOME_ENABLED.setSystemProperty("false");
         GroupProperty.SOCKET_BIND_ANY.setSystemProperty("false");
-
-        Random rand = new Random();
-        int g1 = rand.nextInt(255);
-        int g2 = rand.nextInt(255);
-        int g3 = rand.nextInt(255);
-//        System.setProperty("hazelcast.multicast.group", "224." + g1 + "." + g2 + "." + g3);
     }
 
     public static int THREAD_COUNT = 40;
@@ -54,8 +47,8 @@ public class SimpleMapTestFromClient {
 
     public static void main(String[] args) {
         final ClientConfig clientConfig = new ClientConfig();
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance();
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
         final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         final Stats stats = new Stats();
         if (args != null && args.length > 0) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggerConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggerConfigurationTest.java
@@ -41,8 +41,7 @@ import static org.junit.Assert.assertSame;
 @Category({QuickTest.class})
 public class ClientLoggerConfigurationTest extends HazelcastTestSupport {
 
-    private static TestHazelcastFactory hazelcastFactory;
-    private static HazelcastInstance client;
+    private TestHazelcastFactory hazelcastFactory;
 
     @Rule
     public SaveLoggingPropertiesRule saveLoggingPropertiesRule = new SaveLoggingPropertiesRule();
@@ -78,14 +77,13 @@ public class ClientLoggerConfigurationTest extends HazelcastTestSupport {
         cg.setProperty("hazelcast.logging.type", "jdk");
         hazelcastFactory.newHazelcastInstance(cg);
 
-
         ClientConfig config = new ClientConfig();
         if (programmaticConfiguration) {
             config.setProperty("hazelcast.logging.type", "log4j2");
         } else {
             System.setProperty("hazelcast.logging.type", "log4j2");
         }
-        client = hazelcastFactory.newHazelcastClient(config);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
 
         ILogger clientLogger = client.getLoggingService().getLogger("loggerName");
         // this part is fragile.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class RingbufferTest extends HazelcastTestSupport {
 
-    public static int CAPACITY = 10;
+    public static final int CAPACITY = 10;
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     private HazelcastInstance client;


### PR DESCRIPTION
FindBugs finds a static volatile variable scary that is written from an instance method. An `AtomicBoolean` is easier to understand than trying to figure out how static and volatile work together.

The other changes are mostly dead local stores.