### PR TITLE
Fragment RingbufferService and support predicates and projections

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -93,10 +93,9 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         readManyAsyncResponseDecoder = new ClientMessageDecoder() {
             @Override
             public PortableReadResultSet decodeClientMessage(ClientMessage clientMessage) {
-                final RingbufferReadManyCodec.ResponseParameters responseParameters
-                        = RingbufferReadManyCodec.decodeResponse(clientMessage);
-                PortableReadResultSet readResultSet = new PortableReadResultSet(responseParameters.readCount,
-                        responseParameters.items);
+                final RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(clientMessage);
+                final PortableReadResultSet readResultSet
+                        = new PortableReadResultSet(params.readCount, params.items, params.itemSeqs);
                 readResultSet.setSerializationService(getSerializationService());
                 return readResultSet;
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
@@ -59,13 +59,17 @@ public class RingbufferReadManyMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
-        ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
-        List<Data> items = new ArrayList<Data>(resultSet.size());
+        final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
+        final List<Data> items = new ArrayList<Data>(resultSet.size());
+        final long[] seqs = new long[resultSet.size()];
+        final Data[] dataItems = resultSet.getDataItems();
+
         for (int k = 0; k < resultSet.size(); k++) {
-            items.add(resultSet.getDataItems()[k]);
+            items.add(dataItems[k]);
+            seqs[k] = resultSet.getSequence(k);
         }
 
-        return RingbufferReadManyCodec.encodeResponse(resultSet.readCount(), items);
+        return RingbufferReadManyCodec.encodeResponse(resultSet.readCount(), items, seqs);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -72,6 +72,7 @@ import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.annotation.PrivateApi;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.transaction.HazelcastXAResource;
@@ -92,7 +93,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 
 @PrivateApi
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
-public class HazelcastInstanceImpl implements HazelcastInstance {
+public class HazelcastInstanceImpl implements HazelcastInstance, SerializationServiceSupport {
 
     @SuppressWarnings("checkstyle:visibilitymodifier")
     public final Node node;
@@ -388,6 +389,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
         return proxyService.removeProxyListener(registrationId);
     }
 
+    @Override
     public InternalSerializationService getSerializationService() {
         return node.getSerializationService();
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/ReadResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/ReadResultSet.java
@@ -46,4 +46,26 @@ public interface ReadResultSet<E> extends Iterable<E> {
      * @throws IllegalArgumentException if index out of bounds.
      */
     E get(int index);
+
+    /**
+     * Return the sequence number for the item at the given index.
+     * The method may throw a {@link UnsupportedOperationException} if there are no
+     * sequences available. This can happen when the cluster version is
+     * {@link com.hazelcast.internal.cluster.Versions#V3_8} or lower.
+     *
+     * @param index the index
+     * @return the sequence number for the ringbuffer item
+     * @throws UnsupportedOperationException if the sequence IDs are not available
+     * @see com.hazelcast.internal.cluster.ClusterService#getClusterVersion()
+     * @since 3.9
+     */
+    long getSequence(int index);
+
+    /**
+     * Return the result set size.
+     *
+     * @return the result set size
+     * @since 3.9
+     */
+    int size();
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -27,16 +27,16 @@ import com.hazelcast.ringbuffer.StaleSequenceException;
  * <p/>
  * The ringItems is the ring that contains the actual items.
  */
-public class ArrayRingbuffer implements Ringbuffer {
+public class ArrayRingbuffer<T> implements Ringbuffer<T> {
     // contains the actual items
-    Object[] ringItems;
+    T[] ringItems;
     private long tailSequence = -1;
     private long headSequence = tailSequence + 1;
     private int capacity;
 
     public ArrayRingbuffer(int capacity) {
         this.capacity = capacity;
-        this.ringItems = new Object[capacity];
+        this.ringItems = (T[]) new Object[capacity];
     }
 
     @Override
@@ -76,7 +76,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
-    public long add(Object item) {
+    public long add(T item) {
         tailSequence++;
 
         if (tailSequence - capacity == headSequence) {
@@ -91,7 +91,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
-    public Object read(long sequence) {
+    public T read(long sequence) {
         checkReadSequence(sequence);
         return ringItems[toIndex(sequence)];
     }
@@ -132,7 +132,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
-    public void set(long seq, Object data) {
+    public void set(long seq, T data) {
         ringItems[toIndex(seq)] = data;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+import com.hazelcast.spi.ObjectNamespace;
 
 /**
  * A {@link RingbufferStore} that decorates an RingbufferStore with latency tracking instrumentation.
@@ -34,12 +35,13 @@ class LatencyTrackingRingbufferStore<T> implements RingbufferStore<T> {
     private final LatencyProbe storeAllProbe;
     private final RingbufferStore<T> delegate;
 
-    LatencyTrackingRingbufferStore(RingbufferStore<T> delegate, StoreLatencyPlugin plugin, String ringbufferName) {
+    LatencyTrackingRingbufferStore(RingbufferStore<T> delegate, StoreLatencyPlugin plugin, ObjectNamespace namespace) {
+        final String nsDescription = namespace.getServiceName() + ":" + namespace.getObjectName();
         this.delegate = delegate;
-        this.loadProbe = plugin.newProbe(KEY, ringbufferName, "load");
-        this.getLargestSequenceProbe = plugin.newProbe(KEY, ringbufferName, "getLargestSequence");
-        this.storeProbe = plugin.newProbe(KEY, ringbufferName, "store");
-        this.storeAllProbe = plugin.newProbe(KEY, ringbufferName, "storeAll");
+        this.loadProbe = plugin.newProbe(KEY, nsDescription, "load");
+        this.getLargestSequenceProbe = plugin.newProbe(KEY, nsDescription, "getLargestSequence");
+        this.storeProbe = plugin.newProbe(KEY, nsDescription, "store");
+        this.storeAllProbe = plugin.newProbe(KEY, nsDescription, "storeAll");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
@@ -69,7 +69,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
     public RingbufferProxy(NodeEngine nodeEngine, RingbufferService service, String name, RingbufferConfig config) {
         super(nodeEngine, service);
         this.name = name;
-        this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
+        this.partitionId = service.getRingbufferPartitionId(name);
         this.config = config;
     }
 
@@ -195,7 +195,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
         checkTrue(minCount <= config.getCapacity(), "the minCount should be smaller than or equal to the capacity");
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
-        Operation op = new ReadManyOperation(name, startSequence, minCount, maxCount, filter)
+        Operation op = new ReadManyOperation<E>(name, startSequence, minCount, maxCount, filter)
                 .setPartitionId(partitionId);
         OperationService operationService = getOperationService();
         return operationService.createInvocationBuilder(null, op, partitionId)

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
@@ -16,20 +16,21 @@
 
 package com.hazelcast.ringbuffer.impl;
 
-import com.hazelcast.spi.AbstractWaitNotifyKey;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
 
-import static com.hazelcast.ringbuffer.impl.RingbufferService.SERVICE_NAME;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * A {@link com.hazelcast.spi.AbstractWaitNotifyKey} to make it possible to wait for an item to be published in the ringbuffer.
  */
-public class RingbufferWaitNotifyKey extends AbstractWaitNotifyKey {
+public class RingbufferWaitNotifyKey implements WaitNotifyKey {
 
-    private final String type;
+    private final ObjectNamespace namespace;
 
-    public RingbufferWaitNotifyKey(String name, String type) {
-        super(SERVICE_NAME, name);
-        this.type = type;
+    public RingbufferWaitNotifyKey(ObjectNamespace namespace) {
+        checkNotNull(namespace);
+        this.namespace = namespace;
     }
 
     @Override
@@ -40,19 +41,25 @@ public class RingbufferWaitNotifyKey extends AbstractWaitNotifyKey {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
 
         RingbufferWaitNotifyKey that = (RingbufferWaitNotifyKey) o;
-        return type.equals(that.type);
+
+        return namespace.equals(that.namespace);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + type.hashCode();
-        return result;
+        return namespace.hashCode();
+    }
+
+    @Override
+    public String getServiceName() {
+        return namespace.getServiceName();
+    }
+
+    @Override
+    public String getObjectName() {
+        return namespace.getObjectName();
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/PortableReadResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/PortableReadResultSet.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.ringbuffer.impl.client;
 
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -24,6 +25,7 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.spi.serialization.SerializationService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,17 +37,19 @@ import static com.hazelcast.ringbuffer.impl.client.RingbufferPortableHook.READ_R
 import static java.util.Collections.unmodifiableList;
 
 public class PortableReadResultSet<E> implements Portable, ReadResultSet<E> {
-
     private List<Data> items;
     private int readCount;
     private SerializationService serializationService;
+    private long[] seqs;
 
     public PortableReadResultSet() {
     }
 
-    public PortableReadResultSet(int readCount, List<Data> items) {
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public PortableReadResultSet(int readCount, List<Data> items, long[] seqs) {
         this.readCount = readCount;
         this.items = items;
+        this.seqs = seqs;
     }
 
     public List<Data> getDataItems() {
@@ -77,6 +81,19 @@ public class PortableReadResultSet<E> implements Portable, ReadResultSet<E> {
     }
 
     @Override
+    public long getSequence(int index) {
+        if (seqs == null) {
+            throw new UnsupportedOperationException("Sequence IDs are not available when the cluster version is lower than 3.9");
+        }
+        return seqs[index];
+    }
+
+    @Override
+    public int size() {
+        return items.size();
+    }
+
+    @Override
     public int getFactoryId() {
         return F_ID;
     }
@@ -96,6 +113,9 @@ public class PortableReadResultSet<E> implements Portable, ReadResultSet<E> {
         for (Object item : items) {
             rawDataOutput.writeData((Data) item);
         }
+        if (rawDataOutput.getVersion().isGreaterOrEqual(Versions.V3_9)) {
+            rawDataOutput.writeLongArray(seqs);
+        }
     }
 
     @Override
@@ -109,6 +129,9 @@ public class PortableReadResultSet<E> implements Portable, ReadResultSet<E> {
         for (int k = 0; k < size; k++) {
             Data item = rawDataInput.readData();
             items.add(item);
+        }
+        if (rawDataInput.getVersion().isGreaterOrEqual(Versions.V3_9)) {
+            seqs = rawDataInput.readLongArray();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -36,8 +36,7 @@ import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_OPE
  * the backup operation will put the item under the sequence ID that the master generated. This is to avoid differences
  * in ring buffer data structures.
  */
-public class AddOperation extends AbstractRingBufferOperation
-        implements Notifier, BackupAwareOperation {
+public class AddOperation extends AbstractRingBufferOperation implements Notifier, BackupAwareOperation {
 
     private Data item;
     private long resultSequence;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -55,7 +55,7 @@ public class ReadOneOperation extends AbstractRingBufferOperation implements Blo
     @Override
     public void run() throws Exception {
         RingbufferContainer ringbuffer = getRingBufferContainer();
-        result = ringbuffer.read(sequence);
+        result = ringbuffer.readAsData(sequence);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
@@ -16,30 +16,35 @@
 
 package com.hazelcast.ringbuffer.impl.operations;
 
+import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.VersionAware;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.F_ID;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.REPLICATION_OPERATION;
 import static com.hazelcast.ringbuffer.impl.RingbufferService.SERVICE_NAME;
 
-public class ReplicationOperation extends Operation
-        implements IdentifiedDataSerializable {
+public class ReplicationOperation extends Operation implements IdentifiedDataSerializable, Versioned {
 
-    private Map<String, RingbufferContainer> migrationData;
+    private Map<ObjectNamespace, RingbufferContainer> migrationData;
 
     public ReplicationOperation() {
     }
 
-    public ReplicationOperation(Map<String, RingbufferContainer> migrationData,
+    public ReplicationOperation(Map<ObjectNamespace, RingbufferContainer> migrationData,
                                 int partitionId, int replicaIndex) {
         setPartitionId(partitionId).setReplicaIndex(replicaIndex);
         this.migrationData = migrationData;
@@ -47,12 +52,16 @@ public class ReplicationOperation extends Operation
 
     @Override
     public void run() {
-        RingbufferService service = getService();
-        for (Map.Entry<String, RingbufferContainer> entry : migrationData.entrySet()) {
-            String name = entry.getKey();
-            RingbufferContainer ringbuffer = entry.getValue();
-            service.addRingbuffer(name, ringbuffer);
+        final RingbufferService service = getService();
+        for (Map.Entry<ObjectNamespace, RingbufferContainer> entry : migrationData.entrySet()) {
+            final ObjectNamespace ns = entry.getKey();
+            final RingbufferContainer ringbuffer = entry.getValue();
+            service.addRingbuffer(getPartitionId(), ringbuffer, getRingbufferConfig(service, ns));
         }
+    }
+
+    private RingbufferConfig getRingbufferConfig(RingbufferService service, ObjectNamespace ns) {
+        return service.getRingbufferConfig(ns.getObjectName());
     }
 
     @Override
@@ -73,9 +82,13 @@ public class ReplicationOperation extends Operation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(migrationData.size());
-        for (Map.Entry<String, RingbufferContainer> entry : migrationData.entrySet()) {
-            String ringbufferName = entry.getKey();
-            out.writeUTF(ringbufferName);
+        for (Entry<ObjectNamespace, RingbufferContainer> entry : migrationData.entrySet()) {
+            final ObjectNamespace ns = entry.getKey();
+            if (isGreaterOrEqualV39(out)) {
+                out.writeObject(ns);
+            } else {
+                out.writeUTF(ns.getObjectName());
+            }
             RingbufferContainer container = entry.getValue();
             container.writeData(out);
         }
@@ -84,12 +97,18 @@ public class ReplicationOperation extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, RingbufferContainer>(mapSize);
+        migrationData = new HashMap<ObjectNamespace, RingbufferContainer>(mapSize);
         for (int i = 0; i < mapSize; i++) {
-            String name = in.readUTF();
-            RingbufferContainer container = new RingbufferContainer(name);
+            final ObjectNamespace namespace = isGreaterOrEqualV39(in)
+                    ? (ObjectNamespace) in.readObject()
+                    : RingbufferService.getRingbufferNamespace(in.readUTF());
+            final RingbufferContainer container = new RingbufferContainer(namespace);
             container.readData(in);
-            migrationData.put(name, container);
+            migrationData.put(namespace, container);
         }
+    }
+
+    private static boolean isGreaterOrEqualV39(VersionAware versionAware) {
+        return versionAware.getVersion().isGreaterOrEqual(V3_9);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
@@ -248,6 +248,30 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(    aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(    aListOfStringToByteArrEntry   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -1095,6 +1119,42 @@ public class BinaryCompatibilityFileGenerator {
         outputStream.writeInt(clientMessage.getFrameLength());
         outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
      }
+}
+
+
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeRequest(    aString ,    anInt ,    anInt ,    aData ,    aData   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeResponse(    datas ,    anInt   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(    aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 
 
@@ -3914,6 +3974,30 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(    aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -4219,7 +4303,7 @@ public class BinaryCompatibilityFileGenerator {
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     outputStream.writeInt(clientMessage.getFrameLength());
     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
@@ -248,6 +248,30 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(   aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(   aListOfStringToByteArrEntry   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -1095,6 +1119,42 @@ public class BinaryCompatibilityNullFileGenerator {
         outputStream.writeInt(clientMessage.getFrameLength());
         outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
      }
+}
+
+
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeRequest(   aString ,   anInt ,   anInt ,   aData ,   aData   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeResponse(   datas ,   anInt   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(   aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(   aLong ,   aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(   aString ,   aLong ,   anInt ,   anInt ,   null ,   null   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(   anInt ,   datas ,   null   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 
 
@@ -3914,6 +3974,30 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(   aString   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(   aLong ,   aLong   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(   aString ,   aLong ,   anInt ,   anInt ,   null ,   null   );
+     outputStream.writeInt(clientMessage.getFrameLength());
+     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(   anInt ,   datas ,   null   );
+    outputStream.writeInt(clientMessage.getFrameLength());
+    outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
+}
+
+
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(   anXid   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
@@ -4219,7 +4303,7 @@ public class BinaryCompatibilityNullFileGenerator {
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(   anInt ,   datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(   anInt ,   datas ,   null   );
     outputStream.writeInt(clientMessage.getFrameLength());
     outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
@@ -384,6 +384,10 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1448,6 +1452,12 @@ public class ClientCompatibilityNullTest_1_0 {
     inputStream.read(bytes);
     MapClearNearCacheCodec.ResponseParameters params = MapClearNearCacheCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
 }
+
+
+
+
+
+
 
 
 
@@ -5402,6 +5412,10 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5815,9 +5829,14 @@ public class ClientCompatibilityNullTest_1_0 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -5826,6 +5845,7 @@ public class ClientCompatibilityNullTest_1_0 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
@@ -384,6 +384,10 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1482,6 +1486,12 @@ public class ClientCompatibilityNullTest_1_1 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
+
+
 
 
 
@@ -5447,6 +5457,10 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5860,9 +5874,14 @@ public class ClientCompatibilityNullTest_1_1 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -5871,6 +5890,7 @@ public class ClientCompatibilityNullTest_1_1 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
@@ -384,6 +384,10 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1462,6 +1466,12 @@ public class ClientCompatibilityNullTest_1_2 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
+
+
 
 
 
@@ -5377,6 +5387,10 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5790,9 +5804,14 @@ public class ClientCompatibilityNullTest_1_2 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -5801,6 +5820,7 @@ public class ClientCompatibilityNullTest_1_2 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
@@ -374,6 +374,10 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1452,6 +1456,12 @@ public class ClientCompatibilityNullTest_1_3 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
+
+
 
 
 
@@ -5367,6 +5377,10 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -5780,9 +5794,14 @@ public class ClientCompatibilityNullTest_1_3 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -5791,6 +5810,7 @@ public class ClientCompatibilityNullTest_1_3 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
@@ -374,6 +374,10 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1616,6 +1620,12 @@ public class ClientCompatibilityNullTest_1_4 {
         handler.handle(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
      }
 }
+
+
+
+
+
+
 
 
 
@@ -5596,6 +5606,10 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6009,9 +6023,14 @@ public class ClientCompatibilityNullTest_1_4 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -6020,6 +6039,7 @@ public class ClientCompatibilityNullTest_1_4 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
@@ -396,6 +396,10 @@ public class ClientCompatibilityTest_1_0 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1516,6 +1520,12 @@ public class ClientCompatibilityTest_1_0 {
     inputStream.read(bytes);
     MapClearNearCacheCodec.ResponseParameters params = MapClearNearCacheCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
 }
+
+
+
+
+
+
 
 
 
@@ -5670,6 +5680,10 @@ public class ClientCompatibilityTest_1_0 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6104,9 +6118,14 @@ public class ClientCompatibilityTest_1_0 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -6116,6 +6135,7 @@ public class ClientCompatibilityTest_1_0 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
@@ -396,6 +396,10 @@ public class ClientCompatibilityTest_1_1 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1552,6 +1556,12 @@ public class ClientCompatibilityTest_1_1 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
+
+
 
 
 
@@ -5718,6 +5728,10 @@ public class ClientCompatibilityTest_1_1 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6152,9 +6166,14 @@ public class ClientCompatibilityTest_1_1 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -6164,6 +6183,7 @@ public class ClientCompatibilityTest_1_1 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
@@ -396,6 +396,10 @@ public class ClientCompatibilityTest_1_2 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1532,6 +1536,12 @@ public class ClientCompatibilityTest_1_2 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
+
+
 
 
 
@@ -5648,6 +5658,10 @@ public class ClientCompatibilityTest_1_2 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6082,9 +6096,14 @@ public class ClientCompatibilityTest_1_2 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -6094,6 +6113,7 @@ public class ClientCompatibilityTest_1_2 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
@@ -386,6 +386,10 @@ public class ClientCompatibilityTest_1_3 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1522,6 +1526,12 @@ public class ClientCompatibilityTest_1_3 {
                 assertTrue(isEqual(anInt, params.tableIndex));
                 assertTrue(isEqual(aListOfEntry, params.entries));
 }
+
+
+
+
+
+
 
 
 
@@ -5638,6 +5648,10 @@ public class ClientCompatibilityTest_1_3 {
 
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6072,9 +6086,14 @@ public class ClientCompatibilityTest_1_3 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -6084,6 +6103,7 @@ public class ClientCompatibilityTest_1_3 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
@@ -386,6 +386,10 @@ public class ClientCompatibilityTest_1_4 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     int length = inputStream.readInt();
@@ -1694,6 +1698,12 @@ public class ClientCompatibilityTest_1_4 {
         handler.handle(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
      }
 }
+
+
+
+
+
+
 
 
 {
@@ -5878,6 +5888,10 @@ public class ClientCompatibilityTest_1_4 {
 }
 
 
+
+
+
+
 {
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     int length = inputStream.readInt();
@@ -6312,9 +6326,14 @@ public class ClientCompatibilityTest_1_4 {
 {
     ClientMessage clientMessage = RingbufferReadManyCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -6324,6 +6343,7 @@ public class ClientCompatibilityTest_1_4 {
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(new SafeBuffer(bytes), 0));
                 assertTrue(isEqual(anInt, params.readCount));
                 assertTrue(isEqual(datas, params.items));
+                assertFalse(params.itemSeqsExist);
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
@@ -287,6 +287,24 @@ public class EncodeDecodeCompatibilityNullTest {
     ClientPingCodec.ResponseParameters params = ClientPingCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(    aString   );
+    ClientStatisticsCodec.RequestParameters params = ClientStatisticsCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.stats));
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    ClientStatisticsCodec.ResponseParameters params = ClientStatisticsCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(    aListOfStringToByteArrEntry   );
+    ClientDeployClassesCodec.RequestParameters params = ClientDeployClassesCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aListOfStringToByteArrEntry, params.classDefinitions));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    ClientDeployClassesCodec.ResponseParameters params = ClientDeployClassesCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     MapPutCodec.RequestParameters params = MapPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
@@ -1239,6 +1257,49 @@ public class EncodeDecodeCompatibilityNullTest {
         ClientMessage clientMessage = MapAddNearCacheInvalidationListenerCodec.encodeIMapBatchInvalidationEvent( datas ,  strings ,  uuids ,  longs   );
         handler.handle(ClientMessage.createForDecode(clientMessage.buffer(), 0));
      }
+}
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeRequest(    aString ,    anInt ,    anInt ,    aData ,    aData   );
+    MapFetchWithQueryCodec.RequestParameters params = MapFetchWithQueryCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(anInt, params.tableIndex));
+            assertTrue(isEqual(anInt, params.batch));
+            assertTrue(isEqual(aData, params.projection));
+            assertTrue(isEqual(aData, params.predicate));
+}
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeResponse(    datas ,    anInt   );
+    MapFetchWithQueryCodec.ResponseParameters params = MapFetchWithQueryCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(datas, params.results));
+            assertTrue(isEqual(anInt, params.nextTableIndexToReadFrom));
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(    aString   );
+    MapEventJournalSubscribeCodec.RequestParameters params = MapEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    MapEventJournalSubscribeCodec.ResponseParameters params = MapEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null ,    null   );
+    MapEventJournalReadCodec.RequestParameters params = MapEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(null, params.predicate));
+            assertTrue(isEqual(null, params.projection));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    null   );
+    MapEventJournalReadCodec.ResponseParameters params = MapEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(null, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = MultiMapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong   );
@@ -4194,6 +4255,34 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(aPartitionUuidList, params.partitionUuidList));
 }
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(    aString   );
+    CacheEventJournalSubscribeCodec.RequestParameters params = CacheEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    CacheEventJournalSubscribeCodec.ResponseParameters params = CacheEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    null ,    null   );
+    CacheEventJournalReadCodec.RequestParameters params = CacheEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(null, params.predicate));
+            assertTrue(isEqual(null, params.projection));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    null   );
+    CacheEventJournalReadCodec.ResponseParameters params = CacheEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(null, params.itemSeqs));
+}
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     XATransactionClearRemoteCodec.RequestParameters params = XATransactionClearRemoteCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anXid, params.xid));
@@ -4493,10 +4582,11 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    null   );
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anInt, params.readCount));
             assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(null, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = DurableExecutorShutdownCodec.encodeRequest(    aString   );

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
@@ -287,6 +287,24 @@ public class EncodeDecodeCompatibilityTest {
     ClientPingCodec.ResponseParameters params = ClientPingCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeRequest(    aString   );
+    ClientStatisticsCodec.RequestParameters params = ClientStatisticsCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.stats));
+}
+{
+    ClientMessage clientMessage = ClientStatisticsCodec.encodeResponse( );
+    ClientStatisticsCodec.ResponseParameters params = ClientStatisticsCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeRequest(    aListOfStringToByteArrEntry   );
+    ClientDeployClassesCodec.RequestParameters params = ClientDeployClassesCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aListOfStringToByteArrEntry, params.classDefinitions));
+}
+{
+    ClientMessage clientMessage = ClientDeployClassesCodec.encodeResponse( );
+    ClientDeployClassesCodec.ResponseParameters params = ClientDeployClassesCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+}
+{
     ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
     MapPutCodec.RequestParameters params = MapPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
@@ -1239,6 +1257,49 @@ public class EncodeDecodeCompatibilityTest {
         ClientMessage clientMessage = MapAddNearCacheInvalidationListenerCodec.encodeIMapBatchInvalidationEvent( datas ,  strings ,  uuids ,  longs   );
         handler.handle(ClientMessage.createForDecode(clientMessage.buffer(), 0));
      }
+}
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeRequest(    aString ,    anInt ,    anInt ,    aData ,    aData   );
+    MapFetchWithQueryCodec.RequestParameters params = MapFetchWithQueryCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(anInt, params.tableIndex));
+            assertTrue(isEqual(anInt, params.batch));
+            assertTrue(isEqual(aData, params.projection));
+            assertTrue(isEqual(aData, params.predicate));
+}
+{
+    ClientMessage clientMessage = MapFetchWithQueryCodec.encodeResponse(    datas ,    anInt   );
+    MapFetchWithQueryCodec.ResponseParameters params = MapFetchWithQueryCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(datas, params.results));
+            assertTrue(isEqual(anInt, params.nextTableIndexToReadFrom));
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeRequest(    aString   );
+    MapEventJournalSubscribeCodec.RequestParameters params = MapEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = MapEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    MapEventJournalSubscribeCodec.ResponseParameters params = MapEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+    MapEventJournalReadCodec.RequestParameters params = MapEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(aData, params.predicate));
+            assertTrue(isEqual(aData, params.projection));
+}
+{
+    ClientMessage clientMessage = MapEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    MapEventJournalReadCodec.ResponseParameters params = MapEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = MultiMapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong   );
@@ -4194,6 +4255,34 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aPartitionUuidList, params.partitionUuidList));
 }
 {
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeRequest(    aString   );
+    CacheEventJournalSubscribeCodec.RequestParameters params = CacheEventJournalSubscribeCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalSubscribeCodec.encodeResponse(    aLong ,    aLong   );
+    CacheEventJournalSubscribeCodec.ResponseParameters params = CacheEventJournalSubscribeCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aLong, params.oldestSequence));
+            assertTrue(isEqual(aLong, params.newestSequence));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeRequest(    aString ,    aLong ,    anInt ,    anInt ,    aData ,    aData   );
+    CacheEventJournalReadCodec.RequestParameters params = CacheEventJournalReadCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(aString, params.name));
+            assertTrue(isEqual(aLong, params.startSequence));
+            assertTrue(isEqual(anInt, params.minSize));
+            assertTrue(isEqual(anInt, params.maxSize));
+            assertTrue(isEqual(aData, params.predicate));
+            assertTrue(isEqual(aData, params.projection));
+}
+{
+    ClientMessage clientMessage = CacheEventJournalReadCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
+    CacheEventJournalReadCodec.ResponseParameters params = CacheEventJournalReadCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
+            assertTrue(isEqual(anInt, params.readCount));
+            assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
+}
+{
     ClientMessage clientMessage = XATransactionClearRemoteCodec.encodeRequest(    anXid   );
     XATransactionClearRemoteCodec.RequestParameters params = XATransactionClearRemoteCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anXid, params.xid));
@@ -4493,10 +4582,11 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     RingbufferReadManyCodec.ResponseParameters params = RingbufferReadManyCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(anInt, params.readCount));
             assertTrue(isEqual(datas, params.items));
+            assertTrue(isEqual(arrLongs, params.itemSeqs));
 }
 {
     ClientMessage clientMessage = DurableExecutorShutdownCodec.encodeRequest(    aString   );

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -103,6 +103,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -154,6 +155,11 @@ public class ReferenceObjects {
                 }
             }
             return !(e1.hasNext() || e2.hasNext());
+        }
+        if (a instanceof Entry && b instanceof Entry) {
+            final Entry entryA = (Entry) a;
+            final Entry entryB = (Entry) b;
+            return isEqual(entryA.getKey(), entryB.getKey()) && isEqual(entryA.getValue(), entryB.getValue());
         }
         return a.equals(b);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
@@ -5369,11 +5369,16 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
         inputStream.close();
         input.close();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
@@ -5420,11 +5420,16 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
@@ -5350,11 +5350,16 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
@@ -5340,11 +5340,16 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
@@ -5506,11 +5506,16 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(null, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
@@ -5398,11 +5398,16 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
         inputStream.close();
         input.close();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
@@ -5449,11 +5449,16 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
@@ -5379,11 +5379,16 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
@@ -5369,11 +5369,16 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
@@ -5539,11 +5539,16 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.filter));
 }
 {
-    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas   );
+    ClientMessage clientMessage = RingbufferReadManyCodec.encodeResponse(    anInt ,    datas ,    arrLongs   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.5), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.core.RingbufferStoreFactory;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.ringbuffer.impl.RingbufferStoreWrapper;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -57,7 +58,9 @@ public class RingbufferStoreConfigTest {
     @Test
     public void setStoreImplementation() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        RingbufferStore<Data> store = RingbufferStoreWrapper.create("name", config, OBJECT, serializationService, null);
+        RingbufferStore<Data> store = RingbufferStoreWrapper.create(
+                RingbufferService.getRingbufferNamespace("name"),
+                config, OBJECT, serializationService, null);
 
         config.setStoreImplementation(store);
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.when;
 @Category({QuickTest.class, ParallelTest.class})
 public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
     private static final String NAME = "somerb";
+    private static final ObjectNamespace NAMESPACE = RingbufferService.getRingbufferNamespace(NAME);
 
     private HazelcastInstance hz;
     private StoreLatencyPlugin plugin;
@@ -48,7 +50,8 @@ public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
         hz = createHazelcastInstance();
         plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
         delegate = mock(RingbufferStore.class);
-        ringbufferStore = new LatencyTrackingRingbufferStore<String>(delegate, plugin, NAME);
+        ringbufferStore = new LatencyTrackingRingbufferStore<String>(delegate, plugin,
+                NAMESPACE);
     }
 
     @Test
@@ -97,7 +100,7 @@ public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
     }
 
     public void assertProbeCalledOnce(String methodName) {
-        assertEquals(1, plugin.count(LatencyTrackingRingbufferStore.KEY, NAME, methodName));
+        assertEquals(1, plugin.count(LatencyTrackingRingbufferStore.KEY,
+                NAMESPACE.getServiceName() + ":" + NAMESPACE.getObjectName(), methodName));
     }
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
@@ -98,8 +98,7 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
                 .setInMemoryFormat(inMemoryFormat)
                 .setTimeToLiveSeconds(ttlSeconds);
 
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
         testSerialization(rbContainer);
 
         for (int k = 0; k < config.getCapacity() * 2; k++) {
@@ -119,6 +118,12 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
             ringbuffer.setHeadSequence(ringbuffer.headSequence() + 1);
             testSerialization(rbContainer);
         }
+    }
+
+    private RingbufferContainer getRingbufferContainer(RingbufferConfig config) {
+        return new RingbufferContainer(
+                RingbufferService.getRingbufferNamespace(config.getName()), config,
+                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
     }
 
     private void testSerialization(RingbufferContainer original) {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -65,8 +66,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void constructionNoTTL() {
         final RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(0);
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), rbContainer.getCapacity());
         final ArrayRingbuffer ringbuffer = (ArrayRingbuffer) rbContainer.getRingbuffer();
@@ -81,8 +81,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void constructionWithTTL() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(30);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), ringbuffer.getCapacity());
         assertNotNull(ringbuffer.getExpirationPolicy());
@@ -95,8 +94,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void remainingCapacity_whenTTLDisabled() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(0);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), ringbuffer.remainingCapacity());
 
@@ -105,11 +103,16 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
         assertEquals(config.getCapacity(), ringbuffer.remainingCapacity());
     }
 
+    private RingbufferContainer getRingbufferContainer(RingbufferConfig config) {
+        return new RingbufferContainer(
+                RingbufferService.getRingbufferNamespace(config.getName()), config,
+                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+    }
+
     @Test
     public void remainingCapacity_whenTTLEnabled() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100).setTimeToLiveSeconds(1);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(config.getCapacity(), ringbuffer.remainingCapacity());
 
@@ -125,8 +128,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void size_whenEmpty() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         assertEquals(0, ringbuffer.size());
         assertTrue(ringbuffer.isEmpty());
@@ -135,8 +137,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void size_whenAddingManyItems() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(100);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         for (int k = 0; k < config.getCapacity(); k++) {
             ringbuffer.add(toData(""));
@@ -157,8 +158,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void add() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(10);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
         ringbuffer.add(toData("foo"));
         ringbuffer.add(toData("bar"));
 
@@ -169,47 +169,45 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void add_whenWrapped() {
         RingbufferConfig config = new RingbufferConfig("foo").setInMemoryFormat(InMemoryFormat.OBJECT).setCapacity(3);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer ringbuffer = getRingbufferContainer(config);
 
         ringbuffer.add(toData("1"));
         assertEquals(0, ringbuffer.headSequence());
         assertEquals(0, ringbuffer.tailSequence());
-        assertEquals(toData("1"), ringbuffer.read(0));
+        assertEquals(toData("1"), ringbuffer.readAsData(0));
 
         ringbuffer.add(toData("2"));
         assertEquals(1, ringbuffer.tailSequence());
         assertEquals(0, ringbuffer.headSequence());
-        assertEquals(toData("1"), ringbuffer.read(0));
-        assertEquals(toData("2"), ringbuffer.read(1));
+        assertEquals(toData("1"), ringbuffer.readAsData(0));
+        assertEquals(toData("2"), ringbuffer.readAsData(1));
 
         ringbuffer.add(toData("3"));
         assertEquals(2, ringbuffer.tailSequence());
         assertEquals(0, ringbuffer.headSequence());
-        assertEquals(toData("1"), ringbuffer.read(0));
-        assertEquals(toData("2"), ringbuffer.read(1));
-        assertEquals(toData("3"), ringbuffer.read(2));
+        assertEquals(toData("1"), ringbuffer.readAsData(0));
+        assertEquals(toData("2"), ringbuffer.readAsData(1));
+        assertEquals(toData("3"), ringbuffer.readAsData(2));
 
         ringbuffer.add(toData("4"));
         assertEquals(3, ringbuffer.tailSequence());
         assertEquals(1, ringbuffer.headSequence());
-        assertEquals(toData("2"), ringbuffer.read(1));
-        assertEquals(toData("3"), ringbuffer.read(2));
-        assertEquals(toData("4"), ringbuffer.read(3));
+        assertEquals(toData("2"), ringbuffer.readAsData(1));
+        assertEquals(toData("3"), ringbuffer.readAsData(2));
+        assertEquals(toData("4"), ringbuffer.readAsData(3));
 
         ringbuffer.add(toData("5"));
         assertEquals(4, ringbuffer.tailSequence());
         assertEquals(2, ringbuffer.headSequence());
-        assertEquals(toData("3"), ringbuffer.read(2));
-        assertEquals(toData("4"), ringbuffer.read(3));
-        assertEquals(toData("5"), ringbuffer.read(4));
+        assertEquals(toData("3"), ringbuffer.readAsData(2));
+        assertEquals(toData("4"), ringbuffer.readAsData(3));
+        assertEquals(toData("5"), ringbuffer.readAsData(4));
     }
 
     @Test(expected = StaleSequenceException.class)
     public void read_whenStaleSequence() {
         RingbufferConfig config = new RingbufferConfig("foo").setCapacity(3);
-        RingbufferContainer ringbuffer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        RingbufferContainer<Data> ringbuffer = getRingbufferContainer(config);
 
         ringbuffer.add(toData("1"));
         ringbuffer.add(toData("2"));
@@ -217,14 +215,13 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
         // this one will overwrite the first item
         ringbuffer.add(toData("4"));
 
-        ringbuffer.read(0);
+        ringbuffer.readAsData(0);
     }
 
     @Test
     public void add_whenBinaryInMemoryFormat() {
         final RingbufferConfig config = new RingbufferConfig("foo").setInMemoryFormat(InMemoryFormat.BINARY);
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
         final ArrayRingbuffer ringbuffer = (ArrayRingbuffer) rbContainer.getRingbuffer();
 
         rbContainer.add(toData("foo"));
@@ -234,8 +231,7 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     @Test
     public void add_inObjectInMemoryFormat() {
         final RingbufferConfig config = new RingbufferConfig("foo").setInMemoryFormat(InMemoryFormat.OBJECT);
-        final RingbufferContainer rbContainer = new RingbufferContainer(config.getName(), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        final RingbufferContainer rbContainer = getRingbufferContainer(config);
         final ArrayRingbuffer ringbuffer = (ArrayRingbuffer) rbContainer.getRingbuffer();
 
         rbContainer.add(toData("foo"));

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
@@ -57,8 +57,16 @@ public class RingbufferServiceTest extends HazelcastTestSupport {
 
     @Test
     public void reset() {
-        service.getContainer("foo");
-        service.getContainer("bar");
+        final String foo = "foo";
+        final String bar = "bar";
+        service.getContainer(
+                service.getRingbufferPartitionId(foo),
+                RingbufferService.getRingbufferNamespace(foo),
+                service.getRingbufferConfig(foo));
+        service.getContainer(
+                service.getRingbufferPartitionId(bar),
+                RingbufferService.getRingbufferNamespace(bar),
+                service.getRingbufferConfig(bar));
 
         service.reset();
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
@@ -45,10 +45,14 @@ public class RingbufferTTLTest extends HazelcastTestSupport {
         Config config = new Config();
         config.addRingBufferConfig(ringbufferConfig);
         hz = createHazelcastInstance(config);
-        ringbuffer = hz.getRingbuffer(ringbufferConfig.getName());
+        final String name = ringbufferConfig.getName();
+        ringbuffer = hz.getRingbuffer(name);
 
         RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(ringbufferConfig.getName());
+        ringbufferContainer = ringbufferService.getContainer(
+                ringbufferService.getRingbufferPartitionId(name),
+                RingbufferService.getRingbufferNamespace(name),
+                ringbufferConfig);
         arrayRingbuffer = (ArrayRingbuffer) ringbufferContainer.getRingbuffer();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.ringbuffer.impl;
 
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,21 +34,27 @@ public class RingbufferWaitNotifyKeyTest {
 
     @Test
     public void test_equals() {
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("peter", "java"), true);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("peter", "c#"), false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("talip", "java"), false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                new RingbufferWaitNotifyKey("talip", "c#"), false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                "", false);
-        test_equals(new RingbufferWaitNotifyKey("peter", "java"),
-                null, false);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), true);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "talip"), false);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(MapService.SERVICE_NAME, "peter"), false);
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
+                waitNotifyKey(MapService.SERVICE_NAME, "talip"), false);
+        test_equals(waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), "", false);
+        test_equals(waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), null, false);
 
-        RingbufferWaitNotifyKey key = new RingbufferWaitNotifyKey("peter", "java");
+        RingbufferWaitNotifyKey key = waitNotifyKey(RingbufferService.SERVICE_NAME, "peter");
         test_equals(key, key, true);
+    }
+
+    private RingbufferWaitNotifyKey waitNotifyKey(String service, String object) {
+        return new RingbufferWaitNotifyKey(new DistributedObjectNamespace(service, object));
     }
 
     public void test_equals(Object key1, Object key2, boolean equals) {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperationTest.java
@@ -20,7 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -45,6 +47,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
     private NodeEngineImpl nodeEngine;
     private SerializationService serializationService;
     private Ringbuffer<Object> ringbuffer;
+    private RingbufferService ringbufferService;
 
     @Before
     public void setup() {
@@ -56,6 +59,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
         nodeEngine = getNodeEngineImpl(hz);
         serializationService = getSerializationService(hz);
         ringbuffer = hz.getRingbuffer(rbConfig.getName());
+        ringbufferService = nodeEngine.getService(RingbufferService.SERVICE_NAME);
     }
 
     @Test
@@ -66,8 +70,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, FAIL);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, FAIL);
         addOperation.run();
 
         assertFalse(addOperation.shouldNotify());
@@ -83,8 +86,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, FAIL);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, FAIL);
         addOperation.run();
 
         assertTrue(addOperation.shouldNotify());
@@ -100,8 +102,7 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, OVERWRITE);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, OVERWRITE);
         addOperation.run();
 
         assertTrue(addOperation.shouldNotify());
