### PR TITLE
Update getLocalMember() javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -78,6 +78,11 @@ public interface Cluster {
 
     /**
      * Returns this Hazelcast instance member.
+     * <p>
+     * The returned value will never be null, but it may change when local lite member is promoted to a data member
+     * via {@link #promoteLocalLiteMember()}
+     * or when this member merges to a new cluster after split-brain detected. Returned value should not be
+     * cached but instead this method should be called each time when local member is needed.
      *
      * @return this Hazelcast instance member
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -95,6 +95,11 @@ public interface ClusterService extends CoreService, Cluster {
 
     /**
      * Gets the local member instance.
+     * <p>
+     * The returned value will never be null, but it may change when local lite member is promoted to a data member
+     * via {@link #promoteLocalLiteMember()}
+     * or when this member merges to a new cluster after split-brain detected. Returned value should not be
+     * cached but instead this method should be called each time when local member is needed.
      *
      * @return the local member instance. The returned value will never be null.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -175,7 +175,6 @@ abstract class MapProxySupport<K, V>
     protected final SerializationService serializationService;
     protected final boolean statisticsEnabled;
     protected final MapConfig mapConfig;
-    protected final String localMemberUuid;
 
     // not final for testing purposes
     protected MapOperationProvider operationProvider;
@@ -202,8 +201,6 @@ abstract class MapProxySupport<K, V>
         this.serializationService = nodeEngine.getSerializationService();
         this.thisAddress = nodeEngine.getClusterService().getThisAddress();
         this.statisticsEnabled = mapConfig.isStatisticsEnabled();
-        // it is safe to cache local member uuid here because cluster start must be already completed
-        this.localMemberUuid = mapServiceContext.getNodeEngine().getLocalMember().getUuid();
 
         this.putAllBatchSize = properties.getInteger(MAP_PUT_ALL_BATCH_SIZE);
         this.putAllInitialSizeFactor = properties.getFloat(MAP_PUT_ALL_INITIAL_SIZE_FACTOR);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -518,6 +518,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     public String addNearCacheInvalidationListener(InvalidationListener listener) {
+        // local member uuid may change after a split-brain merge
+        String localMemberUuid = getNodeEngine().getClusterService().getLocalMember().getUuid();
         EventFilter eventFilter = new UuidFilter(localMemberUuid);
         return mapServiceContext.addEventListener(listener, eventFilter, name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -133,7 +133,9 @@ public interface NodeEngine {
     /**
      * Returns the local member.
      * <p/>
-     * The returned value will never change and will never be null.
+     * The returned value will never be null but it may change when local lite member is promoted to a data member
+     * or when this member merges to a new cluster after split-brain detected. Returned value should not be
+     * cached but instead this method should be called each time when local member is needed.
      *
      * @return the local member.
      */


### PR DESCRIPTION
`ClusterService.localMember` field can be updated when a lite member is promoted or a cluster merge happens after a split-brain.