### PR TITLE
Add missing Near Cache invalidation listeners to Near Cache map tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheAddNearCacheInvalidationListenerCodec;
 import com.hazelcast.client.spi.EventHandler;
-import com.hazelcast.internal.nearcache.InvalidationListener;
+import com.hazelcast.internal.nearcache.NearCacheInvalidationListener;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 class ClientCacheInvalidationListener
         extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
-        implements InvalidationListener, EventHandler<ClientMessage> {
+        implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
 
     private final AtomicLong invalidationCount = new AtomicLong();
 
@@ -63,10 +63,10 @@ class ClientCacheInvalidationListener
     public void onListenerRegister() {
     }
 
-    static InvalidationListener createInvalidationEventHandler(ICache clientCache) {
+    static NearCacheInvalidationListener createInvalidationEventHandler(ICache clientCache) {
         EventHandler invalidationListener = new ClientCacheInvalidationListener();
         ((NearCachedClientCacheProxy) clientCache).addNearCacheInvalidationListener(invalidationListener);
 
-        return (InvalidationListener) invalidationListener;
+        return (NearCacheInvalidationListener) invalidationListener;
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.MapAddNearCacheInvalidationListe
 import com.hazelcast.client.proxy.NearCachedClientMapProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.core.IMap;
-import com.hazelcast.internal.nearcache.InvalidationListener;
+import com.hazelcast.internal.nearcache.NearCacheInvalidationListener;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 class ClientMapInvalidationListener
         extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler
-        implements InvalidationListener, EventHandler<ClientMessage> {
+        implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
 
     private final AtomicLong invalidationCount = new AtomicLong();
 
@@ -63,8 +63,8 @@ class ClientMapInvalidationListener
     public void onListenerRegister() {
     }
 
-    static InvalidationListener createInvalidationEventHandler(IMap clientMap) {
-        InvalidationListener invalidationListener = new ClientMapInvalidationListener();
+    static NearCacheInvalidationListener createInvalidationEventHandler(IMap clientMap) {
+        NearCacheInvalidationListener invalidationListener = new ClientMapInvalidationListener();
         ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidationListener((EventHandler) invalidationListener);
 
         return invalidationListener;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapInvalidationListener.java
@@ -22,14 +22,14 @@ import com.hazelcast.client.proxy.ClientReplicatedMapProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.internal.nearcache.InvalidationListener;
+import com.hazelcast.internal.nearcache.NearCacheInvalidationListener;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 class ClientReplicatedMapInvalidationListener
         extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler
-        implements InvalidationListener, EventHandler<ClientMessage> {
+        implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
 
     private final AtomicLong invalidationCount = new AtomicLong();
     private final ReplicatedMap clientMap;
@@ -75,8 +75,8 @@ class ClientReplicatedMapInvalidationListener
     public void onListenerRegister() {
     }
 
-    static InvalidationListener createInvalidationEventHandler(ReplicatedMap clientMap) {
-        InvalidationListener invalidationListener = new ClientReplicatedMapInvalidationListener(clientMap);
+    static NearCacheInvalidationListener createInvalidationEventHandler(ReplicatedMap clientMap) {
+        NearCacheInvalidationListener invalidationListener = new ClientReplicatedMapInvalidationListener(clientMap);
         ((ClientReplicatedMapProxy) clientMap).addNearCacheInvalidationListener((EventHandler) invalidationListener);
 
         return invalidationListener;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -89,7 +89,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         mapNearCacheManager = mapServiceContext.getMapNearCacheManager();
         nearCache = mapNearCacheManager.getOrCreateNearCache(name, mapConfig.getNearCacheConfig());
         if (invalidateOnChange) {
-            addNearCacheInvalidateListener();
+            registerInvalidationListener();
         }
     }
 
@@ -517,10 +517,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         return thisAddress.equals(partitionOwner);
     }
 
-    private void addNearCacheInvalidateListener() {
+    public String addNearCacheInvalidationListener(InvalidationListener listener, EventFilter eventFilter) {
+        return mapServiceContext.addEventListener(listener, eventFilter, name);
+    }
+
+    private void registerInvalidationListener() {
         repairingHandler = mapNearCacheManager.newRepairingHandler(name, nearCache);
         EventFilter eventFilter = new UuidFilter(getNodeEngine().getLocalMember().getUuid());
-        invalidationListenerId = mapServiceContext.addEventListener(new NearCacheInvalidationListener(), eventFilter, name);
+        invalidationListenerId = addNearCacheInvalidationListener(new NearCacheInvalidationListener(), eventFilter);
     }
 
     private final class NearCacheInvalidationListener implements InvalidationListener {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheInvalidationListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheInvalidationListener.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.nearcache;
 /**
  * Listener for Near Cache invalidations.
  */
-public interface InvalidationListener {
+public interface NearCacheInvalidationListener {
 
     long getInvalidationCount();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -95,9 +95,9 @@ public class NearCacheTestContext<K, V, NK, NV> {
      */
     public final DataStructureLoader loader;
     /**
-     * The {@link InvalidationListener} which monitors invalidation events.
+     * The {@link NearCacheInvalidationListener} which monitors invalidation events.
      */
-    public final InvalidationListener invalidationListener;
+    public final NearCacheInvalidationListener invalidationListener;
 
     NearCacheTestContext(NearCacheConfig nearCacheConfig,
                          SerializationService serializationService,
@@ -111,7 +111,7 @@ public class NearCacheTestContext<K, V, NK, NV> {
                          HazelcastServerCacheManager memberCacheManager,
                          boolean hasLocalData,
                          DataStructureLoader loader,
-                         InvalidationListener invalidationListener) {
+                         NearCacheInvalidationListener invalidationListener) {
         this.nearCacheConfig = nearCacheConfig;
         this.serializationService = serializationService;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
@@ -49,7 +49,7 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> extends HazelcastTestSupp
 
     private boolean hasLocalData;
     private DataStructureLoader loader;
-    private InvalidationListener invalidationListener;
+    private NearCacheInvalidationListener invalidationListener;
 
     public NearCacheTestContextBuilder(NearCacheConfig nearCacheConfig, SerializationService serializationService) {
         this.nearCacheConfig = nearCacheConfig;
@@ -106,7 +106,7 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> extends HazelcastTestSupp
         return this;
     }
 
-    public NearCacheTestContextBuilder<K, V, NK, NV> setInvalidationListener(InvalidationListener invalidationListener) {
+    public NearCacheTestContextBuilder<K, V, NK, NV> setInvalidationListener(NearCacheInvalidationListener invalidationListener) {
         this.invalidationListener = invalidationListener;
         return this;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -221,7 +221,7 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
     /**
      * Asserts the number of Near Cache invalidations.
      *
-     * @param context       the given {@link NearCacheTestContext} to retrieve the {@link InvalidationListener} from
+     * @param context       the given {@link NearCacheTestContext} to retrieve the {@link NearCacheInvalidationListener} from
      * @param invalidations the given number of Near Cache invalidations to wait for
      */
     public static void assertNearCacheInvalidations(final NearCacheTestContext<?, ?, ?, ?> context, final int invalidations) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.map.impl.nearcache.MapNearCacheBasicTest.addMapStoreConfig;
 import static java.util.Arrays.asList;
 
@@ -111,6 +112,7 @@ public class LiteMemberMapNearCacheBasicTest extends AbstractNearCacheBasicTest<
                 .setNearCache(nearCache)
                 .setNearCacheManager(nearCacheManager)
                 .setLoader(mapStore)
+                .setInvalidationListener(createInvalidationEventHandler(liteMemberMap))
                 .build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapInvalidationListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapInvalidationListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.NearCacheInvalidationListener;
+import com.hazelcast.internal.nearcache.impl.invalidation.BatchNearCacheInvalidation;
+import com.hazelcast.internal.nearcache.impl.invalidation.Invalidation;
+import com.hazelcast.map.impl.nearcache.invalidation.InvalidationListener;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.spi.EventFilter;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MapInvalidationListener implements NearCacheInvalidationListener, InvalidationListener {
+
+    private final AtomicLong invalidationCount = new AtomicLong();
+
+    @Override
+    public long getInvalidationCount() {
+        return invalidationCount.get();
+    }
+
+    @Override
+    public void resetInvalidationCount() {
+        invalidationCount.set(0);
+    }
+
+    @Override
+    public void onInvalidate(Invalidation invalidation) {
+        if (invalidation instanceof BatchNearCacheInvalidation) {
+            BatchNearCacheInvalidation batch = ((BatchNearCacheInvalidation) invalidation);
+            int invalidationCount = batch.getInvalidations().size();
+            this.invalidationCount.addAndGet(invalidationCount);
+        } else {
+            invalidationCount.incrementAndGet();
+        }
+    }
+
+    public static NearCacheInvalidationListener createInvalidationEventHandler(IMap memberMap) {
+        InvalidationListener invalidationListener = new MapInvalidationListener();
+        ((NearCachedMapProxyImpl) memberMap).addNearCacheInvalidationListener(invalidationListener, new TrueEventFilter());
+
+        return (NearCacheInvalidationListener) invalidationListener;
+    }
+
+    private static class TrueEventFilter implements EventFilter, Serializable {
+        @Override
+        public boolean eval(Object event) {
+            return true;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -52,6 +52,7 @@ import java.util.Collection;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
 import static java.util.Arrays.asList;
 
 /**
@@ -115,6 +116,7 @@ public class MapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, Stri
                 .setNearCacheManager(nearCacheManager)
                 .setLoader(mapStore)
                 .setHasLocalData(true)
+                .setInvalidationListener(createInvalidationEventHandler(nearCacheMap))
                 .build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -53,6 +53,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCach
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
 import static java.util.Arrays.asList;
 
 /**
@@ -103,7 +104,7 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
         HazelcastInstance dataInstance = hazelcastFactory.newHazelcastInstance(config);
 
         // this creates the Near Cache instance
-        nearCacheInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMap<K, V> nearCacheMap = nearCacheInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
 
         NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheInstance);
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
@@ -115,6 +116,7 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
                 .setDataAdapter(new TransactionalMapDataStructureAdapter<K, V>(dataInstance, DEFAULT_NEAR_CACHE_NAME))
                 .setNearCache(nearCache)
                 .setNearCacheManager(nearCacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(nearCacheMap))
                 .build();
     }
 


### PR DESCRIPTION
Fixed remaining spurious test failures like:

**com.hazelcast.map.impl.tx.TxnMapNearCacheBasicTest.whenGetIsUsed_thenNearCacheShouldBePopulated[format:BINARY]**
```java
java.lang.AssertionError: Near Cache size didn't reach the desired value (1000 vs. 975) (NearCacheStatsImpl{ownedEntryCount=975, ownedEntryMemoryCost=145165, creationTime=1494939892551, hits=975, misses=2025, ratio=48.1%, evictions=0, expirations=0, lastPersistenceTime=0, persistenceCount=0, lastPersistenceDuration=0, lastPersistenceWrittenBytes=0, lastPersistenceKeyCount=0, lastPersistenceFailure=''}) expected:<1000> but was:<975>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSize(NearCacheTestUtils.java:280)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils$3.run(NearCacheTestUtils.java:300)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:1037)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:1054)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually(NearCacheTestUtils.java:297)
	at com.hazelcast.map.impl.tx.TxnMapNearCacheBasicTest.whenGetIsUsed_thenNearCacheShouldBePopulated(TxnMapNearCacheBasicTest.java:159)
```
https://hazelcast-l337.ci.cloudbees.com/job/new-lab-fast-pr/8946/testReport/junit/com.hazelcast.map.impl.tx/TxnMapNearCacheBasicTest/whenGetIsUsed_thenNearCacheShouldBePopulated_format_BINARY_/

See https://github.com/hazelcast/hazelcast/pull/10525