### PR TITLE
Clean up on split brain related tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
@@ -40,13 +40,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapReadQuorumTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -44,13 +44,13 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
@@ -44,13 +44,13 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
@@ -53,7 +54,6 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_P
 public class ClientTransactionalMapQuorumTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadQuorumTest.java
@@ -40,13 +40,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
 
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static PartitionedCluster cluster;
 
@@ -79,7 +79,7 @@ public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
         cluster = new PartitionedCluster(factory).createFiveMemberCluster(cacheConfig, quorumConfig);
         initializeClients();
         initializeCaches();
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
         verifyClients();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadWriteQuorumTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -53,7 +54,6 @@ import static org.junit.Assert.assertNull;
 public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static PartitionedCluster cluster;
 
@@ -86,7 +86,7 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
         cluster = new PartitionedCluster(factory).createFiveMemberCluster(cacheConfig, quorumConfig);
         initializeClients();
         initializeCaches();
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
         verifyClients();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheWriteQuorumTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.client.quorum.QuorumTestUtil.getClientConfig;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -53,7 +54,6 @@ import static org.junit.Assert.assertNull;
 public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
 
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static PartitionedCluster cluster;
 
@@ -86,7 +86,7 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
         cluster = new PartitionedCluster(factory).createFiveMemberCluster(cacheConfig, quorumConfig);
         initializeClients();
         initializeCaches();
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
         verifyClients();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
@@ -130,13 +130,13 @@ public class SplitMergeTest extends HazelcastTestSupport {
         MergeLifecycleListener lifecycleListener = new MergeLifecycleListener();
         h2.getLifecycleService().addLifecycleListener(lifecycleListener);
 
+        // block comm to prevent rejoin
+        blockCommunicationBetween(h1, h2);
+
         // create split
         closeConnectionBetween(h1, h2);
         assertClusterSizeEventually(1, h1);
         assertClusterSizeEventually(1, h2);
-
-        // block comm to prevent rejoin
-        blockCommunicationBetween(h1, h2);
 
         // try merge back
         mergeBack(h2, getAddress(h1));

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -758,8 +758,4 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         return factory.getAllHazelcastInstances();
     }
 
-    static void suspectMember(HazelcastInstance suspectingInstance, HazelcastInstance suspectedInstance) {
-        suspectMember(getNode(suspectingInstance), getNode(suspectedInstance));
-    }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingConnectionManager.java
@@ -71,8 +71,11 @@ public class FirewallingConnectionManager implements ConnectionManager, PacketHa
         return getOrConnect(address);
     }
 
