### PR TITLE
Fixed key serialization in StaleReadDetectorImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
@@ -18,8 +18,7 @@ package com.hazelcast.internal.nearcache;
 
 import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.Expirable;
-
-import java.util.UUID;
+import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataContainer;
 
 /**
  * An expirable and evictable data object which represents a Near Cache entry.
@@ -88,27 +87,6 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
     boolean isIdleAt(long maxIdleMilliSeconds, long now);
 
     /**
-     * @return last known invalidation sequence at time of this records' creation
-     */
-    long getInvalidationSequence();
-
-    /**
-     * @param sequence last known invalidation sequence at time of this records' creation
-     */
-    void setInvalidationSequence(long sequence);
-
-    /**
-     * @param uuid last known uuid of invalidation source at time of this records' creation
-     */
-    void setUuid(UUID uuid);
-
-    /**
-     * @return {@code true} if supplied uuid equals existing one, otherwise and when one of supplied
-     * or existing is null returns {@code false}
-     */
-    boolean hasSameUuid(UUID uuid);
-
-    /**
      * @return current state of this record.
      */
     long getRecordState();
@@ -120,4 +98,21 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
      * the actual value was not equal to the expected value.
      */
     boolean casRecordState(long expect, long update);
+
+    /**
+     * Sets the invalidation metadata.
+     *
+     * @param metaDataContainer the invalidation metadata for this container
+     */
+    void setMetaDataContainer(MetaDataContainer metaDataContainer);
+
+    /**
+     * @return last known invalidation sequence at time of this records' creation
+     */
+    long getInvalidationSequence();
+
+    /**
+     * @return {@code true} if reading with the invalidation metadata is stale, {@code false} otherwise
+     */
+    boolean isStaleRead();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetector.java
@@ -35,7 +35,7 @@ public interface StaleReadDetector {
      */
     StaleReadDetector ALWAYS_FRESH = new StaleReadDetector() {
         @Override
-        public boolean isStaleRead(Object key, NearCacheRecord record) {
+        public boolean isStaleRead(NearCacheRecord record) {
             return false;
         }
 
@@ -46,12 +46,11 @@ public interface StaleReadDetector {
     };
 
     /**
-     * @param key    the key
      * @param record the Near Cache record
      * @return {@code true} if reading with the supplied invalidation metadata is stale,
      * otherwise returns {@code false}
      */
-    boolean isStaleRead(Object key, NearCacheRecord record);
+    boolean isStaleRead(NearCacheRecord record);
 
     /**
      * @param key supplied key to get value

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetectorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetectorImpl.java
@@ -27,20 +27,14 @@ public class StaleReadDetectorImpl implements StaleReadDetector {
     private final RepairingHandler repairingHandler;
     private final MinimalPartitionService partitionService;
 
-    public StaleReadDetectorImpl(RepairingHandler repairingHandler, MinimalPartitionService partitionService) {
+    StaleReadDetectorImpl(RepairingHandler repairingHandler, MinimalPartitionService partitionService) {
         this.repairingHandler = repairingHandler;
         this.partitionService = partitionService;
     }
 
     @Override
-    public boolean isStaleRead(Object key, NearCacheRecord record) {
-        MetaDataContainer latestMetaData = repairingHandler.getMetaDataContainer(getPartition(key));
-
-        if (!record.hasSameUuid(latestMetaData.getUuid())) {
-            return true;
-        }
-
-        return record.getInvalidationSequence() < latestMetaData.getStaleSequence();
+    public boolean isStaleRead(NearCacheRecord record) {
+        return record.isStaleRead();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -275,7 +275,7 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
                     return null;
                 }
 
-                if (staleReadDetector.isStaleRead(key, record)) {
+                if (staleReadDetector.isStaleRead(record)) {
                     remove(key);
                     return null;
                 }
@@ -437,8 +437,7 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
         record.setCreationTime(Clock.currentTimeMillis());
         MetaDataContainer metaDataContainer = staleReadDetector.getMetaDataContainer(key);
         if (metaDataContainer != null) {
-            record.setUuid(metaDataContainer.getUuid());
-            record.setInvalidationSequence(metaDataContainer.getSequence());
+            record.setMetaDataContainer(metaDataContainer);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
@@ -68,6 +68,8 @@ public class NearCacheDataRecordStore<K, V> extends BaseHeapNearCacheRecordStore
         return REFERENCE_SIZE
                 // reference to "value" field
                 + REFERENCE_SIZE
+                // reference MetaDataContainer
+                + REFERENCE_SIZE
                 // "uuid" ref size + 2 long in uuid
                 + REFERENCE_SIZE + (2 * (Long.SIZE / Byte.SIZE))
                 // heap cost of this value data


### PR DESCRIPTION
`StaleReadDetector.isStaleRead()` is in the fast path of the Near Cache.
The single serialization to get the partition ID is already crushing our
performance. So we cache the `MetaDataContainer` in the `NearCacheRecord` to
have fast access to the actual `UUID` and `invalidationSequence` to perform
the stale read check.

This PR is needed to show the effect of Near Cache keys stored by-reference. If we don't merge that feature this PR will show not much effect and just increase the memory footage.

This implementation moves a lot of the stale read logic to the `AbstractNearCacheRecord` itself. This will cleanup up the `NearCacheRecord` interface a bit, but you can argue that this logic belongs to the `StaleReadDectorImpl`. The memory costs for the speedup is a reference to the `MetaDataContainer` per `NearCacheRecord` (so 4 or 8 bytes, depending on the JVM settings).

An alternative implementation is https://github.com/hazelcast/hazelcast/pull/10592
Based on the work of @ahmetmircik in https://github.com/hazelcast/hazelcast/pull/10140