### PR TITLE
Clean up on migration / partition listener tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -151,7 +151,7 @@ public class PartitionedCluster {
         h4 = factory.newHazelcastInstance(config);
         h5 = factory.newHazelcastInstance(config);
 
-        assertClusterSize(5, h1, h4);
+        assertClusterSize(5, h1, h5);
         assertClusterSizeEventually(5, h2, h3, h4);
     }
 


### PR DESCRIPTION
* Hold the migrations until all nodes join so that there will be no retries / failed migrations etc.

Fixes #10346
Fixes #10626
Fixes #10625