-    public synchronized void block(Address address) {
+    public synchronized void blockNewConnection(Address address) {
         blockedAddresses.add(address);
+    }
+
+    public synchronized void closeActiveConnection(Address address) {
         Connection connection = getConnection(address);
         if (connection != null) {
             connection.close("Blocked by connection manager", null);

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -25,8 +25,6 @@ import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MembershipAdapter;
 import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.instance.Node;
-import com.hazelcast.nio.tcp.FirewallingConnectionManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -37,12 +35,15 @@ import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.closeConnectionBetween;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
-import static com.hazelcast.test.HazelcastTestSupport.getNode;
-import static com.hazelcast.test.HazelcastTestSupport.suspectMember;
+import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PartitionedCluster {
+
+    public static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static final String SUCCESSFUL_SPLIT_TEST_QUORUM_NAME = "SUCCESSFUL_SPLIT_TEST_QUORUM";
 
@@ -60,17 +61,17 @@ public class PartitionedCluster {
 
     public PartitionedCluster partitionFiveMembersThreeAndTwo(MapConfig mapConfig, QuorumConfig quorumConfig) {
         createFiveMemberCluster(mapConfig, quorumConfig);
-        return splitFiveMembersThreeAndTwo();
+        return splitFiveMembersThreeAndTwo(quorumConfig.getName());
     }
 
     public PartitionedCluster partitionFiveMembersThreeAndTwo(CacheSimpleConfig cacheSimpleConfig, QuorumConfig quorumConfig) {
         createFiveMemberCluster(cacheSimpleConfig, quorumConfig);
-        return splitFiveMembersThreeAndTwo();
+        return splitFiveMembersThreeAndTwo(quorumConfig.getName());
     }
 
     public PartitionedCluster partitionFiveMembersThreeAndTwo(QueueConfig qConfig, QuorumConfig quorumConfig) {
         createFiveMemberCluster(qConfig, quorumConfig);
-        return splitFiveMembersThreeAndTwo();
+        return splitFiveMembersThreeAndTwo(quorumConfig.getName());
     }
 
     private PartitionedCluster createFiveMemberCluster(MapConfig mapConfig, QuorumConfig quorumConfig) {
@@ -114,7 +115,7 @@ public class PartitionedCluster {
         return config;
     }
 
-    public PartitionedCluster splitFiveMembersThreeAndTwo() {
+    public PartitionedCluster splitFiveMembersThreeAndTwo(String quorumId) {
         final CountDownLatch splitLatch = new CountDownLatch(6);
         h4.getCluster().addMembershipListener(new MembershipAdapter() {
             @Override
@@ -134,13 +135,10 @@ public class PartitionedCluster {
         assertOpenEventually(splitLatch, 30);
         assertClusterSizeEventually(3, h1, h2, h3);
         assertClusterSizeEventually(2, h4, h5);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertFalse(h4.getQuorumService().getQuorum(SUCCESSFUL_SPLIT_TEST_QUORUM_NAME).isPresent());
-                assertFalse(h5.getQuorumService().getQuorum(SUCCESSFUL_SPLIT_TEST_QUORUM_NAME).isPresent());
-            }
-        });
+
+        verifyQuorums(SUCCESSFUL_SPLIT_TEST_QUORUM_NAME);
+        verifyQuorums(quorumId);
+
         return this;
     }
 
@@ -164,52 +162,50 @@ public class PartitionedCluster {
     }
 
     private void splitCluster() {
-        Node n1 = getNode(h1);
-        Node n2 = getNode(h2);
-        Node n3 = getNode(h3);
-        Node n4 = getNode(h4);
-        Node n5 = getNode(h5);
+        blockCommunicationBetween(h1, h4);
+        blockCommunicationBetween(h1, h5);
 
-        FirewallingConnectionManager cm1 = getConnectionManager(n1);
-        FirewallingConnectionManager cm2 = getConnectionManager(n2);
-        FirewallingConnectionManager cm3 = getConnectionManager(n3);
-        FirewallingConnectionManager cm4 = getConnectionManager(n4);
-        FirewallingConnectionManager cm5 = getConnectionManager(n5);
+        blockCommunicationBetween(h2, h4);
+        blockCommunicationBetween(h2, h5);
 
-        cm1.block(n4.address);
-        cm2.block(n4.address);
-        cm3.block(n4.address);
+        blockCommunicationBetween(h3, h4);
+        blockCommunicationBetween(h3, h5);
 
-        cm1.block(n5.address);
-        cm2.block(n5.address);
-        cm3.block(n5.address);
+        closeConnectionBetween(h4, h3);
+        closeConnectionBetween(h4, h2);
+        closeConnectionBetween(h4, h1);
 
-        cm4.block(n1.address);
-        cm4.block(n2.address);
-        cm4.block(n3.address);
-
-        cm5.block(n1.address);
-        cm5.block(n2.address);
-        cm5.block(n3.address);
-
-        suspectMember(n4, n1);
-        suspectMember(n4, n2);
-        suspectMember(n4, n3);
-
-        suspectMember(n5, n1);
-        suspectMember(n5, n2);
-        suspectMember(n5, n3);
-
-        suspectMember(n1, n4);
-        suspectMember(n2, n4);
-        suspectMember(n3, n4);
-
-        suspectMember(n1, n5);
-        suspectMember(n2, n5);
-        suspectMember(n3, n5);
+        closeConnectionBetween(h5, h3);
+        closeConnectionBetween(h5, h2);
+        closeConnectionBetween(h5, h1);
     }
 
-    private static FirewallingConnectionManager getConnectionManager(Node node) {
-        return (FirewallingConnectionManager) node.getConnectionManager();
+    private void verifyQuorums(String quorumId) {
+        assertQuorumIsPresentEventually(h1, quorumId);
+        assertQuorumIsPresentEventually(h2, quorumId);
+        assertQuorumIsPresentEventually(h3, quorumId);
+        assertQuorumIsAbsentEventually(h4, quorumId);
+        assertQuorumIsAbsentEventually(h5, quorumId);
     }
+
+    private void assertQuorumIsPresentEventually(final HazelcastInstance instance, final String quorumId) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(instance.getQuorumService().getQuorum(quorumId).isPresent());
+            }
+        });
+    }
+
+    private void assertQuorumIsAbsentEventually(final HazelcastInstance instance, final String quorumId) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertFalse(instance.getQuorumService().getQuorum(quorumId).isPresent());
+            }
+        });
+    }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadQuorumTest.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -48,7 +49,6 @@ import static org.junit.Assert.assertNull;
 public class CacheReadQuorumTest {
 
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static HazelcastServerCachingProvider cachingProvider1;
     private static HazelcastServerCachingProvider cachingProvider2;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadWriteQuorumTest.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -54,7 +55,6 @@ import static org.junit.Assert.assertNull;
 public class CacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static HazelcastServerCachingProvider cachingProvider1;
     private static HazelcastServerCachingProvider cachingProvider2;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheWriteQuorumTest.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -54,7 +55,6 @@ import static org.junit.Assert.assertNull;
 public class CacheWriteQuorumTest {
 
     private static final String CACHE_NAME_PREFIX = "cacheQuorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     private static HazelcastServerCachingProvider cachingProvider1;
     private static HazelcastServerCachingProvider cachingProvider2;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/AbstractLockQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/AbstractLockQuorumTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
@@ -37,7 +38,6 @@ public abstract class AbstractLockQuorumTest {
 
     private static final String LOCK_NAME_PREFIX = "lock";
     private static final String LOCK_NAME = LOCK_NAME_PREFIX + randomString();
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     protected static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadQuorumTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class LockReadQuorumTest extends AbstractLockQuorumTest {
@@ -34,7 +36,7 @@ public class LockReadQuorumTest extends AbstractLockQuorumTest {
     @BeforeClass
     public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ, 3);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadWriteQuorumTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class LockReadWriteQuorumTest extends AbstractLockQuorumTest {
@@ -34,7 +36,7 @@ public class LockReadWriteQuorumTest extends AbstractLockQuorumTest {
     @BeforeClass
     public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockWriteQuorumTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class LockWriteQuorumTest extends AbstractLockQuorumTest {
@@ -34,7 +36,7 @@ public class LockWriteQuorumTest extends AbstractLockQuorumTest {
     @BeforeClass
     public static void initialize() {
         initializeFiveMemberCluster(QuorumType.WRITE, 3);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadQuorumTest.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -45,7 +46,6 @@ import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 public class MapReadQuorumTest {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -48,7 +49,6 @@ import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 public class MapReadWriteQuorumTest {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapWriteQuorumTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -49,7 +50,6 @@ import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 public class MapWriteQuorumTest {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadQuorumTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
@@ -50,7 +51,6 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_P
 public class TransactionalMapReadQuorumTest {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
@@ -51,7 +52,6 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_P
 public class TransactionalMapReadWriteQuorumTest {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapWriteQuorumTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
@@ -50,7 +51,6 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_P
 public class TransactionalMapWriteQuorumTest {
 
     private static final String MAP_NAME_PREFIX = "quorum";
-    private static final String QUORUM_ID = "threeNodeQuorumRule";
 
     static PartitionedCluster cluster;
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/AbstractQueueQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/AbstractQueueQuorumTest.java
@@ -25,12 +25,12 @@ import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import org.junit.Test;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 
 public abstract class AbstractQueueQuorumTest {
 
     protected static final String QUEUE_NAME_PREFIX = "quorum";
-    protected static final String QUORUM_ID = "threeNodeQuorumRule";
 
     protected static final int QUEUE_DATA_COUNT = 50;
     protected static final String QUEUE_NAME = QUEUE_NAME_PREFIX + randomString();

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadQuorumTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class QueueReadQuorumTest extends AbstractQueueQuorumTest {
@@ -35,7 +37,7 @@ public class QueueReadQuorumTest extends AbstractQueueQuorumTest {
     public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ, 3);
         addQueueData(q4);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueReadWriteQuorumTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class QueueReadWriteQuorumTest extends AbstractQueueQuorumTest {
@@ -35,7 +37,7 @@ public class QueueReadWriteQuorumTest extends AbstractQueueQuorumTest {
     public static void initialize() {
         initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
         addQueueData(q4);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueWriteQuorumTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class QueueWriteQuorumTest extends AbstractQueueQuorumTest {
@@ -35,7 +37,7 @@ public class QueueWriteQuorumTest extends AbstractQueueQuorumTest {
     public static void initialize() {
         initializeFiveMemberCluster(QuorumType.WRITE, 3);
         addQueueData(q4);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
+import static com.hazelcast.quorum.PartitionedCluster.QUORUM_ID;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 import static java.util.Arrays.asList;
@@ -62,7 +63,7 @@ public class TransactionalQueueQuorumTest extends AbstractQueueQuorumTest {
         initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
         q4.add("foo");
         addQueueData(q4);
-        cluster.splitFiveMembersThreeAndTwo();
+        cluster.splitFiveMembersThreeAndTwo(QUORUM_ID);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -517,6 +517,10 @@ public abstract class HazelcastTestSupport {
         }
     }
 
+    public static void suspectMember(HazelcastInstance source, HazelcastInstance target) {
+        suspectMember(getNode(source), getNode(target));
+    }
+
     public static void suspectMember(Node suspectingNode, Node suspectedNode) {
         suspectMember(suspectingNode, suspectedNode, null);
     }


### PR DESCRIPTION
* Refactor blocking methods in FirewallingConnectionManager
* Unify and refactor split brain creation scenarios. Refactored tests use utility methods in SplitBrainTestSupport to create splits more consistently. Before blocking connections between two nodes, first make sure that both of them will not be able to create new functioning connections.
* Refactor and clean up quorum tests: Internally, quorum status updates are done asynchronously. Now tests make sure that quorums are initialized during start up.

Fixes #10383