### PR TITLE
Prevent lookup of partition ID on LiteMembers with Near Cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -271,6 +271,8 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
                 LOGGER.warning("The element <eviction-policy/> for <near-cache/> is deprecated, please use <eviction/> instead!");
             } else if ("in-memory-format".equals(nodeName)) {
                 nearCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
+            } else if ("serialize-keys".equals(nodeName)) {
+                nearCacheConfig.setSerializeKeys(Boolean.parseBoolean(value));
             } else if ("invalidate-on-change".equals(nodeName)) {
                 nearCacheConfig.setInvalidateOnChange(Boolean.parseBoolean(value));
             } else if ("cache-local-entries".equals(nodeName)) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -99,7 +99,8 @@ public final class ClientContext {
     private RepairingTask newRepairingTask(String serviceName) {
         MetaDataFetcher metaDataFetcher = newMetaDataFetcher(serviceName);
         ILogger logger = loggingService.getLogger(RepairingTask.class);
-        return new RepairingTask(properties, metaDataFetcher, executionService, minimalPartitionService, localUuid, logger);
+        return new RepairingTask(properties, metaDataFetcher, executionService, serializationService, minimalPartitionService,
+                localUuid, logger);
     }
 
     private MetaDataFetcher newMetaDataFetcher(String serviceName) {

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
@@ -350,6 +350,7 @@
     <xs:complexType name="near-cache">
         <xs:all>
             <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
             <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -136,6 +136,7 @@
         <eviction-policy>LFU</eviction-policy>
         <invalidate-on-change>true</invalidate-on-change>
         <in-memory-format>OBJECT</in-memory-format>
+        <serialize-keys>false</serialize-keys>
         <local-update-policy>INVALIDATE</local-update-policy>
     </near-cache>
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -91,7 +91,7 @@ public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Da
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true)
                 .setLocalUpdatePolicy(localUpdatePolicy);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -91,32 +91,51 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
     public Boolean invalidateOnChange;
 
     @Parameter(value = 7)
+    public Boolean serializeKeys;
+
+    @Parameter(value = 8)
     public LocalUpdatePolicy localUpdatePolicy;
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Parameters(name = "cacheFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} localUpdatePolicy:{7}")
+    @Parameters(name = "cacheFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} serializeKeys:{7} localUpdatePolicy:{8}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, CACHE_ON_UPDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, CACHE_ON_UPDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 0, 0), BINARY, OBJECT, true, CACHE_ON_UPDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 0, 0), BINARY, OBJECT, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 0, 0), BINARY, OBJECT, true, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 0, 0), BINARY, OBJECT, true, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 0, 0), BINARY, OBJECT, false, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 0, 0), BINARY, OBJECT, false, false, CACHE_ON_UPDATE},
 
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 1), OBJECT, BINARY, true, CACHE_ON_UPDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 1), OBJECT, BINARY, false, CACHE_ON_UPDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, true, CACHE_ON_UPDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, INVALIDATE},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, true, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, true, false, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, false, true, CACHE_ON_UPDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false, INVALIDATE},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, false, false, CACHE_ON_UPDATE},
         });
     }
 
@@ -127,7 +146,7 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, true)
                     .setInvalidateOnChange(invalidateOnChange)
                     .setLocalUpdatePolicy(localUpdatePolicy);
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -250,6 +250,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("LFU", nearCacheConfig.getEvictionPolicy());
         assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertTrue(nearCacheConfig.isInvalidateOnChange());
+        assertFalse(nearCacheConfig.isSerializeKeys());
         assertEquals(InMemoryFormat.OBJECT, nearCacheConfig.getInMemoryFormat());
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -76,7 +76,7 @@ public class ClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true);
     }
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -78,22 +78,33 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
     @Parameter(value = 6)
     public Boolean invalidateOnChange;
 
+    @Parameter(value = 7)
+    public Boolean serializeKeys;
+
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} serializeKeys:{7}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
 
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
         });
     }
 
@@ -104,7 +115,7 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, true)
                     .setInvalidateOnChange(invalidateOnChange);
         }
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -70,7 +70,7 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true);
     }
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -74,18 +74,25 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
     @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
+    @Parameter(value = 6)
+    public Boolean serializeKeys;
+
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    @Parameters(name = "replicatedMapFormat:{4} nearCacheFormat:{5}")
+    @Parameters(name = "replicatedMapFormat:{4} nearCacheFormat:{5} serializeKeys:{6}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null},
-                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(0, 1, 1), BINARY, BINARY},
-                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(0, 1, 1), BINARY, BINARY, true},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(0, 1, 1), BINARY, BINARY, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
 
-                {newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, null},
-                {newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, BINARY},
-                {newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT},
+                {newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, null, null},
+                {newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, BINARY, true},
+                {newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, BINARY, false},
+                {newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, true},
+                {newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, false},
         });
     }
 
@@ -96,7 +103,7 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, serializeKeys)
                     // we have to disable invalidations, otherwise there will be an non-deterministic serialization in a listener
                     .setInvalidateOnChange(false);
         }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -2527,7 +2527,8 @@
             <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
         <xs:attribute name="in-memory-format" type="in-memory-format" use="optional" default="BINARY"/>
