### PR TITLE
Migration fragment callback should be urgent task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -37,17 +37,22 @@ class PublishPartitionRuntimeStateTask implements Runnable {
 
     @Override
     public void run() {
-        if (node.isMaster() && node.getState() == NodeState.ACTIVE) {
+        if (node.isMaster()) {
             MigrationManager migrationManager = partitionService.getMigrationManager();
-            final boolean migrationAllowed = migrationManager.isMigrationAllowed()
+            boolean migrationAllowed = migrationManager.isMigrationAllowed()
                     && !partitionService.isFetchMostRecentPartitionTableTaskRequired();
             if (!migrationAllowed) {
                 logger.fine("Not publishing partition runtime state since migration is not allowed.");
                 return;
-            } else if (migrationManager.hasOnGoingMigration()) {
+            }
+
+            if (migrationManager.hasOnGoingMigration()) {
                 logger.info("Remaining migration tasks in queue => " + partitionService.getMigrationQueueSize());
             }
-            partitionService.publishPartitionRuntimeState();
+
+            if (node.getState() == NodeState.ACTIVE) {
+                partitionService.publishPartitionRuntimeState();
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -34,6 +34,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.SimpleExecutionCallback;
@@ -267,7 +268,7 @@ public class MigrationRequestOperation extends BaseMigrationSourceOperation {
         }
     }
 
-    private final class SendNewMigrationFragmentRunnable implements PartitionSpecificRunnable {
+    private final class SendNewMigrationFragmentRunnable implements PartitionSpecificRunnable, UrgentSystemOperation {
 
         @Override
         public int getPartitionId() {


### PR DESCRIPTION
Otherwise, fragment callbacks are scheduled behind normal operations.
When system is under load, that causes large latencies between fragment
migrations.

Periodic remaining migration logs are improved.