### PR TITLE
Fix for testListenersNonSmartRouting* tests

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
@@ -30,6 +30,7 @@ public class ClientEventRegistration {
     private final String serverRegistrationId;
     private final long callId;
     private final ListenerMessageCodec codec;
+    private volatile boolean active = true;
 
     public ClientEventRegistration(String serverRegistrationId,
                                    long callId, Connection subscriber, ListenerMessageCodec codec) {
@@ -74,6 +75,14 @@ public class ClientEventRegistration {
 
     public ListenerMessageCodec getCodec() {
         return codec;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
@@ -164,6 +164,7 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
             @Override
             public void run() {
                 for (ClientEventRegistration registration : registrations.values()) {
+                    registration.setActive(false);
                     removeEventHandler(registration.getCallId());
                 }
             }
@@ -184,7 +185,7 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
                             return Collections.EMPTY_LIST;
                         }
                         LinkedList<ClientEventRegistration> activeRegistrations = new LinkedList<ClientEventRegistration>();
-                        if (getEventHandler(registration.getCallId()) != null) {
+                        if (registration.isActive()) {
                             activeRegistrations.add(registration);
                         }
                         return activeRegistrations;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -53,15 +53,14 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport {
 
-    protected HazelcastInstance client;
-    private AtomicInteger eventCount;
+    private static final int EVENT_COUNT = 10;
+    private final AtomicInteger eventCount = new AtomicInteger();
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final CountDownLatch eventsLatch = new CountDownLatch(1);
+    private final Set<String> events = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
     private String registrationId;
     private int clusterSize;
-
-    private static final int EVENT_COUNT = 10;
-    private TestHazelcastFactory factory = new TestHazelcastFactory();
-    private Set<String> events = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
-    private CountDownLatch eventsLatch = new CountDownLatch(1);
+    protected HazelcastInstance client;
 
     @After
     public void tearDown() {
@@ -463,7 +462,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     private void setupListener() {
         clusterSize = factory.getAllHazelcastInstances().size();
         assertClusterSizeEventually(clusterSize, client);
-        eventCount = new AtomicInteger();
         registrationId = addListener();
     }
 
@@ -507,31 +505,25 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     private void validateListenerFunctionality() {
-        assertTrueEventually(new AssertTask() {
+        for (int i = 0; i < EVENT_COUNT; i++) {
+            events.add(randomString());
+        }
+
+        for (String event : events) {
+            produceEvent(event);
+        }
+
+        assertOpenEventually(eventsLatch);
+
+        assertTrueAllTheTime(new AssertTask() {
             @Override
-            public void run() throws Exception {
-                events.clear();
-                eventCount.set(0);
-                for (int i = 0; i < EVENT_COUNT; i++) {
-                    events.add(randomString());
-                }
-
-                for (String event : events) {
-                    produceEvent(event);
-                }
-                assertOpenEventually(eventsLatch);
-                assertTrueAllTheTime(new AssertTask() {
-                    @Override
-                    public void run()
-                            throws Exception {
-                        int count = eventCount.get();
-                        assertEquals("Received event count is " + count + " but it is expected to stay at " + EVENT_COUNT, EVENT_COUNT,
-                                eventCount.get());
-                    }
-                }, 3);
+            public void run()
+                    throws Exception {
+                int count = eventCount.get();
+                assertEquals("Received event count is " + count + " but it is expected to stay at " + EVENT_COUNT, EVENT_COUNT,
+                        eventCount.get());
             }
-        });
-
+        }, 3);
     }
 
     private void terminateRandomNode() {


### PR DESCRIPTION
Fix on https://github.com/hazelcast/hazelcast/pull/9865
is revised.

Verification part for events is more strict as before.
Verification for listener registrations was broken for non-smart
clients. It is fixed, so that verification of events does not need
assertTrueEventually at the top.

fixes https://github.com/hazelcast/hazelcast/issues/10301
fixes https://github.com/hazelcast/hazelcast/issues/10235
fixes https://github.com/hazelcast/hazelcast/issues/10157
fixes https://github.com/hazelcast/hazelcast/issues/8744
fixes https://github.com/hazelcast/hazelcast/issues/8254
fixes https://github.com/hazelcast/hazelcast/issues/10593
fixes https://github.com/hazelcast/hazelcast/issues/10359