-        <xs:attribute name="invalidate-on-change" use="optional" type="xs:boolean" default="true"/>
+        <xs:attribute name="serialize-keys" use="optional" type="parameterized-boolean" default="true"/>
+        <xs:attribute name="invalidate-on-change" use="optional" type="parameterized-boolean" default="true"/>
         <xs:attribute name="time-to-live-seconds" use="optional" type="xs:string" default="0"/>
         <xs:attribute name="max-idle-seconds" use="optional" type="xs:string" default="0"/>
         <xs:attribute name="eviction-policy" use="optional" type="eviction-policy" default="LRU"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -217,6 +217,7 @@ public class TestClientApplicationContext {
         assertEquals(EvictionPolicy.LRU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertEquals(4000, nearCacheConfig.getEvictionConfig().getSize());
         assertTrue(nearCacheConfig.isInvalidateOnChange());
+        assertFalse(nearCacheConfig.isSerializeKeys());
         assertEquals(CACHE_ON_UPDATE, nearCacheConfig.getLocalUpdatePolicy());
     }
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -317,6 +317,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(EvictionPolicy.LRU, testNearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertEquals(5000, testNearCacheConfig.getEvictionConfig().getSize());
         assertTrue(testNearCacheConfig.isInvalidateOnChange());
+        assertFalse(testNearCacheConfig.isSerializeKeys());
 
         // test that the testMapConfig2's mapStoreConfig implementation
         MapConfig testMapConfig2 = config.getMapConfig("testMap2");

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -266,7 +266,7 @@
                 <hz:map-store enabled="true" class-name="com.hazelcast.spring.DummyStore" write-delay-seconds="0"
                               initial-mode="EAGER" write-batch-size="10"/>
                 <hz:near-cache time-to-live-seconds="0" max-idle-seconds="60" eviction-policy="LRU" max-size="5000"
-                               invalidate-on-change="true"/>
+                               invalidate-on-change="true" serialize-keys="false"/>
 
                 <hz:indexes>
                     <hz:index attribute="name"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -152,7 +152,9 @@
                        max-idle-seconds="70"
                        eviction-policy="LRU"
                        max-size="4000"
-                       invalidate-on-change="true" local-update-policy="CACHE_ON_UPDATE"/>
+                       invalidate-on-change="true"
+                       serialize-keys="false"
+                       local-update-policy="CACHE_ON_UPDATE"/>
 
         <hz:near-cache name="lfuNearCacheEviction" eviction-policy="LFU" />
         <hz:near-cache name="lruNearCacheEviction"

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -92,6 +92,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     private String name = "default";
     private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
+    private boolean serializeKeys = true;
     private boolean invalidateOnChange = true;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private int maxIdleSeconds = DEFAULT_MAX_IDLE_SECONDS;
@@ -163,19 +164,20 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     }
 
     public NearCacheConfig(NearCacheConfig config) {
-        name = config.name;
-        inMemoryFormat = config.inMemoryFormat;
-        invalidateOnChange = config.invalidateOnChange;
-        timeToLiveSeconds = config.timeToLiveSeconds;
-        maxIdleSeconds = config.maxIdleSeconds;
-        maxSize = config.maxSize;
-        evictionPolicy = config.evictionPolicy;
+        this.name = config.name;
+        this.inMemoryFormat = config.inMemoryFormat;
+        this.serializeKeys = config.serializeKeys;
+        this.invalidateOnChange = config.invalidateOnChange;
+        this.timeToLiveSeconds = config.timeToLiveSeconds;
+        this.maxIdleSeconds = config.maxIdleSeconds;
+        this.maxSize = config.maxSize;
+        this.evictionPolicy = config.evictionPolicy;
         // EvictionConfig is not allowed to be null
         if (config.evictionConfig != null) {
             this.evictionConfig = config.evictionConfig;
         }
-        cacheLocalEntries = config.cacheLocalEntries;
-        localUpdatePolicy = config.localUpdatePolicy;
+        this.cacheLocalEntries = config.cacheLocalEntries;
+        this.localUpdatePolicy = config.localUpdatePolicy;
         // NearCachePreloaderConfig is not allowed to be null
         if (config.preloaderConfig != null) {
             this.preloaderConfig = config.preloaderConfig;
@@ -257,6 +259,26 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
         checkNotNull(inMemoryFormat, "In-Memory format cannot be null!");
 
         this.inMemoryFormat = InMemoryFormat.valueOf(inMemoryFormat);
+        return this;
+    }
+
+    /**
+     * Checks if the Near Cache key is stored in serialized format or by-reference.
+     *
+     * @return {@code true} if the key is stored in serialized format, {@code false} if stored by-reference.
+     */
+    public boolean isSerializeKeys() {
+        return serializeKeys;
+    }
+
+    /**
+     * Sets if the Near Cache key is stored in serialized format or by-reference.
+     *
+     * @param serializeKeys {@code true} if the key is stored in serialized format, {@code false} if stored by-reference
+     * @return this Near Cache config instance
+     */
+    public NearCacheConfig setSerializeKeys(boolean serializeKeys) {
+        this.serializeKeys = serializeKeys;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -56,6 +56,11 @@ public class NearCacheConfigReadOnly extends NearCacheConfig {
     }
 
     @Override
+    public NearCacheConfig setSerializeKeys(boolean serializeKeys) {
+        throw new UnsupportedOperationException("This config is read-only");
+    }
+
+    @Override
     public NearCacheConfig setInvalidateOnChange(boolean invalidateOnChange) {
         throw new UnsupportedOperationException("This config is read-only");
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1233,7 +1233,6 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
     }
     //CHECKSTYLE:ON
 
-
     private NearCacheConfig handleNearCacheConfig(Node node) {
         String name = getAttribute(node, "name");
         NearCacheConfig nearCacheConfig = new NearCacheConfig(name);
@@ -1252,6 +1251,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 LOGGER.warning("The element <eviction-policy/> for <near-cache/> is deprecated, please use <eviction/> instead!");
             } else if ("in-memory-format".equals(nodeName)) {
                 nearCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
+            } else if ("serialize-keys".equals(nodeName)) {
+                nearCacheConfig.setSerializeKeys(Boolean.parseBoolean(value));
             } else if ("invalidate-on-change".equals(nodeName)) {
                 nearCacheConfig.setInvalidateOnChange(Boolean.parseBoolean(value));
             } else if ("cache-local-entries".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
@@ -114,6 +114,13 @@ public interface NearCache<K, V> extends InitializingObject {
     NearCacheStats getNearCacheStats();
 
     /**
+     * Checks if the Near Cache key is stored in serialized format or by-reference.
+     *
+     * @return {@code true} if the key is stored in serialized format, {@code false} if stored by-reference.
+     */
+    boolean isSerializeKeys();
+
+    /**
      * Selects the best candidate object to store from the given {@code candidates}.
      *
      * @param candidates the candidates from which the best candidate object will be selected.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -109,8 +109,8 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
 
         MetaDataFetcher metaDataFetcher = new MemberMapMetaDataFetcher(clusterService, operationService, logger);
         String localUuid = nodeEngine.getLocalMember().getUuid();
-        return new RepairingTask(properties, metaDataFetcher, executionService.getGlobalTaskScheduler(), partitionService,
-                localUuid, logger);
+        return new RepairingTask(properties, metaDataFetcher, executionService.getGlobalTaskScheduler(),
+                serializationService, partitionService, localUuid, logger);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -109,8 +109,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public V get(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return toObject(getInternal(keyData));
+        return toObject(getInternal(key));
     }
 
     @Override
@@ -123,9 +122,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        Data result = putInternal(keyData, valueData, ttl, timeunit);
+        Data result = putInternal(key, valueData, ttl, timeunit);
         return toObject(result);
     }
 
@@ -134,9 +132,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        return tryPutInternal(keyData, valueData, timeout, timeunit);
+        return tryPutInternal(key, valueData, timeout, timeunit);
     }
 
     @Override
@@ -149,9 +146,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        Data result = putIfAbsentInternal(keyData, valueData, ttl, timeunit);
+        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit);
         return toObject(result);
     }
 
@@ -160,9 +156,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        putTransientInternal(keyData, valueData, ttl, timeunit);
+        putTransientInternal(key, valueData, ttl, timeunit);
     }
 
     @Override
@@ -171,10 +166,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(oldValue, NULL_VALUE_IS_NOT_ALLOWED);
         checkNotNull(newValue, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data oldValueData = toData(oldValue);
         Data newValueData = toData(newValue);
-        return replaceInternal(keyData, oldValueData, newValueData);
+        return replaceInternal(key, oldValueData, newValueData);
     }
 
     @Override
@@ -182,9 +176,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        return toObject(replaceInternal(keyData, valueData));
+        return toObject(replaceInternal(key, valueData));
     }
 
     @Override
@@ -197,17 +190,15 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        setInternal(keyData, valueData, ttl, timeunit);
+        setInternal(key, valueData, ttl, timeunit);
     }
 
     @Override
     public V remove(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        Data result = removeInternal(keyData);
+        Data result = removeInternal(key);
         return toObject(result);
     }
 
@@ -216,9 +207,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        return removeInternal(keyData, valueData);
+        return removeInternal(key, valueData);
     }
 
     @Override
@@ -232,16 +222,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public void delete(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        deleteInternal(keyData);
+        deleteInternal(key);
     }
 
     @Override
     public boolean containsKey(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return containsKeyInternal(keyData);
+        return containsKeyInternal(key);
     }
 
     @Override
@@ -281,16 +269,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public boolean tryRemove(K key, long timeout, TimeUnit timeunit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return tryRemoveInternal(keyData, timeout, timeunit);
+        return tryRemoveInternal(key, timeout, timeunit);
     }
 
     @Override
     public ICompletableFuture<V> getAsync(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return new DelegatingFuture<V>(getAsyncInternal(keyData), serializationService);
+        return new DelegatingFuture<V>(getAsyncInternal(key), serializationService);
     }
 
     @Override
@@ -311,9 +297,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        return new DelegatingFuture<V>(putAsyncInternal(keyData, valueData, ttl, timeunit), serializationService);
+        return new DelegatingFuture<V>(putAsyncInternal(key, valueData, ttl, timeunit), serializationService);
     }
 
     @Override
@@ -326,17 +311,15 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
         Data valueData = toData(value);
-        return new DelegatingFuture<Void>(setAsyncInternal(keyData, valueData, ttl, timeunit), serializationService);
+        return new DelegatingFuture<Void>(setAsyncInternal(key, valueData, ttl, timeunit), serializationService);
     }
 
     @Override
     public ICompletableFuture<V> removeAsync(K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return new DelegatingFuture<V>(removeAsyncInternal(keyData), serializationService);
+        return new DelegatingFuture<V>(removeAsyncInternal(key), serializationService);
     }
 
     @Override
@@ -345,18 +328,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
             return emptyMap();
         }
 
-        List<Data> requestedKeys = new ArrayList<Data>(keys.size());
-        for (K key : keys) {
-            checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        int keysSize = keys.size();
+        int resultSize = 2 * keysSize;
 
-            Data keyData = toDataWithStrategy(key);
-            requestedKeys.add(keyData);
-        }
+        List<Data> dataKeys = new ArrayList<Data>(keysSize);
+        List<Object> resultingKeyValuePairs = new ArrayList<Object>(resultSize);
+        getAllObjectInternal(keys, dataKeys, resultingKeyValuePairs);
 
-        List<Object> resultingKeyValuePairs = new ArrayList<Object>(2 * keys.size());
-        getAllObjectInternal(requestedKeys, resultingKeyValuePairs);
-
-        Map<K, V> result = createHashMap(keys.size());
+        Map<K, V> result = createHashMap(resultSize);
         for (int i = 0; i < resultingKeyValuePairs.size(); ) {
             K key = toObject(resultingKeyValuePairs.get(i++));
             V value = toObject(resultingKeyValuePairs.get(i++));
@@ -450,8 +429,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return addLocalEntryListenerInternal(listener, predicate, keyData, includeValue);
+        return addLocalEntryListenerInternal(listener, predicate, toDataWithStrategy(key), includeValue);
     }
 
     @Override
@@ -459,8 +437,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        return addLocalEntryListenerInternal(listener, predicate, keyData, includeValue);
+        return addLocalEntryListenerInternal(listener, predicate, toDataWithStrategy(key), includeValue);
     }
 
     @Override
@@ -565,7 +542,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public boolean evict(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        return evictInternal(toDataWithStrategy(key));
+        return evictInternal(key);
     }
 
     @Override
@@ -585,7 +562,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         checkTrue(isMapStoreEnabled(), "First you should configure a map store");
         checkNotNull(keys, "Parameter keys should not be null.");
 
-        loadInternal(convertToData(keys), replaceExistingValues);
+        loadInternal(keys, null, replaceExistingValues);
     }
 
     /**
@@ -695,7 +672,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data result = executeOnKeyInternal(toDataWithStrategy(key), entryProcessor);
+        Data result = executeOnKeyInternal(key, entryProcessor);
         return toObject(result);
     }
 
@@ -708,26 +685,21 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
             return emptyMap();
         }
         Set<Data> dataKeys = new HashSet<Data>(keys.size());
-        for (K key : keys) {
-            dataKeys.add(toDataWithStrategy(key));
-        }
-        return executeOnKeysInternal(dataKeys, entryProcessor);
+        return executeOnKeysInternal(keys, dataKeys, entryProcessor);
     }
 
     @Override
     public void submitToKey(K key, EntryProcessor entryProcessor, ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        executeOnKeyInternal(keyData, entryProcessor, callback);
+        executeOnKeyInternal(key, entryProcessor, callback);
     }
 
     @Override
     public ICompletableFuture submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
-        Data keyData = toDataWithStrategy(key);
-        InternalCompletableFuture future = executeOnKeyInternal(keyData, entryProcessor, null);
+        InternalCompletableFuture future = executeOnKeyInternal(key, entryProcessor, null);
         return new DelegatingFuture(future, serializationService);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -29,7 +29,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.nearcache.invalidation.InvalidationListener;
 import com.hazelcast.map.impl.nearcache.invalidation.UuidFilter;
-import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.EventFilter;
@@ -63,6 +62,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     private final boolean cacheLocalEntries;
     private final boolean invalidateOnChange;
+    private final boolean serializeKeys;
 
     private MapNearCacheManager mapNearCacheManager;
     private NearCache<Object, Object> nearCache;
@@ -76,6 +76,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
         cacheLocalEntries = nearCacheConfig.isCacheLocalEntries();
         invalidateOnChange = nearCacheConfig.isInvalidateOnChange();
+        serializeKeys = nearCacheConfig.isSerializeKeys();
     }
 
     public NearCache<Object, Object> getNearCache() {
@@ -96,7 +97,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     // this operation returns the value as Data, except when it's retrieved from Near Cache with in-memory-format OBJECT
     @Override
     @SuppressWarnings("unchecked")
-    protected V getInternal(Data key) {
+    protected V getInternal(Object key) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         V value = (V) getCachedValue(key, true);
         if (value != NOT_CACHED) {
             return value;
@@ -116,19 +118,20 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected InternalCompletableFuture<Data> getAsyncInternal(final Data key) {
-        Object value = getCachedValue(key, false);
+    protected InternalCompletableFuture<Data> getAsyncInternal(Object key) {
+        final Object ncKey = serializeKeys ? toDataWithStrategy(key) : key;
+        Object value = getCachedValue(ncKey, false);
         if (value != NOT_CACHED) {
             ExecutionService executionService = getNodeEngine().getExecutionService();
             return new CompletedFuture<Data>(serializationService, value, executionService.getExecutor(ASYNC_EXECUTOR));
         }
 
-        final long reservationId = tryReserveForUpdate(key);
+        final long reservationId = tryReserveForUpdate(ncKey);
         InternalCompletableFuture<Data> future;
         try {
-            future = super.getAsyncInternal(key);
+            future = super.getAsyncInternal(ncKey);
         } catch (Throwable t) {
-            invalidateNearCache(key);
+            invalidateNearCache(ncKey);
             throw rethrow(t);
         }
 
@@ -136,12 +139,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
             future.andThen(new ExecutionCallback<Data>() {
                 @Override
                 public void onResponse(Data value) {
-                    nearCache.tryPublishReserved(key, value, reservationId, false);
+                    nearCache.tryPublishReserved(ncKey, value, reservationId, false);
                 }
 
                 @Override
                 public void onFailure(Throwable t) {
-                    invalidateNearCache(key);
+                    invalidateNearCache(ncKey);
                 }
             });
         }
@@ -149,7 +152,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+    protected Data putInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.putInternal(key, value, ttl, timeunit);
         } finally {
@@ -158,7 +162,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean tryPutInternal(Data key, Data value, long timeout, TimeUnit timeunit) {
+    protected boolean tryPutInternal(Object key, Data value, long timeout, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.tryPutInternal(key, value, timeout, timeunit);
         } finally {
@@ -167,7 +172,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putIfAbsentInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.putIfAbsentInternal(key, value, ttl, timeunit);
         } finally {
@@ -176,7 +182,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void putTransientInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             super.putTransientInternal(key, value, ttl, timeunit);
         } finally {
@@ -185,7 +192,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected InternalCompletableFuture<Data> putAsyncInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.putAsyncInternal(key, value, ttl, timeunit);
         } finally {
@@ -194,7 +202,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected InternalCompletableFuture<Data> setAsyncInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.setAsyncInternal(key, value, ttl, timeunit);
         } finally {
@@ -203,7 +212,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean replaceInternal(Data key, Data expect, Data update) {
+    protected boolean replaceInternal(Object key, Data expect, Data update) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.replaceInternal(key, expect, update);
         } finally {
@@ -212,7 +222,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data replaceInternal(Data key, Data value) {
+    protected Data replaceInternal(Object key, Data value) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.replaceInternal(key, value);
         } finally {
@@ -221,7 +232,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void setInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+    protected void setInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             super.setInternal(key, value, ttl, timeunit);
         } finally {
@@ -230,7 +242,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean evictInternal(Data key) {
+    protected boolean evictInternal(Object key) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.evictInternal(key);
         } finally {
@@ -268,16 +281,22 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void loadInternal(Iterable<Data> keys, boolean replaceExistingValues) {
+    protected void loadInternal(Set<K> keys, Iterable<Data> dataKeys, boolean replaceExistingValues) {
+        if (serializeKeys) {
+            dataKeys = convertToData(keys);
+        }
         try {
-            super.loadInternal(keys, replaceExistingValues);
+            super.loadInternal(keys, dataKeys, replaceExistingValues);
         } finally {
-            invalidateNearCache(keys);
+            for (Object key : serializeKeys ? dataKeys : keys) {
+                invalidateNearCache(key);
+            }
         }
     }
 
     @Override
-    protected Data removeInternal(Data key) {
+    protected Data removeInternal(Object key) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.removeInternal(key);
         } finally {
@@ -295,7 +314,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void deleteInternal(Data key) {
+    protected void deleteInternal(Object key) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             super.deleteInternal(key);
         } finally {
@@ -304,7 +324,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean removeInternal(Data key, Data value) {
+    protected boolean removeInternal(Object key, Data value) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.removeInternal(key, value);
         } finally {
@@ -313,7 +334,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean tryRemoveInternal(Data key, long timeout, TimeUnit timeunit) {
+    protected boolean tryRemoveInternal(Object key, long timeout, TimeUnit timeunit) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.tryRemoveInternal(key, timeout, timeunit);
         } finally {
@@ -322,7 +344,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected InternalCompletableFuture<Data> removeAsyncInternal(Data key) {
+    protected InternalCompletableFuture<Data> removeAsyncInternal(Object key) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.removeAsyncInternal(key);
         } finally {
@@ -331,27 +354,36 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean containsKeyInternal(Data keyData) {
-        Object cachedValue = getCachedValue(keyData, false);
+    protected boolean containsKeyInternal(Object key) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
+        Object cachedValue = getCachedValue(key, false);
         if (cachedValue != NOT_CACHED) {
             return true;
         }
-        return super.containsKeyInternal(keyData);
+        return super.containsKeyInternal(key);
     }
 
     @Override
-    protected void getAllObjectInternal(List<Data> dataKeys, List<Object> resultingKeyValuePairs) {
-        getCachedValues(dataKeys, resultingKeyValuePairs);
+    protected void getAllObjectInternal(Set<K> keys, List<Data> dataKeys, List<Object> resultingKeyValuePairs) {
+        if (serializeKeys) {
+            toDataCollection(keys, dataKeys);
+        }
+        Collection ncKeys = serializeKeys ? dataKeys : keys;
 
-        Map<Data, Long> reservations = emptyMap();
+        getCachedValues(ncKeys, resultingKeyValuePairs);
+
+        Map<Object, Long> reservations = emptyMap();
         try {
-            reservations = tryReserveForUpdate(dataKeys);
+            reservations = tryReserveForUpdate(ncKeys);
             int currentSize = resultingKeyValuePairs.size();
 
-            super.getAllObjectInternal(dataKeys, resultingKeyValuePairs);
+            super.getAllObjectInternal(keys, dataKeys, resultingKeyValuePairs);
 
             for (int i = currentSize; i < resultingKeyValuePairs.size(); ) {
-                Data key = toData(resultingKeyValuePairs.get(i++));
+                Object key = resultingKeyValuePairs.get(i++);
+                if (serializeKeys) {
+                    key = toDataWithStrategy(key);
+                }
                 Data value = toData(resultingKeyValuePairs.get(i++));
 
                 Long reservationId = reservations.get(key);
@@ -366,9 +398,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         }
     }
 
-    private Map<Data, Long> tryReserveForUpdate(List<Data> keys) {
-        Map<Data, Long> reservedKeys = createHashMap(keys.size());
-        for (Data key : keys) {
+    private Map<Object, Long> tryReserveForUpdate(Collection keys) {
+        Map<Object, Long> reservedKeys = createHashMap(keys.size());
+        for (Object key : keys) {
             long reservationId = tryReserveForUpdate(key);
             if (reservationId != NOT_RESERVED) {
                 reservedKeys.put(key, reservationId);
@@ -377,28 +409,45 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         return reservedKeys;
     }
 
-    private void releaseReservedKeys(Map<Data, Long> reservationResults) {
-        for (Data key : reservationResults.keySet()) {
+    private void releaseReservedKeys(Map<Object, Long> reservationResults) {
+        for (Object key : reservationResults.keySet()) {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected void invokePutAllOperationFactory(Address address, long size, int[] partitions, MapEntries[] entries)
-            throws Exception {
+    protected void invokePutAllOperationFactory(long size, int[] partitions, MapEntries[] entries) throws Exception {
         try {
-            super.invokePutAllOperationFactory(address, size, partitions, entries);
+            super.invokePutAllOperationFactory(size, partitions, entries);
         } finally {
-            for (MapEntries mapEntries : entries) {
-                for (int i = 0; i < mapEntries.size(); i++) {
-                    invalidateNearCache(mapEntries.getKey(i));
+            if (serializeKeys) {
+                for (MapEntries mapEntries : entries) {
+                    if (mapEntries != null) {
+                        for (int i = 0; i < mapEntries.size(); i++) {
+                            invalidateNearCache(mapEntries.getKey(i));
+                        }
+                    }
                 }
             }
         }
     }
 
     @Override
-    public Data executeOnKeyInternal(Data key, EntryProcessor entryProcessor) {
+    protected void finalizePutAll(Map<?, ?> map) {
+        try {
+            super.finalizePutAll(map);
+        } finally {
+            if (!serializeKeys) {
+                for (Object key : map.keySet()) {
+                    invalidateNearCache(key);
+                }
+            }
+        }
+    }
+
+    @Override
+    public Data executeOnKeyInternal(Object key, EntryProcessor entryProcessor) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.executeOnKeyInternal(key, entryProcessor);
         } finally {
@@ -407,17 +456,23 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    public Map executeOnKeysInternal(Set<Data> keys, EntryProcessor entryProcessor) {
+    public Map<K, Object> executeOnKeysInternal(Set<K> keys, Set<Data> dataKeys, EntryProcessor entryProcessor) {
+        if (serializeKeys) {
+            toDataCollection(keys, dataKeys);
+        }
         try {
-            return super.executeOnKeysInternal(keys, entryProcessor);
+            return super.executeOnKeysInternal(keys, dataKeys, entryProcessor);
         } finally {
-            invalidateNearCache(keys);
+            for (Object key : serializeKeys ? dataKeys : keys) {
+                invalidateNearCache(key);
+            }
         }
     }
 
     @Override
-    public InternalCompletableFuture<Object> executeOnKeyInternal(Data key, EntryProcessor entryProcessor,
+    public InternalCompletableFuture<Object> executeOnKeyInternal(Object key, EntryProcessor entryProcessor,
                                                                   ExecutionCallback<Object> callback) {
+        key = serializeKeys ? toDataWithStrategy(key) : key;
         try {
             return super.executeOnKeyInternal(key, entryProcessor, callback);
         } finally {
@@ -446,10 +501,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         return super.preDestroy();
     }
 
-    private void getCachedValues(List<Data> keys, List<Object> resultingKeyValuePairs) {
-        Iterator<Data> iterator = keys.iterator();
+    private void getCachedValues(Collection keys, List<Object> resultingKeyValuePairs) {
+        Iterator iterator = keys.iterator();
         while (iterator.hasNext()) {
-            Data key = iterator.next();
+            Object key = iterator.next();
             Object value = getCachedValue(key, true);
             if (value == null || value == NOT_CACHED) {
                 continue;
@@ -461,26 +516,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         }
     }
 
-    protected void invalidateNearCache(Data key) {
+    protected void invalidateNearCache(Object key) {
         if (key == null) {
             return;
         }
         nearCache.remove(key);
     }
 
-    protected void invalidateNearCache(Collection<Data> keys) {
-        for (Data key : keys) {
-            nearCache.remove(key);
-        }
-    }
-
-    protected void invalidateNearCache(Iterable<Data> keys) {
-        for (Data key : keys) {
-            nearCache.remove(key);
-        }
-    }
-
-    private Object tryPublishReserved(Data key, Object value, long reservationId) {
+    private Object tryPublishReserved(Object key, Object value, long reservationId) {
         assert value != NOT_CACHED;
 
         // `value` is cached even if it's null
@@ -488,7 +531,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         return cachedValue != null ? cachedValue : value;
     }
 
-    private Object getCachedValue(Data key, boolean deserializeValue) {
+    private Object getCachedValue(Object key, boolean deserializeValue) {
         Object value = nearCache.get(key);
         if (value == null) {
             return NOT_CACHED;
@@ -500,21 +543,21 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         return deserializeValue ? toObject(value) : value;
     }
 
-    private long tryReserveForUpdate(Data key) {
+    private long tryReserveForUpdate(Object key) {
         if (!cachingAllowedFor(key)) {
             return NOT_RESERVED;
         }
         return nearCache.tryReserveForUpdate(key);
     }
 
-    private boolean cachingAllowedFor(Data key) {
+    private boolean cachingAllowedFor(Object key) {
         return cacheLocalEntries || !isOwn(key);
     }
 
-    private boolean isOwn(Data key) {
+    private boolean isOwn(Object key) {
+        key = serializeKeys ? key : toDataWithStrategy(key);
         int partitionId = partitionService.getPartitionId(key);
-        Address partitionOwner = partitionService.getPartitionOwner(partitionId);
-        return thisAddress.equals(partitionOwner);
+        return partitionService.isPartitionOwner(partitionId);
     }
 
     public String addNearCacheInvalidationListener(InvalidationListener listener) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.proxy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.impl.invalidation.BatchNearCacheInvalidation;
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidation;
@@ -60,6 +61,7 @@ import static java.util.Collections.emptyMap;
  */
 public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
+    private final ClusterService clusterService;
     private final boolean cacheLocalEntries;
     private final boolean invalidateOnChange;
     private final boolean serializeKeys;
@@ -72,6 +74,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     public NearCachedMapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine, MapConfig mapConfig) {
         super(name, mapService, nodeEngine, mapConfig);
+
+        clusterService = nodeEngine.getClusterService();
 
         NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
         cacheLocalEntries = nearCacheConfig.isCacheLocalEntries();
@@ -551,7 +555,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     private boolean cachingAllowedFor(Object key) {
-        return cacheLocalEntries || !isOwn(key);
+        return cacheLocalEntries || clusterService.getLocalMember().isLiteMember() || !isOwn(key);
     }
 
     private boolean isOwn(Object key) {

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -41,7 +41,8 @@
                 <xs:element name="partition-group" type="partition-group" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="executor-service" type="executor-service" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="durable-executor-service" type="durable-executor-service" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="scheduled-executor-service" type="scheduled-executor-service" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="scheduled-executor-service" type="scheduled-executor-service" minOccurs="0"
+                            maxOccurs="unbounded"/>
                 <xs:element name="queue" type="queue" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="map" type="map" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="multimap" type="multimap" minOccurs="0" maxOccurs="unbounded"/>
@@ -2407,6 +2408,15 @@
                         BINARY (default): keys and values are stored as binary data.
                         OBJECT: values are stored in their object forms.
                         NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines if the Near Cache keys should be serialized or not.
+                        Keys should be serialized if they are mutable and need to be cloned via serialization.
+                        Default value is true.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigReadOnlyTest.java
@@ -57,6 +57,11 @@ public class NearCacheConfigReadOnlyTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
+    public void setSerializeKeysOnReadOnlyNearCacheConfigShouldFail() {
+        getReadOnlyConfig().setSerializeKeys(true);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
     public void setInvalidateOnChangeOnReadOnlyNearCacheConfigShouldFail() {
         getReadOnlyConfig().setInvalidateOnChange(true);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -827,6 +827,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "  <map name=\"" + mapName + "\">\n"
                 + "    <near-cache name=\"test\">\n"
                 + "      <in-memory-format>OBJECT</in-memory-format>\n"
+                + "      <serialize-keys>false</serialize-keys>\n"
                 + "      <max-size>1234</max-size>\n"
                 + "      <time-to-live-seconds>77</time-to-live-seconds>\n"
                 + "      <max-idle-seconds>92</max-idle-seconds>\n"

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -290,7 +290,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
                 .setSize(maxSize)
                 .setEvictionPolicy(EvictionPolicy.LRU);
 
-        NearCacheConfig nearCacheConfig = createNearCacheConfig(InMemoryFormat.BINARY)
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(InMemoryFormat.BINARY, true)
                 .setName(defaultNearCache)
                 .setInvalidateOnChange(invalidationOnChange)
                 .setEvictionConfig(evictionConfig);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -93,11 +94,12 @@ public class RepairingTaskTest extends HazelcastTestSupport {
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config);
         MetaDataFetcher metaDataFetcher = mock(MetaDataFetcher.class);
         ExecutionService executionService = mock(ExecutionService.class);
+        SerializationService serializationService = mock(SerializationService.class);
         MinimalPartitionService minimalPartitionService = mock(MinimalPartitionService.class);
         String uuid = UuidUtil.newUnsecureUUID().toString();
         ILogger logger = Logger.getLogger(RepairingTask.class);
 
         return new RepairingTask(hazelcastProperties, metaDataFetcher, executionService.getGlobalTaskScheduler(),
-                 minimalPartitionService, uuid, logger);
+                serializationService, minimalPartitionService, uuid, logger);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
@@ -76,7 +76,7 @@ public class LiteMemberMapNearCacheBasicTest extends AbstractNearCacheBasicTest<
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true);
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -79,22 +79,33 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
     @Parameter(value = 6)
     public Boolean invalidateOnChange;
 
+    @Parameter(value = 7)
+    public Boolean serializeKeys;
+
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} serializeKeys:{7}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
 
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
         });
     }
 
@@ -105,7 +116,7 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, true)
                     .setInvalidateOnChange(invalidateOnChange);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -86,26 +86,27 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
 
     @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} serializeKeys:{7}")
     public static Collection<Object[]> parameters() {
+        // FIXME: there shouldn't be more serializations needed when serializeKeys is false!!!
         return asList(new Object[][]{
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
+                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
+                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
+                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
 
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
+                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
+                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
+                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
+                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
         });
     }
 
