### PR TITLE
ClientHeartbeatMonitor.start is moved to ClientEngine init phase

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -143,9 +143,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         this.messageTaskFactory = new CompositeMessageTaskFactory(this.nodeEngine);
         this.clientExceptionFactory = initClientExceptionFactory();
         this.endpointRemoveDelaySeconds = node.getProperties().getInteger(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS);
-        ClientHeartbeatMonitor heartbeatMonitor = new ClientHeartbeatMonitor(
-                endpointManager, this, nodeEngine.getExecutionService(), node.getProperties());
-        heartbeatMonitor.start();
     }
 
     private ClientExceptionFactory initClientExceptionFactory() {
@@ -356,6 +353,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         node.getConnectionManager().addConnectionListener(connectionListener);
+
+        ClientHeartbeatMonitor heartbeatMonitor = new ClientHeartbeatMonitor(
+                endpointManager, this, nodeEngine.getExecutionService(), node.getProperties());
+        heartbeatMonitor.start();
     }
 
     @Override


### PR DESCRIPTION
ClientHeartbeatMonitor was being scheduled during ClientEngine construction.
Instead, it's now scheduled during ClientEngine init phase to prevent
usage of partially constructed Node, ClusterService etc.

Fixes https://github.com/hazelcast/hazelcast/issues/10615