@@ -117,12 +118,18 @@ public class AddAllOperationTest extends HazelcastTestSupport {
 
         Data item = serializationService.toData("newItem");
 
-        AddAllOperation addOperation = new AddAllOperation(ringbuffer.getName(), new Data[]{item}, OVERWRITE);
-        addOperation.setNodeEngine(nodeEngine);
+        AddAllOperation addOperation = getAddAllOperation(new Data[]{item}, OVERWRITE);
         addOperation.run();
 
         assertTrue(addOperation.shouldNotify());
         assertTrue(addOperation.shouldBackup());
         assertEquals(ringbuffer.tailSequence(), addOperation.getResponse());
+    }
+
+    private AddAllOperation getAddAllOperation(Data[] items, OverflowPolicy policy) {
+        AddAllOperation op = new AddAllOperation(ringbuffer.getName(), items, policy);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        op.setNodeEngine(nodeEngine);
+        return op;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
@@ -52,6 +52,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
     private Ringbuffer<Object> ringbuffer;
     private RingbufferContainer ringbufferContainer;
     private SerializationService serializationService;
+    private RingbufferService ringbufferService;
 
     @Before
     public void setup() {
@@ -64,10 +65,14 @@ public class GenericOperationTest extends HazelcastTestSupport {
         hz = createHazelcastInstance(config);
         nodeEngine = getNodeEngineImpl(hz);
         serializationService = nodeEngine.getSerializationService();
-        ringbuffer = hz.getRingbuffer(rbConfig.getName());
+        final String name = rbConfig.getName();
+        ringbuffer = hz.getRingbuffer(name);
 
-        RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(rbConfig.getName());
+        ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
+        ringbufferContainer = ringbufferService.getContainer(
+                ringbufferService.getRingbufferPartitionId(name),
+                RingbufferService.getRingbufferNamespace(name),
+                rbConfig);
     }
 
     @Test
@@ -75,8 +80,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_SIZE);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_SIZE);
 
         op.run();
         Long result = op.getResponse();
