### PR TITLE
Fix rescheduling on stopped tasks after migrating back to origin

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -291,9 +291,7 @@ public class ScheduledExecutorContainer {
                     // to the Executor's Future, hence, we have no access on the runner thread to interrupt. In this case
                     // the line below is only cancelling future runs.
                     try {
-                        descriptor.cancel(true);
-                        descriptor.setScheduledFuture(null);
-                        descriptor.setTaskOwner(false);
+                        descriptor.stopForMigration();
                     } catch (Exception ex) {
                         throw rethrow(ex);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -140,9 +140,15 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
         return future.get();
     }
 
+    void stopForMigration() {
+        // Result is not set, allowing task to get re-scheduled, if/when needed.
+        this.isTaskOwner = false;
+        this.future.cancel(true);
+        this.future = null;
+    }
+
     boolean cancel(boolean mayInterrupt)
             throws ExecutionException, InterruptedException {
-
         if (!resultRef.compareAndSet(null, new ScheduledTaskResult(true)) || future == null) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskStatisticsImpl.java
@@ -39,11 +39,11 @@ public class ScheduledTaskStatisticsImpl
 
     private long lastRunEnd;
 
-    private long lastIdleTime;
+    private long lastIdleDuration;
 
-    private long totalRunTime;
+    private long totalRunDuration;
 
-    private long totalIdleTime;
+    private long totalIdleDuration;
 
     public ScheduledTaskStatisticsImpl() {
     }
@@ -57,9 +57,9 @@ public class ScheduledTaskStatisticsImpl
     public ScheduledTaskStatisticsImpl(long runs, long lastIdleTimeNanos, long totalRunTimeNanos,
                                        long totalIdleTimeNanos) {
         this.runs = runs;
-        this.lastIdleTime = lastIdleTimeNanos;
-        this.totalRunTime = totalRunTimeNanos;
-        this.totalIdleTime = totalIdleTimeNanos;
+        this.lastIdleDuration = lastIdleTimeNanos;
+        this.totalRunDuration = totalRunTimeNanos;
+        this.totalIdleDuration = totalIdleTimeNanos;
     }
 
     ScheduledTaskStatisticsImpl(long createdAt, long runs, long firstRunStartNanos, long lastRunStartNanos,
@@ -70,9 +70,9 @@ public class ScheduledTaskStatisticsImpl
         this.firstRunStart = firstRunStartNanos;
         this.lastRunStart = lastRunStartNanos;
         this.lastRunEnd = lastRunEndNanos;
-        this.lastIdleTime = lastIdleTimeNanos;
-        this.totalRunTime = totalRunTimeNanos;
-        this.totalIdleTime = totalIdleTimeNanos;
+        this.lastIdleDuration = lastIdleTimeNanos;
+        this.totalRunDuration = totalRunTimeNanos;
+        this.totalIdleDuration = totalIdleTimeNanos;
     }
 
     @Override
@@ -88,17 +88,17 @@ public class ScheduledTaskStatisticsImpl
 
     @Override
     public long getLastIdleTime(TimeUnit unit) {
-        return unit.convert(lastIdleTime, MEASUREMENT_UNIT);
+        return unit.convert(lastIdleDuration, MEASUREMENT_UNIT);
     }
 
     @Override
     public long getTotalIdleTime(TimeUnit unit) {
-        return unit.convert(totalIdleTime, MEASUREMENT_UNIT);
+        return unit.convert(totalIdleDuration, MEASUREMENT_UNIT);
     }
 
     @Override
     public long getTotalRunTime(TimeUnit unit) {
-        return unit.convert(totalRunTime, MEASUREMENT_UNIT);
+        return unit.convert(totalRunDuration, MEASUREMENT_UNIT);
     }
 
 
@@ -116,18 +116,18 @@ public class ScheduledTaskStatisticsImpl
     public void writeData(ObjectDataOutput out)
             throws IOException {
         out.writeLong(runs);
-        out.writeLong(lastIdleTime);
-        out.writeLong(totalIdleTime);
-        out.writeLong(totalRunTime);
+        out.writeLong(lastIdleDuration);
+        out.writeLong(totalIdleDuration);
+        out.writeLong(totalRunDuration);
     }
 
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
         runs = in.readLong();
-        lastIdleTime = in.readLong();
-        totalIdleTime = in.readLong();
-        totalRunTime = in.readLong();
+        lastIdleDuration = in.readLong();
+        totalIdleDuration = in.readLong();
+        totalRunDuration = in.readLong();
     }
 
     @Override
@@ -139,8 +139,8 @@ public class ScheduledTaskStatisticsImpl
     public void onBeforeRun() {
         long now = System.nanoTime();
         this.lastRunStart = now;
-        this.lastIdleTime = now - (lastRunEnd != 0L ? lastRunEnd : createdAt);
-        this.totalIdleTime += lastIdleTime;
+        this.lastIdleDuration = now - (lastRunEnd != 0L ? lastRunEnd : createdAt);
+        this.totalIdleDuration += lastIdleDuration;
 
         if (this.firstRunStart == 0L) {
             this.firstRunStart = this.lastRunStart;
@@ -155,7 +155,7 @@ public class ScheduledTaskStatisticsImpl
 
         this.lastRunEnd = now;
         this.runs++;
-        this.totalRunTime += lastRunTime;
+        this.totalRunDuration += lastRunTime;
 
     }
 
@@ -165,8 +165,10 @@ public class ScheduledTaskStatisticsImpl
 
     @Override
     public String toString() {
-        return "ScheduledTaskStatisticsImpl{ runs=" + runs + ", createdAt="
-                + createdAt + ", firstRunStart=" + firstRunStart + ", lastRunStart=" + lastRunStart + ", lastRunEnd=" + lastRunEnd
-                + ", lastIdleTime=" + lastIdleTime + ", totalRunTime=" + totalRunTime + ", totalIdleTime=" + totalIdleTime + '}';
+        return "ScheduledTaskStatisticsImpl{runs=" + runs
+                + ", lastIdleDuration=" + lastIdleDuration
+                + ", totalRunDuration=" + totalRunDuration
+                + ", totalIdleDuration=" + totalIdleDuration
+                + '}';
     }
 }


### PR DESCRIPTION
Starting a task on a single node, and then adding one more member, causes some of the tasks to migrate to partitions owned by the latter member. 
During this process, the container stops currently running task, leaving it in a `cancelled` state. If this state, doesn't get disposed (eg. cluster never gets bigger), when the latter member goes down, the tasks will migrate back to the first one. However, since their state there is marked as cancelled, they never get re-scheduled.

The fix, introduces a `stop` method, which still cancels the task, but doesn't interact with the state.
Fix #10603 

Also, minor cleanup and namings.
