### PR TITLE
Added config string and pointer to Near Cache serialization count tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -139,6 +139,14 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
     }
 
     @Override
+    protected void addConfiguration(StringBuilder config) {
+        appendConfig(config, cacheInMemoryFormat);
+        appendConfig(config, nearCacheInMemoryFormat);
+        appendConfig(config, invalidateOnChange);
+        config.append(localUpdatePolicy);
+    }
+
+    @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig();
         prepareSerializationConfig(config.getSerializationConfig());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -115,6 +115,13 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
     }
 
     @Override
+    protected void addConfiguration(StringBuilder config) {
+        appendConfig(config, mapInMemoryFormat);
+        appendConfig(config, nearCacheInMemoryFormat);
+        config.append(invalidateOnChange);
+    }
+
+    @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig();
         config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -108,6 +108,12 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
     }
 
     @Override
+    protected void addConfiguration(StringBuilder config) {
+        appendConfig(config, replicatedMapInMemoryFormat);
+        config.append(nearCacheInMemoryFormat);
+    }
+
+    @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig();
         config.getReplicatedMapConfig(DEFAULT_NEAR_CACHE_NAME)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -116,6 +116,13 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
     }
 
     @Override
+    protected void addConfiguration(StringBuilder config) {
+        appendConfig(config, mapInMemoryFormat);
+        appendConfig(config, nearCacheInMemoryFormat);
+        config.append(invalidateOnChange);
+    }
+
+    @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance(createConfig(nearCacheConfig, false));
         HazelcastInstance liteMember = hazelcastFactory.newHazelcastInstance(createConfig(nearCacheConfig, true));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -116,6 +116,13 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
     }
 
     @Override
+    protected void addConfiguration(StringBuilder config) {
+        appendConfig(config, mapInMemoryFormat);
+        appendConfig(config, nearCacheInMemoryFormat);
+        config.append(invalidateOnChange);
+    }
+
+    @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config configWithNearCache = getConfig(true);
         Config config = getConfig(false);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -108,6 +108,12 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
     }
 
     @Override
+    protected void addConfiguration(StringBuilder config) {
+        appendConfig(config, mapInMemoryFormat);
+        config.append(nearCacheInMemoryFormat);
+    }
+
+    @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config configWithNearCache = getConfig(true);
         Config config = getConfig(false);


### PR DESCRIPTION
Example failure:
```java
java.lang.AssertionError: value serializeCount on first get(): expected 0, but was 1
newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 1, 0), OBJECT, BINARY
                                            ↑
[com.hazelcast.nio.serialization.HazelcastSerializationException:
        invoked value serialization
    at com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest
        .getStackTrace(AbstractNearCacheSerializationCountTest.java:277)
...]
```
This makes it much easier to find the line and counter on a serialization count failure