@@ -88,8 +92,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_CAPACITY);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_CAPACITY);
 
         op.run();
         Long result = op.getResponse();
@@ -101,8 +104,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_REMAINING_CAPACITY);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_REMAINING_CAPACITY);
 
         op.run();
         Long result = op.getResponse();
@@ -114,8 +116,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer.add("a");
         ringbuffer.add("b");
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_TAIL);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_TAIL);
 
         op.run();
         Long result = op.getResponse();
@@ -128,12 +129,18 @@ public class GenericOperationTest extends HazelcastTestSupport {
             ringbuffer.add("a");
         }
 
-        GenericOperation op = new GenericOperation(ringbuffer.getName(), OPERATION_HEAD);
-        op.setNodeEngine(nodeEngine);
+        GenericOperation op = getGenericOperation(OPERATION_HEAD);
 
         op.run();
         Long result = op.getResponse();
         assertEquals(new Long(ringbufferContainer.headSequence()), result);
+    }
+
+    private GenericOperation getGenericOperation(byte operation) {
+        GenericOperation op = new GenericOperation(ringbuffer.getName(), operation);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        op.setNodeEngine(nodeEngine);
+        return op;
     }
 
     public void serialize() {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -51,6 +51,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     private Ringbuffer<Object> ringbuffer;
     private RingbufferContainer ringbufferContainer;
     private SerializationService serializationService;
+    private RingbufferService ringbufferService;
 
     @Before
     public void setup() {
@@ -61,17 +62,21 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         hz = createHazelcastInstance(config);
         nodeEngine = getNodeEngineImpl(hz);
         serializationService = nodeEngine.getSerializationService();
-        ringbuffer = hz.getRingbuffer(rbConfig.getName());
+        final String name = rbConfig.getName();
+        ringbuffer = hz.getRingbuffer(name);
 
-        RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(rbConfig.getName());
+        ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
+        ringbufferContainer = ringbufferService.getContainer(
+                ringbufferService.getRingbufferPartitionId(name),
+                RingbufferService.getRingbufferNamespace(name),
+                rbConfig);
     }
 
     @Test
     public void whenAtTail() throws Exception {
         ringbuffer.add("tail");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence(), 1, 1, null);
+        ReadManyOperation<String> op = getReadManyOperation(ringbuffer.tailSequence(), 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -89,7 +94,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     public void whenOneAfterTail() throws Exception {
         ringbuffer.add("tail");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() + 1, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 1, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -104,7 +109,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     public void whenTooFarAfterTail() throws Exception {
         ringbuffer.add("tail");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() + 2, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 2, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -113,7 +118,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
     @Test
     public void whenOneAfterTailAndBufferEmpty() throws Exception {
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() + 1, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() + 1, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -127,7 +132,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
 
     @Test(expected = StaleSequenceException.class)
     public void whenOnTailAndBufferEmpty() throws Exception {
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence(), 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence(), 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -140,7 +145,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer.add("item2");
         ringbuffer.add("item3");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.tailSequence() - 1, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.tailSequence() - 1, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -161,7 +166,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer.add("item2");
         ringbuffer.add("item3");
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), ringbuffer.headSequence(), 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(ringbuffer.headSequence(), 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         // since there is an item, we don't need to wait
@@ -185,7 +190,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         long oldhead = ringbuffer.headSequence();
         ringbufferContainer.setHeadSequence(ringbufferContainer.tailSequence());
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), oldhead, 1, 1, null);
+        ReadManyOperation op = getReadManyOperation(oldhead, 1, 1, null);
         op.setNodeEngine(nodeEngine);
 
         op.shouldWait();
@@ -194,7 +199,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenMinimumNumberOfItemsNotAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
         op.setNodeEngine(nodeEngine);
 
         assertTrue(op.shouldWait());
@@ -220,7 +225,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenBelowMinimumAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -239,7 +244,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenMinimumNumberOfItemsAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, null);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -254,7 +259,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenEnoughItemsAvailable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 1, 3, null);
+        ReadManyOperation op = getReadManyOperation(startSequence, 1, 3, null);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -274,7 +279,8 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
     @Test
     public void whenEnoughItemsAvailableAndReturnPortable() throws Exception {
         long startSequence = ringbuffer.tailSequence() + 1;
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 1, 3, null, true);
+        final ReadManyOperation<String> op = new ReadManyOperation<String>(ringbuffer.getName(), startSequence, 1, 3, null, true);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("item1");
@@ -308,7 +314,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
             }
         };
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, filter);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, filter);
         op.setNodeEngine(nodeEngine);
 
         assertTrue(op.shouldWait());
