### PR TITLE
Fixed spelling of Id, id and -id to ID in MessageTask classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/NoSuchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/NoSuchMessageTask.java
@@ -22,11 +22,7 @@ import com.hazelcast.nio.Connection;
 
 import java.security.Permission;
 
-/**
- *
- */
-public class NoSuchMessageTask
-        extends AbstractMessageTask<ClientMessage> {
+public class NoSuchMessageTask extends AbstractMessageTask<ClientMessage> {
 
     public NoSuchMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -70,7 +66,7 @@ public class NoSuchMessageTask
         return null;
     }
 
-    //Overriding the partition id send from client as it is not recognized
+    // overriding the partition ID send from client as it is not recognized
     @Override
     public int getPartitionId() {
         return -1;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
@@ -45,7 +45,7 @@ public class ExecutorServiceSubmitToPartitionMessageTask
     @Override
     protected InvocationBuilder getInvocationBuilder(Operation op) {
         if (parameters.partitionId == -1) {
-            throw new IllegalArgumentException("Partition id is -1");
+            throw new IllegalArgumentException("Partition ID is -1");
         }
 
         final InternalOperationService operationService = nodeEngine.getOperationService();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_ADDALL}
  */
 public class ListAddAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllWithIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllWithIndexMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_ADDALLWITHINDEX}
  */
 public class ListAddAllWithIndexMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_ADD}
  */
 public class ListAddMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddWithIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddWithIndexMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_ADDWITHINDEX}
  */
 public class ListAddWithIndexMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListClearMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_CLEAR}
  */
 public class ListClearMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRemoveAllMessageTask.java
@@ -33,7 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_COMPAREANDREMOVEALL}
  */
 public class ListCompareAndRemoveAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRetainAllMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 import java.util.HashSet;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_COMPAREANDRETAINALL}
  */
 public class ListCompareAndRetainAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsAllMessageTask.java
@@ -33,7 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_CONTAINSALL}
  */
 public class ListContainsAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 import java.util.HashSet;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_CONTAINS}
  */
 public class ListContainsMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetAllMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.impl.SerializableList;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_GETALL}
  */
 public class ListGetAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_GET}
  */
 public class ListGetMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIndexOfMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIndexOfMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_INDEXOF}
  */
 public class ListIndexOfMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIsEmptyMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_ADDLISTENER}
  */
 public class ListIsEmptyMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIteratorMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.impl.SerializableList;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_ITERATOR}
  */
 public class ListIteratorMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListLastIndexOfMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListLastIndexOfMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_LASTINDEXOF}
  */
 public class ListLastIndexOfMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListListIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListListIteratorMessageTask.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.impl.SerializableList;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_LISTITERATOR}
  */
 public class ListListIteratorMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveListenerMessageTask.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.EventService;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_REMOVELISTENER}
  */
 public class ListRemoveListenerMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_REMOVE}
  */
 public class ListRemoveMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveWithIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveWithIndexMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_REMOVEWITHINDEX}
  */
 public class ListRemoveWithIndexMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSetMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_SET}
  */
 public class ListSetMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSizeMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_SIZE}
  */
 public class ListSizeMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSubMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSubMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.impl.SerializableList;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_SUB}
  */
 public class ListSubMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddListenerMessageTask.java
@@ -35,7 +35,7 @@ import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_ADDLISTENER}
  */
 public class MapAddListenerMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_DESTROYCACHE}
  */
 public class MapDestroyCacheMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapMadePublishableMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapMadePublishableMessageTask.java
@@ -29,7 +29,7 @@ import java.security.Permission;
 import java.util.Map;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_MADEPUBLISHABLE}
  */
 public class MapMadePublishableMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
@@ -47,7 +47,7 @@ import java.util.concurrent.Future;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_PUBLISHERCREATE}
  */
 public class MapPublisherCreateMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
@@ -48,7 +48,7 @@ import java.util.concurrent.Future;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_PUBLISHERCREATEWITHVALUE}
  */
 public class MapPublisherCreateWithValueMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetReadCursorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetReadCursorMessageTask.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.ContinuousQueryMessageType#CONTINUOUSQUERY_SETREADCURSOR}
  */
 public class MapSetReadCursorMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceJobProcessInformationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceJobProcessInformationMessageTask.java
@@ -49,7 +49,7 @@ public class MapReduceJobProcessInformationMessageTask
             return MapReduceJobProcessInformationCodec.encodeResponse(jobPartitionStates, current.getProcessedRecords());
         }
         throw new IllegalStateException(
-                "Information not found for map reduce with name: " + parameters.name + ", job id: " + parameters.jobId);
+                "Information not found for map reduce with name: " + parameters.name + ", job ID: " + parameters.jobId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerMessageTask.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_ADDENTRYLISTENER}
  */
 public class MultiMapAddEntryListenerMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerToKeyMessageTask.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_ADDENTRYLISTENERTOKEY}
  */
 public class MultiMapAddEntryListenerToKeyMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapClearMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 import java.util.Map;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_CLEAR}
  */
 public class MultiMapClearMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsEntryMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_CONTAINSENTRY}
  */
 public class MultiMapContainsEntryMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsKeyMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_CONTAINSKEY}
  */
 public class MultiMapContainsKeyMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsValueMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 import java.util.Map;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_CONTAINSVALUE}
  */
 public class MultiMapContainsValueMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapEntrySetMessageTask.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_ENTRYSET}
  */
 public class MultiMapEntrySetMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapForceUnlockMessageTask.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_FORCEUNLOCK}
  */
 public class MultiMapForceUnlockMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapGetMessageTask.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_GET}
  */
 public class MultiMapGetMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapIsLockedMessageTask.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_ISLOCKED}
  */
 public class MultiMapIsLockedMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapKeySetMessageTask.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_KEYSET}
  */
 public class MultiMapKeySetMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_LOCK}
  */
 public class MultiMapLockMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapPutMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_PUT}
  */
 public class MultiMapPutMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryListenerMessageTask.java
@@ -28,7 +28,7 @@ import com.hazelcast.security.permission.MultiMapPermission;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_REMOVEENTRYLISTENER}
  */
 public class MultiMapRemoveEntryListenerMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_REMOVEENTRY}
  */
 public class MultiMapRemoveEntryMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveMessageTask.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_REMOVE}
  */
 public class MultiMapRemoveMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapSizeMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 import java.util.Map;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_SIZE}
  */
 public class MultiMapSizeMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_TRYLOCK}
  */
 public class MultiMapTryLockMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapUnlockMessageTask.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_UNLOCK}
  */
 public class MultiMapUnlockMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValueCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValueCountMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_VALUECOUNT}
  */
 public class MultiMapValueCountMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValuesMessageTask.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_VALUES}
  */
 public class MultiMapValuesMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddAllMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_ADDLISTENER}
  */
 public class QueueAddAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddListenerMessageTask.java
@@ -33,7 +33,7 @@ import com.hazelcast.security.permission.QueuePermission;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_ADDLISTENER}
  */
 public class QueueAddListenerMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueClearMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_CLEAR}
  */
 public class QueueClearMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRemoveAllMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_COMPAREANDREMOVEALL}
  */
 public class QueueCompareAndRemoveAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRetainAllMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_COMPAREANDRETAINALL}
  */
 public class QueueCompareAndRetainAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsAllMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_CONTAINSALL}
  */
 public class QueueContainsAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsMessageTask.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 import java.util.HashSet;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_CONTAINS}
  */
 public class QueueContainsMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMaxSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMaxSizeMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_DRAINTOMAXSIZE}
  */
 public class QueueDrainMaxSizeMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_DRAINTO}
  */
 public class QueueDrainMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIsEmptyMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_ISEMPTY}
  */
 public class QueueIsEmptyMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIteratorMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_ITERATOR}
  */
 public class QueueIteratorMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueOfferMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueOfferMessageTask.java
@@ -31,7 +31,7 @@ import java.security.Permission;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_OFFER}
  */
 public class QueueOfferMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePeekMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePeekMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_PEEK}
  */
 public class QueuePeekMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePollMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePollMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_POLL}
  */
 public class QueuePollMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePutMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_PUT}
  */
 public class QueuePutMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemainingCapacityMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemainingCapacityMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_REMAININGCAPACITY}
  */
 public class QueueRemainingCapacityMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveListenerMessageTask.java
@@ -28,7 +28,7 @@ import com.hazelcast.security.permission.QueuePermission;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_REMOVELISTENER}
  */
 public class QueueRemoveListenerMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_REMOVE}
  */
 public class QueueRemoveMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueSizeMessageTask.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_SIZE}
  */
 public class QueueSizeMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueTakeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueTakeMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_TAKE}
  */
 public class QueueTakeMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddAllMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_ADDALL}
  */
 public class RingbufferAddAllMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_ADD}
  */
 public class RingbufferAddMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_READMANY}
  */
 public class RingbufferReadManyMessageTask

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadOneMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadOneMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.Operation;
 import java.security.Permission;
 
 /**
- * Client Protocol Task for handling messages with type id:
+ * Client Protocol Task for handling messages with type ID:
  * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_READONE}
  */
 public class RingbufferReadOneMessageTask


### PR DESCRIPTION
We have a very inconsistent use of ID in the comments and JavaDoc. This
 makes the existing documentation hard to read. It also makes it hard to
 decide how to write new documentation.

This commit unifies the usage to the style of the reference manual. It
has been chosen since ID and IDs is easier to distinct from it and its.

Old style:
* this id identifies
* all the ids in its chunk
* collects its ids if it's done
* @param id id of the interceptor

New style:
* this ID identifies
* all the IDs in its chunk
* collects its IDs if it's done
* @param id ID of the interceptor