### PR TITLE
Cleanup of JitterRule

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterMonitor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterMonitor.java
@@ -16,24 +16,23 @@
 
 package com.hazelcast.test.jitter;
 
-
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyList;
 
-public class JitterMonitor {
+class JitterMonitor {
+
     private static AtomicBoolean started = new AtomicBoolean();
 
-    private static JitterThread jitterThread;
     private static JitterRecorder jitterRecorder;
 
-    public static void ensureRunning() {
+    static void ensureRunning() {
         if (started.compareAndSet(false, true)) {
             startMonitoringThread();
         }
     }
 
-    public static Iterable<Slot> getSlotsBetween(long startTime, long stopTime) {
+    static Iterable<Slot> getSlotsBetween(long startTime, long stopTime) {
         if (jitterRecorder == null) {
             return emptyList();
         }
@@ -42,8 +41,6 @@ public class JitterMonitor {
 
     private static void startMonitoringThread() {
         jitterRecorder = new JitterRecorder();
-        jitterThread = new JitterThread(jitterRecorder);
-        jitterThread.setDaemon(true);
-        jitterThread.start();
+        new JitterThread(jitterRecorder).start();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRecorder.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRecorder.java
@@ -23,15 +23,16 @@ import static com.hazelcast.test.jitter.JitterRule.AGGREGATION_INTERVAL_MILLIS;
 import static com.hazelcast.test.jitter.JitterRule.CAPACITY;
 import static com.hazelcast.util.QuickMath.modPowerOfTwo;
 
-public class JitterRecorder {
+class JitterRecorder {
+
     private final AtomicReferenceArray<Slot> slots = new AtomicReferenceArray<Slot>(CAPACITY);
 
-    public void recordPause(long startTimeMillis, long hiccupNanos) {
+    void recordPause(long startTimeMillis, long hiccupNanos) {
         Slot slot = getSlotForTimestamp(startTimeMillis);
         slot.recordHiccup(hiccupNanos);
     }
 
-    public Iterable<Slot> getSlotsBetween(long from, long to) {
+    Iterable<Slot> getSlotsBetween(long from, long to) {
         long firstBucket = getBucket(from);
         int slotIndex = toSlotIndex(firstBucket);
 
@@ -54,9 +55,9 @@ public class JitterRecorder {
     }
 
     private Slot getSlotForTimestamp(long startTime) {
-        //bucket on a linear time-line
+        // bucket on a linear time-line
         long bucket = getBucket(startTime);
-        //slot in a circular buffer
+        // slot in a circular buffer
         int slotIndex = toSlotIndex(bucket);
         Slot slot = slots.get(slotIndex);
         if (isNullOrStale(slot, bucket)) {
@@ -86,5 +87,4 @@ public class JitterRecorder {
         long slotBucket = getBucket(slot.getStartIntervalMillis());
         return slotBucket != currentBucket;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRule.java
@@ -33,7 +33,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * JUnit rule for detecting JVM/OS hiccups. It's meant to give you an insight into your environment
  * in the case of a test failure. This is useful for troubleshooting of spuriously failing tests.
  */
+@SuppressWarnings("WeakerAccess")
 public class JitterRule implements TestRule {
+
     /**
      * Time interval aggregated into a single bucket. Smaller interval provides
      * a clearer picture about hiccups in time, too small intervals may use too
@@ -44,7 +46,7 @@ public class JitterRule implements TestRule {
     /**
      * Number of buckets to be created. Jitter monitor records a floating window
      * where the length of the window can be calculated as
-     * <code>AGGREGATION_INTERVAL_MILLIS * CAPACITY</code>
+     * {@code AGGREGATION_INTERVAL_MILLIS * CAPACITY}
      *
      * It has to be a power of two.
      */

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterThread.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterThread.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.test.jitter;
 
-
 import static com.hazelcast.test.jitter.JitterRule.RESOLUTION_NANOS;
 import static java.lang.Math.min;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
@@ -25,23 +24,25 @@ public class JitterThread extends Thread {
 
     private final JitterRecorder jitterRecorder;
 
-    public JitterThread(JitterRecorder jitterRecorder) {
+    JitterThread(JitterRecorder jitterRecorder) {
         this.jitterRecorder = jitterRecorder;
+
+        setName("JitterThread");
+        setDaemon(true);
     }
 
     public void run() {
         long beforeNanos = System.nanoTime();
         long shortestHiccup = Long.MAX_VALUE;
-        for (; ; ) {
+        while (true) {
             long beforeMillis = System.currentTimeMillis();
             sleepNanos(RESOLUTION_NANOS);
             long after = System.nanoTime();
             long delta = after - beforeNanos;
             long currentHiccup = delta - RESOLUTION_NANOS;
 
-            //subtract the shortest observed hiccups. as that's
-            //an inherit cost of the measuring loop and OS scheduler
-            //imprecision.
+            // subtract the shortest observed hiccups, as that's an inherit
+            // cost of the measuring loop and OS scheduler imprecision
             shortestHiccup = min(shortestHiccup, currentHiccup);
             currentHiccup -= shortestHiccup;
 
@@ -53,5 +54,4 @@ public class JitterThread extends Thread {
     private void sleepNanos(long duration) {
         parkNanos(duration);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/Mode.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/Mode.java
@@ -17,9 +17,10 @@
 package com.hazelcast.test.jitter;
 
 /**
- * Operational Modes for {@link JitterRule}
+ * Operational Modes for {@link JitterRule}.
  */
 public enum Mode {
+
     /**
      * JitterRule is explicitly disabled. No jitter monitoring is performed no matter
      * what test or environment is used.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/Slot.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/Slot.java
@@ -23,30 +23,31 @@ import static com.hazelcast.test.jitter.JitterRule.LONG_HICCUP_THRESHOLD;
 import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
-public class Slot {
+class Slot {
+
     private final long startInterval;
 
     private volatile long accumulatedHiccupsNanos;
     private volatile long maxPauseNanos;
     private volatile int pausesOverThreshold;
 
-    public Slot(long startInterval) {
+    Slot(long startInterval) {
         this.startInterval = startInterval;
     }
 
-    public long getStartIntervalMillis() {
+    long getStartIntervalMillis() {
         return startInterval;
     }
 
-    public long getMaxPauseNanos() {
+    long getMaxPauseNanos() {
         return maxPauseNanos;
     }
 
-    public long getAccumulatedHiccupsNanos() {
+    long getAccumulatedHiccupsNanos() {
         return accumulatedHiccupsNanos;
     }
 
-    public void recordHiccup(long hiccupNanos) {
+    void recordHiccup(long hiccupNanos) {
         accumulatedHiccupsNanos += hiccupNanos;
         maxPauseNanos = max(maxPauseNanos, hiccupNanos);
         if (hiccupNanos > LONG_HICCUP_THRESHOLD) {
@@ -54,7 +55,7 @@ public class Slot {
         }
     }
 
-    public String toHumanFriendly(DateFormat dateFormat) {
+    String toHumanFriendly(DateFormat dateFormat) {
         return dateFormat.format(new Date(startInterval))
                 + ", accumulated pauses: " + NANOSECONDS.toMillis(accumulatedHiccupsNanos) + " ms"
                 + ", max pause: " + NANOSECONDS.toMillis(maxPauseNanos) + " ms"


### PR DESCRIPTION
* Made some classes of the `jitter` package more private.
* Ensured that the `JitterThread` is always created as daemon thread.
* Set a name for the `JitterThread`.