### PR TITLE
Add/remove listener fails when a member disconnected on smart routing

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -243,6 +243,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         ioThreadingModel.shutdown();
     }
 
+    @Override
     public ClientConnection getConnection(Address target) {
         target = addressTranslator.translate(target);
         if (target == null) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.listeners;
+
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ListenerTests extends ClientTestSupport {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testSmartListenerRegister_whenNodeLeft() {
+        int nodeCount = 5;
+        for (int i = 0; i < nodeCount - 1; i++) {
+            factory.newHazelcastInstance();
+        }
+        final HazelcastInstance node = factory.newHazelcastInstance();
+
+        HazelcastInstance client = factory.newHazelcastClient();
+        IMap<Object, Object> map = client.getMap("test");
+
+
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                node.getLifecycleService().terminate();
+            }
+        }, 1, TimeUnit.SECONDS);
+
+        EntryAdapter listener = new EntryAdapter();
+
+        LinkedList<String> registrationIds = new LinkedList<String>();
+        while (client.getCluster().getMembers().size() == nodeCount) {
+            registrationIds.add(map.addEntryListener(listener, false));
+        }
+
+        for (String registrationId : registrationIds) {
+            assertTrue(map.removeEntryListener(registrationId));
+        }
+        executorService.shutdown();
+
+    }
+}


### PR DESCRIPTION
Add/remove listener sends invocation to all members in cluster in
smart routing. If one of the invocations can not be done, we were
failing related operation completely.

If invocation can not be done because connection is disconnected,
then that invocation can be ignored safely. No need to fail add/removeListener
action.

fixes https://github.com/hazelcast/hazelcast/issues/10595

backport of https://github.com/hazelcast/hazelcast/pull/10681