### PR TITLE
Optimize loadAll invocations with respect to bulk load

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStoreTest.java
@@ -37,9 +37,11 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -76,6 +78,47 @@ public class QueueStoreTest extends HazelcastTestSupport {
 
         IQueue<Object> queue = instance.getQueue("testQueueStore");
         assertEquals("Queue Size should be equal to max size", maxSize, queue.size());
+    }
+
+    @Test
+    public void testQueueStoreDrainTo() {
+        int maxSize = 10000;
+        TestQueueStore queueStore = new TestQueueStore(0, 0, 0, 0, 2 * maxSize, 0);
+        Config config = getConfigForDrainToTest(maxSize, 1, queueStore);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        // initialize queue store with 2 * maxSize
+        for (int i = 0; i < maxSize * 2; i++) {
+            queueStore.store.put((long) i, i);
+        }
+
+        IQueue<Object> queue = instance.getQueue("testQueueStore");
+        List<Object> items = new ArrayList<Object>();
+        int count = queue.drainTo(items);
+        assertEquals(2 * maxSize, count);
+        assertOpenEventually(queueStore.latchLoad);
+    }
+
+    @Test
+    public void testQueueStoreDrainTo_whenBulkLoadEnabled() {
+        int maxSize = 10000;
+        int queueStoreSize = 2 * maxSize;
+        int bulkLoadSize = 10;
+        TestQueueStore queueStore = new TestQueueStore(0, 0, 0,
+                0, 0, queueStoreSize / bulkLoadSize);
+        Config config = getConfigForDrainToTest(maxSize, bulkLoadSize, queueStore);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        // setup queue store with 2 * maxSize
+        for (int i = 0; i < queueStoreSize; i++) {
+            queueStore.store.put((long) i, i);
+        }
+
+        IQueue<Object> queue = instance.getQueue("testQueueStore");
+        List<Object> items = new ArrayList<Object>();
+        int count = queue.drainTo(items);
+        assertEquals(queueStoreSize, count);
+        assertOpenEventually(queueStore.latchLoadAll);
     }
 
     @Test
@@ -270,6 +313,21 @@ public class QueueStoreTest extends HazelcastTestSupport {
         queueStoreConfig.setProperty("memory-limit", "0");
         queueStoreConfig.setProperty("bulk-load", "100");
         return queueStoreConfig;
+    }
+
+
+    private Config getConfigForDrainToTest(int maxSize, int bulkLoadSize, QueueStore queueStore) {
+        Config config = new Config();
+        QueueConfig queueConfig = config.getQueueConfig("testQueueStore");
+        queueConfig.setMaxSize(maxSize);
+
+        QueueStoreConfig queueStoreConfig = new QueueStoreConfig();
+        queueStoreConfig.setStoreImplementation(queueStore);
+        queueConfig.setQueueStoreConfig(queueStoreConfig);
+        if (bulkLoadSize > 0) {
+            queueConfig.getQueueStoreConfig().setProperty("bulk-load", Integer.toString(bulkLoadSize));
+        }
+        return config;
     }
 
     private static class MyQueueStore implements QueueStore<Object>, Serializable {


### PR DESCRIPTION
`QueueContainer` now keeps track of the max last loaded ID, so next time it is bulk loading from `QueueStore.loadlAll`, fresh item IDs will be requested.
Also improves code coverage of `QueueContainer.drainTo` when `QueueStore` is configured.

Fixes #10621 