### PR TITLE
Cleanup of Map proxy classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -35,7 +35,6 @@ import com.hazelcast.map.impl.query.AggregationResult;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryResult;
-import com.hazelcast.map.impl.query.QueryResultUtils;
 import com.hazelcast.map.impl.query.Target;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
@@ -84,6 +83,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.map.impl.query.QueryResultUtils.transformToSet;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequests.newQueryCacheRequest;
 import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -106,85 +106,85 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     }
 
     @Override
-    public V get(Object k) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+    public V get(Object key) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        return toObject(getInternal(key));
+        Data keyData = toDataWithStrategy(key);
+        return toObject(getInternal(keyData));
     }
 
     @Override
-    public V put(K k, V v) {
-        return put(k, v, -1, TimeUnit.MILLISECONDS);
+    public V put(K key, V value) {
+        return put(key, value, -1, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public V put(K k, V v, long ttl, TimeUnit timeunit) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public V put(K key, V value, long ttl, TimeUnit timeunit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        Data result = putInternal(key, value, ttl, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        Data result = putInternal(keyData, valueData, ttl, timeunit);
         return toObject(result);
     }
 
     @Override
-    public boolean tryPut(K k, V v, long timeout, TimeUnit timeunit) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public boolean tryPut(K key, V value, long timeout, TimeUnit timeunit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        return tryPutInternal(key, value, timeout, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        return tryPutInternal(keyData, valueData, timeout, timeunit);
     }
 
     @Override
-    public V putIfAbsent(K k, V v) {
-        return putIfAbsent(k, v, -1, TimeUnit.MILLISECONDS);
+    public V putIfAbsent(K key, V value) {
+        return putIfAbsent(key, value, -1, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public V putIfAbsent(K k, V v, long ttl, TimeUnit timeunit) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public V putIfAbsent(K key, V value, long ttl, TimeUnit timeunit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        Data result = putIfAbsentInternal(key, value, ttl, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        Data result = putIfAbsentInternal(keyData, valueData, ttl, timeunit);
         return toObject(result);
     }
 
     @Override
-    public void putTransient(K k, V v, long ttl, TimeUnit timeunit) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public void putTransient(K key, V value, long ttl, TimeUnit timeunit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        putTransientInternal(key, value, ttl, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        putTransientInternal(keyData, valueData, ttl, timeunit);
     }
 
     @Override
-    public boolean replace(K k, V o, V v) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(o, NULL_VALUE_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public boolean replace(K key, V oldValue, V newValue) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(oldValue, NULL_VALUE_IS_NOT_ALLOWED);
+        checkNotNull(newValue, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data oldValue = toData(o);
-        Data value = toData(v);
-        return replaceInternal(key, oldValue, value);
+        Data keyData = toDataWithStrategy(key);
+        Data oldValueData = toData(oldValue);
+        Data newValueData = toData(newValue);
+        return replaceInternal(keyData, oldValueData, newValueData);
     }
 
     @Override
-    public V replace(K k, V v) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public V replace(K key, V value) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        return toObject(replaceInternal(key, value));
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        return toObject(replaceInternal(keyData, valueData));
     }
 
     @Override
@@ -193,32 +193,32 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     }
 
     @Override
-    public void set(K k, V v, long ttl, TimeUnit timeunit) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public void set(K key, V value, long ttl, TimeUnit timeunit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        setInternal(key, value, ttl, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        setInternal(keyData, valueData, ttl, timeunit);
     }
 
     @Override
-    public V remove(Object k) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+    public V remove(Object key) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data result = removeInternal(key);
+        Data keyData = toDataWithStrategy(key);
+        Data result = removeInternal(keyData);
         return toObject(result);
     }
 
     @Override
-    public boolean remove(Object k, Object v) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public boolean remove(Object key, Object value) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        Data value = toData(v);
-        return removeInternal(key, value);
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        return removeInternal(keyData, valueData);
     }
 
     @Override
@@ -229,36 +229,35 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     }
 
     @Override
-    public void delete(Object k) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+    public void delete(Object key) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        deleteInternal(key);
+        Data keyData = toDataWithStrategy(key);
+        deleteInternal(keyData);
     }
 
     @Override
-    public boolean containsKey(Object k) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+    public boolean containsKey(Object key) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        return containsKeyInternal(key);
+        Data keyData = toDataWithStrategy(key);
+        return containsKeyInternal(keyData);
     }
 
     @Override
-    public boolean containsValue(Object v) {
-        checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
+    public boolean containsValue(Object value) {
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data value = toData(v);
-        return containsValueInternal(value);
+        Data valueData = toData(value);
+        return containsValueInternal(valueData);
     }
 
     @Override
     public void lock(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        NodeEngine nodeEngine = getNodeEngine();
-        Data dataKey = toData(key, partitionStrategy);
-        lockSupport.lock(nodeEngine, dataKey);
+        Data keyData = toDataWithStrategy(key);
+        lockSupport.lock(getNodeEngine(), keyData);
     }
 
     @Override
@@ -266,43 +265,40 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkPositive(leaseTime, "leaseTime should be positive");
 
-        Data dataKey = toData(key, partitionStrategy);
-        lockSupport.lock(getNodeEngine(), dataKey, timeUnit.toMillis(leaseTime));
+        Data keyData = toDataWithStrategy(key);
+        lockSupport.lock(getNodeEngine(), keyData, timeUnit.toMillis(leaseTime));
     }
 
     @Override
     public void unlock(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        NodeEngine nodeEngine = getNodeEngine();
-        Data dataKey = toData(key, partitionStrategy);
-        lockSupport.unlock(nodeEngine, dataKey);
+        Data keyData = toDataWithStrategy(key);
+        lockSupport.unlock(getNodeEngine(), keyData);
     }
 
     @Override
     public boolean tryRemove(K key, long timeout, TimeUnit timeunit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        return tryRemoveInternal(dataKey, timeout, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        return tryRemoveInternal(keyData, timeout, timeunit);
     }
 
     @Override
-    public ICompletableFuture<V> getAsync(K k) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+    public ICompletableFuture<V> getAsync(K key) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        NodeEngine nodeEngine = getNodeEngine();
-        return new DelegatingFuture<V>(getAsyncInternal(key), nodeEngine.getSerializationService());
+        Data keyData = toDataWithStrategy(key);
+        return new DelegatingFuture<V>(getAsyncInternal(keyData), serializationService);
     }
 
     @Override
-    public boolean isLocked(K k) {
-        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+    public boolean isLocked(K key) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data key = toData(k, partitionStrategy);
-        NodeEngine nodeEngine = getNodeEngine();
-        return lockSupport.isLocked(nodeEngine, key);
+        Data keyData = toDataWithStrategy(key);
+        return lockSupport.isLocked(getNodeEngine(), keyData);
     }
 
     @Override
@@ -315,10 +311,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        Data dataValue = toData(value);
-        return new DelegatingFuture<V>(putAsyncInternal(dataKey, dataValue, ttl, timeunit),
-                getNodeEngine().getSerializationService());
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        return new DelegatingFuture<V>(putAsyncInternal(keyData, valueData, ttl, timeunit), serializationService);
     }
 
     @Override
@@ -331,18 +326,17 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        Data dataValue = toData(value);
-        return new DelegatingFuture<Void>(setAsyncInternal(dataKey, dataValue, ttl, timeunit),
-                getNodeEngine().getSerializationService());
+        Data keyData = toDataWithStrategy(key);
+        Data valueData = toData(value);
+        return new DelegatingFuture<Void>(setAsyncInternal(keyData, valueData, ttl, timeunit), serializationService);
     }
 
     @Override
     public ICompletableFuture<V> removeAsync(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        return new DelegatingFuture<V>(removeAsyncInternal(dataKey), getNodeEngine().getSerializationService());
+        Data keyData = toDataWithStrategy(key);
+        return new DelegatingFuture<V>(removeAsyncInternal(keyData), serializationService);
     }
 
     @Override
@@ -355,8 +349,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         for (K key : keys) {
             checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-            Data dataKey = toData(key, partitionStrategy);
-            requestedKeys.add(dataKey);
+            Data keyData = toDataWithStrategy(key);
+            requestedKeys.add(keyData);
         }
 
         List<Object> resultingKeyValuePairs = new ArrayList<Object>(2 * keys.size());
@@ -380,16 +374,16 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public boolean tryLock(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        return lockSupport.tryLock(getNodeEngine(), dataKey);
+        Data keyData = toDataWithStrategy(key);
+        return lockSupport.tryLock(getNodeEngine(), keyData);
     }
 
     @Override
     public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        return lockSupport.tryLock(getNodeEngine(), dataKey, time, timeunit);
+        Data keyData = toDataWithStrategy(key);
+        return lockSupport.tryLock(getNodeEngine(), keyData, time, timeunit);
     }
 
     @Override
@@ -397,16 +391,16 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
             throws InterruptedException {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        return lockSupport.tryLock(getNodeEngine(), dataKey, time, timeunit, leaseTime, leaseTimeUnit);
+        Data keyData = toDataWithStrategy(key);
+        return lockSupport.tryLock(getNodeEngine(), keyData, time, timeunit, leaseTime, leaseTimeUnit);
     }
 
     @Override
     public void forceUnlock(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data dataKey = toData(key, partitionStrategy);
-        lockSupport.forceUnlock(getNodeEngine(), dataKey);
+        Data keyData = toDataWithStrategy(key);
+        lockSupport.forceUnlock(getNodeEngine(), keyData);
     }
 
     @Override
@@ -452,22 +446,20 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     }
 
     @Override
-    public String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, K key,
-                                        boolean includeValue) {
+    public String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        Data keyData = toData(key, partitionStrategy);
+        Data keyData = toDataWithStrategy(key);
         return addLocalEntryListenerInternal(listener, predicate, keyData, includeValue);
     }
 
     @Override
