### PR TITLE
HeapData reuses byte[] of ClientMessage to avoid copy

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -399,7 +399,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     @SuppressWarnings("unchecked")
     private void cacheOrInvalidate(Data keyData, Data valueData, V value) {
         if (cacheOnUpdate) {
-            V valueToStore = (V) nearCache.selectToSave(valueData, value);
+            V valueToStore = (V) nearCache.selectToSave(valueData.compact(), value);
             nearCache.put(keyData, valueToStore);
         } else {
             invalidateNearCache(keyData);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -157,7 +157,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
             ((ClientDelegatingFuture) future).andThenInternal(new ExecutionCallback<Data>() {
                 @Override
                 public void onResponse(Data value) {
-                    nearCache.tryPublishReserved(key, value, reservationId, false);
+                    nearCache.tryPublishReserved(key, value.compact(), reservationId, false);
                 }
 
                 @Override
@@ -392,8 +392,8 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
             responses = super.getAllInternal(pIdToKeyData, result);
             for (MapGetAllCodec.ResponseParameters resultParameters : responses) {
                 for (Entry<Data, Data> entry : resultParameters.response) {
-                    Data key = entry.getKey();
-                    Data value = entry.getValue();
+                    Data key = entry.getKey().compact();
+                    Data value = entry.getValue().compact();
 
                     Long reservationId = reservations.get(key);
                     if (reservationId != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
@@ -20,9 +20,7 @@ import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.serialization.Data;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -178,15 +176,14 @@ public class MessageFlyweight {
         return new HeapData(getByteArray());
     }
 
-    public List<Data> getDataList() {
+    public Data getDataReuse() {
         final int length = buffer.getInt(index + offset);
         index += Bits.INT_SIZE_IN_BYTES;
-        final List<Data> result = new ArrayList<Data>();
-        for (int i = 0; i < length; i++) {
-            result.add(getData());
-        }
-        return result;
+        Data data = new HeapData(buffer.byteArray(), index + offset, length);
+        index += length;
+        return data;
     }
+
     //endregion GET Overloads
 
     protected int int32Get(int index) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -116,7 +116,6 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     // These 3 fields are only used during read/write. Otherwise they have no meaning.
     private int valueOffset;
-    private int size;
     private boolean headerComplete;
 
     public Packet() {
@@ -254,8 +253,7 @@ public final class Packet extends HeapData implements OutboundFrame {
             dst.put(VERSION);
             dst.putChar(flags);
             dst.putInt(partitionId);
-            size = totalSize();
-            dst.putInt(size);
+            dst.putInt(totalSize());
             headerComplete = true;
         }
 
@@ -283,7 +281,7 @@ public final class Packet extends HeapData implements OutboundFrame {
 
             flags = src.getChar();
             partitionId = src.getInt();
-            size = src.getInt();
+            length = src.getInt();
             headerComplete = true;
         }
 
@@ -294,13 +292,13 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     private boolean readValue(ByteBuffer src) {
         if (payload == null) {
-            payload = new byte[size];
+            payload = new byte[length];
         }
 
-        if (size > 0) {
+        if (length > 0) {
             int bytesReadable = src.remaining();
 
-            int bytesNeeded = size - valueOffset;
+            int bytesNeeded = length - valueOffset;
 
             boolean done;
             int bytesRead;
@@ -325,12 +323,12 @@ public final class Packet extends HeapData implements OutboundFrame {
     }
 
     private boolean writeValue(ByteBuffer dst) {
-        if (size > 0) {
+        if (length > 0) {
             // the number of bytes that can be written to the bb.
             int bytesWritable = dst.remaining();
 
             // the number of bytes that need to be written.
-            int bytesNeeded = size - valueOffset;
+            int bytesNeeded = length - valueOffset;
 
             int bytesWrite;
             boolean done;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
@@ -25,6 +25,21 @@ import com.hazelcast.spi.serialization.SerializationService;
 public interface Data {
 
     /**
+     * if internal byte-buffer contains more data, content from offset is copied to a new array with size totalSize()
+     *
+     * @return compact version of this data. If already compact returns itself.
+     */
+    Data compact();
+
+    /**
+     * toByteArray(); returns internal byte buffer which can contain more data then actual data
+     *
+     * @return offset of actual data starting point on internal byte array, if internal byte-array contains only data
+     * then offset is 0
+     */
+    int offset();
+
+    /**
      * Returns byte array representation of internal binary format.
      *
      * @return binary data
@@ -57,8 +72,8 @@ public interface Data {
      * The reason this method exists instead of relying on the {@link #toByteArray()} is the existence of the NativeMemoryData.
      * With the NativeMemoryData it would lead to a temporary byte-array. This method prevents this temporary byte-array needing
      * to be created.
-      *
-     * @param dest to byte-buffer to write to
+     *
+     * @param dest    to byte-buffer to write to
      * @param destPos the position in the destination buffer.
      */
     void copyTo(byte[] dest, int destPos);

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/FlyweightTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/FlyweightTest.java
@@ -18,7 +18,8 @@ package com.hazelcast.client.protocol;
 
 import com.hazelcast.client.impl.protocol.util.MessageFlyweight;
 import com.hazelcast.client.impl.protocol.util.SafeBuffer;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -34,11 +35,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Flyweight Tests
- */
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class FlyweightTest {
 
     private static byte[] DATA = new byte[]{(byte) 0x61, (byte) 0x62, (byte) 0x63, (byte) 0xC2, (byte) 0xA9, (byte) 0xE2,

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/ToHeapDataConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/ToHeapDataConverterTest.java
@@ -53,6 +53,16 @@ public class ToHeapDataConverterTest {
     class AnotherDataImpl implements Data {
 
         @Override
+        public Data compact() {
+            return this;
+        }
+
+        @Override
+        public int offset() {
+            return 0;
+        }
+
+        @Override
         public byte[] toByteArray() {
             return new byte[0];
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
@@ -42,7 +42,7 @@ public class EntryCostEstimatorTest
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
     // the JVM-independent portion of the cost of Integer key + Long value record is 124 bytes
     // (without taking into account 8 references to key, record and value objects)
-    private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 124;
+    private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 140;
     // JVM-dependent total cost of entry
     private static final int ENTRY_COST_IN_BYTES = JVM_INDEPENDENT_ENTRY_COST_IN_BYTES + 9 * REFERENCE_COST_IN_BYTES;
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 @Category({QuickTest.class, ParallelTest.class})
 public class LazyEntryViewFromRecordTest {
 
-    private static final int ENTRY_VIEW_COST_IN_BYTES = 97 + 4 * REFERENCE_COST_IN_BYTES;
+    private static final int ENTRY_VIEW_COST_IN_BYTES = 105 + 4 * REFERENCE_COST_IN_BYTES;
 
     private final String key = "key";
     private final String value = "value";


### PR DESCRIPTION
Follow up to https://github.com/hazelcast/hazelcast/pull/10584

When internal array of ClientMessage is used inside Data, Data consumes large memory. 
When ClientMessage read from server, it does not reuse internal Data. In server, less memory consumption is chosen, instead of avoiding copy. 

When Client Message read from client, all data's read from ClientMessage reuses internal byte array of ClientMessage. In the places where it needs be stored, Data is copied. `compact` method is introduced on Data for this.

Related Protocol side changes https://github.com/hazelcast/hazelcast-client-protocol/pull/79/files

fixes https://github.com/hazelcast/hazelcast/issues/10312