### PR TITLE
Fixed spelling of Id, id and -id to ID in test classes

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceCancelTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceCancelTest.java
@@ -44,13 +44,14 @@ import static org.junit.Assert.assertTrue;
 @Ignore
 /*
  * This test is failing because of order problem between actual invoke and cancel.
- * For random and partition, the reason of broken order is also unknown to me (@sancar )
+ * For random and partition, the reason of broken order is also unknown to me (@sancar)
  * For submit to member, it is because we do not have order guarantee in the first place.
- * and when there is partition movement, we can not is partition id since tasks will not move with partitions
+ * and when there is partition movement, we can not is partition ID since tasks will not move with partitions
  */
 public class ClientExecutorServiceCancelTest extends HazelcastTestSupport {
 
     public static final int SLEEP_TIME = 1000000;
+
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     private HazelcastInstance server1;
     private HazelcastInstance server2;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
@@ -65,7 +65,7 @@ public class NestedPredicateVersionedPortablesTest extends HazelcastTestSupport 
                     case 2:
                         return new Limb();
                     default:
-                        throw new IllegalStateException("Wrong class Id");
+                        throw new IllegalStateException("Wrong class ID");
                 }
             }
         });

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
@@ -97,7 +97,7 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
     // needed to have an invocation and this is the easiest way how to get one and do not bother with its result
     private static class GetLostPartitionOperation extends DummyOperation {
         {
-            // we need to set the call-id to prevent running the operation on the calling-thread
+            // we need to set the call ID to prevent running the operation on the calling-thread
             setPartitionId(1);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -470,11 +470,11 @@ public abstract class HazelcastTestSupport {
     }
 
     // ##################################
-    // ########## partition id ##########
+    // ########## partition ID ##########
     // ##################################
 
     /**
-     * Gets a partition id owned by this particular member.
+     * Gets a partition ID owned by this particular member.
      */
     public static int getPartitionId(HazelcastInstance hz) {
         warmUpPartitions(hz);


### PR DESCRIPTION
We have a very inconsistent use of ID in the comments and JavaDoc. This
 makes the existing documentation hard to read. It also makes it hard to
 decide how to write new documentation.

This commit unifies the usage to the style of the reference manual. It
has been chosen since ID and IDs is easier to distinct from it and its.

Old style:
* this id identifies
* all the ids in its chunk
* collects its ids if it's done
* @param id id of the interceptor

New style:
* this ID identifies
* all the IDs in its chunk
* collects its IDs if it's done
* @param id ID of the interceptor