@@ -116,7 +117,7 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, true)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, serializeKeys)
                     .setInvalidateOnChange(invalidateOnChange);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -90,23 +90,23 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
         return asList(new Object[][]{
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
-                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true},
-                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true},
-                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true},
-                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
 
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
-                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
-                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
-                {newInt(1, 3, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
-                {newInt(1, 2, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
         });
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -32,8 +32,8 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -66,19 +66,24 @@ public class MapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, Stri
     @Parameter
     public InMemoryFormat inMemoryFormat;
 
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "format:{0}")
+    @Parameters(name = "format:{0}, serializeKeys:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {InMemoryFormat.BINARY},
-                {InMemoryFormat.OBJECT},
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
         });
     }
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true)
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
                 .setCacheLocalEntries(true);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -78,7 +78,7 @@ public class MapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, Stri
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true)
                 .setCacheLocalEntries(true);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -85,26 +85,27 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
 
     @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} serializeKeys:{7}")
     public static Collection<Object[]> parameters() {
+        // FIXME: there shouldn't be more serializations needed when serializeKeys is false!!!
         return asList(new Object[][]{
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
 
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
+                {newInt(1, 2, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
                 {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
+                {newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
         });
     }
 
@@ -115,7 +116,7 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, true)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, serializeKeys)
                     .setInvalidateOnChange(invalidateOnChange)
                     .setCacheLocalEntries(true);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -78,22 +78,33 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
     @Parameter(value = 6)
     public Boolean invalidateOnChange;
 
+    @Parameter(value = 7)
+    public Boolean serializeKeys;
+
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} invalidateOnChange:{6} serializeKeys:{7}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false, false},
 
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 1), OBJECT, BINARY, false, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
         });
     }
 
