### PR TITLE
Added getRecord(K key) method to NearCacheRecordStore

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheRecordStateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheRecordStateStressTest.java
@@ -26,8 +26,8 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
+import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
-import com.hazelcast.internal.nearcache.impl.store.AbstractNearCacheRecordStore;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -201,7 +201,7 @@ public class ClientCacheRecordStateStressTest extends HazelcastTestSupport {
     private void assertFinalRecordStateIsReadPermitted(Cache clientCache, InternalSerializationService serializationService) {
         NearCachedClientCacheProxy proxy = (NearCachedClientCacheProxy) clientCache;
         DefaultNearCache nearCache = (DefaultNearCache) proxy.getNearCache().unwrap(DefaultNearCache.class);
-        AbstractNearCacheRecordStore nearCacheRecordStore = (AbstractNearCacheRecordStore) nearCache.getNearCacheRecordStore();
+        NearCacheRecordStore nearCacheRecordStore = nearCache.getNearCacheRecordStore();
 
         for (int i = 0; i < KEY_SPACE; i++) {
             Data key = serializationService.toData(i);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -30,11 +30,12 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
+import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataContainer;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
-import com.hazelcast.internal.nearcache.impl.store.AbstractNearCacheRecordStore;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -197,7 +198,7 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
                 Data keyData = getSerializationService(serverInstance).toData(i);
                 int partitionId = partitionService.getPartitionId(keyData);
 
-                AbstractNearCacheRecordStore nearCacheRecordStore = getAbstractNearCacheRecordStore();
+                NearCacheRecordStore nearCacheRecordStore = getNearCacheRecordStore();
                 NearCacheRecord record = nearCacheRecordStore.getRecord(keyData);
                 long recordSequence = record == null ? NO_SEQUENCE : record.getInvalidationSequence();
 
@@ -215,9 +216,10 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
                 return cacheEventHandler.getMetaDataGenerator();
             }
 
-            private AbstractNearCacheRecordStore getAbstractNearCacheRecordStore() {
-                DefaultNearCache defaultNearCache = (DefaultNearCache) ((NearCachedClientCacheProxy) clientCache).getNearCache().unwrap(DefaultNearCache.class);
-                return (AbstractNearCacheRecordStore) defaultNearCache.getNearCacheRecordStore();
+            private NearCacheRecordStore getNearCacheRecordStore() {
+                NearCache nearCache = ((NearCachedClientCacheProxy) clientCache).getNearCache();
+                DefaultNearCache defaultNearCache = (DefaultNearCache) nearCache.unwrap(DefaultNearCache.class);
+                return defaultNearCache.getNearCacheRecordStore();
             }
         });
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapRecordStateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapRecordStateStressTest.java
@@ -23,8 +23,8 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
+import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
-import com.hazelcast.internal.nearcache.impl.store.AbstractNearCacheRecordStore;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -145,7 +145,7 @@ public class ClientMapRecordStateStressTest extends HazelcastTestSupport {
     private static void assertFinalRecordStateIsReadPermitted(IMap clientMap, InternalSerializationService serializationService) {
         NearCachedClientMapProxy proxy = (NearCachedClientMapProxy) clientMap;
         DefaultNearCache nearCache = (DefaultNearCache) proxy.getNearCache().unwrap(DefaultNearCache.class);
-        AbstractNearCacheRecordStore nearCacheRecordStore = (AbstractNearCacheRecordStore) nearCache.getNearCacheRecordStore();
+        NearCacheRecordStore nearCacheRecordStore = nearCache.getNearCacheRecordStore();
 
         for (int i = 0; i < KEY_SPACE; i++) {
             Data key = serializationService.toData(i);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
@@ -40,6 +40,14 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
     V get(K key);
 
     /**
+     * Gets the record associated with the given {@code key}.
+     *
+     * @param key the key from which to get the associated {@link NearCacheRecord}.
+     * @return the {@link NearCacheRecord} associated with the given {@code key}.
+     */
+    NearCacheRecord getRecord(K key);
+
+    /**
      * Puts (associates) a value with the given {@code key}.
      *
      * @param key   the key to which the given value will be associated.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -134,6 +134,9 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
         return staleReadDetector;
     }
 
+    @Override
+    public abstract R getRecord(K key);
+
     protected abstract EvictionChecker createNearCacheEvictionChecker(EvictionConfig evictionConfig,
                                                                       NearCacheConfig nearCacheConfig);
 
@@ -148,9 +151,6 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
     protected abstract void updateRecordValue(R record, V value);
 
     protected abstract V recordToValue(R record);
-
-    // public for tests
-    public abstract R getRecord(K key);
 
     protected abstract R getOrCreateToReserve(K key);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
@@ -281,6 +281,11 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         }
 
         @Override
+        public NearCacheRecord getRecord(Integer key) {
+            return null;
+        }
+
+        @Override
         public void put(Integer key, String value) {
             if (expectedKeyValueMappings == null) {
                 throw new IllegalStateException("Near-Cache is already destroyed");

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -29,7 +29,6 @@ import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
 import com.hazelcast.internal.adapter.MethodAvailableMatcher;
 import com.hazelcast.internal.adapter.ReplicatedMapDataStructureAdapter;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
-import com.hazelcast.internal.nearcache.impl.store.AbstractNearCacheRecordStore;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.monitor.NearCacheStats;
@@ -49,7 +48,6 @@ import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UP
 import static com.hazelcast.internal.nearcache.NearCacheRecord.READ_PERMITTED;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
@@ -160,12 +158,12 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
      *
      * @param context the {@link NearCacheTestContext} to retrieve the Near Cache from
      * @param key     the key to get the value from
-     * @return the {@link NearCacheRecord} of the given key from the Near Cache
+     * @return the {@link NearCacheRecord} of the given key from the Near Cache or {@code null} if record store cannot be casted
      */
     @SuppressWarnings("unchecked")
     public static NearCacheRecord getRecordFromNearCache(NearCacheTestContext<?, ?, ?, ?> context, Object key) {
         DefaultNearCache nearCache = (DefaultNearCache) context.nearCache;
-        AbstractNearCacheRecordStore nearCacheRecordStore = (AbstractNearCacheRecordStore) nearCache.getNearCacheRecordStore();
+        NearCacheRecordStore nearCacheRecordStore = nearCache.getNearCacheRecordStore();
         return nearCacheRecordStore.getRecord(key);
     }
 
@@ -235,9 +233,10 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
             assertEquals("value-" + i, value);
 
             NearCacheRecord record = getRecordFromNearCache(context, key);
-            assertNotNull(format("The NearCacheRecord for key %d should exist", i), record);
-            assertEquals(format("The NearCacheRecord for key %d should be READ_PERMITTED (%s)", i, record),
-                    READ_PERMITTED, record.getRecordState());
+            if (record != null) {
+                assertEquals(format("The NearCacheRecord for key %d should be READ_PERMITTED (%s)", i, record),
+                        READ_PERMITTED, record.getRecordState());
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapRecordStateStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapRecordStateStressTest.java
@@ -21,8 +21,8 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
+import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
-import com.hazelcast.internal.nearcache.impl.store.AbstractNearCacheRecordStore;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.nio.serialization.Data;
@@ -151,7 +151,7 @@ public class MemberMapRecordStateStressTest extends HazelcastTestSupport {
     private static void assertFinalRecordStateIsReadPermitted(IMap memberMap, InternalSerializationService serializationService) {
         NearCachedMapProxyImpl proxy = (NearCachedMapProxyImpl) memberMap;
         DefaultNearCache nearCache = (DefaultNearCache) proxy.getNearCache().unwrap(DefaultNearCache.class);
-        AbstractNearCacheRecordStore nearCacheRecordStore = (AbstractNearCacheRecordStore) nearCache.getNearCacheRecordStore();
+        NearCacheRecordStore nearCacheRecordStore = nearCache.getNearCacheRecordStore();
 
         for (int i = 0; i < KEY_SPACE; i++) {
             Data key = serializationService.toData(i);


### PR DESCRIPTION
This enabled to test `NearCacheRecord` on OS and EE without casting
madness.