### PR TITLE
KeyToData in MapProxySupport should use PartitionStrategy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1199,7 +1199,7 @@ abstract class MapProxySupport<K, V>
 
         @Override
         public Data apply(K key) {
-            return toData(key);
+            return toDataWithStrategy(key);
         }
     }
 }


### PR DESCRIPTION
All keys in a map proxy should be serialized with the `PartitionStrategy`.