@@ -104,7 +115,7 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, true)
                     .setInvalidateOnChange(invalidateOnChange)
                     .setCacheLocalEntries(true);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -79,7 +79,7 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true)
                 .setCacheLocalEntries(true)
                 // we have to configure invalidation, otherwise the Near Cache in the TransactionalMap will not be used
                 .setInvalidateOnChange(true);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
@@ -51,7 +52,7 @@ import static java.util.Arrays.asList;
  * Near Cache serialization count tests for {@link com.hazelcast.core.TransactionalMap} on Hazelcast members.
  */
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSerializationCountTest<Data, String> {
 
@@ -73,18 +74,25 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
     @Parameter(value = 5)
     public InMemoryFormat nearCacheInMemoryFormat;
 
+    @Parameter(value = 6)
+    public Boolean serializeKeys;
+
     private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
-    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5}")
+    @Parameters(name = "mapFormat:{4} nearCacheFormat:{5} serializeKeys:{6}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, OBJECT},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, OBJECT, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, OBJECT, false},
 
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, BINARY},
-                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, OBJECT},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, BINARY, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, BINARY, false},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, OBJECT, true},
+                {newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, OBJECT, false},
         });
     }
 
@@ -95,7 +103,7 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
         expectedValueSerializationCounts = valueSerializationCounts;
         expectedValueDeserializationCounts = valueDeserializationCounts;
         if (nearCacheInMemoryFormat != null) {
-            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat)
+            nearCacheConfig = createNearCacheConfig(nearCacheInMemoryFormat, serializeKeys)
                     // we have to enable invalidations, otherwise the Near Cache in the TransactionalMap will not be used
                     .setInvalidateOnChange(true)
                     .setCacheLocalEntries(true);


### PR DESCRIPTION
With the key store-by-reference feature for the Near Cache the
`NearCachedMapProxyImpl.isOwn()` method introduced an unwanted
serialization of the key to check if a key belongs to this member.
Lite Members can skip this check, since they never have local keys.


This PR is needed to show the effect of Near Cache keys stored by-reference.
If we don't merge that feature this PR will show not much effect.

Depends on https://github.com/hazelcast/hazelcast/pull/10555