### PR TITLE
Fixed key serialization in StaleReadDetectorImpl

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataContainer;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.internal.nearcache.impl.invalidation.StaleReadDetector;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -205,7 +206,8 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
                 MetaDataGenerator metaDataGenerator = getMetaDataGenerator();
                 long memberSequence = metaDataGenerator.currentSequence("/hz/" + DEFAULT_CACHE_NAME, partitionId);
 
-                MetaDataContainer metaDataContainer = nearCacheRecordStore.getStaleReadDetector().getMetaDataContainer(keyData);
+                StaleReadDetector staleReadDetector = nearCacheRecordStore.getStaleReadDetector();
+                MetaDataContainer metaDataContainer = staleReadDetector.getMetaDataContainer(partitionId);
                 return String.format("partition=%d, onRecordSequence=%d, latestSequence=%d, staleSequence=%d, memberSequence=%d",
                         partitionService.getPartitionId(keyData), recordSequence, metaDataContainer.getSequence(),
                         metaDataContainer.getStaleSequence(), memberSequence);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
@@ -88,27 +88,6 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
     boolean isIdleAt(long maxIdleMilliSeconds, long now);
 
     /**
-     * @return last known invalidation sequence at time of this records' creation
-     */
-    long getInvalidationSequence();
-
-    /**
-     * @param sequence last known invalidation sequence at time of this records' creation
-     */
-    void setInvalidationSequence(long sequence);
-
-    /**
-     * @param uuid last known uuid of invalidation source at time of this records' creation
-     */
-    void setUuid(UUID uuid);
-
-    /**
-     * @return {@code true} if supplied uuid equals existing one, otherwise and when one of supplied
-     * or existing is null returns {@code false}
-     */
-    boolean hasSameUuid(UUID uuid);
-
-    /**
      * @return current state of this record.
      */
     long getRecordState();
@@ -120,4 +99,35 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
      * the actual value was not equal to the expected value.
      */
     boolean casRecordState(long expect, long update);
+
+    /**
+     * @return the partition ID of this record
+     */
+    int getPartitionId();
+
+    /**
+     * @param partitionId the partition ID of this record
+     */
+    void setPartitionId(int partitionId);
+
+    /**
+     * @return last known invalidation sequence at time of this records' creation
+     */
+    long getInvalidationSequence();
+
+    /**
+     * @param sequence last known invalidation sequence at time of this records' creation
+     */
+    void setInvalidationSequence(long sequence);
+
+    /**
+     * @param uuid last known UUID of invalidation source at time of this records' creation
+     */
+    void setUuid(UUID uuid);
+
+    /**
+     * @return {@code true} if supplied uuid equals existing one, otherwise and when one of supplied
+     * or existing is null returns {@code false}
+     */
+    boolean hasSameUuid(UUID uuid);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetector.java
@@ -40,7 +40,12 @@ public interface StaleReadDetector {
         }
 
         @Override
-        public MetaDataContainer getMetaDataContainer(Object key) {
+        public int getPartitionId(Object key) {
+            return 0;
+        }
+
+        @Override
+        public MetaDataContainer getMetaDataContainer(int partitionId) {
             return null;
         }
     };
