### PR TITLE
Added SSLEngineFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
@@ -29,18 +29,22 @@ public final class SSLConfig {
     private Properties properties = new Properties();
 
     /**
-     * Returns the name of the {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation class.
+     * Returns the name of the implementation class.
      *
-     * @return the name of the {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation class
+     * Class can either be an  {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     *
+     * @return the name implementation class.
      */
     public String getFactoryClassName() {
         return factoryClassName;
     }
 
     /**
-     * Sets the name for the {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation class.
+     * Sets the name for the implementation class.
      *
-     * @param factoryClassName the name of the {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation class to set
+     * Class can either be an  {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     *
+     * @param factoryClassName the name implementation class.
      */
     public SSLConfig setFactoryClassName(String factoryClassName) {
         this.factoryClassName = factoryClassName;
@@ -67,9 +71,12 @@ public final class SSLConfig {
     }
 
     /**
-     * Sets the {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation object.
+     * Sets the implementation object.
      *
-     * @param factoryImplementation the factory {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation object
+     * Object must be instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory} or
+     * {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     *
+     * @param factoryImplementation the implementation object.
      * @return this SSLConfig instance
      */
     public SSLConfig setFactoryImplementation(Object factoryImplementation) {
@@ -78,9 +85,11 @@ public final class SSLConfig {
     }
 
     /**
-     * Returns the factory {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation object.
+     * Returns the factory implementation object.
      *
-     * @return the factory {@link com.hazelcast.nio.ssl.SSLContextFactory} implementation object
+     * Object is instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory} or {@link com.hazelcast.nio.ssl.SSLEngineFactory}.
+     *
+     * @return the factory implementation object
      */
     public Object getFactoryImplementation() {
         return factoryImplementation;

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactory.java
@@ -16,22 +16,28 @@
 
 package com.hazelcast.nio.ssl;
 
-import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import java.util.Properties;
 
-public class BasicSSLContextFactory extends SSLEngineFactorySupport implements SSLContextFactory {
+/**
+ * The {@link SSLEngineFactory} is responsible for creating an SSLEngine instance.
+ */
+public interface SSLEngineFactory {
 
-    private SSLContext sslContext;
+    /**
+     * Initializes this class with config from {@link com.hazelcast.config.SSLConfig}
+     *
+     * @param properties properties form config
+     * @throws Exception
+     */
+    void init(Properties properties) throws Exception;
 
-    @Override
-    public void init(Properties properties) throws Exception {
-        load(properties);
-        sslContext = SSLContext.getInstance(protocol);
-        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-    }
 
-    @Override
-    public SSLContext getSSLContext() {
-        return sslContext;
-    }
+    /**
+     * Creates a SSLEngine.
+     *
+     * @param clientMode if the SSLEngine should be in client mode, or server-mode. See {@link SSLEngine#getUseClientMode()}.
+     * @return the created SSLEngine.
+     */
+    SSLEngine create(boolean clientMode);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactorySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactorySupport.java
@@ -31,9 +31,10 @@ import java.security.cert.CertificateException;
 import java.util.Properties;
 
 /**
- * Abstract SSLContextFactory that create the logic for KeyManager and TrustManager.
+ * A support class for {@link SSLEngineFactory} and {@link SSLContextFactory} implementation that takes care of
+ * the logic for KeyManager and TrustManager.
  */
-public abstract class AbstractSSLContextFactory implements SSLContextFactory {
+abstract class SSLEngineFactorySupport {
 
     public static final String JAVA_NET_SSL_PREFIX = "javax.net.ssl.";
 


### PR DESCRIPTION
This is needed so that HZ enterprise can switch between SSLContextFactory and
SSLEngineFactory implementations. On the serverside when an SSLContextFactory
is encountered, it will be adapted to a SSLEngineFactory.