### PR TITLE
Fix master confirmation timeout bug during mastership claim

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -492,6 +492,10 @@ public class ClusterHeartbeatManager {
      * @return if the member has been removed
      */
     private boolean removeMemberIfMasterConfirmationExpired(long now, MemberImpl member) {
+        if (clusterService.getClusterJoinManager().isMastershipClaimInProgress()) {
+            return false;
+        }
+
         Long lastConfirmation = masterConfirmationTimes.get(member);
         if (lastConfirmation == null) {
             lastConfirmation = 0L;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -940,6 +940,7 @@ public class MembershipManager {
                 }
 
                 updateMembers(newMembersView);
+                clusterService.getClusterHeartbeatManager().resetMemberMasterConfirmations();
                 clusterService.getClusterJoinManager().reset();
                 sendMemberListToOthers();
                 logger.info("Mastership is claimed with: " + newMembersView);


### PR DESCRIPTION
If the mastership claim process is still running, we should not suspect any member because of master confirmation timeout because members may not have sent their periodic master confirmations yet.