### PR TITLE
Handled exception in ClearExpiredOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
@@ -59,7 +59,7 @@ public class ChangeClusterStateOperation extends AbstractOperation implements Al
     public void run() throws Exception {
         ClusterServiceImpl service = getService();
         ClusterStateManager clusterStateManager = service.getClusterStateManager();
-        getLogger().info("Changing cluster state state to " + newState + ", Initiator: " + initiator);
+        getLogger().info("Changing cluster state to " + newState + ", Initiator: " + initiator);
         clusterStateManager.commitClusterState(newState, initiator, txnId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -71,11 +71,24 @@ public class ClearExpiredOperation extends AbstractOperation implements Partitio
 
     @Override
     public void afterRun() throws Exception {
-        final MapService mapService = getService();
+        prepareToNextCleanup();
+    }
+
+    private void prepareToNextCleanup() {
+        MapService mapService = getService();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        final PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(getPartitionId());
+        PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(getPartitionId());
         partitionContainer.setHasRunningCleanup(false);
         partitionContainer.setLastCleanupTime(Clock.currentTimeMillis());
+    }
+
+    @Override
+    public void onExecutionFailure(Throwable e) {
+        try {
+            super.onExecutionFailure(e);
+        } finally {
+            prepareToNextCleanup();
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationAgainstClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationAgainstClusterStateTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cluster.ClusterState.ACTIVE;
+import static com.hazelcast.cluster.ClusterState.PASSIVE;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ExpirationAgainstClusterStateTest extends HazelcastTestSupport {
+
+    private static final int TTL_SECONDS = 5;
+    private static final String MAP_NAME = "test";
+
+    private Cluster cluster;
+    private IMap<Integer, Integer> map;
+
+    @Before
+    public void setUp() throws Exception {
+        Config config = new Config();
+
+        MapConfig mapConfig = config.getMapConfig(MAP_NAME);
+        mapConfig.setTimeToLiveSeconds(TTL_SECONDS);
+
+        HazelcastInstance node = createHazelcastInstance(config);
+        map = node.getMap(MAP_NAME);
+
+        cluster = node.getCluster();
+    }
+
+    @Test
+    public void expired_entries_removed_after_cluster_state_changes() throws Exception {
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+
+        cluster.changeClusterState(PASSIVE);
+
+        sleepSeconds(TTL_SECONDS * 3);
+
+        cluster.changeClusterState(ACTIVE);
+
+        assertSizeEventually(0, map);
+    }
+}


### PR DESCRIPTION
In PASSIVE cluster state, background expiration task can get exception during execution. But after cluster state transition to ACTIVE, it should continue to process. This PR resets its progress conditions in case of any execution exception. 

This issue only happens in 3.7 and its patches. Other minor versions later than 3.7 are safe.