### PR TITLE
Prevented thread dump on assumeThat() mismatch

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -29,6 +29,7 @@ import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.utility.JavaModule;
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.runners.statements.RunAfters;
@@ -396,12 +397,15 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             try {
                 next.evaluate();
             } catch (Throwable e) {
-                System.err.println("THREAD DUMP FOR TEST FAILURE: \"" + e.getMessage() + "\" at \"" + method.getName() + "\"\n");
-                try {
-                    System.err.println(generateThreadDump());
-                } catch (Throwable t) {
-                    System.err.println("Unable to get thread dump!");
-                    e.printStackTrace();
+                if (!isJUnitAssumeException(e)) {
+                    System.err.println("THREAD DUMP FOR TEST FAILURE: \"" + e.getMessage()
+                            + "\" at \"" + method.getName() + "\"\n");
+                    try {
+                        System.err.println(generateThreadDump());
+                    } catch (Throwable t) {
+                        System.err.println("Unable to get thread dump!");
+                        e.printStackTrace();
+                    }
                 }
                 errors.add(e);
             } finally {
@@ -414,6 +418,10 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
                 }
             }
             MultipleFailureException.assertEmpty(errors);
+        }
+
+        private boolean isJUnitAssumeException(Throwable e) {
+            return e instanceof AssumptionViolatedException;
         }
     }
 


### PR DESCRIPTION
The motivation behind this PR is to prevent thread dumps when a test was skipped during runtime due to a assumeThat() mismatch. For example the unified Near Cache tests use this a lot to skip tests on methods, which are not available on all data structures:
```java
22:24:45,343  INFO |whenGetAsyncIsUsed_thenNearCacheShouldBePopulated[format:BINARY]| -
    [MethodAvailableMatcher] whenGetAsyncIsUsed_thenNearCacheShouldBePopulated -
    TransactionalMapDataStructureAdapter.getAsync(Object) is available: false
    ([@com.hazelcast.internal.adapter.MethodNotAvailable()])!
THREAD DUMP FOR TEST FAILURE: "got: <class com.hazelcast.internal.adapter.TransactionalMapDataStructureAdapter>,
    expected: getAsync(Object) to be available" at "whenGetAsyncIsUsed_thenNearCacheShouldBePopulated"

(...) huge thread dump
```
This leads to a thread dump, although this is no real failure. Throwing an `AssumptionViolatedException` is just the system used by JUnit to end a test on a `assumeThat()` mismatch.

With this change the size of the `com.hazelcast.map.impl.tx.TxnMapNearCacheBasicTest-output.txt` should shrink from about 19.7 MB to 952 KB.