-    public String addLocalEntryListener(EntryListener listener, Predicate<K, V> predicate, K key,
-                                        boolean includeValue) {
+    public String addLocalEntryListener(EntryListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        Data keyData = toData(key, partitionStrategy);
+        Data keyData = toDataWithStrategy(key);
         return addLocalEntryListenerInternal(listener, predicate, keyData, includeValue);
     }
 
@@ -593,14 +585,13 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkTrue(isMapStoreEnabled(), "First you should configure a map store");
         checkNotNull(keys, "Parameter keys should not be null.");
 
-        Iterable<Data> dataKeys = convertToData(keys);
-        loadInternal(dataKeys, replaceExistingValues);
+        loadInternal(convertToData(keys), replaceExistingValues);
     }
 
     /**
      * This method clears the map and calls deleteAll on MapStore which if connected to a database,
      * will delete the records from that database.
-     * <p/>
+     * <p>
      * If you wish to clear the map only without calling deleteAll, use #clearMapOnly.
      *
      * @see #clearMapOnly
@@ -662,7 +653,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         if (predicate instanceof PartitionPredicate) {
             PartitionPredicate partitionPredicate = (PartitionPredicate) predicate;
             Data key = toData(partitionPredicate.getPartitionKey());
-            int partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
+            int partitionId = partitionService.getPartitionId(key);
             Query query = Query.of()
                     .mapName(getName())
                     .predicate(partitionPredicate.getTarget())
@@ -677,7 +668,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
                     .build();
             result = queryEngine.execute(query, Target.ALL_NODES);
         }
-        return QueryResultUtils.transformToSet(serializationService, result, predicate, iterationType, uniqueResult);
+        return transformToSet(serializationService, result, predicate, iterationType, uniqueResult);
     }
 
     @Override
@@ -697,7 +688,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
                 .iterationType(IterationType.KEY)
                 .build();
         QueryResult result = queryEngine.execute(query, Target.LOCAL_NODE);
-        return QueryResultUtils.transformToSet(serializationService, result, predicate, IterationType.KEY, false);
+        return transformToSet(serializationService, result, predicate, IterationType.KEY, false);
     }
 
     @Override
@@ -727,7 +718,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public void submitToKey(K key, EntryProcessor entryProcessor, ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toData(key, partitionStrategy);
+        Data keyData = toDataWithStrategy(key);
         executeOnKeyInternal(keyData, entryProcessor, callback);
     }
 
@@ -735,10 +726,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public ICompletableFuture submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        MapService service = getService();
-        Data keyData = toData(key, partitionStrategy);
-        InternalCompletableFuture f = executeOnKeyInternal(keyData, entryProcessor, null);
-        return new DelegatingFuture(f, service.getMapServiceContext().getNodeEngine().getSerializationService());
+        Data keyData = toDataWithStrategy(key);
+        InternalCompletableFuture future = executeOnKeyInternal(keyData, entryProcessor, null);
+        return new DelegatingFuture(future, serializationService);
     }
 
     @Override
@@ -818,8 +808,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
                 .projection(projection)
                 .build();
         QueryResult result = queryEngine.execute(query, Target.ALL_NODES);
-        return QueryResultUtils.transformToSet(serializationService, result, TruePredicate.INSTANCE,
-                IterationType.VALUE, false);
+        return transformToSet(serializationService, result, TruePredicate.INSTANCE, IterationType.VALUE, false);
     }
 
     @Override
@@ -838,8 +827,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
                 .build();
         queryEngine.execute(query, Target.ALL_NODES);
         QueryResult result = queryEngine.execute(query, Target.ALL_NODES);
-        return QueryResultUtils.transformToSet(serializationService, result, predicate,
-                IterationType.VALUE, false);
+        return transformToSet(serializationService, result, predicate, IterationType.VALUE, false);
     }
 
     @Override
@@ -884,9 +872,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     }
 
     protected Object invoke(Operation operation, int partitionId) throws Throwable {
-        NodeEngine nodeEngine = getNodeEngine();
-        Future f = nodeEngine.getOperationService().invokeOnPartition(SERVICE_NAME, operation, partitionId);
-        Object response = f.get();
+        Future future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
+        Object response = future.get();
         Object returnObj = toObject(response);
         if (returnObj instanceof Throwable) {
             throw (Throwable) returnObj;
@@ -949,7 +936,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         QueryCacheContext queryCacheContext = request.getContext();
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
-        return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(),
-                request.getUserGivenCacheName(), constructorFunction);
+        return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getUserGivenCacheName(),
+                constructorFunction);
     }
 }


### PR DESCRIPTION
* added method `toDataWithStrategy()`
* made use of class fields instead of getter methods
* inlined some private methods to retrieve fields
* unified naming of key/value parameters and variables
* renamed single-letter variables
* used static imports
* moved some getter methods to the top of `MapProxySupport`
* moved class definitions to bottom of `MapProxySupport`