@@ -53,9 +58,11 @@ public interface StaleReadDetector {
      */
     boolean isStaleRead(Object key, NearCacheRecord record);
 
+    int getPartitionId(Object key);
+
     /**
-     * @param key supplied key to get value
+     * @param partitionId supplied partition ID to get value
      * @return {@link MetaDataContainer} for this key
      */
-    MetaDataContainer getMetaDataContainer(Object key);
+    MetaDataContainer getMetaDataContainer(int partitionId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/AbstractNearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/AbstractNearCacheRecord.java
@@ -42,8 +42,10 @@ public abstract class AbstractNearCacheRecord<V> implements NearCacheRecord<V> {
             AtomicLongFieldUpdater.newUpdater(AbstractNearCacheRecord.class, "recordState");
 
     protected long creationTime = TIME_NOT_SET;
-    protected long sequence;
-    protected UUID uuid;
+
+    protected volatile int partitionId;
+    protected volatile long sequence;
+    protected volatile UUID uuid;
 
     protected volatile V value;
     protected volatile long expirationTime = TIME_NOT_SET;
@@ -123,29 +125,6 @@ public abstract class AbstractNearCacheRecord<V> implements NearCacheRecord<V> {
     }
 
     @Override
-    public long getInvalidationSequence() {
-        return sequence;
-    }
-
-    @Override
-    public void setInvalidationSequence(long sequence) {
-        this.sequence = sequence;
-    }
-
-    @Override
-    public boolean hasSameUuid(UUID thatUuid) {
-        if (uuid == null || thatUuid == null) {
-            return false;
-        }
-        return uuid.equals(thatUuid);
-    }
-
-    @Override
-    public void setUuid(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    @Override
     public boolean isIdleAt(long maxIdleMilliSeconds, long now) {
         if (maxIdleMilliSeconds > 0) {
             if (accessTime > TIME_NOT_SET) {
@@ -166,6 +145,36 @@ public abstract class AbstractNearCacheRecord<V> implements NearCacheRecord<V> {
     @Override
     public boolean casRecordState(long expect, long update) {
         return RECORD_STATE.compareAndSet(this, expect, update);
+    }
+
+    @Override
+    public int getPartitionId() {
+        return partitionId;
+    }
+
+    @Override
+    public void setPartitionId(int partitionId) {
+        this.partitionId = partitionId;
+    }
+
+    @Override
+    public long getInvalidationSequence() {
+        return sequence;
+    }
+
+    @Override
+    public void setInvalidationSequence(long sequence) {
+        this.sequence = sequence;
+    }
+
+    @Override
+    public void setUuid(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public boolean hasSameUuid(UUID thatUuid) {
+        return uuid != null && thatUuid != null && uuid.equals(thatUuid);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -435,10 +435,12 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
 
     private void onRecordCreate(K key, R record) {
         record.setCreationTime(Clock.currentTimeMillis());
-        MetaDataContainer metaDataContainer = staleReadDetector.getMetaDataContainer(key);
+        int partitionId = staleReadDetector.getPartitionId(key);
+        MetaDataContainer metaDataContainer = staleReadDetector.getMetaDataContainer(partitionId);
         if (metaDataContainer != null) {
-            record.setUuid(metaDataContainer.getUuid());
+            record.setPartitionId(partitionId);
             record.setInvalidationSequence(metaDataContainer.getSequence());
+            record.setUuid(metaDataContainer.getUuid());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
@@ -68,6 +68,8 @@ public class NearCacheDataRecordStore<K, V> extends BaseHeapNearCacheRecordStore
         return REFERENCE_SIZE
                 // reference to "value" field
                 + REFERENCE_SIZE
+                // partition Id
+                + (Integer.SIZE / Byte.SIZE)
                 // "uuid" ref size + 2 long in uuid
                 + REFERENCE_SIZE + (2 * (Long.SIZE / Byte.SIZE))
                 // heap cost of this value data


### PR DESCRIPTION
`StaleReadDetector.isStaleRead()` is in the fast path of the Near Cache.
The single serialization to get the partition ID is already crushing our
performance. So we cache the `MetaDataContainer` in the `NearCacheRecord` to
have fast access to the actual `UUID` and `invalidationSequence` to perform
the stale read check.

This PR is needed to show the effect of Near Cache keys stored by-reference. If we don't merge that feature this PR will show not much effect and just increase the memory footage.

The memory costs for the speedup is an integer for the partition ID for a fast `MetaDataContainer` lookup per `AbstractNearCacheRecord` (so 4 bytes).

Based on the work of @ahmetmircik in https://github.com/hazelcast/hazelcast/pull/10140