### PR TITLE
Added keys to Near Cache serialization count tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -58,34 +58,50 @@ import static java.util.Arrays.asList;
 public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheSerializationCountTest<Data, String> {
 
     @Parameter
-    public int[] expectedSerializationCounts;
+    public int[] keySerializationCounts;
 
     @Parameter(value = 1)
-    public int[] expectedDeserializationCounts;
+    public int[] keyDeserializationCounts;
 
     @Parameter(value = 2)
-    public InMemoryFormat mapInMemoryFormat;
+    public int[] valueSerializationCounts;
 
     @Parameter(value = 3)
+    public int[] valueDeserializationCounts;
+
+    @Parameter(value = 4)
+    public InMemoryFormat mapInMemoryFormat;
+
+    @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Parameters(name = "mapFormat:{2} nearCacheFormat:{3}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT,},
 
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY,},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT,},
         });
     }
 
     @Before
     public void setUp() {
+        expectedKeySerializationCounts = keySerializationCounts;
+        expectedKeyDeserializationCounts = keyDeserializationCounts;
+        expectedValueSerializationCounts = valueSerializationCounts;
+        expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
             nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat);
         }
@@ -94,16 +110,6 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
     @After
     public void tearDown() {
         hazelcastFactory.shutdownAll();
-    }
-
-    @Override
-    protected int[] getExpectedSerializationCounts() {
-        return expectedSerializationCounts;
-    }
-
-    @Override
-    protected int[] getExpectedDeserializationCounts() {
-        return expectedDeserializationCounts;
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -57,34 +57,44 @@ import static java.util.Arrays.asList;
 public class ClientReplicatedMapNearCacheSerializationCountTest extends AbstractNearCacheSerializationCountTest<Data, String> {
 
     @Parameter
-    public int[] expectedSerializationCounts;
+    public int[] keySerializationCounts;
 
     @Parameter(value = 1)
-    public int[] expectedDeserializationCounts;
+    public int[] keyDeserializationCounts;
 
     @Parameter(value = 2)
-    public InMemoryFormat replicatedMapInMemoryFormat;
+    public int[] valueSerializationCounts;
 
     @Parameter(value = 3)
+    public int[] valueDeserializationCounts;
+
+    @Parameter(value = 4)
+    public InMemoryFormat replicatedMapInMemoryFormat;
+
+    @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Parameters(name = "replicatedMapFormat:{2} nearCacheFormat:{3}")
+    @Parameters(name = "replicatedMapFormat:{4} nearCacheFormat:{5}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
-                {new int[]{1, 1, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT,},
+                {new int[]{1, 1, 1}, new int[]{0, 0, 0}, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
+                {new int[]{1, 1, 0}, new int[]{0, 0, 0}, new int[]{1, 1, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
+                {new int[]{1, 1, 0}, new int[]{0, 0, 0}, new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT,},
 
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
-                {new int[]{1, 2, 0}, new int[]{1, 1, 1}, OBJECT, BINARY,},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT,},
+                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, new int[]{1, 0, 0}, new int[]{1, 0, 0}, OBJECT, null,},
+                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, new int[]{1, 0, 0}, new int[]{1, 0, 0}, OBJECT, BINARY,},
+                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, new int[]{1, 0, 0}, new int[]{1, 0, 0}, OBJECT, OBJECT,},
         });
     }
 
     @Before
     public void setUp() {
+        expectedKeySerializationCounts = keySerializationCounts;
+        expectedKeyDeserializationCounts = keyDeserializationCounts;
+        expectedValueSerializationCounts = valueSerializationCounts;
+        expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
             nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat);
         }
@@ -93,16 +103,6 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
     @After
     public void tearDown() {
         hazelcastFactory.shutdownAll();
-    }
-
-    @Override
-    protected int[] getExpectedSerializationCounts() {
-        return expectedSerializationCounts;
-    }
-
-    @Override
-    protected int[] getExpectedDeserializationCounts() {
-        return expectedDeserializationCounts;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
@@ -53,39 +54,49 @@ import static java.util.Arrays.asList;
  * Near Cache serialization count tests for {@link IMap} on Hazelcast Lite members.
  */
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCacheSerializationCountTest<Data, String> {
 
     @Parameter
-    public int[] expectedSerializationCounts;
+    public int[] keySerializationCounts;
 
     @Parameter(value = 1)
-    public int[] expectedDeserializationCounts;
+    public int[] keyDeserializationCounts;
 
     @Parameter(value = 2)
-    public InMemoryFormat mapInMemoryFormat;
+    public int[] valueSerializationCounts;
 
     @Parameter(value = 3)
+    public int[] valueDeserializationCounts;
+
+    @Parameter(value = 4)
+    public InMemoryFormat mapInMemoryFormat;
+
+    @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "mapFormat:{2} nearCacheFormat:{3}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT},
 
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT},
         });
     }
 
     @Before
     public void setUp() {
+        expectedKeySerializationCounts = keySerializationCounts;
+        expectedKeyDeserializationCounts = keyDeserializationCounts;
+        expectedValueSerializationCounts = valueSerializationCounts;
+        expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
             nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat);
         }
