### PR TITLE
Compatibility test infrastructure improvements

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAbstractTest.java
@@ -207,7 +207,7 @@ public abstract class AtomicLongAbstractTest extends HazelcastTestSupport {
         }
     }
 
-    private static class FailingFunction implements IFunction<Long, Long> {
+    protected static class FailingFunction implements IFunction<Long, Long> {
         @Override
         public Long apply(Long input) {
             throw new ExpectedRuntimeException();

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
@@ -308,7 +308,7 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
         }
     }
 
-    private static class FailingFunction implements IFunction<String, String> {
+    protected static class FailingFunction implements IFunction<String, String> {
         @Override
         public String apply(String input) {
             throw new HazelcastException();

--- a/hazelcast/src/test/java/com/hazelcast/test/ExpectedRuntimeException.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ExpectedRuntimeException.java
@@ -18,6 +18,8 @@ package com.hazelcast.test;
 
 public class ExpectedRuntimeException extends RuntimeException {
 
+    private static final long serialVersionUID = 83105880382695411L;
+
     public ExpectedRuntimeException() {
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/TestForCompatibilitySince.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/TestForCompatibilitySince.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+import com.hazelcast.test.AutoRegisteredTestRule;
+import com.hazelcast.test.starter.IgnoreCompatibilityTestsWithSinceRule;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicate that a compatibility test is meant to be executed once the current codebase version is at least
+ * the one indicated in {@link #value()}.
+ */
+@Retention(RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@AutoRegisteredTestRule(testRule = IgnoreCompatibilityTestsWithSinceRule.class)
+public @interface TestForCompatibilitySince {
+    /**
+     * @return codebase version since which the annotated test will be executed as a compatibility test
+     */
+    String value();
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/AbstractStarterObjectConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/AbstractStarterObjectConstructor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Abstract superclass for {@code ConstructorFunction}s which, given a target {@code Class}, create an {@code Object} of
+ * target {@code Class} off an input {@code Object}. For example, assuming a {@code Config} instance in current classloader,
+ * the appropriate {@code ConstructorFunction} would create a {@code Config} object representing the same configuration for
+ * the classloader that loads Hazelcast version 3.8.
+ */
+public abstract class AbstractStarterObjectConstructor implements ConstructorFunction<Object, Object> {
+
+    protected final Class<?> targetClass;
+
+    public AbstractStarterObjectConstructor(Class<?> targetClass) {
+        this.targetClass = targetClass;
+    }
+
+    @Override
+    public Object createNew(Object arg) {
+        try {
+            return createNew0(arg);
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+    }
+
+    abstract Object createNew0(Object delegate) throws Exception;
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/AddressConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/AddressConstructor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+public class AddressConstructor extends AbstractStarterObjectConstructor {
+
+    public AddressConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        // obtain reference to constructor Address(String host, int port)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(String.class, Integer.TYPE);
+
+        Object host = getFieldValueReflectively(delegate, "host");
+        Integer port = (Integer) getFieldValueReflectively(delegate, "port");
+        Object[] args = new Object[] {host, port.intValue()};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ConfigConstructor.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.isJDKClass;
+
+/**
+ * Clone the configuration from {@code mainConfig} to a new configuration object loaded in the
+ * target {@code classloader}. The returned configuration has its classloader set to the target classloader.
+ */
+public class ConfigConstructor extends AbstractStarterObjectConstructor {
+
+    public ConfigConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        ClassLoader classloader = targetClass.getClassLoader();
+        Object otherConfig = cloneConfig(delegate, classloader);
+
+        Method setClassLoaderMethod = targetClass.getMethod("setClassLoader", ClassLoader.class);
+        setClassLoaderMethod.invoke(otherConfig, classloader);
+        return otherConfig;
+    }
+
+    private static boolean isGetter(Method method) {
+        if (!method.getName().startsWith("get") && !method.getName().startsWith("is")) {
+            return false;
+        }
+        if (method.getParameterTypes().length != 0) {
+            return false;
+        }
+        if (void.class.equals(method.getReturnType())) {
+            return false;
+        }
+        return true;
+    }
+
+    private static Object cloneConfig(Object thisConfigObject, ClassLoader classloader)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException {
+        if (thisConfigObject == null) {
+            return null;
+        }
+
+        Class thisConfigClass = thisConfigObject.getClass();
+        if (thisConfigClass.isPrimitive() || isJDKClass(thisConfigClass)) {
+            return thisConfigObject;
+        }
+
+        Class<?> otherConfigClass = classloader.loadClass(thisConfigClass.getName());
+        Object otherConfigObject = otherConfigClass.newInstance();
+
+        for (Method method : thisConfigClass.getMethods()) {
+            Class returnType = method.getReturnType();
+            Method setter;
+            if (isGetter(method)
+                    && (setter = getSetter(otherConfigClass, getOtherReturnType(classloader, returnType), createSetterName(method))) != null) {
+
+                if (Properties.class.isAssignableFrom(returnType)) {
+                    //ignore
+                } else if (Map.class.isAssignableFrom(returnType) || ConcurrentMap.class.isAssignableFrom(returnType)) {
+                    Map map = (Map) method.invoke(thisConfigObject, null);
+                    Map otherMap = ConcurrentMap.class.isAssignableFrom(returnType) ? new ConcurrentHashMap() : new HashMap();
+                    for (Object entry : map.entrySet()) {
+                        String key = (String) ((Map.Entry) entry).getKey();
+                        Object value = ((Map.Entry) entry).getValue();
+                        Object otherMapItem = cloneConfig(value, classloader);
+                        otherMap.put(key, otherMapItem);
+                    }
+                    updateConfig(setter, otherConfigObject, otherMap);
+                } else if (returnType.equals(List.class)) {
+                    List list = (List) method.invoke(thisConfigObject, null);
+                    List otherList = new ArrayList();
+                    for (Object item : list) {
+                        Object otherItem = cloneConfig(item, classloader);
+                        otherList.add(otherItem);
+                    }
+                    updateConfig(setter, otherConfigObject, otherList);
+                } else if (returnType.isEnum()) {
+                    Enum thisSubConfigObject = (Enum) method.invoke(thisConfigObject, null);
+                    Class otherEnumClass = classloader.loadClass(thisSubConfigObject.getClass().getName());
+                    Object otherEnumValue = Enum.valueOf(otherEnumClass, thisSubConfigObject.name());
+                    updateConfig(setter, otherConfigObject, otherEnumValue);
+                } else if (returnType.getName().startsWith("java") || returnType.isPrimitive()) {
+                    Object thisSubConfigObject = method.invoke(thisConfigObject, null);
+                    updateConfig(setter, otherConfigObject, thisSubConfigObject);
+                } else if (returnType.getName().startsWith("com.hazelcast.memory.MemorySize")) {
+                    //ignore
+                } else if (returnType.getName().startsWith("com.hazelcast")) {
+                    Object thisSubConfigObject = method.invoke(thisConfigObject, null);
+                    Object otherSubConfig = cloneConfig(thisSubConfigObject, classloader);
+                    updateConfig(setter, otherConfigObject, otherSubConfig);
+                } else {
+                    //
+                }
+            }
+        }
+        return otherConfigObject;
+    }
+
+    private static Class<?> getOtherReturnType(ClassLoader classloader, Class returnType)
+            throws ClassNotFoundException {
+        String returnTypeName = returnType.getName();
+        if (returnTypeName.startsWith("com.hazelcast")) {
+            return classloader.loadClass(returnTypeName);
+        }
+        return returnType;
+    }
+
+    private static Method getSetter(Class otherConfigClass, Class returnType, String setterName) {
+        try {
+            return otherConfigClass.getMethod(setterName, returnType);
+        } catch (NoSuchMethodException e) {
+        }
+        return null;
+    }
+
+    private static void updateConfig(Method setterMethod, Object otherConfigObject, Object value) {
+        try {
+            setterMethod.invoke(otherConfigObject, value);
+        } catch (IllegalAccessException e) {
+        } catch (InvocationTargetException e) {
+        } catch (IllegalArgumentException e) {
+            System.out.println(setterMethod);
+            System.out.println(e);
+        }
+    }
+
+    private static String createSetterName(Method getter) {
+        if (getter.getName().startsWith("get")) {
+            return "s" + getter.getName().substring(1);
+        }
+        if (getter.getName().startsWith("is")) {
+            return "set" + getter.getName().substring(2);
+        }
+        throw new IllegalArgumentException("Unknown getter method name: " + getter.getName());
+    }
+
+    public static Object getValue(Object obj, String getter)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = obj.getClass().getMethod(getter, null);
+        return method.invoke(obj, null);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/DataAwareEntryEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/DataAwareEntryEventConstructor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+public class DataAwareEntryEventConstructor extends AbstractStarterObjectConstructor {
+
+    public DataAwareEntryEventConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        // locate required classes on target class loader
+        ClassLoader starterClassLoader = targetClass.getClassLoader();
+        Class<?> dataClass = starterClassLoader.loadClass("com.hazelcast.nio.serialization.Data");
+        Class<?> memberClass = starterClassLoader.loadClass("com.hazelcast.core.Member");
+        Class<?> serServiceClass = starterClassLoader.loadClass("com.hazelcast.spi.serialization.SerializationService");
+        Constructor<?> constructor = targetClass.getConstructor(memberClass, Integer.TYPE, String.class, dataClass,
+                dataClass, dataClass, dataClass, serServiceClass);
+
+        Object serializationService = getFieldValueReflectively(delegate, "serializationService");
+        Object source = getFieldValueReflectively(delegate, "source");
+        Object member = getFieldValueReflectively(delegate, "member");
+        Object entryEventType = getFieldValueReflectively(delegate, "entryEventType");
+        Integer eventTypeId = (Integer) entryEventType.getClass().getMethod("getType").invoke(entryEventType);
+        Object dataKey = getFieldValueReflectively(delegate, "dataKey");
+        Object dataNewValue = getFieldValueReflectively(delegate, "dataNewValue");
+        Object dataOldValue = getFieldValueReflectively(delegate, "dataOldValue");
+        Object dataMergingValue = getFieldValueReflectively(delegate, "dataMergingValue");
+
+        Object[] args = new Object[] {member, eventTypeId.intValue(), source,
+                                      dataKey, dataNewValue,
+                                      dataOldValue, dataMergingValue,
+                                      serializationService};
+
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, starterClassLoader);
+
+        return constructor.newInstance(proxiedArgs);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/GuardianException.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/GuardianException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+public class GuardianException extends RuntimeException {
+
+    public GuardianException(String message) {
+        super(message);
+    }
+
+    public GuardianException(Throwable t) {
+        super(t);
+    }
+
+    public GuardianException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.nio.IOUtil.toByteArray;
+import static com.hazelcast.test.compatibility.SamplingSerializationService.isTestClass;
+
+/**
+ * Classloader which delegates to its parent except when the fully qualified name of the class starts with
+ * "com.hazelcast". In this case:
+ *  - if the class is a test class, then locate its bytes from the parent classloader but load it as a new class
+ *  in the target class loader. This way user objects implemented in test classpath are loaded on the target classloader
+ *  therefore implement the appropriate loaded class for any Hazelcast interfaces they implement (eg EntryListener,
+ *  Predicate etc).
+ *  - otherwise load the requested class from the URLs given to this classloader as constructor argument.
+ */
+public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
+
+    static final Set<String> DELEGATION_WHITE_LIST;
+
+    private Object mutex = new Object();
+
+    static {
+        Set<String> alwaysDelegateWhiteList = new HashSet<String>();
+        alwaysDelegateWhiteList.add("com.hazelcast.test.starter.ProxyInvocationHandler");
+        alwaysDelegateWhiteList.add("com.hazelcast.test.starter.HazelcastAPIDelegatingClassloader");
+        DELEGATION_WHITE_LIST = Collections.unmodifiableSet(alwaysDelegateWhiteList);
+    }
+
+    public HazelcastAPIDelegatingClassloader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Utils.debug("Calling getResource with " + name);
+        if (name.contains("hazelcast")) {
+            return findResources(name);
+        }
+        return super.getResources(name);
+    }
+
+    @Override
+    public URL getResource(String name) {
+        Utils.debug("Getting resource " + name);
+        if (name.contains("hazelcast")) {
+            return findResource(name);
+        }
+        return super.getResource(name);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (shouldDelegate(name)) {
+            return super.loadClass(name, resolve);
+        } else {
+            synchronized (mutex) {
+                Class<?> loadedClass = findLoadedClass(name);
+                if (loadedClass == null) {
+                    // locate test class' bytes in the current codebase but load the class in this classloader
+                    // so that the test class implements interfaces from the old Hazelcast version
+                    // eg. EntryListener's, EntryProcessor's etc.
+                    if (isHazelcastTestClass(name)) {
+                        loadedClass = findClassInParentURLs(name);
+                    }
+                    if (loadedClass == null) {
+                        loadedClass = findClass(name);
+                    }
+                }
+                //at this point it's always non-null.
+                if (resolve) {
+                    resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+        }
+    }
+
+    /**
+     * Attempts to locate a class' bytes as a resource in parent classpath, then loads the class in this classloader.
+     * @return
+     */
+    private Class<?> findClassInParentURLs(final String name) {
+        String classFilePath = name.replaceAll("\\.", "/").concat(".class");
+        InputStream classInputStream = getParent().getResourceAsStream(classFilePath);
+        if (classInputStream != null) {
+            byte[] classBytes = null;
+            try {
+                classBytes = toByteArray(classInputStream);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            if (classBytes != null) {
+                Class<?> klass = this.defineClass(name, classBytes, 0, classBytes.length);
+                return klass;
+            }
+        }
+        return null;
+    }
+
+    // delegate to parent if class is not under com.hazelcast package or if class is ProxyInvocationHandler itself.
+    private boolean shouldDelegate(String name) {
+        if (!name.startsWith("com.hazelcast")) {
+            return true;
+        }
+
+        if (DELEGATION_WHITE_LIST.contains(name)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isHazelcastTestClass(String name) {
+        if (!name.startsWith("com.hazelcast")) {
+            return false;
+        }
+
+        if (isTestClass(name)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import com.hazelcast.core.IFunction;
+import com.hazelcast.util.ConcurrentReferenceHashMap;
+import com.hazelcast.util.ConstructorFunction;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.Transformer;
+import net.bytebuddy.dynamic.scaffold.MethodRegistry;
+import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy;
+import net.bytebuddy.implementation.InvocationHandlerAdapter;
+import net.bytebuddy.implementation.SuperMethodCall;
+import net.bytebuddy.implementation.attribute.MethodAttributeAppender;
+import net.bytebuddy.matcher.ElementMatchers;
+import net.bytebuddy.matcher.LatentMatcher;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.nio.ClassLoaderUtil.getAllInterfaces;
+import static com.hazelcast.test.starter.HazelcastAPIDelegatingClassloader.DELEGATION_WHITE_LIST;
+import static com.hazelcast.test.starter.HazelcastProxyFactory.ProxyPolicy.RETURN_SAME;
+import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG;
+import static net.bytebuddy.jar.asm.Opcodes.ACC_PUBLIC;
+import static net.bytebuddy.matcher.ElementMatchers.is;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+public class HazelcastProxyFactory {
+
+    // classes in this whitelist will not be proxied, instead instances of the same class (by name)
+    // are constructed on target classloader
+    private static final Set<String> NO_PROXYING_WHITELIST;
+    // classes in this whitelist are explicitly selected for subclass proxying
+    private static final Set<String> SUBCLASS_PROXYING_WHITELIST;
+    // <Class toProxy, ClassLoader targetClassLoader> -> Class<?> proxy mapping for subclass proxies
+    // java.lang.reflect.Proxy already maintains its own cache
+    private static final ConcurrentReferenceHashMap<ProxySource, Class<?>> PROXIES
+            = new ConcurrentReferenceHashMap<ProxySource, Class<?>>(16, STRONG, STRONG);
+
+    // <Class targetClass, ClassLoader targetClassLoader> -> ConstructorFunction<?>
+    private static final ConcurrentReferenceHashMap<Class<?>, ConstructorFunction<Object, Object>> CONSTRUCTORS
+            = new ConcurrentReferenceHashMap<Class<?>, ConstructorFunction<Object, Object>>(16, STRONG, STRONG);
+
+    private static final String CLASS_NAME_ENTRY_EVENT = "com.hazelcast.core.EntryEvent";
+    private static final String CLASS_NAME_LIFECYCLE_EVENT = "com.hazelcast.core.LifecycleEvent";
+    private static final String CLASS_NAME_DATA_AWARE_ENTRY_EVENT = "com.hazelcast.map.impl.DataAwareEntryEvent";
+    private static final String CLASS_NAME_MAP_EVENT = "com.hazelcast.core.MapEvent";
+    private static final String CLASS_NAME_CONFIG = "com.hazelcast.config.Config";
+    private static final String CLASS_NAME_CLIENT_CONFIG = "com.hazelcast.client.config.ClientConfig";
+    private static final String CLASS_NAME_ADDRESS = "com.hazelcast.nio.Address";
+    private static final String CLASS_NAME_VERSION = "com.hazelcast.version.Version";
+
+    static {
+        Set<String> notProxiedClasses = new HashSet<String>();
+        notProxiedClasses.add(CLASS_NAME_DATA_AWARE_ENTRY_EVENT);
+        notProxiedClasses.add(CLASS_NAME_MAP_EVENT);
+        notProxiedClasses.add(CLASS_NAME_CONFIG);
+        notProxiedClasses.add(CLASS_NAME_CLIENT_CONFIG);
+        notProxiedClasses.add(CLASS_NAME_ADDRESS);
+        notProxiedClasses.add(CLASS_NAME_VERSION);
+        NO_PROXYING_WHITELIST = notProxiedClasses;
+
+        Set<String> subclassProxiedClasses = new HashSet<String>();
+        subclassProxiedClasses.add(CLASS_NAME_ENTRY_EVENT);
+        subclassProxiedClasses.add(CLASS_NAME_LIFECYCLE_EVENT);
+        SUBCLASS_PROXYING_WHITELIST = subclassProxiedClasses;
+    }
+
+    /**
+     * This is the main entry point to obtain proxies for a target class loader.
+     * Create an Object valid for the Hazelcast version started with {@code targetClassLoader} that proxies
+     * the given {@code arg} which is valid in the current Hazelcast version.
+     * @param targetClassLoader
+     * @param arg
+     * @return
+     * @throws ClassNotFoundException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    public static Object proxyObjectForStarter(ClassLoader targetClassLoader, Object arg)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
+
+        if (arg.getClass().getClassLoader() == targetClassLoader) {
+            return arg;
+        }
+
+        Class<?>[] ifaces = getAllInterfacesIncludingSelf(arg.getClass());
+        Class<?>[] delegateIfaces = new Class<?>[ifaces.length];
+        Object newArg;
+        ProxyPolicy proxyPolicy = shouldProxy(arg.getClass(), ifaces);
+        Utils.debug("Proxy policy for " + arg.getClass() + " is " + proxyPolicy);
+        switch (proxyPolicy) {
+            case NO_PROXY:
+                newArg = constructWithoutProxy(targetClassLoader, arg);
+                break;
+            case SUBCLASS_PROXY:
+                newArg = constructWithSubclassProxy(targetClassLoader, arg);
+                break;
+            case JDK_PROXY:
+                newArg = constructWithJdkProxy(targetClassLoader, arg, ifaces, delegateIfaces);
+                break;
+            case RETURN_SAME:
+                newArg = arg;
+                break;
+            default:
+                throw new GuardianException("Unsupported proxy policy: " + proxyPolicy);
+        }
+        return newArg;
+    }
+
+    /**
+     * Convenience method to proxy an array of objects to be passed as arguments to a method on a class that is
+     * loaded by {@code targetClassLoader}
+     * @param args
+     * @param targetClassLoader
+     * @return
+     * @throws ClassNotFoundException
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     */
+    public static Object[] proxyArgumentsIfNeeded(Object[] args, ClassLoader targetClassLoader)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException,
+            NoSuchMethodException, InvocationTargetException {
+        if (args == null) {
+            return null;
+        }
+
+        Object[] newArgs = new Object[args.length];
+        for (int i = 0; i < args.length; i++) {
+            Object arg = args[i];
+            if (arg == null || isJDKClass(arg.getClass())) {
+                newArgs[i] = arg;
+            } else {
+                newArgs[i] = proxyObjectForStarter(targetClassLoader, arg);
+            }
+        }
+        return newArgs;
+    }
+
+    static boolean isJDKClass(Class clazz) {
+        return clazz.getClassLoader() == String.class.getClassLoader();
+    }
+
+    private static Object constructWithJdkProxy(ClassLoader targetClassLoader, Object arg, Class<?>[] ifaces,
+                                                Class<?>[] delegateIfaces)
+            throws ClassNotFoundException {
+        for (int j = 0; j < ifaces.length; j++) {
+            Class<?> clazz = ifaces[j];
+            Class<?> delegateInterface = targetClassLoader.loadClass(clazz.getName());
+            delegateIfaces[j] = delegateInterface;
+        }
+        return generateProxyForInterface(arg, targetClassLoader, delegateIfaces);
+    }
+
+    private static Object constructWithSubclassProxy(ClassLoader targetClassLoader, Object arg)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
+        // proxy class via subclassing the existing class implementation in the target targetClassLoader
+        Class<?> delegateClass = targetClassLoader.loadClass(arg.getClass().getName());
+        return proxyWithSubclass(targetClassLoader, arg, delegateClass);
+    }
+
+    private static Object constructWithoutProxy(ClassLoader targetClassLoader, Object arg)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException,
+            NoSuchMethodException, InvocationTargetException {
+
+        if (isJDKClass(arg.getClass())) {
+            return arg;
+        }
+
+        // obtain class in targetClassLoader
+        Class<?> targetClass = targetClassLoader.loadClass(arg.getClass().getName());
+        return construct(targetClass, arg);
+    }
+
+    /**
+     * Generate a JDK dynamic proxy implementing the expected interfaces.
+     * @param delegate
+     * @param proxyTargetClassloader
+     * @param expectedInterfaces
+     * @param <T>
+     * @return
+     */
+    private static <T> T generateProxyForInterface(Object delegate, ClassLoader proxyTargetClassloader, Class<?>...expectedInterfaces) {
+        InvocationHandler myInvocationHandler = new ProxyInvocationHandler(delegate);
+        return (T) Proxy.newProxyInstance(proxyTargetClassloader, expectedInterfaces, myInvocationHandler);
+    }
+
+    /**
+     *
+     * @param targetClassLoader
+     * @param arg
+     * @param delegateClass
+     * @return
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    private static Object proxyWithSubclass(ClassLoader targetClassLoader, final Object arg, Class<?> delegateClass)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException,
+            InvocationTargetException, ClassNotFoundException {
+
+        Class<?> targetClass;
+        ProxySource proxySource = ProxySource.of(arg.getClass(), targetClassLoader);
+        targetClass = PROXIES.applyIfAbsent(proxySource, new IFunction<ProxySource, Class<?>>() {
+            @Override
+            public Class<?> apply(ProxySource input) {
+                return new ByteBuddy().subclass(input.getToProxy(), AllAsPublicConstructorStrategy.INSTANCE)
+                                      .method(ElementMatchers.isDeclaredBy(input.getToProxy()))
+                                      .intercept(InvocationHandlerAdapter.of(new ProxyInvocationHandler(arg)))
+                                      .make()
+                                      .load(input.getTargetClassLoader())
+                                      .getLoaded();
+            }
+        });
+        return construct(targetClass, arg);
+    }
+
+    /**
+     * Decide whether given {@code delegateClass} should be proxied by subclassing, dynamic JDK proxy or not
+     * proxied at all.
+     * @param delegateClass  class of object to be proxied
+     * @param ifaces         interfaces implemented by delegateClass
+     * @return
+     */
+    private static ProxyPolicy shouldProxy(Class<?> delegateClass, Class<?>[] ifaces) {
+        if (delegateClass.isPrimitive() || isJDKClass(delegateClass)) {
+            return ProxyPolicy.RETURN_SAME;
+        }
+
+        String className = delegateClass.getName();
+        if (DELEGATION_WHITE_LIST.contains(className)) {
+            return RETURN_SAME;
+        }
+
+        if (NO_PROXYING_WHITELIST.contains(className)) {
+            return ProxyPolicy.NO_PROXY;
+        }
+
+        if (SUBCLASS_PROXYING_WHITELIST.contains(className) || ifaces.length == 0) {
+            return ProxyPolicy.SUBCLASS_PROXY;
+        }
+
+        return ProxyPolicy.JDK_PROXY;
+    }
+
+    private static Object construct(Class<?> klass, Object delegate)
+            throws IllegalAccessException, InstantiationException, ClassNotFoundException,
+            NoSuchMethodException, InvocationTargetException {
+
+        ConstructorFunction<Object, Object> constructorFunction = CONSTRUCTORS.applyIfAbsent(klass,
+                new IFunction<Class<?>, ConstructorFunction<Object, Object>>() {
+                    @Override
+                    public ConstructorFunction<Object, Object> apply(Class<?> input) {
+                        String className = input.getName();
+                        if (className.equals(CLASS_NAME_DATA_AWARE_ENTRY_EVENT)) {
+                            return new DataAwareEntryEventConstructor(input);
+                        } else if (className.equals(CLASS_NAME_MAP_EVENT)) {
+                            return new MapEventConstructor(input);
+                        } else if (className.equals(CLASS_NAME_LIFECYCLE_EVENT)) {
+                            return new LifecycleEventConstructor(input);
+                        } else if (className.equals(CLASS_NAME_ADDRESS)) {
+                            return new AddressConstructor(input);
+                        } else if (className.equals(CLASS_NAME_CONFIG) ||
+                                className.equals(CLASS_NAME_CLIENT_CONFIG)) {
+                            return new ConfigConstructor(input);
+                        } else if (className.equals(CLASS_NAME_VERSION)) {
+                            return new VersionConstructor(input);
+                        } else {
+                            throw new UnsupportedOperationException("Cannot construct target object "
+                                    + "for target class" + input + " on classloader " + input.getClassLoader());
+                        }
+                    }
+                });
+
+        return constructorFunction.createNew(delegate);
+    }
+
+    /**
+     * Return all interfaces implemented by {@code type}, along with {@code type} itself if it is an interface
+     * @param type
+     * @return
+     */
+    private static Class<?>[] getAllInterfacesIncludingSelf(Class<?> type) {
+        Set<Class<?>> interfaces = new HashSet<Class<?>>();
+        interfaces.addAll(Arrays.asList(getAllInterfaces(type)));
+        //if the return type itself is an interface then we have to add it
+        //to the list of interfaces implemented by the proxy
+        if (type.isInterface()) {
+            interfaces.add(type);
+        }
+        return interfaces.toArray(new Class<?>[0]);
+    }
+
+    /**
+     * (Class toProxy, ClassLoader targetClassLoader) tuple that is used as a key for caching the generated
+     * proxy class for {@code toProxy} on {@code targetClassloader}.
+     */
+    private static class ProxySource {
+        private final Class<?> toProxy;
+        private final ClassLoader targetClassLoader;
+
+        public ProxySource(Class<?> toProxy, ClassLoader targetClassLoader) {
+            this.toProxy = toProxy;
+            this.targetClassLoader = targetClassLoader;
+        }
+
+        public Class<?> getToProxy() {
+            return toProxy;
+        }
+
+        public ClassLoader getTargetClassLoader() {
+            return targetClassLoader;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ProxySource that = (ProxySource) o;
+
+            if (!toProxy.equals(that.toProxy)) {
+                return false;
+            }
+            return targetClassLoader.equals(that.targetClassLoader);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = toProxy.hashCode();
+            result = 31 * result + targetClassLoader.hashCode();
+            return result;
+        }
+
+        public static ProxySource of(Class<?> klass, ClassLoader targetClassLoader) {
+            return new ProxySource(klass, targetClassLoader);
+        }
+    }
+
+    public enum ProxyPolicy {
+        /**
+         * Indicates that a class can be proxied by a JDK proxy implementing its interfaces
+         */
+        JDK_PROXY,
+        /**
+         * Proxy class by creating a subclass of delegate's class on target class loader
+         */
+        SUBCLASS_PROXY,
+        /**
+         * Do not proxy class, instead construct an instance of delegate's class on target class loader
+         */
+        NO_PROXY,
+        /**
+         * Do not proxy, neither attempt locating class at target classloader; instead return the object itself
+         */
+        RETURN_SAME,
+    }
+
+    public static class AllAsPublicConstructorStrategy implements ConstructorStrategy {
+
+        public static final AllAsPublicConstructorStrategy INSTANCE = new AllAsPublicConstructorStrategy();
+
+        @Override
+        public MethodRegistry inject(MethodRegistry methodRegistry) {
+            return methodRegistry.append(new LatentMatcher.Resolved<MethodDescription>(isConstructor()),
+                    new MethodRegistry.Handler.ForImplementation(SuperMethodCall.INSTANCE),
+                    MethodAttributeAppender.NoOp.INSTANCE,
+                    Transformer.NoOp.<MethodDescription>make());
+        }
+
+        @Override
+        public List<MethodDescription.Token> extractConstructors(TypeDescription instrumentedType) {
+            List<MethodDescription.Token> tokens = doExtractConstructors(instrumentedType), stripped = new ArrayList<MethodDescription.Token>(tokens.size());
+            for (MethodDescription.Token token : tokens) {
+                stripped.add(new MethodDescription.Token(token.getName(),
+                        ACC_PUBLIC,
+                        token.getTypeVariableTokens(),
+                        token.getReturnType(),
+                        token.getParameterTokens(),
+                        token.getExceptionTypes(),
+                        token.getAnnotations(),
+                        token.getDefaultValue(),
+                        TypeDescription.Generic.UNDEFINED));
+            }
+            return stripped;
+        }
+
+        protected List<MethodDescription.Token> doExtractConstructors(TypeDescription instrumentedType) {
+            TypeDescription.Generic superClass = instrumentedType.getSuperClass();
+            return (superClass == null
+                    ? new MethodList.Empty<MethodDescription.InGenericShape>()
+                    : superClass.getDeclaredMethods().filter(isConstructor())).asTokenList(is(instrumentedType));
+        }
+
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import com.google.common.io.Files;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.NodeContext;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyObjectForStarter;
+import static com.hazelcast.test.starter.Utils.rethrow;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
+public class HazelcastStarter {
+
+    public static final File WORKING_DIRECTORY = Files.createTempDir();
+
+    // Cache downloaded files & classloader used to load their classes per version string
+    private static final ConcurrentMap<String, HazelcastVersionClassloaderFuture> loadedVersions =
+            new ConcurrentHashMap<String, HazelcastVersionClassloaderFuture>();
+
+    public static HazelcastInstance newHazelcastInstance(String version) {
+        return newHazelcastInstance(version, null);
+    }
+
+    /**
+     * Start a new {@link HazelcastInstance} of the given {@code version}, configured with the given {@code Config}.
+     *
+     * @param version           Hazelcast version to start; must be a published artifact on maven central
+     * @param configTemplate    configuration object to clone on the target HazelcastInstance
+     * @return
+     */
+    public static HazelcastInstance newHazelcastInstance(String version, Config configTemplate) {
+        return newHazelcastInstance(version, configTemplate, null);
+    }
+
+    public static HazelcastInstance newHazelcastInstance(String version, Config configTemplate,
+                                                         NodeContext nodeContextTemplate) {
+        HazelcastAPIDelegatingClassloader versionClassLoader = getTargetVersionClassloader(version);
+
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(null);
+        try {
+            return newHazelcastMemberWithNetwork(configTemplate, versionClassLoader);
+        } catch (ClassNotFoundException e) {
+            throw rethrow(e);
+        } catch (NoSuchMethodException e) {
+            throw rethrow(e);
+        } catch (IllegalAccessException e) {
+            throw rethrow(e);
+        } catch (InvocationTargetException e) {
+            throw rethrow(e);
+        } catch (InstantiationException e) {
+            throw rethrow(e);
+        } finally {
+            if (contextClassLoader != null) {
+                Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
+        }
+    }
+
+    /**
+     * Obtain a {@link HazelcastAPIDelegatingClassloader} with the given version's binaries in its classpath.
+     * Classloaders are cached, so requesting the classloader for a given version multiple times will return the
+     * same instance.
+     *
+     * @param version   the target Hazelcast version e.g. "3.8.1", must be a published release version.
+     * @return          a classloader with given version's artifacts in its classpath
+     */
+    public static HazelcastAPIDelegatingClassloader getTargetVersionClassloader(String version) {
+        HazelcastAPIDelegatingClassloader versionClassLoader = null;
+        HazelcastVersionClassloaderFuture future = loadedVersions.get(version);
+
+        if (future != null) {
+            versionClassLoader = future.get();
+        }
+
+        future = new HazelcastVersionClassloaderFuture(version);
+        HazelcastVersionClassloaderFuture found = loadedVersions.putIfAbsent(version, future);
+
+        if (found != null) {
+            versionClassLoader = found.get();
+        }
+
+        if (versionClassLoader == null) {
+            try {
+                versionClassLoader = future.get();
+            } catch (Throwable t) {
+                loadedVersions.remove(version, future);
+                throw rethrow(t);
+            }
+        }
+        return versionClassLoader;
+    }
+
+    public static InternalSerializationService getTargetVersionSerializationService(String version) {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        HazelcastAPIDelegatingClassloader targetClassloader = getTargetVersionClassloader(version);
+        Class klass = null;
+        try {
+            klass = targetClassloader.loadClass("com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder");
+            SerializationServiceBuilder targetBuilder = (SerializationServiceBuilder)
+                    proxyObjectForStarter(DefaultSerializationServiceBuilder.class.getClassLoader(), klass.newInstance());
+
+            Thread.currentThread().setContextClassLoader(targetClassloader);
+            InternalSerializationService targetSerializationService = targetBuilder
+                    .setClassLoader(targetClassloader)
+                    .setVersion(InternalSerializationService.VERSION_1).build();
+
+            return targetSerializationService;
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    private static HazelcastInstance newHazelcastMemberWithNetwork(Config configTemplate,
+                                                                   HazelcastAPIDelegatingClassloader classloader)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
+        Class<Hazelcast> hazelcastClass = (Class<Hazelcast>) classloader.loadClass("com.hazelcast.core.Hazelcast");
+        System.out.println(hazelcastClass + " loaded by " + hazelcastClass.getClassLoader());
+        Class<?> configClass = classloader.loadClass("com.hazelcast.config.Config");
+        Object config;
+        config = getConfig(configTemplate, classloader, configClass);
+
+        Method newHazelcastInstanceMethod = hazelcastClass.getMethod("newHazelcastInstance", configClass);
+        Object delegate = newHazelcastInstanceMethod.invoke(null, config);
+
+        return (HazelcastInstance) proxyObjectForStarter(HazelcastStarter.class.getClassLoader(), delegate);
+    }
+
+    private static Object getConfig(Config configTemplate, HazelcastAPIDelegatingClassloader classloader,
+                                    Class<?> configClass)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException,
+            InvocationTargetException, ClassNotFoundException {
+        Object config;
+        if (configTemplate == null) {
+            config = configClass.newInstance();
+            Method setClassLoaderMethod = configClass.getMethod("setClassLoader", ClassLoader.class);
+            setClassLoaderMethod.invoke(config, classloader);
+        } else {
+            config = proxyObjectForStarter(classloader, configTemplate);
+        }
+        return config;
+    }
+
+    public static HazelcastInstance newHazelcastClient(String version) {
+        File versionDir = getOrCreateVersionVersionDirectory(version);
+        File[] files = HazelcastVersionLocator.locateVersion(version, versionDir, true);
+        URL[] urls = fileIntoUrls(files);
+        ClassLoader parentClassloader = HazelcastStarter.class.getClassLoader();
+        HazelcastAPIDelegatingClassloader classloader = new HazelcastAPIDelegatingClassloader(urls, parentClassloader);
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(null);
+        try {
+            Class<Hazelcast> hazelcastClass = (Class<Hazelcast>) classloader.loadClass("com.hazelcast.client.HazelcastClient");
+            System.out.println(hazelcastClass + " loaded by " + hazelcastClass.getClassLoader());
+            Class<?> configClass = classloader.loadClass("com.hazelcast.client.config.ClientConfig");
+            Object config = configClass.newInstance();
+            Method setClassLoaderMethod = configClass.getMethod("setClassLoader", ClassLoader.class);
+            setClassLoaderMethod.invoke(config, classloader);
+
+            Method newHazelcastInstanceMethod = hazelcastClass.getMethod("newHazelcastClient", configClass);
+            Object delegate = newHazelcastInstanceMethod.invoke(null, config);
+            return (HazelcastInstance) proxyObjectForStarter(HazelcastStarter.class.getClassLoader(), delegate);
+
+        } catch (ClassNotFoundException e) {
+            throw rethrow(e);
+        } catch (NoSuchMethodException e) {
+            throw rethrow(e);
+        } catch (IllegalAccessException e) {
+            throw rethrow(e);
+        } catch (InvocationTargetException e) {
+            throw rethrow(e);
+        } catch (InstantiationException e) {
+            throw rethrow(e);
+        } finally {
+            if (contextClassLoader != null) {
+                Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
+        }
+    }
+
+    private static URL[] fileIntoUrls(File[] files) {
+        URL[] urls = new URL[files.length];
+        for (int i = 0; i < files.length; i++) {
+            try {
+                urls[i] = files[i].toURL();
+            } catch (MalformedURLException e) {
+                throw rethrow(e);
+            }
+        }
+        return urls;
+    }
+
+    private static File getOrCreateVersionVersionDirectory(String version) {
+        File workingDir = WORKING_DIRECTORY;
+        if (!workingDir.isDirectory() || !workingDir.exists()) {
+            throw new GuardianException("Working directory " + workingDir + " does not exist.");
+        }
+
+        File versionDir = new File(WORKING_DIRECTORY, version);
+        versionDir.mkdir();
+        return versionDir;
+    }
+
+    private static class HazelcastVersionClassloaderFuture {
+        private final String version;
+
+        private HazelcastAPIDelegatingClassloader classLoader;
+
+        HazelcastVersionClassloaderFuture(String version) {
+            this.version = version;
+        }
+
+        public HazelcastAPIDelegatingClassloader get() {
+            if (classLoader != null) {
+                return classLoader;
+            }
+
+            synchronized (this) {
+                File versionDir = getOrCreateVersionVersionDirectory(version);
+                File[] files = HazelcastVersionLocator.locateVersion(version, versionDir, true);
+                URL[] urls = fileIntoUrls(files);
+                ClassLoader parentClassloader = HazelcastStarter.class.getClassLoader();
+                classLoader = new HazelcastAPIDelegatingClassloader(urls, parentClassloader);
+                return classLoader;
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static java.io.File.separator;
+import static java.lang.String.format;
+import static org.apache.http.HttpStatus.SC_OK;
+
+public class HazelcastVersionLocator {
+
+    private static final String LOCAL_M2_REPOSITORY_PREFIX;
+    private static final String MAVEN_CENTRAL_PREFIX;
+    private static final String HAZELCAST_REPOSITORY_PREFIX;
+
+    private static final String MEMBER_PATH = "/com/hazelcast/hazelcast/%1$s/hazelcast-%1$s.jar";
+    private static final String EE_MEMBER_PATH = "/com/hazelcast/hazelcast-enterprise/%1$s/hazelcast-enterprise-%1$s.jar";
+    private static final String CLIENT_PATH = "/com/hazelcast/hazelcast-client/%1$s/hazelcast-client-%1$s.jar";
+    private static final String EE_CLIENT_PATH = "/com/hazelcast/hazelcast-enterprise-client/%1$s/hazelcast-enterprise-client-%1$s.jar";
+
+    static {
+        StringBuilder localM2ReposBasePath = new StringBuilder(System.getProperty("user.home"));
+        localM2ReposBasePath.append(separator).append(".m2")
+                            .append(separator).append("repository");
+        LOCAL_M2_REPOSITORY_PREFIX = localM2ReposBasePath.toString();
+        MAVEN_CENTRAL_PREFIX = "https://repo1.maven.org/maven2";
+        HAZELCAST_REPOSITORY_PREFIX = "https://repository-hazelcast-l337.forge.cloudbees.com/release";
+    }
+
+    public static File[] locateVersion(String version, File target, boolean enterprise) {
+        File[] files;
+        if (enterprise) {
+            files = new File[4];
+            files[2] = locateMember(version, target, true);
+            files[3] = locateClient(version, target, true);
+        } else {
+            files = new File[2];
+        }
+        files[0] = locateMember(version, target, false);
+        files[1] = locateClient(version, target, false);
+        return files;
+    }
+
+    // attempts to locate member artifact in local maven repository, then downloads
+    private static File locateMember(String version, File target, boolean enterprise) {
+        File artifact = new File(LOCAL_M2_REPOSITORY_PREFIX + constructPathForMember(version, enterprise));
+        if (artifact.exists()) {
+            return artifact;
+        } else {
+            return downloadMember(version, target, enterprise);
+        }
+    }
+
+    // first attempt to locate artifact in local maven repository, then download
+    private static File locateClient(String version, File target, boolean enterprise) {
+        File artifact = new File(LOCAL_M2_REPOSITORY_PREFIX + constructPathForClient(version, enterprise));
+        if (artifact.exists()) {
+            return artifact;
+        } else {
+            return downloadClient(version, target, enterprise);
+        }
+    }
+
+    private static File downloadClient(String version, File target, boolean enterprise) {
+        String url = constructUrlForClient(version, enterprise);
+        String filename = extractFilenameFromUrl(url);
+        return downloadFile(url, target, filename);
+    }
+
+    private static File downloadMember(String version, File target, boolean enterprise) {
+        String url = constructUrlForMember(version, enterprise);
+        String filename = extractFilenameFromUrl(url);
+        return downloadFile(url, target, filename);
+    }
+
+    private static String extractFilenameFromUrl(String url) {
+        int lastIndexOf = url.lastIndexOf('/');
+        return url.substring(lastIndexOf);
+    }
+
+    private static File downloadFile(String url, File targetDirectory, String filename) {
+        CloseableHttpClient client = HttpClients.createDefault();
+        File targetFile = new File(targetDirectory, filename);
+        if (targetFile.isFile() && targetFile.exists()) {
+            return targetFile;
+        }
+        HttpGet request = new HttpGet(url);
+        try {
+            CloseableHttpResponse response = client.execute(request);
+            if (response.getStatusLine().getStatusCode() != SC_OK) {
+                throw new GuardianException("Cannot download file from " + url + ", http response code: "
+                                + response.getStatusLine().getStatusCode());
+            }
+            HttpEntity entity = response.getEntity();
+            FileOutputStream  fos = new FileOutputStream(targetFile);
+            entity.writeTo(fos);
+            fos.close();
+            targetFile.deleteOnExit();
+            return targetFile;
+        } catch (IOException e) {
+            throw Utils.rethrow(e);
+        } finally {
+            try {
+                client.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    private static String constructUrlForClient(String version, boolean enterprise) {
+        return (enterprise ? HAZELCAST_REPOSITORY_PREFIX : MAVEN_CENTRAL_PREFIX)
+                + constructPathForClient(version, enterprise);
+    }
+
+    private static String constructUrlForMember(String version, boolean enterprise) {
+        return (enterprise ? HAZELCAST_REPOSITORY_PREFIX : MAVEN_CENTRAL_PREFIX)
+                + constructPathForMember(version, enterprise);
+    }
+
+    private static String constructPathForClient(String version, boolean enterprise) {
+        return format(enterprise ? EE_CLIENT_PATH : CLIENT_PATH, version);
+    }
+
+    private static String constructPathForMember(String version, boolean enterprise) {
+        return format(enterprise ? EE_MEMBER_PATH : MEMBER_PATH, version);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/IgnoreCompatibilityTestsWithSinceRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/IgnoreCompatibilityTestsWithSinceRule.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.annotation.TestForCompatibilitySince;
+import com.hazelcast.version.Version;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import static java.lang.String.format;
+
+/**
+ * Ignore tests annotated with {@code @TestForCompatibilitySince("X.Y")} as long as current codebase version
+ * is less than {@code X.Y}
+ */
+public class IgnoreCompatibilityTestsWithSinceRule implements TestRule {
+
+    private static final ILogger LOGGER = Logger
+            .getLogger(IgnoreCompatibilityTestsWithSinceRule.class);
+
+
+    @Override
+    public Statement apply(Statement base, final Description description) {
+        TestForCompatibilitySince testSince = description.getAnnotation(TestForCompatibilitySince.class);
+        if (testSince == null) {
+            testSince = description.getTestClass().getAnnotation(TestForCompatibilitySince.class);
+        }
+        if (testSince != null) {
+            final Version currentCodebaseVersion = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
+            final Version testSinceVersion = Version.of(testSince.value());
+            if (currentCodebaseVersion.isLessThan(testSinceVersion)) {
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        LOGGER.finest(format("Ignoring `%s` because it is meant for execution since %s while "
+                                        + "current version is %s"
+                                , description.getClassName(), testSinceVersion, currentCodebaseVersion));
+                    }
+                };
+            }
+        }
+        return base;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/LifecycleEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/LifecycleEventConstructor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+/**
+ *
+ */
+public class LifecycleEventConstructor extends AbstractStarterObjectConstructor {
+
+    public LifecycleEventConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        ClassLoader starterClassLoader = targetClass.getClassLoader();
+        Class<?> stateClass = starterClassLoader.loadClass("com.hazelcast.core.LifecycleEvent$LifecycleState");
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(stateClass);
+
+        Object state = getFieldValueReflectively(delegate, "state");
+        Object[] args = new Object[] {state};
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, starterClassLoader);
+
+        return constructor.newInstance(proxiedArgs);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/MapEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/MapEventConstructor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+/**
+ *
+ */
+public class MapEventConstructor extends AbstractStarterObjectConstructor {
+
+    public MapEventConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        ClassLoader starterClassLoader = targetClass.getClassLoader();
+        Class<?> memberClass = starterClassLoader.loadClass("com.hazelcast.core.Member");
+        Constructor<?> constructor = targetClass.getConstructor(Object.class, memberClass, Integer.TYPE, Integer.TYPE);
+
+        Object source = getFieldValueReflectively(delegate, "source");
+        Object member = getFieldValueReflectively(delegate, "member");
+        Object entryEventType = getFieldValueReflectively(delegate, "entryEventType");
+        Integer eventTypeId = (Integer) entryEventType.getClass().getMethod("getType").invoke(entryEventType);
+        Object numberOfKeysAffected = getFieldValueReflectively(delegate, "numberOfEntriesAffected");
+
+        Object[] args = new Object[] {source, member, eventTypeId.intValue(), numberOfKeysAffected};
+
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, starterClassLoader);
+
+        return constructor.newInstance(proxiedArgs);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+class ProxyInvocationHandler implements InvocationHandler, Serializable {
+
+    private final Object delegate;
+
+    ProxyInvocationHandler(Object delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        ClassLoader targetClassLoader = proxy.getClass().getClassLoader();
+        Utils.debug("Proxy " + this + " called. Method: " + method);
+        Class<?> delegateClass = delegate.getClass();
+        Method methodDelegate = getMethodDelegate(method, delegateClass);
+
+        Type returnType = method.getGenericReturnType();
+        Type delegateReturnType = methodDelegate.getGenericReturnType();
+        ClassLoader delegateClassClassLoader = delegateClass.getClassLoader();
+        Object[] newArgs = HazelcastProxyFactory.proxyArgumentsIfNeeded(args, delegateClassClassLoader);
+        Object delegateResult = invokeMethodDelegate(methodDelegate, newArgs);
+        if (!shouldProxy(method, methodDelegate, delegateResult)) {
+            return delegateResult;
+        }
+
+        if (returnType instanceof ParameterizedType) {
+            ParameterizedType parameterizedReturnType = (ParameterizedType) returnType;
+            ParameterizedType parameterizedDelegateReturnType = (ParameterizedType) delegateReturnType;
+
+            if (Collection.class.isAssignableFrom((Class) parameterizedDelegateReturnType.getRawType())) {
+                Collection result;
+                Collection delegateCollectionResult = (Collection) delegateResult;
+                // check if the raw types are equal: if yes, then return a collection of the same type
+                // otherwise proxy it
+                if (parameterizedDelegateReturnType.getRawType().equals(parameterizedReturnType.getRawType())) {
+                    result = delegateCollectionResult;
+                } else {
+                    result = (Collection) proxyReturnObject(targetClassLoader, delegateResult);
+                }
+
+                // if the parameter type is not equal, need to proxy it
+                Type returnParameterType = parameterizedReturnType.getActualTypeArguments()[0];
+                Type delegateParameterType = parameterizedDelegateReturnType.getActualTypeArguments()[0];
+                // if the type argument is equal, just return the result, otherwise proxy each item in the collection
+                if (returnParameterType.equals(delegateParameterType)) {
+                    return result;
+                } else {
+                    Collection temp = newCollectionFor((Class) parameterizedDelegateReturnType.getRawType());
+                    for (Object o : delegateCollectionResult) {
+                        temp.add(proxyReturnObject(targetClassLoader, o));
+                    }
+                    try {
+                        result.clear();
+                        result.addAll(temp);
+                        return result;
+                    } catch (UnsupportedOperationException e) {
+                        return temp;
+                    }
+                }
+            } else {
+                return proxyReturnObject(targetClassLoader, delegateResult);
+            }
+        } else {
+            // at this point we know the delegate returned something loaded by
+            // different classloader than the proxy -> we need to proxy the result
+            return proxyReturnObject(targetClassLoader, delegateResult);
+        }
+    }
+
+    /**
+     *
+     * @param targetClassLoader the classloader on which the proxy will be created
+     * @param delegate    the object to be delegated to by the proxy
+     * @return                  a proxy to delegate
+     */
+    private Object proxyReturnObject(ClassLoader targetClassLoader, Object delegate) {
+        Object resultingProxy;
+        try {
+            resultingProxy = HazelcastProxyFactory.proxyObjectForStarter(targetClassLoader, delegate);
+        } catch (Exception e) {
+            throw new GuardianException(e);
+        }
+        printInfoAboutResultProxy(resultingProxy);
+        return resultingProxy;
+    }
+
+    private Object invokeMethodDelegate(Method methodDelegate, Object[] args) throws Throwable {
+        Object delegateResult;
+        try {
+            methodDelegate.setAccessible(true);
+            delegateResult = methodDelegate.invoke(delegate, args);
+        } catch (IllegalAccessException e) {
+            throw Utils.rethrow(e);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+        return delegateResult;
+    }
+
+    private Method getMethodDelegate(Method method, Class<?> delegateClass) {
+        Method methodDelegate;
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes != null) {
+            for (int i = 0; i < parameterTypes.length; i++) {
+                Class<?> parameterType = parameterTypes[i];
+                ClassLoader parameterTypeClassloader = parameterType.getClassLoader();
+                ClassLoader delegateClassLoader = delegateClass.getClassLoader();
+                if (parameterTypeClassloader != String.class.getClassLoader() && parameterTypeClassloader != delegateClassLoader) {
+                    try {
+                        Class<?> delegateParameterType = delegateClassLoader.loadClass(parameterType.getName());
+                        parameterTypes[i] = delegateParameterType;
+                    } catch (ClassNotFoundException e) {
+                        throw Utils.rethrow(e);
+                    }
+                }
+            }
+        }
+        try {
+            methodDelegate = delegateClass.getMethod(method.getName(), parameterTypes);
+        } catch (NoSuchMethodException e) {
+            throw Utils.rethrow(e);
+        }
+        return methodDelegate;
+    }
+
+    private static void printInfoAboutResultProxy(Object resultingProxy) {
+        if (!Utils.DEBUG_ENABLED) {
+            return;
+        }
+        Utils.debug("Returning proxy " + resultingProxy + ", loaded by " + resultingProxy.getClass().getClassLoader());
+        Class<?>[] ifaces = resultingProxy.getClass().getInterfaces();
+        Utils.debug("The proxy implements interfaces: ");
+        for (Class<?> iface : ifaces) {
+            Utils.debug(iface + ", loaded by " + iface.getClassLoader());
+        }
+    }
+
+    /**
+     * @return a new Collection object of a class that is assignable from the given type
+     */
+    private static Collection newCollectionFor(Class type) {
+        if (Set.class.isAssignableFrom(type)) {
+            // original set might be ordered
+            return new LinkedHashSet();
+        } else if (List.class.isAssignableFrom(type)) {
+            return new ArrayList();
+        } else if (Queue.class.isAssignableFrom(type)) {
+            return new ConcurrentLinkedQueue();
+        } else if (Collection.class.isAssignableFrom(type)) {
+            return new LinkedList();
+        } else {
+            throw new UnsupportedOperationException("Cannot locate collection type for " + type);
+        }
+    }
+
+    private boolean shouldProxy(Method proxyMethod, Method delegateMethod, Object delegateResult) {
+        if (delegateResult == null) {
+            return false;
+        }
+
+        Type returnType = proxyMethod.getGenericReturnType();
+        if (returnType instanceof ParameterizedType) {
+            return true;
+        }
+
+        // if there return types are equals -> they are loaded
+        // by the same classloader -> no need to proxy what it returns
+        Class<?> returnClass = proxyMethod.getReturnType();
+        Class<?> delegateReturnClass = delegateMethod.getReturnType();
+        return !(returnClass.equals(delegateReturnClass));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import org.junit.Assert;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Reflection utilities
+ */
+public class ReflectionUtils {
+
+    private ReflectionUtils() {
+    }
+
+    public static Object getFieldValueReflectively(Object arg, String fieldName)
+            throws IllegalAccessException {
+        checkNotNull(arg, "Argument cannot be null");
+        checkHasText(fieldName, "Field name cannot be null");
+
+        Field field = getAllFieldsByName(arg.getClass()).get(fieldName);
+        if (field == null) {
+            throw new NoSuchFieldError("Field " + fieldName + " does not exist on object " + arg);
+        }
+
+        field.setAccessible(true);
+        return field.get(arg);
+    }
+
+    public static void setFieldValueReflectively(Object arg, String fieldName, Object newValue)
+            throws IllegalAccessException {
+        checkNotNull(arg, "Argument cannot be null");
+        checkHasText(fieldName, "Field name cannot be null");
+
+        Field field = getAllFieldsByName(arg.getClass()).get(fieldName);
+        if (field == null) {
+            throw new NoSuchFieldError("Field " + fieldName + " does not exist on object " + arg);
+        }
+
+        field.setAccessible(true);
+        field.set(arg, newValue);
+    }
+
+    public static Map<String, Field> getAllFieldsByName(Class<?> clazz) {
+        ConcurrentMap<String, Field> fields = new ConcurrentHashMap<String, Field>();
+        Field[] ownFields = clazz.getDeclaredFields();
+        for (Field field : ownFields) {
+            fields.put(field.getName(), field);
+        }
+        Class<?> superClass = clazz.getSuperclass();
+        while (superClass != null) {
+            ownFields = superClass.getDeclaredFields();
+            for (Field field : ownFields) {
+                fields.putIfAbsent(field.getName(), field);
+            }
+            superClass = superClass.getSuperclass();
+        }
+        return fields;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/Utils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/Utils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import static org.junit.Assert.assertEquals;
+
+public class Utils {
+    public static final boolean DEBUG_ENABLED = false;
+
+    public static RuntimeException rethrow(Exception e) {
+        if (e instanceof RuntimeException) {
+            throw (RuntimeException)e;
+        }
+        throw new GuardianException(e);
+    }
+
+    public static void debug(String text) {
+        if (DEBUG_ENABLED) {
+            System.out.println(text);
+        }
+    }
+
+    // When running compatibility tests, Hazelcast classes are loaded by various ClassLoaders, so instanceof
+    // conditions fail even though it's the same class loaded on a different classloader. In this case, it is
+    // desirable to assert an object is an instance of a class by its name
+    public static void assertInstanceOfByClassName(String className, Object object) {
+        assertEquals(className, object.getClass().getName());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/VersionConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/VersionConstructor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.Method;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+/**
+ * Constructor for {@link com.hazelcast.version.Version} class proxies
+ */
+public class VersionConstructor extends AbstractStarterObjectConstructor {
+
+    public VersionConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        ClassLoader starterClassLoader = targetClass.getClassLoader();
+        Class<?> versionClass = starterClassLoader.loadClass("com.hazelcast.version.Version");
+        Method versionOf = versionClass.getDeclaredMethod("of", Integer.TYPE, Integer.TYPE);
+
+        Byte major = (Byte) getFieldValueReflectively(delegate, "major");
+        Byte minor = (Byte) getFieldValueReflectively(delegate, "minor");
+
+        Object[] args = new Object[] {major.intValue(), minor.intValue()};
+
+        return versionOf.invoke(null, args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/package-info.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Hazelcast Starter allows starting Hazelcast instances of arbitrary version in the same JVM.
+ */
+package com.hazelcast.test.starter;

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/ConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.test;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ListConfig;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.ConfigConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigTest {
+
+    @Test
+    public void configCloneTest() throws Exception {
+        Config thisConfig = new Config();
+        thisConfig.setInstanceName("TheAssignedName");
+        thisConfig.addMapConfig(new MapConfig("myMap"));
+
+        thisConfig.addListConfig(new ListConfig("myList"));
+
+        thisConfig.addListenerConfig(new ListenerConfig("the.listener.config.class"));
+
+        ConfigConstructor configConstructor = new ConfigConstructor(Config.class);
+
+        Config otherConfig = (Config) configConstructor.createNew(thisConfig);
+        assertEquals(otherConfig.getInstanceName(), thisConfig.getInstanceName());
+        assertEquals(otherConfig.getMapConfigs().size(), thisConfig.getMapConfigs().size());
+        assertEquals(otherConfig.getListConfigs().size(), thisConfig.getListConfigs().size());
+        assertEquals(otherConfig.getListenerConfigs().size(), thisConfig.getListenerConfigs().size());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastProxyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastProxyFactoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.test;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.starter.HazelcastAPIDelegatingClassloader;
+import com.hazelcast.test.starter.HazelcastProxyFactory;
+import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ *
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class HazelcastProxyFactoryTest {
+
+    @Test
+    public void testRetunedProxyImplements_sameInterfaceByNameOnTargetClassLoader()
+            throws Exception {
+        ProxiedInterface delegate = new ProxiedInterface() {
+            @Override
+            public void get() {
+            }
+        };
+
+        // HazelcastAPIDelegatingClassloader will reload the bytes of ProxiedInterface as a new class
+        // as happens with every com.hazelcast class that contains "test"
+        HazelcastAPIDelegatingClassloader targetClassLoader =
+                new HazelcastAPIDelegatingClassloader(new URL[] {}, HazelcastProxyFactoryTest.class.getClassLoader());
+
+        Object proxy = HazelcastProxyFactory.proxyObjectForStarter(targetClassLoader, delegate);
+
+        assertNotNull(proxy);
+        Class<?>[] ifaces = proxy.getClass().getInterfaces();
+        assertEquals(1, ifaces.length);
+
+        Class<?> proxyInterface = ifaces[0];
+        // it is not the same class but has the same name on a different classloader
+        assertNotEquals(ProxiedInterface.class, proxyInterface);
+        assertEquals(ProxiedInterface.class.getName(), proxyInterface.getName());
+        assertEquals(targetClassLoader, proxyInterface.getClassLoader());
+    }
+
+    @Test
+    public void testProxyHazelcastInstanceClasses_ofSameVersion_areSame() {
+        HazelcastInstance hz1 = HazelcastStarter.newHazelcastInstance("3.8");
+        HazelcastInstance hz2 = HazelcastStarter.newHazelcastInstance("3.8");
+        try {
+            assertEquals(hz1.getClass(), hz2.getClass());
+        } finally {
+            hz1.shutdown();
+            hz2.shutdown();
+        }
+    }
+
+    public interface ProxiedInterface {
+        void get();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastStarterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastStarterTest.java
@@ -21,7 +21,7 @@ public class HazelcastStarterTest {
 
     @Test
     public void testMember() throws InterruptedException {
-        HazelcastInstance alwaysRunningMember = HazelcastStarter.newHazelcastInstance("3.7", true);
+        HazelcastInstance alwaysRunningMember = HazelcastStarter.newHazelcastInstance("3.7", false);
 
         for (int i = 1; i < 6; i++) {
             String version = "3.7." + i;
@@ -39,7 +39,7 @@ public class HazelcastStarterTest {
         Config config = new Config();
         config.setInstanceName("test-name");
 
-        HazelcastInstance alwaysRunningMember = HazelcastStarter.newHazelcastInstance("3.8", config, true);
+        HazelcastInstance alwaysRunningMember = HazelcastStarter.newHazelcastInstance("3.8", config, false);
 
         assertEquals(alwaysRunningMember.getName(),"test-name");
         alwaysRunningMember.shutdown();
@@ -52,7 +52,7 @@ public class HazelcastStarterTest {
         for (int i = 1; i < 6; i++) {
             String version = "3.7." + i;
             System.out.println("Starting client " + version);
-            HazelcastInstance instance = HazelcastStarter.newHazelcastClient(version);
+            HazelcastInstance instance = HazelcastStarter.newHazelcastClient(version, false);
             System.out.println("Stopping client " + version);
             instance.shutdown();
         }
@@ -63,7 +63,7 @@ public class HazelcastStarterTest {
     @Test
     public void testClientMap() throws InterruptedException {
         HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2");
+        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2", false);
 
         IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
         IMap<Integer, Integer> memberMap = memberInstance.getMap("myMap");
@@ -79,7 +79,7 @@ public class HazelcastStarterTest {
     @Test
     public void testAdvancedClientMap() throws InterruptedException {
         HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2");
+        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2", false);
 
         System.out.println("About to terminate the client");
         clientInstance.getLifecycleService().terminate();
@@ -91,7 +91,7 @@ public class HazelcastStarterTest {
     @Test
     public void testClientMap_async() throws InterruptedException, ExecutionException {
         HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2");
+        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2", false);
 
         IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
         clientMap.put(0, 1);

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastStarterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastStarterTest.java
@@ -1,0 +1,106 @@
+package com.hazelcast.test.starter.test;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class HazelcastStarterTest {
+
+    @Test
+    public void testMember() throws InterruptedException {
+        HazelcastInstance alwaysRunningMember = HazelcastStarter.newHazelcastInstance("3.7", true);
+
+        for (int i = 1; i < 6; i++) {
+            String version = "3.7." + i;
+            System.out.println("Starting member " + version);
+            HazelcastInstance instance = HazelcastStarter.newHazelcastInstance(version);
+            System.out.println("Stopping member " + version);
+            instance.shutdown();
+        }
+
+        alwaysRunningMember.shutdown();
+    }
+
+    @Test
+    public void testMemberWithConfig() throws InterruptedException {
+        Config config = new Config();
+        config.setInstanceName("test-name");
+
+        HazelcastInstance alwaysRunningMember = HazelcastStarter.newHazelcastInstance("3.8", config, true);
+
+        assertEquals(alwaysRunningMember.getName(),"test-name");
+        alwaysRunningMember.shutdown();
+    }
+
+    @Test
+    public void testClientLifecycle() throws InterruptedException {
+        HazelcastInstance member = HazelcastStarter.newHazelcastInstance("3.7");
+
+        for (int i = 1; i < 6; i++) {
+            String version = "3.7." + i;
+            System.out.println("Starting client " + version);
+            HazelcastInstance instance = HazelcastStarter.newHazelcastClient(version);
+            System.out.println("Stopping client " + version);
+            instance.shutdown();
+        }
+
+        member.shutdown();
+    }
+
+    @Test
+    public void testClientMap() throws InterruptedException {
+        HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2");
+
+        IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
+        IMap<Integer, Integer> memberMap = memberInstance.getMap("myMap");
+
+        clientMap.put(1, 2);
+
+        assertEquals(2, (int)memberMap.get(1));
+
+        clientInstance.shutdown();
+        memberInstance.shutdown();
+    }
+
+    @Test
+    public void testAdvancedClientMap() throws InterruptedException {
+        HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2");
+
+        System.out.println("About to terminate the client");
+        clientInstance.getLifecycleService().terminate();
+        System.out.println("Client terminated");
+
+        memberInstance.shutdown();
+    }
+
+    @Test
+    public void testClientMap_async() throws InterruptedException, ExecutionException {
+        HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+        HazelcastInstance clientInstance = HazelcastStarter.newHazelcastClient("3.7.2");
+
+        IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
+        clientMap.put(0, 1);
+        ICompletableFuture<Integer> async = clientMap.getAsync(0);
+        int value = async.get();
+
+        assertEquals(1, value);
+
+        clientInstance.shutdown();
+        memberInstance.shutdown();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.test;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.starter.HazelcastVersionLocator;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelTest.class})
+public class HazelcastVersionLocatorTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testDownloadVersion() throws IOException {
+        File[] files = HazelcastVersionLocator.locateVersion("3.6", folder.getRoot(), true);
+        HashFunction md5Hash = Hashing.md5();
+
+        byte[] memberBytes = Files.toByteArray(files[0]);
+        HashCode memberHash = md5Hash.hashBytes(memberBytes);
+        assertEquals("89563f7dab02bd5f592082697c24d167", memberHash.toString());
+
+        byte[] clientBytes = Files.toByteArray(files[1]);
+        HashCode clientHash = md5Hash.hashBytes(clientBytes);
+        assertEquals("fd6022e35908b42d24fe10a9c9fdaad5", clientHash.toString());
+
+        byte[] eeMemberBytes = Files.toByteArray(files[2]);
+        HashCode eeMemberHash = md5Hash.hashBytes(eeMemberBytes);
+        assertEquals("c5718ba5c280339fff9b54ecb5e61549", eeMemberHash.toString());
+
+        byte[] eeClientBytes = Files.toByteArray(files[3]);
+        HashCode eeClientHash = md5Hash.hashBytes(eeClientBytes);
+        assertEquals("b1cf93ec4bb9bcda8809b81349f48cb3", eeClientHash.toString());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.test;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class PatchLevelCompatibilityTest {
+
+    @Test
+    public void testAll_V37_Versions() {
+        String[] versions = new String[]{"3.7", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.7.5", "3.7.6", "3.7.7"};
+        HazelcastInstance[] instances = new HazelcastInstance[versions.length];
+        for (int i = 0; i < versions.length; i++) {
+            instances[i] = HazelcastStarter.newHazelcastInstance(versions[i]);
+        }
+        assertClusterSizeEventually(versions.length, instances[0]);
+        for (HazelcastInstance hz : instances) {
+            hz.shutdown();
+        }
+    }
+
+    @Test
+    public void testAll_V38_Versions() {
+        String[] versions = new String[]{"3.8", "3.8.1", "3.8.2"};
+        HazelcastInstance[] instances = new HazelcastInstance[versions.length];
+        for (int i = 0; i < versions.length; i++) {
+            instances[i] = HazelcastStarter.newHazelcastInstance(versions[i]);
+        }
+        assertClusterSizeEventually(versions.length, instances[0]);
+        for (HazelcastInstance hz : instances) {
+            hz.shutdown();
+        }
+    }
+
+    @Test
+    public void testMap_whenMixed_V37_Cluster() {
+        HazelcastInstance hz374 = HazelcastStarter.newHazelcastInstance("3.7.4");
+        HazelcastInstance hz375 = HazelcastStarter.newHazelcastInstance("3.7.5");
+
+        IMap<Integer, String> map374 = hz374.getMap("myMap");
+        map374.put(42, "GUI = Cheating!");
+
+        IMap<Integer, String> myMap = hz375.getMap("myMap");
+        String ancientWisdom = myMap.get(42);
+
+        assertEquals("GUI = Cheating!", ancientWisdom);
+        hz374.shutdown();
+        hz375.shutdown();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/package-info.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for Hazelcast Starter
+ */
+package com.hazelcast.test.starter.test;


### PR DESCRIPTION
* `HazelcastTestSupport.createHazelcastInstanceFactory` should create a `CompatibilityTestHazelcastInstanceFactory` when test environment is executing compatibility tests.
* Minor updates in `AtomicLong` & `AtomicReference` tests to allow subclassing
* `HazelcastStarter` infrastructure moved to OSS
* Logs a warning for each artifact download (along with the mvn command to install it in the local repos)
* Introduces annotation to defer execution of compatibility test in subsequent version

Requires an EE counterpart.

Edited to describe the broader than initial scope of changes