### PR TITLE
Speed up Near Cache tests by calling assumeThat() methods first

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.ICacheCacheLoader;
 import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
 import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
@@ -37,6 +38,7 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -96,6 +98,11 @@ public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Da
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected void assumeThatMethodIsAvailable(DataStructureAdapterMethod method) {
+        NearCacheTestUtils.assumeThatMethodIsAvailable(ICacheDataStructureAdapter.class, method);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
 import com.hazelcast.internal.adapter.IMapMapStore;
 import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
@@ -30,6 +31,7 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -80,6 +82,11 @@ public class ClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected void assumeThatMethodIsAvailable(DataStructureAdapterMethod method) {
+        NearCacheTestUtils.assumeThatMethodIsAvailable(IMapDataStructureAdapter.class, method);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -23,12 +23,14 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.ReplicatedMapDataStructureAdapter;
 import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -73,6 +75,11 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected void assumeThatMethodIsAvailable(DataStructureAdapterMethod method) {
+        NearCacheTestUtils.assumeThatMethodIsAvailable(ReplicatedMapDataStructureAdapter.class, method);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcher.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcher.java
@@ -27,9 +27,9 @@ import java.util.Arrays;
 import static java.lang.String.format;
 
 /**
- * Checks if the given {@link DataStructureAdapter} implements a specified method.
+ * Checks if the given {@link DataStructureAdapter} class implements a specified method.
  */
-public final class MethodAvailableMatcher extends TypeSafeMatcher<DataStructureAdapter> {
+public final class MethodAvailableMatcher extends TypeSafeMatcher<Class<? extends DataStructureAdapter>> {
 
     private static final ILogger LOGGER = Logger.getLogger(MethodAvailableMatcher.class);
 
@@ -44,14 +44,13 @@ public final class MethodAvailableMatcher extends TypeSafeMatcher<DataStructureA
     }
 
     /**
-     * Matches the given {@link DataStructureAdapter} with the specified method name and parameter types.
+     * Matches the given {@link DataStructureAdapter} class with the specified method name and parameter types.
      *
-     * @param dataStructureAdapter the {@link DataStructureAdapter} to test
+     * @param dataStructureAdapterClass the {@link DataStructureAdapter} class to test
      * @return {@code true} if the method is found and is not annotated with {@link MethodNotAvailable}
      */
     @Override
-    public boolean matchesSafely(DataStructureAdapter dataStructureAdapter) {
-        Class<? extends DataStructureAdapter> dataStructureAdapterClass = dataStructureAdapter.getClass();
+    public boolean matchesSafely(Class<? extends DataStructureAdapter> dataStructureAdapterClass) {
         try {
             Method method = dataStructureAdapterClass.getMethod(methodName, adapterMethod.getParameterTypes());
             boolean isAvailable = !method.isAnnotationPresent(MethodNotAvailable.class);
@@ -70,8 +69,9 @@ public final class MethodAvailableMatcher extends TypeSafeMatcher<DataStructureA
     }
 
     @Override
-    protected void describeMismatchSafely(DataStructureAdapter dataStructureAdapter, Description mismatchDescription) {
-        mismatchDescription.appendText(format("%s.%s(%s) is annotated with @%s", dataStructureAdapter.getClass().getSimpleName(),
+    protected void describeMismatchSafely(Class<? extends DataStructureAdapter> dataStructureAdapterClass,
+                                          Description mismatchDescription) {
+        mismatchDescription.appendText(format("%s.%s(%s) is annotated with @%s", dataStructureAdapterClass.getSimpleName(),
                 methodName, parameterTypeString, MethodNotAvailable.class.getSimpleName()));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcherTest.java
@@ -35,28 +35,28 @@ public class MethodAvailableMatcherTest {
     @Rule
     public ExpectedException expected = ExpectedException.none();
 
-    private DataStructureAdapter<Integer, String> adapter = new ReplicatedMapDataStructureAdapter<Integer, String>(null);
+    private Class<? extends DataStructureAdapter> adapterClass = ReplicatedMapDataStructureAdapter.class;
 
     @Test
     public void assertThat_withAvailableMethod() {
-        assertThat(adapter, new MethodAvailableMatcher(DataStructureMethods.CLEAR));
+        assertThat(adapterClass, new MethodAvailableMatcher(DataStructureMethods.CLEAR));
     }
 
     @Test
     public void assertThat_withAvailableMethod_withParameter() {
-        assertThat(adapter, new MethodAvailableMatcher(DataStructureMethods.GET));
+        assertThat(adapterClass, new MethodAvailableMatcher(DataStructureMethods.GET));
     }
 
     @Test
     public void assertThat_withAvailableMethod_withMultipleParameters() {
-        assertThat(adapter, new MethodAvailableMatcher(DataStructureMethods.PUT));
+        assertThat(adapterClass, new MethodAvailableMatcher(DataStructureMethods.PUT));
     }
 
     @Test
     public void assertThat_withAvailableMethod_withParameterMismatch() {
         expected.expect(AssertionError.class);
-        expected.expectMessage("Could not find method " + adapter.getClass().getSimpleName() + ".put(Integer, String)");
-        assertThat(adapter, new MethodAvailableMatcher(new DataStructureAdapterMethod() {
+        expected.expectMessage("Could not find method " + adapterClass.getSimpleName() + ".put(Integer, String)");
+        assertThat(adapterClass, new MethodAvailableMatcher(new DataStructureAdapterMethod() {
             @Override
             public String getMethodName() {
                 return "put";
@@ -78,14 +78,14 @@ public class MethodAvailableMatcherTest {
     public void assertThat_withUnavailableMethod_withParameter() {
         expected.expect(AssertionError.class);
         expected.expectMessage("removeAsync(Object) to be available");
-        assertThat(adapter, new MethodAvailableMatcher(DataStructureMethods.REMOVE_ASYNC));
+        assertThat(adapterClass, new MethodAvailableMatcher(DataStructureMethods.REMOVE_ASYNC));
     }
 
     @Test
     public void assertThat_withUnavailableMethod_withMultipleParameters() {
         expected.expect(AssertionError.class);
         expected.expectMessage("putIfAbsentAsync(Object, Object) to be available");
-        assertThat(adapter, new MethodAvailableMatcher(DataStructureMethods.PUT_IF_ABSENT_ASYNC));
+        assertThat(adapterClass, new MethodAvailableMatcher(DataStructureMethods.PUT_IF_ABSENT_ASYNC));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractNearCacheSerializationCountTest<NK, NV> extends Ha
         SerializationCountingData value = new SerializationCountingData();
 
         context.nearCacheAdapter.put(key, value);
-        if (isCacheOnUpdate(context)) {
+        if (isCacheOnUpdate(nearCacheConfig)) {
             assertNearCacheSizeEventually(context, 1);
         }
         assertAndReset("put()", getExpectedSerializationCounts()[0], getExpectedDeserializationCounts()[0]);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -146,11 +146,11 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
      * Checks if the {@link com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy} of a {@link NearCacheConfig}
      * is {@link com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy#CACHE_ON_UPDATE}.
      *
-     * @param context the {@link NearCacheTestContext} to retrieve the {@link NearCacheConfig} from
+     * @param nearCacheConfig the {@link NearCacheConfig} to check
      * @return {@code true} if the {@code LocalUpdatePolicy} is {@code CACHE_ON_UPDATE}, {@code false} otherwise
      */
-    static boolean isCacheOnUpdate(NearCacheTestContext<?, ?, ?, ?> context) {
-        return context.nearCacheConfig != null && context.nearCacheConfig.getLocalUpdatePolicy() == CACHE_ON_UPDATE;
+    static boolean isCacheOnUpdate(NearCacheConfig nearCacheConfig) {
+        return nearCacheConfig != null && nearCacheConfig.getLocalUpdatePolicy() == CACHE_ON_UPDATE;
     }
 
     /**
@@ -160,37 +160,38 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
      * @param method  {@link DataStructureAdapterMethod} to search for
      */
     public static boolean isMethodAvailable(DataStructureAdapter adapter, DataStructureAdapterMethod method) {
-        return new MethodAvailableMatcher(method).matchesSafely(adapter);
+        return new MethodAvailableMatcher(method).matchesSafely(adapter.getClass());
     }
 
     /**
      * Assumes that the given {@link NearCacheConfig} has
      * {@link com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy#INVALIDATE} configured.
      *
-     * @param context the {@link NearCacheTestContext} to retrieve the {@link NearCacheConfig} from
+     * @param nearCacheConfig the {@link NearCacheConfig} to check
      */
-    public static void assumeThatLocalUpdatePolicyIsInvalidate(NearCacheTestContext<?, ?, ?, ?> context) {
-        assumeFalse(isCacheOnUpdate(context));
+    public static void assumeThatLocalUpdatePolicyIsInvalidate(NearCacheConfig nearCacheConfig) {
+        assumeFalse(isCacheOnUpdate(nearCacheConfig));
     }
 
     /**
      * Assumes that the given {@link NearCacheConfig} has
      * {@link com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy#CACHE_ON_UPDATE} configured.
      *
-     * @param context the {@link NearCacheTestContext} to retrieve the {@link NearCacheConfig} from
+     * @param nearCacheConfig the {@link NearCacheConfig} to check
      */
-    public static void assumeThatLocalUpdatePolicyIsCacheOnUpdate(NearCacheTestContext<?, ?, ?, ?> context) {
-        assumeTrue(isCacheOnUpdate(context));
+    public static void assumeThatLocalUpdatePolicyIsCacheOnUpdate(NearCacheConfig nearCacheConfig) {
+        assumeTrue(isCacheOnUpdate(nearCacheConfig));
     }
 
     /**
      * Assumes that the given {@link DataStructureAdapter} implements a specified {@link DataStructureMethods}.
      *
-     * @param adapter the {@link DataStructureAdapter} to test
-     * @param method  {@link DataStructureAdapterMethod} to search for
+     * @param adapterClass the {@link DataStructureAdapter} class to test
+     * @param method       {@link DataStructureAdapterMethod} to search for
      */
-    public static void assumeThatMethodIsAvailable(DataStructureAdapter adapter, DataStructureAdapterMethod method) {
-        assumeThat(adapter, new MethodAvailableMatcher(method));
+    public static void assumeThatMethodIsAvailable(Class<? extends DataStructureAdapter> adapterClass,
+                                                   DataStructureAdapterMethod method) {
+        assumeThat(adapterClass, new MethodAvailableMatcher(method));
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
 import com.hazelcast.internal.adapter.IMapMapStore;
 import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
@@ -28,6 +29,7 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -79,6 +81,11 @@ public class LiteMemberMapNearCacheBasicTest extends AbstractNearCacheBasicTest<
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected void assumeThatMethodIsAvailable(DataStructureAdapterMethod method) {
+        NearCacheTestUtils.assumeThatMethodIsAvailable(IMapDataStructureAdapter.class, method);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
 import com.hazelcast.internal.adapter.IMapMapStore;
 import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
@@ -29,6 +30,7 @@ import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -82,6 +84,11 @@ public class MapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, Stri
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected void assumeThatMethodIsAvailable(DataStructureAdapterMethod method) {
+        NearCacheTestUtils.assumeThatMethodIsAvailable(IMapDataStructureAdapter.class, method);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -21,12 +21,14 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods;
+import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.TransactionalMapDataStructureAdapter;
 import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -49,7 +51,6 @@ import java.util.Collection;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSize;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats;
-import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assumeThatMethodIsAvailable;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
 import static java.util.Arrays.asList;
@@ -86,6 +87,11 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected void assumeThatMethodIsAvailable(DataStructureAdapterMethod method) {
+        NearCacheTestUtils.assumeThatMethodIsAvailable(TransactionalMapDataStructureAdapter.class, method);
     }
 
     @Override
@@ -127,8 +133,8 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
      */
     @Override
     protected void whenGetIsUsed_thenNearCacheShouldBePopulated(DataStructureMethods method) {
+        assumeThatMethodIsAvailable(method);
         NearCacheTestContext<Integer, String, Data, String> context = createContext();
-        assumeThatMethodIsAvailable(context.nearCacheAdapter, method);
 
         // populate the data structure
         populateDataAdapter(context);


### PR DESCRIPTION
The `assumeThatMethodIsAvailable()` method used the `NearCacheTestContext`
to retrieve a `DataStructureAdapter`. The test passed the actually used
`DataStructureAdapter` to the test (`dataAdapter` or `nearCacheAdapter`),
because in theory they could be different. In reality they are the same,
so we always had to create the `NearCacheContext` (which fires up HZ
instances). This slowed down a lot of tests and creates unnecessary
logging.

Since 310 of 784 Near Cache tests are skipped, this should improve the
total test duration significantly.

Local execution duration:
master: 3m 3s
branch: 2m 32s