@@ -94,16 +105,6 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
     @After
     public void tearDown() {
         hazelcastFactory.shutdownAll();
-    }
-
-    @Override
-    protected int[] getExpectedSerializationCounts() {
-        return expectedSerializationCounts;
-    }
-
-    @Override
-    protected int[] getExpectedDeserializationCounts() {
-        return expectedDeserializationCounts;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -58,34 +58,44 @@ import static java.util.Arrays.asList;
 public class MapNearCacheSerializationCountTest extends AbstractNearCacheSerializationCountTest<Data, String> {
 
     @Parameter
-    public int[] expectedSerializationCounts;
+    public int[] keySerializationCounts;
 
     @Parameter(value = 1)
-    public int[] expectedDeserializationCounts;
+    public int[] keyDeserializationCounts;
 
     @Parameter(value = 2)
-    public InMemoryFormat mapInMemoryFormat;
+    public int[] valueSerializationCounts;
 
     @Parameter(value = 3)
+    public int[] valueDeserializationCounts;
+
+    @Parameter(value = 4)
+    public InMemoryFormat mapInMemoryFormat;
+
+    @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "mapFormat:{2} nearCacheFormat:{3}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT},
 
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY},
-                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT},
         });
     }
 
     @Before
     public void setUp() {
+        expectedKeySerializationCounts = keySerializationCounts;
+        expectedKeyDeserializationCounts = keyDeserializationCounts;
+        expectedValueSerializationCounts = valueSerializationCounts;
+        expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
             nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
                     .setCacheLocalEntries(true);
@@ -95,16 +105,6 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
     @After
     public void tearDown() {
         hazelcastFactory.shutdownAll();
-    }
-
-    @Override
-    protected int[] getExpectedSerializationCounts() {
-        return expectedSerializationCounts;
-    }
-
-    @Override
-    protected int[] getExpectedDeserializationCounts() {
-        return expectedDeserializationCounts;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -56,34 +56,44 @@ import static java.util.Arrays.asList;
 public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSerializationCountTest<Data, String> {
 
     @Parameter
-    public int[] expectedSerializationCounts;
+    public int[] keySerializationCounts;
 
     @Parameter(value = 1)
-    public int[] expectedDeserializationCounts;
+    public int[] keyDeserializationCounts;
 
     @Parameter(value = 2)
-    public InMemoryFormat mapInMemoryFormat;
+    public int[] valueSerializationCounts;
 
     @Parameter(value = 3)
+    public int[] valueDeserializationCounts;
+
+    @Parameter(value = 4)
+    public InMemoryFormat mapInMemoryFormat;
+
+    @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "mapFormat:{2} nearCacheFormat:{3}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
-                {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, OBJECT,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, null,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, OBJECT,},
 
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, BINARY,},
-                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, OBJECT,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, BINARY,},
+                {INT_ARRAY_1, INT_ARRAY_0, new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, OBJECT,},
         });
     }
 
     @Before
     public void setUp() {
+        expectedKeySerializationCounts = keySerializationCounts;
+        expectedKeyDeserializationCounts = keyDeserializationCounts;
+        expectedValueSerializationCounts = valueSerializationCounts;
+        expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
             nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
                     .setCacheLocalEntries(true)
@@ -95,16 +105,6 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
     @After
     public void tearDown() {
         hazelcastFactory.shutdownAll();
-    }
-
-    @Override
-    protected int[] getExpectedSerializationCounts() {
-        return expectedSerializationCounts;
-    }
-
-    @Override
-    protected int[] getExpectedDeserializationCounts() {
-        return expectedDeserializationCounts;
     }
 
     @Override


### PR DESCRIPTION
The serialization count test were just measuring the (de)serialization counts of values. With this PR we also measure the key (de)serializations, so we can eventually proof that the Near Cache key store-by-reference will eliminate all serializations in the code path of a simple `put()` and `get()` of all data structures with Near Cache support.