@@ -365,7 +371,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
             }
         };
 
-        ReadManyOperation op = new ReadManyOperation(ringbuffer.getName(), startSequence, 3, 3, filter);
+        ReadManyOperation op = getReadManyOperation(startSequence, 3, 3, filter);
         op.setNodeEngine(nodeEngine);
 
         ringbuffer.add("bad1");
@@ -378,5 +384,12 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         assertFalse(op.shouldWait());
         assertEquals(startSequence + 6, op.sequence);
         assertEquals(asList("good1", "good2", "good3"), op.getResponse());
+    }
+
+    private <T> ReadManyOperation<T> getReadManyOperation(long start, int min, int max, IFunction<T, Boolean> filter) {
+        final ReadManyOperation<T> op = new ReadManyOperation<T>(ringbuffer.getName(), start, min, max, filter);
+        op.setPartitionId(ringbufferService.getRingbufferPartitionId(ringbuffer.getName()));
+        op.setNodeEngine(nodeEngine);
+        return op;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.topic.impl.reliable;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -29,10 +30,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -81,8 +83,11 @@ public class ReliableTopicDestroyTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                ConcurrentMap<String, RingbufferContainer> containers = ringbufferService.getContainers();
-                assertFalse(containers.containsKey(topic.ringbuffer.getName()));
+                final String name = topic.ringbuffer.getName();
+                final Map<ObjectNamespace, RingbufferContainer> partitionContainers =
+                        ringbufferService.getContainers().get(ringbufferService.getRingbufferPartitionId(name));
+                assertTrue(partitionContainers != null);
+                assertFalse(partitionContainers.containsKey(RingbufferService.getRingbufferNamespace(name)));
             }
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.5.0-2</client.protocol.version>
+        <client.protocol.version>1.5.0-3</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
Adapt RingbufferService to hold ringbuffers for other services (e.g.
map). This means that it should implement
FragmentedMigrationAwareService and return partition namespace data
for other services when requested.

Also, the read result sets were returning only how many items were
read as well as the matching items. In case the ringbuffer is read
with a filter, not all items match and the result set may not contain
items with a contiguous set of sequences. The itemCount is the
difference between the sequence ID of the last and first returned
item and is a hack not to send all sequence IDs.

We will send the sequence IDs instead. This allows the user to store
the sequence ID and resume processing even if the processing crashes
mid-point in the result set.

The ringbuffer already has supports for IFilter but we also add support
for predicates and projections.

Depends on : 
https://github.com/hazelcast/hazelcast-client-protocol/pull/87