### PR TITLE
Moved warmupPartitionsAndWaitForAllSafeState() to NearCacheTestContextBuilder

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+
 public final class TestUtil {
 
     static final private SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
@@ -64,23 +66,29 @@ public final class TestUtil {
         hz.getLifecycleService().terminate();
     }
 
-    public static void warmUpPartitions(HazelcastInstance... instances) throws InterruptedException {
+    public static void warmUpPartitions(HazelcastInstance... instances) {
         for (HazelcastInstance instance : instances) {
+            if (instance == null) {
+                continue;
+            }
             final PartitionService ps = instance.getPartitionService();
             for (Partition partition : ps.getPartitions()) {
                 while (partition.getOwner() == null) {
-                    Thread.sleep(10);
+                    sleepMillis(10);
                 }
             }
         }
     }
 
-    public static void warmUpPartitions(Collection<HazelcastInstance> instances) throws InterruptedException {
+    public static void warmUpPartitions(Collection<HazelcastInstance> instances) {
         for (HazelcastInstance instance : instances) {
+            if (instance == null) {
+                continue;
+            }
             final PartitionService ps = instance.getPartitionService();
             for (Partition partition : ps.getPartitions()) {
                 while (partition.getOwner() == null) {
-                    Thread.sleep(10);
+                    sleepMillis(10);
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -57,7 +57,6 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getFuture;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.isCacheOnUpdate;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.setEvictionConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.waitUntilLoaded;
-import static com.hazelcast.internal.nearcache.NearCacheTestUtils.warmupPartitionsAndWaitForAllSafeState;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -676,9 +675,8 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
         NearCacheTestContext<Integer, String, NK, NV> context = createContext(true);
         DataStructureAdapter<Integer, String> adapter = useDataAdapter ? context.dataAdapter : context.nearCacheAdapter;
 
-        // wait until the initial load is done and the cluster is in a safe state
+        // wait until the initial load is done
         waitUntilLoaded(context);
-        warmupPartitionsAndWaitForAllSafeState(context);
 
         populateDataAdapter(context);
         populateNearCache(context);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.isCacheOnUpdate;
-import static com.hazelcast.internal.nearcache.NearCacheTestUtils.warmupPartitionsAndWaitForAllSafeState;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
@@ -109,7 +108,6 @@ public abstract class AbstractNearCacheSerializationCountTest<NK, NV> extends Ha
     @Test
     public void testSerializationCounts() {
         NearCacheTestContext<String, SerializationCountingData, NK, NV> context = createContext();
-        warmupPartitionsAndWaitForAllSafeState(context);
 
         String key = randomString();
         SerializationCountingData value = new SerializationCountingData();

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.adapter.DataStructureLoader;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastTestSupport;
 
 import javax.cache.CacheManager;
 
@@ -31,7 +32,7 @@ import static org.junit.Assert.assertNotEquals;
 /**
  * Builder for {@link NearCacheTestContext}.
  */
-public class NearCacheTestContextBuilder<K, V, NK, NV> {
+public class NearCacheTestContextBuilder<K, V, NK, NV> extends HazelcastTestSupport {
 
     private NearCacheConfig nearCacheConfig;
     private SerializationService serializationService;
@@ -116,7 +117,7 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> {
         assertNotEquals("nearCacheInstance and dataInstance have to be different instances", nearCacheInstance, dataInstance);
         assertNotEquals("nearCacheAdapter and dataAdapter have to be different instances", nearCacheAdapter, dataAdapter);
 
-        return new NearCacheTestContext<K, V, NK, NV>(
+        NearCacheTestContext<K, V, NK, NV> context = new NearCacheTestContext<K, V, NK, NV>(
                 nearCacheConfig,
                 serializationService,
                 nearCacheInstance,
@@ -130,5 +131,10 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> {
                 hasLocalData,
                 loader,
                 invalidationListener);
+
+        warmUpPartitions(context.dataInstance, context.nearCacheInstance);
+        waitAllForSafeState(context.dataInstance, context.nearCacheInstance);
+
+        return context;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -208,18 +208,6 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
     }
 
     /**
-     * Calls {@link HazelcastTestSupport#warmUpPartitions(HazelcastInstance...)} and
-     * {@link HazelcastTestSupport#waitAllForSafeState(HazelcastInstance...)} on the instances of the given
-     * {@link NearCacheTestContext}.
-     *
-     * @param context the given {@link NearCacheTestContext} to retrieve the Hazelcast instances from
-     */
-    public static void warmupPartitionsAndWaitForAllSafeState(NearCacheTestContext<?, ?, ?, ?> context) {
-        warmUpPartitions(context.dataInstance, context.nearCacheInstance);
-        waitAllForSafeState(context.dataInstance, context.nearCacheInstance);
-    }
-
-    /**
      * Waits until the {@link com.hazelcast.internal.adapter.DataStructureLoader} is finished.
      *
      * @param context the given {@link NearCacheTestContext} to retrieve the {@link DataStructureAdapter} from

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -532,19 +532,11 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void warmUpPartitions(HazelcastInstance... instances) {
-        try {
-            TestUtil.warmUpPartitions(instances);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        TestUtil.warmUpPartitions(instances);
     }
 
     public static void warmUpPartitions(Collection<HazelcastInstance> instances) {
-        try {
-            TestUtil.warmUpPartitions(instances);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        TestUtil.warmUpPartitions(instances);
     }
 
     public static boolean isInstanceInSafeState(HazelcastInstance instance) {
@@ -634,6 +626,9 @@ public abstract class HazelcastTestSupport {
     public static void assertAllInSafeState(Collection<HazelcastInstance> nodes) {
         Map<Address, PartitionServiceState> nonSafeStates = new HashMap<Address, PartitionServiceState>();
         for (HazelcastInstance node : nodes) {
+            if (node == null) {
+                continue;
+            }
             final PartitionServiceState state = getPartitionServiceState(node);
             if (state != PartitionServiceState.SAFE) {
                 nonSafeStates.put(getAddress(node), state);


### PR DESCRIPTION
There is no significant change in the runtime (most tests anyway have a single member instance), but this might help to reduce some migrations during the Hazelcast member IMap and LiteMember test execution.