### PR TITLE
Fixed NearCacheConfig.isSerializeKeys() for NATIVE in-memory format

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -373,7 +373,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
         NearCacheConfig ncConfig = clientConfig.getNearCacheConfig(mapName);
 
         assertEquals(InMemoryFormat.NATIVE, ncConfig.getInMemoryFormat());
-        assertFalse(ncConfig.isSerializeKeys());
+        assertTrue(ncConfig.isSerializeKeys());
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -265,13 +265,13 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     /**
      * Checks if the Near Cache key is stored in serialized format or by-reference.
      * <p>
-     * <b>NOTE:</b> When the in-memory-format is {@code NATIVE}, this method will always return {@code false}.
+     * <b>NOTE:</b> When the in-memory-format is {@code NATIVE}, this method will always return {@code true}.
      *
-     * @return {@code true} if the key is stored in serialized format, {@code false} if stored by-reference
-     * or in-memory-format is {@code NATIVE}
+     * @return {@code true} if the key is stored in serialized format or in-memory-format is {@code NATIVE},
+     * {@code false} if the key is stored by-reference and in-memory-format is {@code BINARY} or {@code OBJECT}
      */
     public boolean isSerializeKeys() {
-        return serializeKeys && inMemoryFormat != InMemoryFormat.NATIVE;
+        return serializeKeys || inMemoryFormat == InMemoryFormat.NATIVE;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
@@ -137,10 +137,10 @@ public class NearCacheConfigTest {
     }
 
     @Test
-    public void testIsSerializeKeys_whenNativeMemoryFormat() {
-        config.setSerializeKeys(true);
+    public void testIsSerializeKeys_whenNativeMemoryFormat_thenAlwaysReturnTrue() {
+        config.setSerializeKeys(false);
         config.setInMemoryFormat(InMemoryFormat.NATIVE);
-        assertFalse(config.isSerializeKeys());
+        assertTrue(config.isSerializeKeys());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -781,7 +781,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         NearCacheConfig ncConfig = mapConfig.getNearCacheConfig();
 
         assertEquals(InMemoryFormat.NATIVE, ncConfig.getInMemoryFormat());
-        assertFalse(ncConfig.isSerializeKeys());
+        assertTrue(ncConfig.isSerializeKeys());
     }
 
     @Test


### PR DESCRIPTION
How do you call an "off-by-one" error with a boolean?

The code was matching the JavaDoc, it was even tested, but unfortunately the returned value is wrong. We always need to return `true` with `NATIVE` in-memory format. EE tests are failing at the moment, confirmed locally that this will fix them.