### PR TITLE
Renamed IOBalancing getHandleCount to getLoad

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratableHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratableHandler.java
@@ -45,10 +45,10 @@ public interface MigratableHandler {
     NioThread getOwner();
 
     /**
-     * Get number of events recorded by the current handler. It can be used to calculate whether
+     * Get 'load' recorded by the current handler. It can be used to calculate whether
      * this handler should be migrated to a different {@link NioThread}
      *
-     * @return total number of events recorded by this handler
+     * @return total load recorded by this handler
      */
-    long getEventCount();
+    long getLoad();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
@@ -73,7 +73,7 @@ public final class NioChannelReader
     }
 
     @Override
-    public long getEventCount() {
+    public long getLoad() {
         switch (LOAD_TYPE) {
             case 0:
                 return handleCount.get();

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
@@ -96,7 +96,7 @@ public final class NioChannelWriter
     }
 
     @Override
-    public long getEventCount() {
+    public long getLoad() {
         switch (LOAD_TYPE) {
             case 0:
                 return handleCount.get();

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategy.java
@@ -81,7 +81,7 @@ class EventCountBasicMigrationStrategy implements MigrationStrategy {
         MigratableHandler candidate = null;
         long eventCountInSelectedHandler = 0;
         for (MigratableHandler handler : candidates) {
-            long eventCount = imbalance.getEventCount(handler);
+            long eventCount = imbalance.getLoad(handler);
             if (eventCount > eventCountInSelectedHandler) {
                 if (eventCount < migrationThreshold) {
                     eventCountInSelectedHandler = eventCount;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
@@ -41,12 +41,12 @@ class LoadImbalance {
     NioThread destinationSelector;
 
     private final Map<NioThread, Set<MigratableHandler>> selectorToHandlers;
-    private final ItemCounter<MigratableHandler> handlerEventsCounter;
+    private final ItemCounter<MigratableHandler> handlerLoadCounter;
 
     LoadImbalance(Map<NioThread, Set<MigratableHandler>> selectorToHandlers,
-                  ItemCounter<MigratableHandler> handlerEventsCounter) {
+                  ItemCounter<MigratableHandler> handlerLoadCounter) {
         this.selectorToHandlers = selectorToHandlers;
-        this.handlerEventsCounter = handlerEventsCounter;
+        this.handlerLoadCounter = handlerLoadCounter;
     }
 
     /**
@@ -61,7 +61,7 @@ class LoadImbalance {
      * @param handler
      * @return number of events recorded by the handler
      */
-    long getEventCount(MigratableHandler handler) {
-        return handlerEventsCounter.get(handler);
+    long getLoad(MigratableHandler handler) {
+        return handlerLoadCounter.get(handler);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -163,7 +163,7 @@ class LoadTracker {
     }
 
     private long getEventCountSinceLastCheck(MigratableHandler handler) {
-        long eventCount = handler.getEventCount();
+        long eventCount = handler.getLoad();
         Long lastEventCount = lastEventCounter.getAndSet(handler, eventCount);
         return eventCount - lastEventCount;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -110,7 +110,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
                 NioChannelReader socketReader = (NioChannelReader) connection.getChannelReader();
                 if (socketReader.getOwner() == in) {
-                    sb.append("\t" + socketReader + " eventCount:" + socketReader.getEventCount() + "\n");
+                    sb.append("\t" + socketReader + " eventCount:" + socketReader.getLoad() + "\n");
                 }
             }
         }
@@ -121,7 +121,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
                 NioChannelWriter socketWriter = (NioChannelWriter) connection.getChannelWriter();
                 if (socketWriter.getOwner() == in) {
-                    sb.append("\t" + socketWriter + " eventCount:" + socketWriter.getEventCount() + "\n");
+                    sb.append("\t" + socketWriter + " eventCount:" + socketWriter.getLoad() + "\n");
                 }
             }
         }
@@ -154,7 +154,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         MigratableHandler activeHandler = iterator.next();
         if (handlers.size() == 2) {
             MigratableHandler deadHandler = iterator.next();
-            if (activeHandler.getEventCount() < deadHandler.getEventCount()) {
+            if (activeHandler.getLoad() < deadHandler.getLoad()) {
                 MigratableHandler tmp = deadHandler;
                 deadHandler = activeHandler;
                 activeHandler = tmp;
@@ -163,11 +163,11 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             // the maximum number of events seen on the dead connection is 3. 10 should be save to assume the
             // connection is dead.
             assertTrue("at most 10 event should have been received, number of events received:"
-                    + deadHandler.getEventCount(), deadHandler.getEventCount() < 10);
+                    + deadHandler.getLoad(), deadHandler.getLoad() < 10);
         }
 
-        assertTrue("activeHandlerEvent count should be at least 1000, but was:" + activeHandler.getEventCount(),
-                activeHandler.getEventCount() > 1000);
+        assertTrue("activeHandlerEvent count should be at least 1000, but was:" + activeHandler.getLoad(),
+                activeHandler.getLoad() > 1000);
     }
 
     private void add(Map<NioThread, Set<MigratableHandler>> handlersPerSelector, MigratableHandler handler) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
@@ -56,14 +56,14 @@ public class LoadTrackerTest {
     @Test
     public void testUpdateImbalance() throws Exception {
         MigratableHandler selector1Handler1 = mock(MigratableHandler.class);
-        when(selector1Handler1.getEventCount()).thenReturn(0L)
+        when(selector1Handler1.getLoad()).thenReturn(0L)
                 .thenReturn(100L);
         when(selector1Handler1.getOwner())
                 .thenReturn(selector1);
         loadTracker.addHandler(selector1Handler1);
 
         MigratableHandler selector2Handler1 = mock(MigratableHandler.class);
-        when(selector2Handler1.getEventCount())
+        when(selector2Handler1.getLoad())
                 .thenReturn(0L)
                 .thenReturn(200L);
         when(selector2Handler1.getOwner())
@@ -71,7 +71,7 @@ public class LoadTrackerTest {
         loadTracker.addHandler(selector2Handler1);
 
         MigratableHandler selector2Handler3 = mock(MigratableHandler.class);
-        when(selector2Handler3.getEventCount())
+        when(selector2Handler3.getLoad())
                 .thenReturn(0L)
                 .thenReturn(100L);
         when(selector2Handler3.getOwner())
@@ -94,17 +94,17 @@ public class LoadTrackerTest {
     public void testUpdateImbalance_notUsingSingleHandlerSelectorAsSource() throws Exception {
         MigratableHandler selector1Handler1 = mock(MigratableHandler.class);
         // the first selector has a handler with a large number of events
-        when(selector1Handler1.getEventCount()).thenReturn(10000L);
+        when(selector1Handler1.getLoad()).thenReturn(10000L);
         when(selector1Handler1.getOwner()).thenReturn(selector1);
         loadTracker.addHandler(selector1Handler1);
 
         MigratableHandler selector2Handler = mock(MigratableHandler.class);
-        when(selector2Handler.getEventCount()).thenReturn(200L);
+        when(selector2Handler.getLoad()).thenReturn(200L);
         when(selector2Handler.getOwner()).thenReturn(selector2);
         loadTracker.addHandler(selector2Handler);
 
         MigratableHandler selector2Handler2 = mock(MigratableHandler.class);
-        when(selector2Handler2.getEventCount()).thenReturn(200L);
+        when(selector2Handler2.getLoad()).thenReturn(200L);
         when(selector2Handler2.getOwner()).thenReturn(selector2);
         loadTracker.addHandler(selector2Handler2);
 


### PR DESCRIPTION
The mechanism is now relying on a general load concept and the strategy
to determine load is configurable. So it is best to rename the method
'getHandleCount' (the original load policy) to something that better
fits the higher level concept of 'load'.