### PR TITLE
Add map and cache event journal

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -20,11 +20,16 @@ import com.hazelcast.cache.impl.CacheEntryProcessorResult;
 import com.hazelcast.cache.impl.CacheEventListenerAdaptor;
 import com.hazelcast.cache.impl.event.CachePartitionLostEvent;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
+import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheAddEntryListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheAddPartitionLostListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheContainsKeyCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheEntryProcessorCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheEventJournalReadCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheEventJournalSubscribeCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheEventJournalSubscribeCodec.ResponseParameters;
 import com.hazelcast.client.impl.protocol.codec.CacheListenerRegistrationCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheLoadAllCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
@@ -32,12 +37,20 @@ import com.hazelcast.client.impl.protocol.codec.CacheRemovePartitionLostListener
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.ringbuffer.impl.client.PortableReadResultSet;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Predicate;
 
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
@@ -68,19 +81,45 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * {@link com.hazelcast.cache.ICache} implementation for Hazelcast clients.
- *
+ * <p>
  * This proxy is the implementation of {@link com.hazelcast.cache.ICache} and {@link javax.cache.Cache} which is returned by
  * {@link HazelcastClientCacheManager}. Represents a cache on client.
- *
+ * <p>
  * This implementation is a thin proxy implementation using hazelcast client infrastructure.
  *
  * @param <K> key type
  * @param <V> value type
  */
+@SuppressWarnings("checkstyle:classfanoutcomplexity")
 public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V> {
+    private ClientMessageDecoder eventJournalReadResponseDecoder;
+    private ClientMessageDecoder eventJournalSubscribeResponseDecoder;
+
 
     ClientCacheProxy(CacheConfig<K, V> cacheConfig, ClientContext context) {
         super(cacheConfig, context);
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+        eventJournalReadResponseDecoder = new ClientMessageDecoder() {
+            @Override
+            public ReadResultSet<?> decodeClientMessage(ClientMessage message) {
+                final CacheEventJournalReadCodec.ResponseParameters params = CacheEventJournalReadCodec.decodeResponse(message);
+                final PortableReadResultSet<?> resultSet
+                        = new PortableReadResultSet<Object>(params.readCount, params.items, params.itemSeqs);
+                resultSet.setSerializationService(getSerializationService());
+                return resultSet;
+            }
+        };
+        eventJournalSubscribeResponseDecoder = new ClientMessageDecoder() {
+            @Override
+            public EventJournalInitialSubscriberState decodeClientMessage(ClientMessage message) {
+                final ResponseParameters resp = CacheEventJournalSubscribeCodec.decodeResponse(message);
+                return new EventJournalInitialSubscriberState(resp.oldestSequence, resp.newestSequence);
+            }
+        };
     }
 
     @Override
@@ -470,6 +509,58 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V> {
     @Override
     public boolean removePartitionLostListener(String id) {
         return getContext().getListenerService().deregisterListener(id);
+    }
+
+
+    /**
+     * Subscribe to the event journal for this cache and a specific partition ID.
+     * The method will return the newest and oldest event journal sequence.
+     *
+     * @param partitionId the partition ID of the entries to which we are subscribing
+     * @return future with the initial subscriber state containing the newest and oldest event journal sequence
+     * @throws UnsupportedOperationException if the cluster version is lower than 3.9 or there is no event journal
+     *                                       configured for this cache
+     * @since 3.9
+     */
+    public ICompletableFuture<EventJournalInitialSubscriberState> subscribeToEventJournal(int partitionId) {
+        final ClientMessage request = CacheEventJournalSubscribeCodec.encodeRequest(nameWithPrefix);
+        final ClientInvocationFuture fut = new ClientInvocation(getClient(), request, partitionId).invoke();
+        return new ClientDelegatingFuture<EventJournalInitialSubscriberState>(fut, getSerializationService(),
+                eventJournalSubscribeResponseDecoder);
+    }
+
+    /**
+     * Reads from the event journal. The returned future may throw {@link UnsupportedOperationException}
+     * if the cluster version is lower than 3.9 or there is no event journal configured for this cache.
+     * <p>
+     * <b>NOTE:</b>
+     * Configuring evictions may cause unexpected results when reading from the event journal and
+     * there are cluster changes (a backup replica is promoted into a partition owner). See
+     * {@link com.hazelcast.cache.impl.journal.CacheEventJournal} for more details.
+     *
+     * @param startSequence the sequence of the first item to read
+     * @param maxSize       the maximum number of items to read
+     * @param partitionId   the partition ID of the entries in the journal
+     * @param predicate     the predicate which the events must pass to be included in the response.
+     *                      May be {@code null} in which case all events pass the predicate
+     * @param projection    the projection which is applied to the events before returning.
+     *                      May be {@code null} in which case the event is returned without being projected
+     * @param <T>           the return type of the projection. It is equal to the journal event type
+     *                      if the projection is {@code null} or it is the identity projection
+     * @return the future with the filtered and projected journal items
+     * @since 3.9
+     */
+    public <T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+            Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        final SerializationService ss = getSerializationService();
+        final ClientMessage request = CacheEventJournalReadCodec.encodeRequest(
+                nameWithPrefix, startSequence, 1, maxSize, ss.toData(predicate), ss.toData(projection));
+        final ClientInvocationFuture fut = new ClientInvocation(getClient(), request, partitionId).invoke();
+        return new ClientDelegatingFuture<ReadResultSet<T>>(fut, ss, eventJournalReadResponseDecoder);
     }
 
     private final class ClientCachePartitionLostEventHandler

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientBasicCacheJournalTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientBasicCacheJournalTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.journal.BasicCacheJournalTest;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
+import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.util.function.Predicate;
+import org.junit.After;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+
+public class ClientBasicCacheJournalTest extends BasicCacheJournalTest {
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance client;
+
+    @Override
+    protected HazelcastInstance getRandomInstance() {
+        return client;
+    }
+
+    @Override
+    protected HazelcastInstance[] createInstances() {
+        factory = new TestHazelcastFactory();
+        final HazelcastInstance[] instances = factory.newInstances(getConfig(), 2);
+        client = factory.newHazelcastClient();
+        return instances;
+    }
+
+    @Override
+    protected CacheManager createCacheManager() {
+        final HazelcastClientCachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
+        return provider.getCacheManager();
+    }
+
+    @Override
+    protected <K, V> ICache<K, V> getCache(String cacheName) {
+        return (ICache<K, V>) cacheManager.getCache(cacheName);
+    }
+
+    @Override
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(Cache<K, V> cache, int partitionId) throws Exception{
+        return ((ClientCacheProxy<K, V>) cache).subscribeToEventJournal(partitionId).get();
+    }
+
+    @Override
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(Cache<K, V> cache,
+                                                                                  long startSequence,
+                                                                                  int maxSize,
+                                                                                  int partitionId,
+                                                                                  Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+                                                                                  Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        return ((ClientCacheProxy<K, V>) cache).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+    @After
+    public final void terminate() {
+        factory.terminateAll();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientBasicMapJournalTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientBasicMapJournalTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.journal.BasicMapJournalTest;
+import com.hazelcast.map.impl.journal.EventJournalMapEvent;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.util.function.Predicate;
+import org.junit.After;
+
+public class ClientBasicMapJournalTest extends BasicMapJournalTest {
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance client;
+
+    @Override
+    protected HazelcastInstance getRandomInstance() {
+        return client;
+    }
+
+    @Override
+    protected HazelcastInstance[] createInstances() {
+        factory = new TestHazelcastFactory();
+        final HazelcastInstance[] instances = factory.newInstances(getConfig(), 2);
+        client = factory.newHazelcastClient();
+        return instances;
+    }
+
+    @Override
+    protected <K, V> IMap<K, V> getMap(String mapName) {
+        return client.getMap(mapName);
+    }
+
+    @Override
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(IMap<K, V> map, int partitionId) throws Exception{
+        return ((ClientMapProxy<K, V>) map).subscribeToEventJournal(partitionId).get();
+    }
+
+    @Override
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(IMap<K, V> map,
+                                                                                  long startSequence,
+                                                                                  int maxSize,
+                                                                                  int partitionId,
+                                                                                  Predicate<? super EventJournalMapEvent<K, V>> predicate,
+                                                                                  Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        return ((ClientMapProxy<K, V>) map).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+    @After
+    public final void terminate() {
+        factory.terminateAll();
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -30,6 +30,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.HotRestartConfig;
@@ -165,6 +166,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> executorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> durableExecutorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> scheduledExecutorManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> mapEventJournalManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> cacheEventJournalManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> cardinalityEstimatorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> wanReplicationManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> jobTrackerManagedMap;
@@ -188,6 +191,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.executorManagedMap = createManagedMap("executorConfigs");
             this.durableExecutorManagedMap = createManagedMap("durableExecutorConfigs");
             this.scheduledExecutorManagedMap = createManagedMap("scheduledExecutorConfigs");
+            this.mapEventJournalManagedMap = createManagedMap("mapEventJournalConfigs");
+            this.cacheEventJournalManagedMap = createManagedMap("cacheEventJournalConfigs");
             this.cardinalityEstimatorManagedMap = createManagedMap("cardinalityEstimatorConfigs");
             this.wanReplicationManagedMap = createManagedMap("wanReplicationConfigs");
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
@@ -222,6 +227,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleDurableExecutor(node);
                     } else if ("scheduled-executor-service".equals(nodeName)) {
                         handleScheduledExecutor(node);
+                    } else if ("event-journal".equals(nodeName)) {
+                        handleEventJournal(node);
                     } else if ("cardinality-estimator".equals(nodeName)) {
                         handleCardinalityEstimator(node);
                     } else if ("queue".equals(nodeName)) {
@@ -561,7 +568,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             for (Node n : childElements(node)) {
                 String name = cleanNodeName(n);
                 if ("trusted-interfaces".equals(name)) {
-                    for (Node i: childElements(n)) {
+                    for (Node i : childElements(n)) {
                         name = cleanNodeName(i);
                         if ("interface".equals(name)) {
                             String value = getTextContent(i);
@@ -622,6 +629,19 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 }
             }
             lockManagedMap.put(getAttribute(node, "name"), lockConfigBuilder.getBeanDefinition());
+        }
+
+        public void handleEventJournal(Node node) {
+            final BeanDefinitionBuilder eventJournalBuilder = createBeanBuilder(EventJournalConfig.class);
+            fillAttributeValues(node, eventJournalBuilder);
+            final String mapName = getAttribute(node, "map-name");
+            final String cacheName = getAttribute(node, "cache-name");
+            if (!StringUtil.isNullOrEmpty(mapName)) {
+                mapEventJournalManagedMap.put(mapName, eventJournalBuilder.getBeanDefinition());
+            }
+            if (!StringUtil.isNullOrEmpty(cacheName)) {
+                cacheEventJournalManagedMap.put(cacheName, eventJournalBuilder.getBeanDefinition());
+            }
         }
 
         public void handleRingbuffer(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -977,6 +977,58 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element name="event-journal" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Configuration for an event journal. The event journal keeps events related
+                                        to a specific partition and data structure. For instance, it could keep
+                                        map add, update, remove, merge events along with the key, old value, new value and so on.
+                                        This configuration is not tied to a specific data structure and can be reused.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:attribute name="map-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the map to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the cache to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="enabled" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            True if the event journal is enabled, false otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="capacity" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of items in the event journal. If no time-to-live-seconds
+                                            is set, the size will always be equal to capacity after the event
+                                            journal has been filled. This is because no items are getting retired.
+                                            The default value is 10000.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="time-to-live-seconds" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum number of seconds for each entry to stay in the event journal.
+                                            Entries that are older than &lt;time-to-live-seconds&gt; are evicted from the journal.
+                                            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="multimap" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
@@ -1042,4 +1043,23 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         assertEquals(expectedComparatorClassName, mapConfig.getMapEvictionPolicy().getClass().getName());
     }
+
+    @Test
+    public void testMapEventJournalConfigIsWellParsed() {
+        final EventJournalConfig journalConfig = config.getMapEventJournalConfig("mapName");
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(123, journalConfig.getCapacity());
+        assertEquals(321, journalConfig.getTimeToLiveSeconds());
+    }
+
+    @Test
+    public void testCacheEventJournalConfigIsWellParsed() {
+        final EventJournalConfig journalConfig = config.getCacheEventJournalConfig("cacheName");
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(123, journalConfig.getCapacity());
+        assertEquals(321, journalConfig.getTimeToLiveSeconds());
+    }
+
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd
+		hazelcast-spring-3.9.xsd
 		http://www.hazelcast.com/schema/sample
 		hazelcast-sample-service.xsd">
 
@@ -409,6 +409,9 @@
                 </hz:wan-replication-ref>
                 <hz:hot-restart enabled="true" fsync="true" />
             </hz:cache>
+
+            <hz:event-journal map-name="mapName" cache-name="cacheName" enabled="true"
+                              capacity="123" time-to-live-seconds="321"/>
 
             <hz:multimap name="testMultimap"
                          value-collection-type="LIST" binary="false" statistics-enabled="false">

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -19,6 +19,8 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
+import com.hazelcast.cache.impl.journal.CacheEventJournal;
+import com.hazelcast.cache.impl.journal.RingbufferCacheEventJournalImpl;
 import com.hazelcast.cache.impl.operation.PostJoinCacheOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -105,6 +107,7 @@ public abstract class AbstractCacheService implements ICacheService, PostJoinAwa
     protected CachePartitionSegment[] segments;
     protected CacheEventHandler cacheEventHandler;
     protected CacheSplitBrainHandler cacheSplitBrainHandler;
+    protected RingbufferCacheEventJournalImpl eventJournal;
     protected ILogger logger;
 
     @Override
@@ -118,6 +121,7 @@ public abstract class AbstractCacheService implements ICacheService, PostJoinAwa
         this.cacheEventHandler = new CacheEventHandler(nodeEngine);
         this.cacheSplitBrainHandler = new CacheSplitBrainHandler(nodeEngine, configs, segments);
         this.logger = nodeEngine.getLogger(getClass());
+        this.eventJournal = new RingbufferCacheEventJournalImpl(nodeEngine);
         postInit(nodeEngine, properties);
     }
 
@@ -702,5 +706,10 @@ public abstract class AbstractCacheService implements ICacheService, PostJoinAwa
 
     public CacheEventHandler getCacheEventHandler() {
         return cacheEventHandler;
+    }
+
+    @Override
+    public CacheEventJournal getEventJournal() {
+        return eventJournal;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -18,6 +18,11 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
+import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
+import com.hazelcast.cache.impl.journal.CacheEventJournalReadResultSetImpl;
+import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
+import com.hazelcast.cache.impl.journal.DeserializingEventJournalCacheEvent;
+import com.hazelcast.cache.impl.journal.InternalEventJournalCacheEvent;
 import com.hazelcast.cache.impl.merge.entry.DefaultCacheEntryView;
 import com.hazelcast.cache.impl.operation.CacheBackupEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheClearBackupOperation;
@@ -137,8 +142,13 @@ public final class CacheDataSerializerHook
     public static final short CACHE_ASSIGN_AND_GET_UUIDS_FACTORY = 53;
     public static final short CACHE_NEAR_CACHE_STATE_HOLDER = 54;
     public static final short CACHE_EVENT_LISTENER_ADAPTOR = 55;
+    public static final short EVENT_JOURNAL_SUBSCRIBE_OPERATION = 56;
+    public static final short EVENT_JOURNAL_READ_OPERATION = 57;
+    public static final short EVENT_JOURNAL_DESERIALIZING_CACHE_EVENT = 58;
+    public static final short EVENT_JOURNAL_INTERNAL_CACHE_EVENT = 59;
+    public static final short EVENT_JOURNAL_READ_RESULT_SET = 60;
 
-    private static final int LEN = CACHE_EVENT_LISTENER_ADAPTOR + 1;
+    private static final int LEN = EVENT_JOURNAL_READ_RESULT_SET + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -412,6 +422,31 @@ public final class CacheDataSerializerHook
         constructors[CACHE_EVENT_LISTENER_ADAPTOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheEventListenerAdaptor();
+            }
+        };
+        constructors[EVENT_JOURNAL_SUBSCRIBE_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEventJournalSubscribeOperation();
+            }
+        };
+        constructors[EVENT_JOURNAL_READ_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEventJournalReadOperation<Object, Object, Object>();
+            }
+        };
+        constructors[EVENT_JOURNAL_DESERIALIZING_CACHE_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DeserializingEventJournalCacheEvent<Object, Object>();
+            }
+        };
+        constructors[EVENT_JOURNAL_INTERNAL_CACHE_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new InternalEventJournalCacheEvent();
+            }
+        };
+        constructors[EVENT_JOURNAL_READ_RESULT_SET] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEventJournalReadResultSetImpl<Object, Object, Object>();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -19,17 +19,25 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.cache.impl.event.InternalCachePartitionLostListenerAdapter;
+import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
+import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
 import com.hazelcast.cache.impl.operation.CacheListenerRegistrationOperation;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.util.function.Predicate;
 
 import javax.cache.CacheException;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -68,8 +76,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @param <K> the type of key.
  * @param <V> the type of value.
  */
-public class CacheProxy<K, V>
-        extends AbstractCacheProxy<K, V> {
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
+public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> {
 
     protected final ILogger logger;
 
@@ -359,5 +367,54 @@ public class CacheProxy<K, V>
         checkNotNull(id, "Listener ID should not be null!");
         return getService().getNodeEngine().getEventService()
                 .deregisterListener(AbstractCacheService.SERVICE_NAME, name, id);
+    }
+
+    /**
+     * Subscribe to the event journal for this cache and a specific partition ID.
+     * The method will return the newest and oldest event journal sequence.
+     *
+     * @param partitionId the partition ID of the entries to which we are subscribing
+     * @return future with the initial subscriber state containing the newest and oldest event journal sequence
+     * @throws UnsupportedOperationException if the cluster version is lower than 3.9 or there is no event journal
+     *                                       configured for this cache
+     * @since 3.9
+     */
+    public ICompletableFuture<EventJournalInitialSubscriberState> subscribeToEventJournal(int partitionId) {
+        final CacheEventJournalSubscribeOperation op = new CacheEventJournalSubscribeOperation(nameWithPrefix);
+        op.setPartitionId(partitionId);
+        return getNodeEngine().getOperationService().invokeOnPartition(op);
+    }
+
+    /**
+     * Reads from the event journal. The returned future may throw {@link UnsupportedOperationException}
+     * if the cluster version is lower than 3.9 or there is no event journal configured for this cache.
+     * <p>
+     * <b>NOTE:</b>
+     * Configuring evictions may cause unexpected results when reading from the event journal and
+     * there are cluster changes (a backup replica is promoted into a partition owner). See
+     * {@link com.hazelcast.cache.impl.journal.CacheEventJournal} for more details.
+     *
+     * @param startSequence the sequence of the first item to read
+     * @param maxSize       the maximum number of items to read
+     * @param partitionId   the partition ID of the entries in the journal
+     * @param predicate     the predicate which the events must pass to be included in the response.
+     *                      May be {@code null} in which case all events pass the predicate
+     * @param projection    the projection which is applied to the events before returning.
+     *                      May be {@code null} in which case the event is returned without being projected
+     * @param <T>           the return type of the projection. It is equal to the journal event type
+     *                      if the projection is {@code null} or it is the identity projection
+     * @return the future with the filtered and projected journal items
+     * @since 3.9
+     */
+    public <T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+            Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        final CacheEventJournalReadOperation<K, V, T> op = new CacheEventJournalReadOperation<K, V, T>(
+                nameWithPrefix, startSequence, 1, maxSize, predicate, projection);
+        op.setPartitionId(partitionId);
+        return getNodeEngine().getOperationService().invokeOnPartition(op);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.cache.impl.event.CacheWanEventPublisher;
+import com.hazelcast.cache.impl.journal.CacheEventJournal;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.nio.serialization.Data;
@@ -41,8 +42,23 @@ public interface ICacheService
 
     String SERVICE_NAME = "hz:impl:cacheService";
 
+    /**
+     * Gets or creates a cache record store with the prefixed {@code name}
+     * and partition ID.
+     *
+     * @param name        the full cache name containing the prefix
+     * @param partitionId the record store partition ID
+     * @return the cache partition record store
+     */
     ICacheRecordStore getOrCreateRecordStore(String name, int partitionId);
 
+    /**
+     * Gets a cache record store with the prefixed {@code name} and partition ID.
+     *
+     * @param name        the full cache name containing the prefix
+     * @param partitionId the record store partition ID
+     * @return the cache partition record store
+     */
     ICacheRecordStore getRecordStore(String name, int partitionId);
 
     CachePartitionSegment getSegment(int partitionId);
@@ -97,4 +113,6 @@ public interface ICacheService
     boolean isWanReplicationEnabled(String cacheName);
 
     CacheWanEventPublisher getCacheWanEventPublisher();
+
+    CacheEventJournal getEventJournal();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ObjectNamespace;
+
+/**
+ * The event journal is a container for events related to a data structure.
+ * This interface provides methods for cache event journals. This includes
+ * events such as add, update, remove, evict and others. Each cache and
+ * partition has it's own event journal.
+ * <p>
+ * If a cache is destroyed or the migrated, the related event journal will be destroyed or
+ * migrated as well. In this sense, the event journal is co-located with the cache partition
+ * and it's replicas.
+ * <p>
+ * <b>NOTE :</b>
+ * Cache evictions are based on random samples which are then compared according to
+ * an eviction policy. This is done separately on the partition owner and the backup replica
+ * and can cause different entries to be evicted on the primary and backup replica.
+ * Because of this, the record store can contain different entries and the event journal
+ * can contain eviction/remove events for different entries on different replicas. This may
+ * cause some issues if the partition owner crashes and the backup replica is promoted to
+ * the partition owner. Readers of the event journal will then continue reading from the
+ * promoted replica and may get update and remove events for entries which have already
+ * been removed.
+ *
+ * @since 3.9
+ */
+public interface CacheEventJournal extends EventJournal<InternalEventJournalCacheEvent> {
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#UPDATED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param oldValue    the old value
+     * @param newValue    the new value
+     */
+    void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#CREATED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeCreatedEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#REMOVED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#EVICTED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.cache.impl.CacheEventType#EXPIRED} to the event journal.
+     * If there is no event journal configured for this cache, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeExpiredEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.journal.EventJournalReadOperation;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.util.function.Predicate;
+
+import java.io.IOException;
+
+/**
+ * Reads from the cache event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * If the event journal currently contains less events than the required minimum, the
+ * call will wait until it has sufficient items.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @since 3.9
+ */
+public class CacheEventJournalReadOperation<K, V, T> extends EventJournalReadOperation<T, InternalEventJournalCacheEvent> {
+    protected Predicate<? super EventJournalCacheEvent<K, V>> predicate;
+    protected Projection<? super EventJournalCacheEvent<K, V>, T> projection;
+
+    public CacheEventJournalReadOperation() {
+    }
+
+    public CacheEventJournalReadOperation(String cacheName, long startSequence, int minSize, int maxSize,
+                                          Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+                                          Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        super(cacheName, startSequence, minSize, maxSize);
+        this.predicate = predicate;
+        this.projection = projection;
+    }
+
+    @Override
+    protected EventJournal<InternalEventJournalCacheEvent> getJournal() {
+        final CacheService service = getService();
+        return service.getEventJournal();
+    }
+
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_READ_OPERATION;
+    }
+
+    @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(predicate);
+        out.writeObject(projection);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        predicate = in.readObject();
+        projection = in.readObject();
+    }
+
+    @Override
+    protected ReadResultSetImpl<InternalEventJournalCacheEvent, T> createResultSet() {
+        return new CacheEventJournalReadResultSetImpl<K, V, T>(
+                minSize, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.nio.serialization.SerializableByConvention;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Predicate;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class CacheEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetImpl<InternalEventJournalCacheEvent, T> {
+
+    public CacheEventJournalReadResultSetImpl() {
+    }
+
+    CacheEventJournalReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
+                                       final Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+                                       final Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        super(minSize, maxSize, serializationService,
+                predicate == null ? null : new Predicate<InternalEventJournalCacheEvent>() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+                    public boolean test(InternalEventJournalCacheEvent e) {
+                        return predicate.test((DeserializingEventJournalCacheEvent<K, V>) e);
+                    }
+                },
+                projection == null ? null : new ProjectionAdapter<K, V, T>(projection));
+    }
+
+    @Override
+    public void addItem(long seq, Object item) {
+        // the event journal ringbuffer supports only OBJECT format for now
+        final InternalEventJournalCacheEvent e = (InternalEventJournalCacheEvent) item;
+        final DeserializingEventJournalCacheEvent<K, V> deserialisingEvent
+                = new DeserializingEventJournalCacheEvent<K, V>(serializationService, e);
+        super.addItem(seq, deserialisingEvent);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_READ_RESULT_SET;
+    }
+
+    @SerializableByConvention
+    private static class ProjectionAdapter<K, V, T> extends Projection<InternalEventJournalCacheEvent, T> {
+
+        private final Projection<? super EventJournalCacheEvent<K, V>, T> projection;
+
+        ProjectionAdapter(Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+            this.projection = projection;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+        public T transform(InternalEventJournalCacheEvent input) {
+            return projection.transform((DeserializingEventJournalCacheEvent<K, V>) input);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.version.Version;
+
+/**
+ * Performs the initial subscription to the cache event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @since 3.9
+ */
+public class CacheEventJournalSubscribeOperation
+        extends AbstractNamedOperation
+        implements PartitionAwareOperation, IdentifiedDataSerializable, ReadonlyOperation {
+    private EventJournalInitialSubscriberState response;
+    private DistributedObjectNamespace namespace;
+
+    public CacheEventJournalSubscribeOperation() {
+    }
+
+    public CacheEventJournalSubscribeOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        super.beforeRun();
+
+        final Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        if (clusterVersion.isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is " + clusterVersion);
+        }
+
+        namespace = new DistributedObjectNamespace(CacheService.SERVICE_NAME, name);
+        final CacheService service = getService();
+        if (!service.getEventJournal().hasEventJournal(namespace)) {
+            throw new UnsupportedOperationException(
+                    "Cannot subscribe to event journal because it is either not configured or disabled for cache " + name);
+        }
+    }
+
+    @Override
+    public void run() {
+        final CacheService service = getService();
+        final CacheEventJournal eventJournal = service.getEventJournal();
+        final long newestSequence = eventJournal.newestSequence(namespace, getPartitionId());
+        final long oldestSequence = eventJournal.oldestSequence(namespace, getPartitionId());
+        response = new EventJournalInitialSubscriberState(oldestSequence, newestSequence);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_SUBSCRIBE_OPERATION;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ICacheService.SERVICE_NAME;
+    }
+
+
+    @Override
+    public EventJournalInitialSubscriberState getResponse() {
+        return response;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.io.IOException;
+
+public class DeserializingEventJournalCacheEvent<K, V>
+        extends InternalEventJournalCacheEvent
+        implements EventJournalCacheEvent<K, V>, HazelcastInstanceAware {
+    private SerializationService serializationService;
+
+    private K objectKey;
+    private V objectNewValue;
+    private V objectOldValue;
+
+    public DeserializingEventJournalCacheEvent() {
+    }
+
+    public DeserializingEventJournalCacheEvent(SerializationService serializationService, InternalEventJournalCacheEvent je) {
+        super(je.getDataKey(), je.getDataNewValue(), je.getDataOldValue(), je.getEventType());
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_DESERIALIZING_CACHE_EVENT;
+    }
+
+    @Override
+    public K getKey() {
+        if (objectKey == null && dataKey != null) {
+            objectKey = serializationService.toObject(dataKey);
+        }
+        return objectKey;
+    }
+
+    @Override
+    public V getNewValue() {
+        if (objectNewValue == null && dataNewValue != null) {
+            objectNewValue = serializationService.toObject(dataNewValue);
+        }
+        return objectNewValue;
+    }
+
+    @Override
+    public V getOldValue() {
+        if (objectOldValue == null && dataOldValue != null) {
+            objectOldValue = serializationService.toObject(dataOldValue);
+        }
+        return objectOldValue;
+    }
+
+    @Override
+    public CacheEventType getType() {
+        return CacheEventType.getByType(eventType);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        out.writeData(toData(dataKey, objectKey));
+        out.writeData(toData(dataNewValue, objectNewValue));
+        out.writeData(toData(dataOldValue, objectOldValue));
+    }
+
+    private Data toData(Data data, Object o) {
+        return o != null ? serializationService.toData(o) : data;
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/EventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/EventJournalCacheEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheEventType;
+
+/**
+ * The event for the cache event journal.
+ *
+ * @param <K> the entry key type
+ * @param <V> the entry value type
+ */
+public interface EventJournalCacheEvent<K, V> {
+    /**
+     * Returns the key for the event entry.
+     *
+     * @return the entry key
+     */
+    K getKey();
+
+    /**
+     * Returns the new value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link CacheEventType#CREATED}, the new
+     * value is non-{@code null} but when it is of type {@link CacheEventType#REMOVED},
+     * the value is {@code null}.
+     *
+     * @return the entry new value
+     */
+    V getNewValue();
+
+    /**
+     * Returns the old value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link CacheEventType#CREATED}, the old
+     * value is {@code null} but when it is of type {@link CacheEventType#REMOVED},
+     * the value is non-{@code null}.
+     *
+     * @return the entry old value
+     */
+    V getOldValue();
+
+    /**
+     * Returns the event type.
+     *
+     * @return the event type
+     */
+    CacheEventType getType();
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * The event journal item for map events. It contains serialized
+ * values for key and all values included in map mutations as well as
+ * the event type.
+ */
+public class InternalEventJournalCacheEvent implements IdentifiedDataSerializable {
+    protected Data dataKey;
+    protected Data dataNewValue;
+    protected Data dataOldValue;
+    protected int eventType;
+
+    public InternalEventJournalCacheEvent() {
+    }
+
+    public InternalEventJournalCacheEvent(Data dataKey, Data dataNewValue, Data dataOldValue, int eventType) {
+        this.eventType = eventType;
+        this.dataKey = dataKey;
+        this.dataNewValue = dataNewValue;
+        this.dataOldValue = dataOldValue;
+    }
+
+    public Data getDataKey() {
+        return dataKey;
+    }
+
+    public Data getDataNewValue() {
+        return dataNewValue;
+    }
+
+    public Data getDataOldValue() {
+        return dataOldValue;
+    }
+
+    /**
+     * Return the integer defining the event type. It can be turned into an
+     * enum value by calling {@link com.hazelcast.cache.impl.CacheEventType#getByType(int)}.
+     *
+     * @return the integer defining the event type
+     */
+    public int getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.EVENT_JOURNAL_INTERNAL_CACHE_EVENT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        out.writeData(dataKey);
+        out.writeData(dataNewValue);
+        out.writeData(dataOldValue);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        eventType = in.readInt();
+        dataKey = in.readData();
+        dataNewValue = in.readData();
+        dataOldValue = in.readData();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.CacheNotExistsException;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.ringbuffer.impl.RingbufferWaitNotifyKey;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationparker.OperationParker;
+
+import static com.hazelcast.cache.impl.CacheEventType.CREATED;
+import static com.hazelcast.cache.impl.CacheEventType.EVICTED;
+import static com.hazelcast.cache.impl.CacheEventType.EXPIRED;
+import static com.hazelcast.cache.impl.CacheEventType.REMOVED;
+import static com.hazelcast.cache.impl.CacheEventType.UPDATED;
+
+
+/**
+ * The cache event journal implementation based on the {@link com.hazelcast.ringbuffer.Ringbuffer}.
+ * It will add all journal events into a {@link RingbufferContainer} with the provided namespace
+ * and partition ID and allows checking if the cache has a configured event journal.
+ * Adapts the {@link EventJournalConfig} to the {@link RingbufferConfig} when creating the ringbuffer.
+ */
+public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
+    private final NodeEngineImpl nodeEngine;
+
+    public RingbufferCacheEventJournalImpl(NodeEngine engine) {
+        this.nodeEngine = (NodeEngineImpl) engine;
+    }
+
+    @Override
+    public void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue) {
+        addToEventRingbuffer(namespace, partitionId, UPDATED, key, oldValue, newValue);
+    }
+
+    @Override
+    public void writeCreatedEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, CREATED, key, null, value);
+    }
+
+    @Override
+    public void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, REMOVED, key, value, null);
+    }
+
+    @Override
+    public void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, EVICTED, key, value, null);
+    }
+
+    @Override
+    public void writeExpiredEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, EXPIRED, key, value, null);
+    }
+
+    @Override
+    public long newestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).tailSequence();
+    }
+
+    @Override
+    public long oldestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).headSequence();
+    }
+
+    @Override
+    public void destroy(ObjectNamespace namespace, int partitionId) {
+        getRingbufferService().destroyContainer(partitionId, namespace);
+    }
+
+    @Override
+    public void isAvailableOrNextSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        getRingbufferOrFail(namespace, partitionId).checkBlockableReadSequence(sequence);
+    }
+
+    @Override
+    public boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        return getRingbufferOrFail(namespace, partitionId).shouldWait(sequence);
+    }
+
+    @Override
+    public WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
+        return new RingbufferWaitNotifyKey(namespace);
+    }
+
+    @Override
+    public <T> long readMany(ObjectNamespace namespace, int partitionId, long beginSequence,
+                             ReadResultSetImpl<InternalEventJournalCacheEvent, T> resultSet) {
+        return getRingbufferOrFail(namespace, partitionId).readMany(beginSequence, resultSet);
+    }
+
+    @Override
+    public void cleanup(ObjectNamespace namespace, int partitionId) {
+        getRingbufferOrFail(namespace, partitionId).cleanup();
+    }
+
+    /**
+     * {@inheritDoc}
+     * NOTE: The cache config should have already been created in the cache service before
+     * invoking this method.
+     *
+     * @param namespace the cache namespace, containing the full prefixed cache name
+     * @return {@code true} if the object has a configured and enabled event journal, {@code false} otherwise
+     */
+    @Override
+    public boolean hasEventJournal(ObjectNamespace namespace) {
+        return getEventJournalConfig(namespace) != null;
+    }
+
+    @Override
+    public EventJournalConfig getEventJournalConfig(ObjectNamespace namespace) {
+        final String name = namespace.getObjectName();
+        final CacheConfig cacheConfig = getCacheService().getCacheConfig(name);
+        if (cacheConfig == null) {
+            throw new CacheNotExistsException("Cache " + name + " is already destroyed or not created yet, on "
+                    + nodeEngine.getLocalMember());
+        }
+        final String cacheSimpleName = cacheConfig.getName();
+        final EventJournalConfig config = nodeEngine.getConfig().getCacheEventJournalConfig(cacheSimpleName);
+        if (config == null || !config.isEnabled()) {
+            return null;
+        }
+        return config;
+    }
+
+    @Override
+    public RingbufferConfig toRingbufferConfig(EventJournalConfig config) {
+        return new RingbufferConfig()
+                .setAsyncBackupCount(0)
+                .setBackupCount(0)
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setCapacity(config.getCapacity())
+                .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
+    }
+
+    private void addToEventRingbuffer(ObjectNamespace namespace, int partitionId, CacheEventType eventType,
+                                      Data key, Object oldValue, Object newValue) {
+        final RingbufferContainer<InternalEventJournalCacheEvent> eventContainer = getRingbufferOrNull(namespace, partitionId);
+        if (eventContainer == null) {
+            return;
+        }
+        final InternalEventJournalCacheEvent event
+                = new InternalEventJournalCacheEvent(toData(key), toData(newValue), toData(oldValue), eventType.getType());
+        eventContainer.add(event);
+        getOperationParker().unpark(eventContainer);
+    }
+
+    protected Data toData(Object val) {
+        return getSerializationService().toData(val, DataType.HEAP);
+    }
+
+    /**
+     * Gets or creates a ringbuffer for an event journal or throws an exception if no
+     * event journal is configured. The caller should call
+     * {@link #hasEventJournal(ObjectNamespace)} before invoking this method to avoid getting
+     * the exception. This method can be used to get the ringbuffer on which future events
+     * will be added once the cache has been created.
+     * <p>
+     * NOTE: The cache config should have already been created in the cache service before
+     * invoking this method.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the cache partition ID
+     * @return the cache partition event journal
+     * @throws IllegalStateException if there is no event journal configured for this cache
+     */
+    private RingbufferContainer<InternalEventJournalCacheEvent> getRingbufferOrFail(ObjectNamespace namespace, int partitionId) {
+        final RingbufferService ringbufferService = getRingbufferService();
+        if (ringbufferService.hasContainer(partitionId, namespace)) {
+            return ringbufferService.getContainer(partitionId, namespace, null);
+        }
+
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        if (config == null) {
+            throw new IllegalStateException("There is no event journal configured for cache with name: "
+                    + namespace.getObjectName());
+        }
+        return getOrCreateRingbufferContainer(namespace, partitionId, config);
+    }
+
+    /**
+     * Gets or creates a ringbuffer for an event journal or returns {@link null} if no
+     * event journal is configured. The cache record store should have been already created
+     * at the point when this method is invoked.
+     * This method can be used to get the ringbuffer when we already know that the cache record
+     * store has been created.
+     * <p>
+     * NOTE: The cache config should have already been created in the cache service before
+     * invoking this method.
+     *
+     * @param namespace   the cache namespace, containing the full prefixed cache name
+     * @param partitionId the cache partition ID
+     * @return the cache partition event journal or {@code null} if no journal is configured for this cache
+     * @throws CacheNotExistsException if the cache hasn't been already created
+     */
+    private RingbufferContainer<InternalEventJournalCacheEvent> getRingbufferOrNull(ObjectNamespace namespace, int partitionId) {
+        final RingbufferService ringbufferService = getRingbufferService();
+        if (ringbufferService.hasContainer(partitionId, namespace)) {
+            return ringbufferService.getContainer(partitionId, namespace, null);
+        }
+
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        return config != null ? getOrCreateRingbufferContainer(namespace, partitionId, config) : null;
+    }
+
+    private RingbufferContainer<InternalEventJournalCacheEvent> getOrCreateRingbufferContainer(ObjectNamespace namespace,
+                                                                                               int partitionId,
+                                                                                               EventJournalConfig config) {
+        final RingbufferConfig ringbufferConfig = toRingbufferConfig(config);
+        return getRingbufferService().getContainer(partitionId, namespace, ringbufferConfig);
+    }
+
+    private RingbufferService getRingbufferService() {
+        return nodeEngine.getService(RingbufferService.SERVICE_NAME);
+    }
+
+    private OperationParker getOperationParker() {
+        return nodeEngine.getOperationParker();
+    }
+
+    private InternalSerializationService getSerializationService() {
+        return (InternalSerializationService) nodeEngine.getSerializationService();
+    }
+
+    private CacheService getCacheService() {
+        return nodeEngine.getService(CacheService.SERVICE_NAME);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * Base Cache Operation. Cache operations are named operations. Key based operations are subclasses of this base
  * class providing a cacheRecordStore access and partial backup support.
  */
-abstract class AbstractCacheOperation
+public abstract class AbstractCacheOperation
         extends AbstractNamedOperation
         implements PartitionAwareOperation, ServiceNamespaceAware, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -18,6 +18,8 @@ package com.hazelcast.client.impl.protocol;
 
 import com.hazelcast.client.impl.protocol.task.DeployClassesMessageTask;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
+import com.hazelcast.client.impl.protocol.task.cache.CacheEventJournalReadTask;
+import com.hazelcast.client.impl.protocol.task.cache.CacheEventJournalSubscribeTask;
 import com.hazelcast.client.impl.protocol.task.cache.Pre38CacheAddInvalidationListenerTask;
 import com.hazelcast.client.impl.protocol.task.cardinality.CardinalityEstimatorAddMessageTask;
 import com.hazelcast.client.impl.protocol.task.cardinality.CardinalityEstimatorEstimateMessageTask;
@@ -26,6 +28,8 @@ import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableEx
 import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableExecutorRetrieveResultMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapAggregateMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapAggregateWithPredicateMessageTask;
+import com.hazelcast.client.impl.protocol.task.map.MapEventJournalReadTask;
+import com.hazelcast.client.impl.protocol.task.map.MapEventJournalSubscribeTask;
 import com.hazelcast.client.impl.protocol.task.map.MapProjectionMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapProjectionWithPredicateMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.Pre38MapAddNearCacheEntryListenerMessageTask;
@@ -385,6 +389,16 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.CacheIterateEntriesCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new com.hazelcast.client.impl.protocol.task.cache.CacheIterateEntriesMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.CacheEventJournalSubscribeCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new CacheEventJournalSubscribeTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.CacheEventJournalReadCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new CacheEventJournalReadTask<Object, Object, Object>(clientMessage, node, connection);
             }
         };
 
@@ -1599,6 +1613,16 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.MapFetchWithQueryCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new com.hazelcast.client.impl.protocol.task.map.MapFetchWithQueryMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.MapEventJournalSubscribeCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new MapEventJournalSubscribeTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.MapEventJournalReadCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new MapEventJournalReadTask<Object, Object, Object>(clientMessage, node, connection);
             }
         };
 //endregion

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.cache;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
+import com.hazelcast.cache.impl.journal.EventJournalCacheEvent;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheEventJournalReadCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.function.Predicate;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads from the cache event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * If the event journal currently contains less events than the required minimum, the
+ * call will wait until it has sufficient items.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <K> cache key type
+ * @param <V> cache value type
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @see CacheEventJournalReadOperation
+ * @since 3.9
+ */
+public class CacheEventJournalReadTask<K, V, T>
+        extends AbstractCacheMessageTask<CacheEventJournalReadCodec.RequestParameters> {
+
+    public CacheEventJournalReadTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        final Projection<? super EventJournalCacheEvent<K, V>, T> projection
+                = serializationService.toObject(parameters.projection);
+        final Predicate<? super EventJournalCacheEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);
+        return new CacheEventJournalReadOperation<K, V, T>(parameters.name,
+                parameters.startSequence, parameters.minSize, parameters.maxSize, predicate, projection);
+    }
+
+    @Override
+    protected CacheEventJournalReadCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return CacheEventJournalReadCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
+        final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
+        final List<Data> items = new ArrayList<Data>(resultSet.size());
+        final long[] seqs = new long[resultSet.size()];
+        final Data[] dataItems = resultSet.getDataItems();
+
+        for (int k = 0; k < resultSet.size(); k++) {
+            items.add(dataItems[k]);
+            seqs[k] = resultSet.getSequence(k);
+        }
+
+        return CacheEventJournalReadCodec.encodeResponse(resultSet.readCount(), items, seqs);
+    }
+
+    @Override
+    public final String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "readFromEventJournal";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{
+                parameters.startSequence, parameters.maxSize, getPartitionId(), parameters.predicate, parameters.projection, };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalReadCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.journal.EventJournalMapEvent;
+import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.MapPermission;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.function.Predicate;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads from the map event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * If the event journal currently contains less events than the required minimum, the
+ * call will wait until it has sufficient items.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @see MapEventJournalReadOperation
+ * @since 3.9
+ */
+public class MapEventJournalReadTask<K, V, T>
+        extends AbstractMapPartitionMessageTask<MapEventJournalReadCodec.RequestParameters> {
+
+    public MapEventJournalReadTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        final Projection<? super EventJournalMapEvent<K, V>, T> projection = serializationService.toObject(parameters.projection);
+        final Predicate<? super EventJournalMapEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);
+        return new MapEventJournalReadOperation<K, V, T>(parameters.name,
+                parameters.startSequence, parameters.minSize, parameters.maxSize, predicate, projection);
+    }
+
+    @Override
+    protected MapEventJournalReadCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapEventJournalReadCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
+        final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
+        final List<Data> items = new ArrayList<Data>(resultSet.size());
+        final long[] seqs = new long[resultSet.size()];
+        final Data[] dataItems = resultSet.getDataItems();
+
+        for (int k = 0; k < resultSet.size(); k++) {
+            items.add(dataItems[k]);
+            seqs[k] = resultSet.getSequence(k);
+        }
+
+        return MapEventJournalReadCodec.encodeResponse(resultSet.readCount(), items, seqs);
+    }
+
+    @Override
+    public final String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new MapPermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "readFromEventJournal";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{
+                parameters.startSequence, parameters.maxSize, getPartitionId(), parameters.predicate, parameters.projection, };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapEventJournalSubscribeCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.MapPermission;
+import com.hazelcast.spi.Operation;
+
+import java.security.Permission;
+
+/**
+ * Performs the initial subscription to the map event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @see com.hazelcast.map.impl.proxy.MapProxyImpl#subscribeToEventJournal
+ * @see com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation
+ * @since 3.9
+ */
+public class MapEventJournalSubscribeTask
+        extends AbstractMapPartitionMessageTask<MapEventJournalSubscribeCodec.RequestParameters> {
+
+    public MapEventJournalSubscribeTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is 3.9 or higher");
+        }
+        return new MapEventJournalSubscribeOperation(parameters.name);
+    }
+
+    @Override
+    protected MapEventJournalSubscribeCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapEventJournalSubscribeCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        final EventJournalInitialSubscriberState state = (EventJournalInitialSubscriberState) response;
+        return MapEventJournalSubscribeCodec.encodeResponse(state.getOldestSequence(), state.getNewestSequence());
+    }
+
+    @Override
+    public final String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    public Permission getRequiredPermission() {
+        return new MapPermission(parameters.name, ActionConstants.ACTION_LISTEN);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "subscribeToEventJournal";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{getPartitionId()};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.util.StringUtil;
 
 import java.io.File;
 import java.net.URL;
@@ -103,6 +104,10 @@ public class Config {
 
     private final Map<String, CardinalityEstimatorConfig> cardinalityEstimatorConfigs =
             new ConcurrentHashMap<String, CardinalityEstimatorConfig>();
+
+    private final Map<String, EventJournalConfig> mapEventJournalConfigs = new ConcurrentHashMap<String, EventJournalConfig>();
+
+    private final Map<String, EventJournalConfig> cacheEventJournalConfigs = new ConcurrentHashMap<String, EventJournalConfig>();
 
     private ServicesConfig servicesConfig = new ServicesConfig();
 
@@ -1194,6 +1199,97 @@ public class Config {
         return this;
     }
 
+    public EventJournalConfig findMapEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        final EventJournalConfig config = lookupByPattern(mapEventJournalConfigs, baseName);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getMapEventJournalConfig("default").getAsReadOnly();
+    }
+
+    public EventJournalConfig findCacheEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        final EventJournalConfig config = lookupByPattern(cacheEventJournalConfigs, baseName);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getCacheEventJournalConfig("default").getAsReadOnly();
+    }
+
+    public EventJournalConfig getMapEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        EventJournalConfig config = lookupByPattern(mapEventJournalConfigs, baseName);
+        if (config != null) {
+            return config;
+        }
+        EventJournalConfig defConfig = mapEventJournalConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new EventJournalConfig().setMapName("default").setEnabled(false);
+            addEventJournalConfig(defConfig);
+        }
+        config = new EventJournalConfig(defConfig).setMapName(name);
+        addEventJournalConfig(config);
+        return config;
+    }
+
+    public EventJournalConfig getCacheEventJournalConfig(String name) {
+        final String baseName = getBaseName(name);
+        EventJournalConfig config = lookupByPattern(cacheEventJournalConfigs, baseName);
+        if (config != null) {
+            return config;
+        }
+        EventJournalConfig defConfig = cacheEventJournalConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new EventJournalConfig().setCacheName("default").setEnabled(false);
+            addEventJournalConfig(defConfig);
+        }
+        config = new EventJournalConfig(defConfig).setCacheName(name);
+        addEventJournalConfig(config);
+        return config;
+    }
+
+    public Config addEventJournalConfig(EventJournalConfig eventJournalConfig) {
+        final String mapName = eventJournalConfig.getMapName();
+        final String cacheName = eventJournalConfig.getCacheName();
+        if (StringUtil.isNullOrEmpty(mapName) && StringUtil.isNullOrEmpty(cacheName)) {
+            throw new IllegalArgumentException("Event journal config should have non-empty map name and/or cache name");
+        }
+        if (!StringUtil.isNullOrEmpty(mapName)) {
+            mapEventJournalConfigs.put(eventJournalConfig.getMapName(), eventJournalConfig);
+        }
+        if (!StringUtil.isNullOrEmpty(cacheName)) {
+            cacheEventJournalConfigs.put(eventJournalConfig.getCacheName(), eventJournalConfig);
+        }
+        return this;
+    }
+
+    public Map<String, EventJournalConfig> getMapEventJournalConfigs() {
+        return mapEventJournalConfigs;
+    }
+
+    public Map<String, EventJournalConfig> getCacheEventJournalConfigs() {
+        return cacheEventJournalConfigs;
+    }
+
+    public Config setMapEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        this.mapEventJournalConfigs.clear();
+        this.mapEventJournalConfigs.putAll(eventJournalConfigs);
+        for (Entry<String, EventJournalConfig> entry : eventJournalConfigs.entrySet()) {
+            entry.getValue().setMapName(entry.getKey());
+        }
+        return this;
+    }
+
+    public Config setCacheEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        this.cacheEventJournalConfigs.clear();
+        this.cacheEventJournalConfigs.putAll(eventJournalConfigs);
+        for (Entry<String, EventJournalConfig> entry : eventJournalConfigs.entrySet()) {
+            entry.getValue().setCacheName(entry.getKey());
+        }
+        return this;
+    }
+
     public SerializationConfig getSerializationConfig() {
         return serializationConfig;
     }
@@ -1370,6 +1466,8 @@ public class Config {
                 + ", ringbufferConfigs=" + ringbufferConfigs
                 + ", wanReplicationConfigs=" + wanReplicationConfigs
                 + ", listenerConfigs=" + listenerConfigs
+                + ", mapEventJournalConfigs=" + mapEventJournalConfigs
+                + ", cacheEventJournalConfigs=" + cacheEventJournalConfigs
                 + ", partitionGroupConfig=" + partitionGroupConfig
                 + ", managementCenterConfig=" + managementCenterConfig
                 + ", securityConfig=" + securityConfig

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -118,6 +118,7 @@ public class ConfigXmlGenerator {
         executorXmlGenerator(gen, config);
         durableExecutorXmlGenerator(gen, config);
         scheduledExecutorXmlGenerator(gen, config);
+        eventJournalXmlGenerator(gen, config);
         partitionGroupXmlGenerator(gen, config);
         cardinalityEstimatorXmlGenerator(gen, config);
         listenerXmlGenerator(gen, config);
@@ -192,6 +193,25 @@ public class ConfigXmlGenerator {
             gen.node("listener", classNameOrImplClass(lc.getClassName(), lc.getImplementation()));
         }
         gen.close();
+    }
+
+    private static void eventJournalXmlGenerator(XmlGenerator gen, Config config) {
+        final Collection<EventJournalConfig> mapJournalConfigs = config.getMapEventJournalConfigs().values();
+        final Collection<EventJournalConfig> cacheJournalConfigs = config.getCacheEventJournalConfigs().values();
+        for (EventJournalConfig c : mapJournalConfigs) {
+            gen.open("event-journal", "enabled", c.isEnabled())
+               .node("mapName", c.getMapName())
+               .node("capacity", c.getCapacity())
+               .node("time-to-live-seconds", c.getTimeToLiveSeconds())
+               .close();
+        }
+        for (EventJournalConfig c : cacheJournalConfigs) {
+            gen.open("event-journal", "enabled", c.isEnabled())
+               .node("cacheName", c.getCacheName())
+               .node("capacity", c.getCapacity())
+               .node("time-to-live-seconds", c.getTimeToLiveSeconds())
+               .close();
+        }
     }
 
     @SuppressWarnings({"checkstyle:npathcomplexity"})

--- a/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.annotation.Beta;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.Preconditions.checkPositive;
+
+/**
+ * Configuration for an event journal. The event journal keeps events related
+ * to a specific partition and data structure. For instance, it could keep
+ * map add, update, remove, merge events along with the key, old value, new value and so on.
+ * This configuration is not tied to a specific data structure and can be reused.
+ * <b>NOTE</b>
+ * This config is intended to be used with <a href="http://jet.hazelcast.org">Hazelcast Jet</a>
+ * and does not expose any features in Hazelcast IMDG.
+ */
+@Beta
+public class EventJournalConfig {
+
+    /**
+     * Default value of capacity of the event journal.
+     */
+    public static final int DEFAULT_CAPACITY = 10 * 1000;
+    /**
+     * Default value for the time to live property.
+     */
+    public static final int DEFAULT_TTL_SECONDS = 0;
+
+    private String mapName;
+    private String cacheName;
+    private boolean enabled = true;
+    private int capacity = DEFAULT_CAPACITY;
+    private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
+
+    public EventJournalConfig() {
+    }
+
+    /**
+     * Clones a {@link EventJournalConfig}.
+     *
+     * @param config the event journal config to clone
+     * @throws NullPointerException if the config is null
+     */
+    public EventJournalConfig(EventJournalConfig config) {
+        checkNotNull(config, "config can't be null");
+        this.enabled = config.enabled;
+        this.mapName = config.mapName;
+        this.cacheName = config.cacheName;
+        this.capacity = config.capacity;
+        this.timeToLiveSeconds = config.timeToLiveSeconds;
+    }
+
+    /**
+     * Gets the capacity of the event journal.
+     * The capacity is the total number of items that the event journal can hold at any moment.
+     * The actual number of items contained in the journal can be lower.
+     *
+     * @return the capacity.
+     */
+    public int getCapacity() {
+        return capacity;
+    }
+
+    /**
+     * Sets the capacity of the event journal.
+     *
+     * @param capacity the capacity.
+     * @return the updated config.
+     * @throws java.lang.IllegalArgumentException if capacity smaller than 1.
+     * @see #getCapacity()
+     */
+    public EventJournalConfig setCapacity(int capacity) {
+        checkPositive(capacity, "capacity can't be smaller than 1");
+        this.capacity = capacity;
+        return this;
+    }
+
+    /**
+     * Gets the time to live in seconds.
+     *
+     * @return the time to live in seconds. Returns 0 the time to live if the items don't expire.
+     */
+    public int getTimeToLiveSeconds() {
+        return timeToLiveSeconds;
+    }
+
+    /**
+     * Sets the time to live in seconds.
+     * Time to live is the time the event journal retains items before removing them from the journal.
+     * The events are removed on journal read and write actions, not while the journal is idle.
+     * <p>
+     * Time to live can be disabled by setting timeToLiveSeconds to 0. This means that the
+     * events never expire but they can be overwritten when the capacity of the journal is exceeed.
+     *
+     * @param timeToLiveSeconds the time to live period in seconds
+     * @return the updated config
+     * @throws IllegalArgumentException if timeToLiveSeconds smaller than 0.
+     */
+    public EventJournalConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
+        this.timeToLiveSeconds = checkNotNegative(timeToLiveSeconds, "timeToLiveSeconds can't be smaller than 0");
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "EventJournalConfig{"
+                + "mapName='" + mapName + '\''
+                + ", cacheName='" + cacheName + '\''
+                + ", enabled=" + enabled
+                + ", capacity=" + capacity
+                + ", timeToLiveSeconds=" + timeToLiveSeconds
+                + '}';
+    }
+
+    /**
+     * Returns an immutable version of this configuration.
+     *
+     * @return immutable version of this configuration
+     */
+    EventJournalConfig getAsReadOnly() {
+        return new EventJournalConfigReadOnly(this);
+    }
+
+    /**
+     * Returns the map name to which this config applies.
+     *
+     * @return the map name
+     */
+    public String getMapName() {
+        return mapName;
+    }
+
+    /**
+     * Sets the map name to which this config applies. Map names
+     * are also matched by pattern and event journal with map name "default"
+     * applies to all maps that do not have more specific event journal configs.
+     *
+     * @param mapName the map name
+     * @return the event journal config
+     */
+    public EventJournalConfig setMapName(String mapName) {
+        this.mapName = mapName;
+        return this;
+    }
+
+    /**
+     * Returns the cache name to which this config applies.
+     *
+     * @return the cache name
+     */
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    /**
+     * Sets the cache name to which this config applies. Cache names
+     * are also matched by pattern and event journal with cache name "default"
+     * applies to all caches that do not have more specific event journal configs.
+     *
+     * @param cacheName the cache name
+     * @return the event journal config
+     */
+    public EventJournalConfig setCacheName(String cacheName) {
+        this.cacheName = checkHasText(cacheName, "name must contain text");
+        return this;
+    }
+
+    /**
+     * Returns if the event journal is enabled.
+     *
+     * @return {@code true} if the event journal is enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+
+    /**
+     * Enables or disables the event journal.
+     *
+     * @param enabled {@code true} if enabled, {@code false} otherwise.
+     * @return the updated config.
+     */
+    public EventJournalConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+
+    @Beta
+    private static class EventJournalConfigReadOnly extends EventJournalConfig {
+        EventJournalConfigReadOnly(EventJournalConfig config) {
+            super(config);
+        }
+
+        @Override
+        public EventJournalConfig setCapacity(int capacity) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setEnabled(boolean enabled) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setMapName(String mapName) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public EventJournalConfig setCacheName(String cacheName) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -64,6 +64,7 @@ import static com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import static com.hazelcast.config.XmlElements.CACHE;
 import static com.hazelcast.config.XmlElements.CARDINALITY_ESTIMATOR;
 import static com.hazelcast.config.XmlElements.DURABLE_EXECUTOR_SERVICE;
+import static com.hazelcast.config.XmlElements.EVENT_JOURNAL;
 import static com.hazelcast.config.XmlElements.EXECUTOR_SERVICE;
 import static com.hazelcast.config.XmlElements.GROUP;
 import static com.hazelcast.config.XmlElements.HOT_RESTART_PERSISTENCE;
@@ -318,6 +319,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleDurableExecutor(node);
         } else if (SCHEDULED_EXECUTOR_SERVICE.isEqual(nodeName)) {
             handleScheduledExecutor(node);
+        } else if (EVENT_JOURNAL.isEqual(nodeName)) {
+            handleEventJournal(node);
         } else if (SERVICES.isEqual(nodeName)) {
             handleServices(node);
         } else if (QUEUE.isEqual(nodeName)) {
@@ -1879,6 +1882,12 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             }
         }
         config.addSemaphoreConfig(sConfig);
+    }
+
+    private void handleEventJournal(Node node) throws Exception {
+        final EventJournalConfig journalConfig = new EventJournalConfig();
+        handleViaReflection(node, config, journalConfig);
+        config.addEventJournalConfig(journalConfig);
     }
 
     private void handleRingbuffer(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -30,6 +30,7 @@ enum XmlElements {
     EXECUTOR_SERVICE("executor-service", true),
     DURABLE_EXECUTOR_SERVICE("durable-executor-service", true),
     SCHEDULED_EXECUTOR_SERVICE("scheduled-executor-service", true),
+    EVENT_JOURNAL("event-journal", true),
     QUEUE("queue", true),
     MAP("map", true),
     CACHE("cache", true),

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.internal.serialization;
 
+import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.Disposable;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -53,6 +55,12 @@ public interface InternalSerializationService extends SerializationService, Disp
      * disabled.
      */
     byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash);
+
+    <B extends Data> B toData(Object obj, DataType type);
+
+    <B extends Data> B toData(Object obj, DataType type, PartitioningStrategy strategy);
+
+    <B extends Data> B convertData(Data data, DataType type);
 
     void writeObject(ObjectDataOutput out, Object obj);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -137,6 +137,9 @@ public final class FactoryIdHelper {
     public static final String ENTERPRISE_SECURITY_DS_FACTORY = "hazelcast.serialization.ds.security";
     public static final int ENTERPRISE_SECURITY_DS_FACTORY_ID = -44;
 
+    public static final String EVENT_JOURNAL_DS_FACTORY = "hazelcast.serialization.ds.event_journal";
+    public static final int EVENT_JOURNAL_DS_FACTORY_ID = -45;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.nio.serialization.FieldDefinition;
 import com.hazelcast.nio.serialization.FieldType;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -109,6 +110,30 @@ public class SerializationServiceV1 extends AbstractSerializationService {
                 new JavaDefaultSerializers.ExternalizableSerializer(enableCompression), this);
         registerConstantSerializers();
         registerJavaTypeSerializers();
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type) {
+        if (type == DataType.NATIVE) {
+            throw new IllegalArgumentException("Native data type is not supported");
+        }
+        return toData(obj);
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type, PartitioningStrategy strategy) {
+        if (type == DataType.NATIVE) {
+            throw new IllegalArgumentException("Native data type is not supported");
+        }
+        return toData(obj, strategy);
+    }
+
+    @Override
+    public <B extends Data> B convertData(Data data, DataType type) {
+        if (type == DataType.NATIVE) {
+            throw new IllegalArgumentException("Native data type is not supported");
+        }
+        return (B) data;
     }
 
     public PortableReader createPortableReader(Data data) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
+
+/**
+ * The event journal is a container for events related to a data structure.
+ * This interface provides methods for distributed object event journals.
+ * Each distributed object and partition has it's own event journal.
+ * <p>
+ * If a object is destroyed or the migrated, the related event journal will be destroyed or
+ * migrated as well. In this sense, the event journal is co-located with the object partition
+ * and it's replicas.
+ *
+ * @param <E> journal event type
+ * @since 3.9
+ */
+public interface EventJournal<E> {
+    /**
+     * Returns the sequence of the newest event stored in the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the event journal
+     * @return the sequence of the last stored event
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    long newestSequence(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Returns the sequence of the oldest event stored in the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the event journal
+     * @return the sequence of the oldest stored event
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    long oldestSequence(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Destroys the event journal for the given object and partition ID.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     */
+    void destroy(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Checks if the sequence is of an item that can be read immediately
+     * or is the sequence of the next item to be added into the event journal.
+     * Since this method allows the sequence to be one larger than
+     * the {@link #newestSequence(ObjectNamespace, int)}, the caller can use this method
+     * to check the sequence before performing a possibly blocking read.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @param sequence    the sequence wanting to be read
+     * @throws StaleSequenceException   if the requested sequence is smaller than the
+     *                                  sequence of the oldest event (the sequence has
+     *                                  been overwritten)
+     * @throws IllegalArgumentException if the requested sequence is greater than the
+     *                                  next available sequence + 1
+     * @throws IllegalStateException    if there is no event journal configured for this object
+     */
+    void isAvailableOrNextSequence(ObjectNamespace namespace, int partitionId, long sequence);
+
+    /**
+     * Checks if the {@code sequence} is the sequence of the next event to
+     * be added to the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @param sequence    the sequence to be checked
+     * @return {@code true} if the {@code sequence} is one greater
+     * than the sequence of the last event, {@code false} otherwise
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence);
+
+    /**
+     * Return the {@link WaitNotifyKey} for objects waiting and notifying on the event journal.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @return the key for a wait notify object
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Reads events from the journal in batches. It will read up to
+     * the maximum number that the set can hold - see {@link ReadResultSetImpl#isMaxSizeReached()}
+     * or until the journal is exhausted. The {@code resultSet} allows
+     * filtering and projections on journal items so that the caller
+     * can control which data is returned.
+     * <p>
+     * If the set has reached it's max size, the returned sequence
+     * one greater than the sequence of the last item in the set.
+     * In other cases it means that the set hasn't reached it's full
+     * size because we have reached the end of the event journal. In
+     * this case the returned sequence is one greater than the sequence
+     * of the last stored event.
+     *
+     * @param namespace     the object namespace
+     * @param partitionId   the partition ID of the entries in the journal
+     * @param beginSequence the sequence of the first item to read.
+     * @param resultSet     the container for read, filtered and projected events
+     * @param <T>           the return type of the projected events
+     * @return returns the sequenceId of the next item to read
+     * @throws IllegalStateException    if there is no event journal configured for this object
+     * @throws StaleSequenceException   if the requested sequence is smaller than the sequence of the oldest event
+     * @throws IllegalArgumentException if the requested sequence is greater than the sequence of the newest event + 1
+     * @see #isAvailableOrNextSequence(ObjectNamespace, int, long)
+     */
+    <T> long readMany(ObjectNamespace namespace, int partitionId, long beginSequence, ReadResultSetImpl<E, T> resultSet);
+
+    /**
+     * Cleans up the event journal by removing any expired items. Items are considered
+     * expired as according to the configured expiration policy.
+     *
+     * @param namespace   the object namespace
+     * @param partitionId the partition ID of the entries in the journal
+     * @throws IllegalStateException if there is no event journal configured for this object
+     */
+    void cleanup(ObjectNamespace namespace, int partitionId);
+
+    /**
+     * Returns {@code true} if the object has a configured and enabled event journal.
+     *
+     * @param namespace the object namespace
+     * @return {@code true} if the object has a configured and enabled event journal, {@code false} otherwise
+     */
+    boolean hasEventJournal(ObjectNamespace namespace);
+
+    EventJournalConfig getEventJournalConfig(ObjectNamespace namespace);
+
+    RingbufferConfig toRingbufferConfig(EventJournalConfig config);
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalDataSerializerHook.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.EVENT_JOURNAL_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.EVENT_JOURNAL_DS_FACTORY_ID;
+
+/**
+ * Data serializer hook for common classes related to the {@link EventJournal}. Data structure specific
+ * (map, cache,...) event journal classes are under the other respective serializer hooks.
+ */
+public final class EventJournalDataSerializerHook implements DataSerializerHook {
+    /**
+     * Factory ID for the event journal {@link IdentifiedDataSerializable} classes
+     */
+    public static final int F_ID = FactoryIdHelper.getFactoryId(EVENT_JOURNAL_DS_FACTORY, EVENT_JOURNAL_DS_FACTORY_ID);
+
+    /**
+     * Type ID for the {@link EventJournalInitialSubscriberState} class
+     */
+    public static final int EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE = 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        return new DataSerializableFactory() {
+            @Override
+            public IdentifiedDataSerializable create(int typeId) {
+                switch (typeId) {
+                    case EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE:
+                        return new EventJournalInitialSubscriberState();
+                    default:
+                        return null;
+                }
+            }
+        };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalInitialSubscriberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalInitialSubscriberState.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * The response for the event journal subcription. This includes
+ * the sequence IDs of the newest and oldest event in the event
+ * journal from which new events can be read.
+ * Keep in mind that these sequence IDs may be overwritten at any point
+ * and may be stale by the time you decide to read them.
+ *
+ * @see com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation
+ * @see com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation
+ * @since 3.9
+ */
+public class EventJournalInitialSubscriberState implements IdentifiedDataSerializable {
+    private long oldestSequence;
+    private long newestSequence;
+
+    public EventJournalInitialSubscriberState() {
+    }
+
+    public EventJournalInitialSubscriberState(long oldestSequence, long newestSequence) {
+        this.oldestSequence = oldestSequence;
+        this.newestSequence = newestSequence;
+    }
+
+    public long getOldestSequence() {
+        return oldestSequence;
+    }
+
+    public long getNewestSequence() {
+        return newestSequence;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return EventJournalDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return EventJournalDataSerializerHook.EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeLong(oldestSequence);
+        out.writeLong(newestSequence);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        oldestSequence = in.readLong();
+        newestSequence = in.readLong();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReadOperation.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.journal;
+
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.BlockingOperation;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.version.Version;
+
+import java.io.IOException;
+
+/**
+ * Reads from the map event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * If the event journal currently contains less events than the required minimum, the
+ * call will wait until it has sufficient items.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to the journal event type
+ *            if the projection is {@code null} or it is the identity projection
+ * @param <J> journal event type
+ * @since 3.9
+ */
+public abstract class EventJournalReadOperation<T, J> extends Operation
+        implements IdentifiedDataSerializable, PartitionAwareOperation, BlockingOperation {
+    protected String name;
+    protected int minSize;
+    protected int maxSize;
+    protected long startSequence;
+
+    protected transient ReadResultSetImpl<J, T> resultSet;
+    protected transient long sequence;
+    protected transient DistributedObjectNamespace namespace;
+    private WaitNotifyKey waitNotifyKey;
+
+    public EventJournalReadOperation() {
+    }
+
+    public EventJournalReadOperation(String name, long startSequence, int minSize, int maxSize) {
+        this.name = name;
+        this.minSize = minSize;
+        this.maxSize = maxSize;
+        this.startSequence = startSequence;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Checks the precondition that the start sequence is already
+     * available (in the event journal) or is the sequence of the
+     * next event to be added into the journal.
+     */
+    @Override
+    public void beforeRun() {
+        final Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        if (clusterVersion.isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is " + clusterVersion);
+        }
+
+        namespace = new DistributedObjectNamespace(getServiceName(), name);
+
+        final EventJournal<J> journal = getJournal();
+        if (!journal.hasEventJournal(namespace)) {
+            throw new UnsupportedOperationException(
+                    "Cannot subscribe to event journal because it is either not configured or disabled for " + namespace);
+        }
+
+        final int partitionId = getPartitionId();
+        journal.cleanup(namespace, partitionId);
+        journal.isAvailableOrNextSequence(namespace, partitionId, startSequence);
+        // we'll store the wait notify key because ICache destroys the record store
+        // and the cache config is unavailable at the time operations are being
+        // cancelled. Hence, we cannot create the journal and fetch it's wait notify
+        // key
+        waitNotifyKey = journal.getWaitNotifyKey(namespace, partitionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * On every invocation this method reads from the event journal until
+     * it has collected the minimum required number of response items.
+     * Returns {@code true} if there are currently not enough
+     * elements in the response and the operation should be parked.
+     *
+     * @return if the operation should wait on the wait/notify key
+     */
+    @Override
+    public boolean shouldWait() {
+        if (resultSet == null) {
+            resultSet = createResultSet();
+            sequence = startSequence;
+        }
+
+        final EventJournal<J> journal = getJournal();
+        final int partitionId = getPartitionId();
+        journal.cleanup(namespace, partitionId);
+        if (minSize == 0) {
+            if (!journal.isNextAvailableSequence(namespace, partitionId, sequence)) {
+                sequence = journal.readMany(namespace, partitionId, sequence, resultSet);
+            }
+            return false;
+        }
+
+        if (resultSet.isMinSizeReached()) {
+            // enough items have been read, we are done.
+            return false;
+        }
+
+        if (journal.isNextAvailableSequence(namespace, partitionId, sequence)) {
+            // the sequence is not readable
+            return true;
+        }
+
+        sequence = journal.readMany(namespace, partitionId, sequence, resultSet);
+        return !resultSet.isMinSizeReached();
+    }
+
+    @Override
+    public void run() throws Exception {
+        // no-op; we already did the work in the shouldWait method.
+    }
+
+    @Override
+    public Object getResponse() {
+        return resultSet;
+    }
+
+    @Override
+    public WaitNotifyKey getWaitKey() {
+        return waitNotifyKey;
+    }
+
+    @Override
+    public void onWaitExpire() {
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(name);
+        out.writeInt(minSize);
+        out.writeInt(maxSize);
+        out.writeLong(startSequence);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        name = in.readUTF();
+        minSize = in.readInt();
+        maxSize = in.readInt();
+        startSequence = in.readLong();
+    }
+
+    @Override
+    public void logError(Throwable e) {
+        if (e instanceof StaleSequenceException) {
+            ILogger logger = getLogger();
+            if (logger.isFinestEnabled()) {
+                logger.finest(e.getMessage(), e);
+            } else if (logger.isFineEnabled()) {
+                logger.fine(e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        } else {
+            super.logError(e);
+        }
+    }
+
+    public abstract String getServiceName();
+
+    protected abstract ReadResultSetImpl<J, T> createResultSet();
+
+    protected abstract EventJournal<J> getJournal();
+}

--- a/hazelcast/src/main/java/com/hazelcast/journal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains supporting classes for data structure specific event journals.
+ * The event journal is a container for events related to a data structure.
+ * This includes events such as add, update, remove, evict and others.
+ * Each distributed object and partition has it's own event journal.
+ *
+ * @since 3.9
+ */
+
+package com.hazelcast.journal;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -25,6 +25,11 @@ import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
+import com.hazelcast.map.impl.journal.DeserializingEventJournalMapEvent;
+import com.hazelcast.map.impl.journal.InternalEventJournalMapEvent;
+import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
+import com.hazelcast.map.impl.journal.MapEventJournalReadResultSetImpl;
+import com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation;
 import com.hazelcast.map.impl.nearcache.invalidation.UuidFilter;
 import com.hazelcast.map.impl.operation.AccumulatorConsumerOperation;
 import com.hazelcast.map.impl.operation.AddIndexOperation;
@@ -288,12 +293,17 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int REMOVE_FROM_LOAD_ALL = 134;
     public static final int ENTRY_REMOVING_PROCESSOR = 135;
     public static final int ENTRY_OFFLOADABLE_SET_UNLOCK = 136;
-    public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 138;
-    public static final int FETCH_WITH_QUERY = 139;
-    public static final int RESULT_SEGMENT = 140;
-    public static final int EVICT_BATCH_BACKUP = 141;
+    public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 137;
+    public static final int FETCH_WITH_QUERY = 138;
+    public static final int RESULT_SEGMENT = 139;
+    public static final int EVICT_BATCH_BACKUP = 140;
+    public static final int EVENT_JOURNAL_SUBSCRIBE_OPERATION = 141;
+    public static final int EVENT_JOURNAL_READ = 142;
+    public static final int EVENT_JOURNAL_DESERIALIZING_MAP_EVENT = 143;
+    public static final int EVENT_JOURNAL_INTERNAL_MAP_EVENT = 144;
+    public static final int EVENT_JOURNAL_READ_RESULT_SET = 145;
 
-    private static final int LEN = EVICT_BATCH_BACKUP + 1;
+    private static final int LEN = EVENT_JOURNAL_READ_RESULT_SET + 1;
 
     @Override
     public int getFactoryId() {
@@ -987,6 +997,31 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[EVICT_BATCH_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new EvictBatchBackupOperation();
+            }
+        };
+        constructors[EVENT_JOURNAL_SUBSCRIBE_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapEventJournalSubscribeOperation();
+            }
+        };
+        constructors[EVENT_JOURNAL_READ] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapEventJournalReadOperation<Object, Object, Object>();
+            }
+        };
+        constructors[EVENT_JOURNAL_DESERIALIZING_MAP_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DeserializingEventJournalMapEvent<Object, Object>();
+            }
+        };
+        constructors[EVENT_JOURNAL_INTERNAL_MAP_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new InternalEventJournalMapEvent();
+            }
+        };
+        constructors[EVENT_JOURNAL_READ_RESULT_SET] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapEventJournalReadResultSetImpl<Object, Object, Object>();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
@@ -132,6 +133,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     MergePolicyProvider getMergePolicyProvider();
 
     MapEventPublisher getMapEventPublisher();
+
+    MapEventJournal getEventJournal();
 
     MapQueryEngine getMapQueryEngine(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -26,6 +26,8 @@ import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.event.MapEventPublisherImpl;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
+import com.hazelcast.map.impl.journal.MapEventJournal;
+import com.hazelcast.map.impl.journal.RingbufferMapEventJournalImpl;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.operation.BasePutOperation;
@@ -134,12 +136,13 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
     protected final PartitioningStrategyFactory partitioningStrategyFactory;
     protected final QueryCacheContext queryCacheContext;
-    protected MapEventPublisher mapEventPublisher;
+    protected final MapEventJournal eventJournal;
+    protected final MapEventPublisher mapEventPublisher;
+    protected final EventService eventService;
+    protected final MapOperationProviders operationProviders;
+    protected final ResultProcessorRegistry resultProcessorRegistry;
     protected MapService mapService;
-    protected EventService eventService;
     protected IndexProvider indexProvider;
-    protected MapOperationProviders operationProviders;
-    protected ResultProcessorRegistry resultProcessorRegistry;
 
     MapServiceContextImpl(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -152,6 +155,7 @@ class MapServiceContextImpl implements MapServiceContext {
         this.localMapStatsProvider = createLocalMapStatsProvider();
         this.mergePolicyProvider = new MergePolicyProvider(nodeEngine);
         this.mapEventPublisher = createMapEventPublisherSupport();
+        this.eventJournal = createEventJournal();
         this.queryOptimizer = newOptimizer(nodeEngine.getProperties());
         this.resultProcessorRegistry = createResultProcessorRegistry(nodeEngine.getSerializationService());
         this.partitionScanRunner = createPartitionScanRunner();
@@ -175,6 +179,10 @@ class MapServiceContextImpl implements MapServiceContext {
     // this method is overridden in another context.
     MapEventPublisherImpl createMapEventPublisherSupport() {
         return new MapEventPublisherImpl(this);
+    }
+
+    private MapEventJournal createEventJournal() {
+        return new RingbufferMapEventJournalImpl(getNodeEngine());
     }
 
     private LocalMapStatsProvider createLocalMapStatsProvider() {
@@ -266,8 +274,10 @@ class MapServiceContextImpl implements MapServiceContext {
             Iterator<RecordStore> iter = container.getMaps().values().iterator();
             while (iter.hasNext()) {
                 RecordStore recordStore = iter.next();
-                if (backupCount > recordStore.getMapContainer().getTotalBackupCount()) {
+                final MapContainer mapContainer = recordStore.getMapContainer();
+                if (backupCount > mapContainer.getTotalBackupCount()) {
                     recordStore.clearPartition(false);
+                    eventJournal.destroy(mapContainer.getObjectNamespace(), partitionId);
                     iter.remove();
                 }
             }
@@ -280,6 +290,7 @@ class MapServiceContextImpl implements MapServiceContext {
         if (container != null) {
             for (RecordStore mapPartition : container.getMaps().values()) {
                 mapPartition.clearPartition(false);
+                eventJournal.destroy(mapPartition.getMapContainer().getObjectNamespace(), partitionId);
             }
             container.getMaps().clear();
         }
@@ -430,6 +441,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public MapEventPublisher getMapEventPublisher() {
         return mapEventPublisher;
+    }
+
+    @Override
+    public MapEventJournal getEventJournal() {
+        return eventJournal;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -211,6 +211,8 @@ public class PartitionContainer {
     public void clear(boolean onShutdown) {
         for (RecordStore recordStore : maps.values()) {
             recordStore.clearPartition(onShutdown);
+            mapService.getMapServiceContext().getEventJournal().destroy(
+                    recordStore.getMapContainer().getObjectNamespace(), partitionId);
         }
         maps.clear();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -118,5 +118,8 @@ public interface MapEventPublisher {
      */
     void addEventToQueryCache(Object eventData);
 
+    /**
+     * Returns {@code true} if there is at least one listener registered for the specified {@code mapName}.
+     */
     boolean hasEventListener(String mapName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -293,6 +293,9 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         return eventService.getRegistrations(SERVICE_NAME, mapName);
     }
 
+    /**
+     * Returns the hashCode of the {@code key} or -1 if {@code null}
+     */
     private int pickOrderKey(Data key) {
         return key == null ? -1 : key.hashCode();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.SerializationServiceSupport;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.io.IOException;
+
+public class DeserializingEventJournalMapEvent<K, V>
+        extends InternalEventJournalMapEvent
+        implements EventJournalMapEvent<K, V>, HazelcastInstanceAware {
+    private SerializationService serializationService;
+    private K objectKey;
+    private V objectNewValue;
+    private V objectOldValue;
+
+    public DeserializingEventJournalMapEvent() {
+    }
+
+    public DeserializingEventJournalMapEvent(SerializationService serializationService, InternalEventJournalMapEvent je) {
+        super(je.getDataKey(), je.getDataNewValue(), je.getDataOldValue(), je.getEventType());
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_DESERIALIZING_MAP_EVENT;
+    }
+
+    @Override
+    public K getKey() {
+        if (objectKey == null && dataKey != null) {
+            objectKey = serializationService.toObject(dataKey);
+        }
+        return objectKey;
+    }
+
+    @Override
+    public V getNewValue() {
+        if (objectNewValue == null && dataNewValue != null) {
+            objectNewValue = serializationService.toObject(dataNewValue);
+        }
+        return objectNewValue;
+    }
+
+    @Override
+    public V getOldValue() {
+        if (objectOldValue == null && dataOldValue != null) {
+            objectOldValue = serializationService.toObject(dataOldValue);
+        }
+        return objectOldValue;
+    }
+
+    @Override
+    public EntryEventType getType() {
+        return EntryEventType.getByType(eventType);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        out.writeData(toData(dataKey, objectKey));
+        out.writeData(toData(dataNewValue, objectNewValue));
+        out.writeData(toData(dataOldValue, objectOldValue));
+    }
+
+    private Data toData(Data data, Object o) {
+        return o != null ? serializationService.toData(o) : data;
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        serializationService = ((SerializationServiceSupport) hazelcastInstance).getSerializationService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/EventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/EventJournalMapEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.core.EntryEventType;
+
+/**
+ * The event for the map event journal.
+ *
+ * @param <K> the entry key type
+ * @param <V> the entry value type
+ */
+public interface EventJournalMapEvent<K, V> {
+    /**
+     * Returns the key for the event entry.
+     *
+     * @return the entry key
+     */
+    K getKey();
+
+    /**
+     * Returns the new value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link EntryEventType#ADDED}, the new
+     * value is non-{@code null} but when it is of type {@link EntryEventType#REMOVED},
+     * the value is {@code null}.
+     *
+     * @return the entry new value
+     */
+    V getNewValue();
+
+    /**
+     * Returns the old value for the event entry. In some cases this
+     * is {@code null} while in other cases it may be non-{@code null}. For instance,
+     * when the event is of type {@link EntryEventType#ADDED}, the old
+     * value is {@code null} but when it is of type {@link EntryEventType#REMOVED},
+     * the value is non-{@code null}.
+     *
+     * @return the entry old value
+     */
+    V getOldValue();
+
+    /**
+     * Returns the event type.
+     *
+     * @return the event type
+     */
+    EntryEventType getType();
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * The event journal item for map events. It contains serialized
+ * values for key and all values included in map mutations as well as
+ * the event type.
+ */
+public class InternalEventJournalMapEvent implements IdentifiedDataSerializable {
+    protected Data dataKey;
+    protected Data dataNewValue;
+    protected Data dataOldValue;
+    protected int eventType;
+
+    public InternalEventJournalMapEvent() {
+    }
+
+    public InternalEventJournalMapEvent(Data dataKey, Data dataNewValue, Data dataOldValue, int eventType) {
+        this.eventType = eventType;
+        this.dataKey = dataKey;
+        this.dataNewValue = dataNewValue;
+        this.dataOldValue = dataOldValue;
+    }
+
+    public Data getDataKey() {
+        return dataKey;
+    }
+
+    public Data getDataNewValue() {
+        return dataNewValue;
+    }
+
+    public Data getDataOldValue() {
+        return dataOldValue;
+    }
+
+    /**
+     * Return the integer defining the event type. It can be turned into an
+     * enum value by calling {@link com.hazelcast.core.EntryEventType#getByType(int)}.
+     *
+     * @return the integer defining the event type
+     */
+    public int getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_INTERNAL_MAP_EVENT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        out.writeData(dataKey);
+        out.writeData(dataNewValue);
+        out.writeData(dataOldValue);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        eventType = in.readInt();
+        dataKey = in.readData();
+        dataNewValue = in.readData();
+        dataOldValue = in.readData();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ObjectNamespace;
+
+/**
+ * The event journal is a container for events related to a data structure.
+ * This interface provides methods for map event journals. This includes
+ * events such as add, update, remove, evict and others. Each map and
+ * partition has it's own event journal.
+ * <p>
+ * If a map is destroyed or the migrated, the related event journal will be destroyed or
+ * migrated as well. In this sense, the event journal is co-located with the map partition
+ * and it's replicas.
+ * <p>
+ * <b>NOTE :</b>
+ * Map evictions are based on random samples which are then compared according to
+ * an eviction policy. This is done separately on the partition owner and the backup replica
+ * and can cause different entries to be evicted on the primary and backup replica.
+ * Because of this, the record store can contain different entries and the event journal
+ * can contain eviction/remove events for different entries on different replicas. This may
+ * cause some issues if the partition owner crashes and the backup replica is promoted to
+ * the partition owner. Readers of the event journal will then continue reading from the
+ * promoted replica and may get update and remove events for entries which have already
+ * been removed.
+ *
+ * @since 3.9
+ */
+public interface MapEventJournal extends EventJournal<InternalEventJournalMapEvent> {
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#UPDATED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param oldValue    the old value
+     * @param newValue    the new value
+     */
+    void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue);
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#ADDED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeAddEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#REMOVED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#EVICTED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param namespace   the map namespace
+     * @param partitionId the entry key partition
+     * @param key         the entry key
+     * @param value       the entry value
+     */
+    void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
+     * Returns {@code true} if the object has a configured and enabled event journal.
+     *
+     * @param namespace the object namespace
+     * @return {@code true} if the object has a configured and enabled event journal, {@code false} otherwise
+     */
+    boolean hasEventJournal(ObjectNamespace namespace);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.journal.EventJournal;
+import com.hazelcast.journal.EventJournalReadOperation;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.util.function.Predicate;
+
+import java.io.IOException;
+
+/**
+ * Reads from the map event journal in batches. You may specify the start sequence,
+ * the minumum required number of items in the response, the maximum number of items
+ * in the response, a predicate that the events should pass and a projection to
+ * apply to the events in the journal.
+ * If the event journal currently contains less events than the required minimum, the
+ * call will wait until it has sufficient items.
+ * The predicate, filter and projection may be {@code null} in which case all elements are returned
+ * and no projection is applied.
+ *
+ * @param <T> the return type of the projection. It is equal to an implementation of {@link }
+ *            if the projection is {@code null} or it is the identity projection
+ * @since 3.9
+ */
+public class MapEventJournalReadOperation<K, V, T> extends EventJournalReadOperation<T, InternalEventJournalMapEvent> {
+
+    protected Predicate<? super EventJournalMapEvent<K, V>> predicate;
+    protected Projection<? super EventJournalMapEvent<K, V>, T> projection;
+
+    public MapEventJournalReadOperation() {
+    }
+
+    public MapEventJournalReadOperation(String mapName, long startSequence, int minSize, int maxSize,
+                                        Predicate<? super EventJournalMapEvent<K, V>> predicate,
+                                        Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        super(mapName, startSequence, minSize, maxSize);
+        this.predicate = predicate;
+        this.projection = projection;
+    }
+
+    @Override
+    protected ReadResultSetImpl<InternalEventJournalMapEvent, T> createResultSet() {
+        return new MapEventJournalReadResultSetImpl<K, V, T>(
+                minSize, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
+    }
+
+    @Override
+    protected EventJournal<InternalEventJournalMapEvent> getJournal() {
+        final MapService service = getService();
+        return service.getMapServiceContext().getEventJournal();
+    }
+
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_READ;
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(predicate);
+        out.writeObject(projection);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        predicate = in.readObject();
+        projection = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.serialization.SerializableByConvention;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Predicate;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class MapEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetImpl<InternalEventJournalMapEvent, T> {
+
+    public MapEventJournalReadResultSetImpl() {
+    }
+
+    MapEventJournalReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
+                                     final Predicate<? super EventJournalMapEvent<K, V>> predicate,
+                                     final Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        super(minSize, maxSize, serializationService,
+                predicate == null ? null : new Predicate<InternalEventJournalMapEvent>() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+                    public boolean test(InternalEventJournalMapEvent e) {
+                        return predicate.test((DeserializingEventJournalMapEvent<K, V>) e);
+                    }
+                },
+                projection == null ? null : new ProjectionAdapter<K, V, T>(projection));
+    }
+
+    @Override
+    public void addItem(long seq, Object item) {
+        // the event journal ringbuffer supports only OBJECT format for now
+        final InternalEventJournalMapEvent e = (InternalEventJournalMapEvent) item;
+        final DeserializingEventJournalMapEvent<K, V> deserialisingEvent
+                = new DeserializingEventJournalMapEvent<K, V>(serializationService, e);
+        super.addItem(seq, deserialisingEvent);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_READ_RESULT_SET;
+    }
+
+    @SerializableByConvention
+    private static class ProjectionAdapter<K, V, T> extends Projection<InternalEventJournalMapEvent, T> {
+
+        private final Projection<? super EventJournalMapEvent<K, V>, T> projection;
+
+        ProjectionAdapter(Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+            this.projection = projection;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
+        public T transform(InternalEventJournalMapEvent e) {
+            return projection.transform((DeserializingEventJournalMapEvent<K, V>) e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.MapOperation;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.version.Version;
+
+/**
+ * Performs the initial subscription to the map event journal.
+ * This includes retrieving the event journal sequences of the
+ * oldest and newest event in the journal.
+ *
+ * @since 3.9
+ */
+public class MapEventJournalSubscribeOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
+    private EventJournalInitialSubscriberState response;
+    private DistributedObjectNamespace namespace;
+
+    public MapEventJournalSubscribeOperation() {
+    }
+
+    public MapEventJournalSubscribeOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        super.beforeRun();
+
+        final Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        if (clusterVersion.isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException(
+                    "Event journal actions are not available when cluster version is " + clusterVersion);
+        }
+        namespace = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
+        if (!mapServiceContext.getEventJournal().hasEventJournal(namespace)) {
+            throw new UnsupportedOperationException(
+                    "Cannot subscribe to event journal because it is either not configured or disabled for map " + name);
+        }
+    }
+
+    @Override
+    public void run() {
+        final MapEventJournal eventJournal = mapServiceContext.getEventJournal();
+        final long newestSequence = eventJournal.newestSequence(namespace, getPartitionId());
+        final long oldestSequence = eventJournal.oldestSequence(namespace, getPartitionId());
+        response = new EventJournalInitialSubscriberState(oldestSequence, newestSequence);
+    }
+
+    @Override
+    public EventJournalInitialSubscriberState getResponse() {
+        return response;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_JOURNAL_SUBSCRIBE_OPERATION;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
+import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.ringbuffer.impl.RingbufferWaitNotifyKey;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationparker.OperationParker;
+
+import static com.hazelcast.core.EntryEventType.ADDED;
+import static com.hazelcast.core.EntryEventType.EVICTED;
+import static com.hazelcast.core.EntryEventType.REMOVED;
+import static com.hazelcast.core.EntryEventType.UPDATED;
+
+/**
+ * The map event journal implementation based on the {@link com.hazelcast.ringbuffer.Ringbuffer}.
+ * It will add all journal events into a {@link RingbufferContainer} with the provided namespace
+ * and partition ID and allows checking if the map has a configured event journal.
+ * Adapts the {@link EventJournalConfig} to the {@link RingbufferConfig} when creating the ringbuffer.
+ */
+public class RingbufferMapEventJournalImpl implements MapEventJournal {
+    private final NodeEngineImpl nodeEngine;
+
+    public RingbufferMapEventJournalImpl(NodeEngine engine) {
+        this.nodeEngine = (NodeEngineImpl) engine;
+    }
+
+    @Override
+    public void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue) {
+        addToEventRingbuffer(namespace, partitionId, UPDATED, key, oldValue, newValue);
+    }
+
+    @Override
+    public void writeAddEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, ADDED, key, null, value);
+    }
+
+    @Override
+    public void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, REMOVED, key, value, null);
+    }
+
+    @Override
+    public void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
+        addToEventRingbuffer(namespace, partitionId, EVICTED, key, value, null);
+    }
+
+    @Override
+    public long newestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).tailSequence();
+    }
+
+    @Override
+    public long oldestSequence(ObjectNamespace namespace, int partitionId) {
+        return getRingbufferOrFail(namespace, partitionId).headSequence();
+    }
+
+    @Override
+    public void destroy(ObjectNamespace namespace, int partitionId) {
+        getRingbufferService().destroyContainer(partitionId, namespace);
+    }
+
+    @Override
+    public void isAvailableOrNextSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        getRingbufferOrFail(namespace, partitionId).checkBlockableReadSequence(sequence);
+    }
+
+    @Override
+    public boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence) {
+        return getRingbufferOrFail(namespace, partitionId).shouldWait(sequence);
+    }
+
+    @Override
+    public WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
+        return new RingbufferWaitNotifyKey(namespace);
+    }
+
+    @Override
+    public <T> long readMany(ObjectNamespace namespace, int partitionId, long beginSequence,
+                             ReadResultSetImpl<InternalEventJournalMapEvent, T> resultSet) {
+        return getRingbufferOrFail(namespace, partitionId).readMany(beginSequence, resultSet);
+    }
+
+    @Override
+    public void cleanup(ObjectNamespace namespace, int partitionId) {
+        getRingbufferOrFail(namespace, partitionId).cleanup();
+    }
+
+    @Override
+    public boolean hasEventJournal(ObjectNamespace namespace) {
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        return config != null && config.isEnabled();
+    }
+
+    @Override
+    public EventJournalConfig getEventJournalConfig(ObjectNamespace namespace) {
+        return nodeEngine.getConfig().getMapEventJournalConfig(namespace.getObjectName());
+    }
+
+    @Override
+    public RingbufferConfig toRingbufferConfig(EventJournalConfig config) {
+        return new RingbufferConfig()
+                .setAsyncBackupCount(0)
+                .setBackupCount(0)
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setCapacity(config.getCapacity())
+                .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
+    }
+
+    private void addToEventRingbuffer(ObjectNamespace namespace, int partitionId, EntryEventType eventType,
+                                      Data key, Object oldValue, Object newValue) {
+        final RingbufferContainer<InternalEventJournalMapEvent> eventContainer = getRingbufferOrNull(namespace, partitionId);
+        if (eventContainer == null) {
+            return;
+        }
+        final InternalEventJournalMapEvent event
+                = new InternalEventJournalMapEvent(toData(key), toData(newValue), toData(oldValue), eventType.getType());
+        eventContainer.add(event);
+        getOperationParker().unpark(eventContainer);
+    }
+
+    private Data toData(Object val) {
+        return getSerializationService().toData(val, DataType.HEAP);
+    }
+
+    private RingbufferContainer<InternalEventJournalMapEvent> getRingbufferOrFail(ObjectNamespace namespace, int partitionId) {
+        final RingbufferContainer<InternalEventJournalMapEvent> ringbuffer = getRingbufferOrNull(namespace, partitionId);
+        if (ringbuffer == null) {
+            throw new IllegalStateException("There is no event journal configured for map with name: "
+                    + namespace.getObjectName());
+        }
+        return ringbuffer;
+    }
+
+    private RingbufferContainer<InternalEventJournalMapEvent> getRingbufferOrNull(ObjectNamespace namespace, int partitionId) {
+        final RingbufferService service = getRingbufferService();
+        final RingbufferConfig ringbufferConfig;
+        if (service.hasContainer(partitionId, namespace)) {
+            ringbufferConfig = null;
+        } else {
+            final EventJournalConfig config = getEventJournalConfig(namespace);
+            if (config == null || !config.isEnabled()) {
+                return null;
+            }
+            ringbufferConfig = toRingbufferConfig(config);
+        }
+        return service.getContainer(partitionId, namespace, ringbufferConfig);
+    }
+
+    private RingbufferService getRingbufferService() {
+        return nodeEngine.getService(RingbufferService.SERVICE_NAME);
+    }
+
+    private OperationParker getOperationParker() {
+        return nodeEngine.getOperationParker();
+    }
+
+    private InternalSerializationService getSerializationService() {
+        return (InternalSerializationService) nodeEngine.getSerializationService();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
@@ -32,7 +32,10 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Removes data from Record store on LoadAllOperation that replaces existing values
+ * Removes keys that are contained in the {@link com.hazelcast.map.impl.recordstore.RecordStore} from the provided list,
+ * leaving only keys which are not contained in the record store.
+ *
+ * @see com.hazelcast.core.IMap#loadAll(java.util.Set, boolean)
  */
 public class RemoveFromLoadAllOperation extends MapOperation implements PartitionAwareOperation, MutatingOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -167,6 +167,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void destroy() {
         clearPartition(false);
         storage.destroy(false);
+        eventJournal.destroy(mapContainer.getObjectNamespace(), partitionId);
     }
 
     @Override
@@ -228,6 +229,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void putRecord(Data key, Record record) {
         markRecordStoreExpirable(record.getTtl());
         storage.put(key, record);
+        eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
         updateStatsOnPut(record.getHits());
     }
 
@@ -245,6 +247,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             record = createRecord(value, ttl, now);
             storage.put(key, record);
+            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
         } else {
             updateRecord(key, record, value, now);
         }
@@ -420,6 +423,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (value != null) {
             record = createRecord(value, DEFAULT_TTL, getNow());
             storage.put(key, record);
+            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
             if (!backup) {
                 saveIndex(record, null);
             }
@@ -463,6 +467,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         Iterator<Record> iterator = recordsToRemove.iterator();
         while (iterator.hasNext()) {
             Record record = iterator.next();
+            eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
             storage.removeRecord(record);
             updateStatsOnRemove(record.getHits());
             iterator.remove();
@@ -498,6 +503,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void reset() {
         mapDataStore.reset();
         storage.clear(false);
+        eventJournal.destroy(mapContainer.getObjectNamespace(), partitionId);
         resetStats();
     }
 
@@ -509,6 +515,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = record.getValue();
             mapDataStore.flush(key, value, backup);
             removeIndex(record);
+            eventJournal.writeEvictEvent(mapContainer.getObjectNamespace(), partitionId, key, value);
             storage.removeRecord(record);
             updateStatsOnRemove(record.getHits());
             if (!backup) {
@@ -536,6 +543,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             return;
         }
+        eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
         storage.removeRecord(record);
         updateStatsOnRemove(record.getHits());
         mapDataStore.removeBackup(key, now);
@@ -580,6 +588,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             removeIndex(record);
             mapDataStore.remove(key, now);
             onStore(record);
+            eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, key, oldValue);
             storage.removeRecord(record);
             updateStatsOnRemove(record.getHits());
             removed = true;
@@ -761,6 +770,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             record = createRecord(value, ttl, now);
             storage.put(key, record);
+            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
         } else {
             updateRecord(key, record, value, now);
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
@@ -790,6 +800,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             record = createRecord(newValue, DEFAULT_TTL, now);
             mergeRecordExpiration(record, mergingEntry);
             storage.put(key, record);
+            eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, key, null, record.getValue());
         } else {
             oldValue = record.getValue();
             EntryView existingEntry = EntryViews.createLazyEntryView(record.getKey(), record.getValue(),
@@ -800,6 +811,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 removeIndex(record);
                 mapDataStore.remove(key, now);
                 onStore(record);
+                eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, key, oldValue, null);
                 storage.removeRecord(record);
                 updateStatsOnRemove(record.getHits());
                 return true;
@@ -813,6 +825,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             }
             newValue = mapDataStore.add(key, newValue, now);
             onStore(record);
+            eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, key, oldValue, newValue);
             storage.updateRecordValue(key, record, newValue);
         }
         saveIndex(record, oldValue);
@@ -873,6 +886,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
+            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
         } else {
             oldValue = record.getValue();
             value = mapServiceContext.interceptPut(name, oldValue, value);
@@ -917,6 +931,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
+            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
         } else {
             oldValue = record.getValue();
             value = mapServiceContext.interceptPut(name, oldValue, value);
@@ -962,6 +977,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             if (oldValue != null) {
                 record = createRecord(oldValue, DEFAULT_TTL, now);
                 storage.put(key, record);
+                eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
             }
         } else {
             accessRecord(record, now);
@@ -973,6 +989,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             onStore(record);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
+            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
         }
         saveIndex(record, oldValue);
@@ -993,6 +1010,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             mapDataStore.remove(key, now);
             onStore(record);
         }
+        eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
         storage.removeRecord(record);
         updateStatsOnRemove(record.getHits());
         return oldValue;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
+
+/**
+ * Defines type of the Data: heap or native.
+ */
+public enum DataType {
+
+    /**
+     * Heap data type.
+     */
+    HEAP,
+
+    /**
+     * Native data type.
+     */
+    NATIVE
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -27,7 +27,9 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
@@ -48,7 +50,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * it is null to save space.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class RingbufferContainer<T> implements IdentifiedDataSerializable, Versioned {
+public class RingbufferContainer<T> implements IdentifiedDataSerializable, Notifier, Versioned {
 
     private static final long TTL_DISABLED = 0;
 
@@ -578,5 +580,15 @@ public class RingbufferContainer<T> implements IdentifiedDataSerializable, Versi
     @Override
     public int getId() {
         return RingbufferDataSerializerHook.RINGBUFFER_CONTAINER;
+    }
+
+    @Override
+    public boolean shouldNotify() {
+        return true;
+    }
+
+    @Override
+    public WaitNotifyKey getNotifiedKey() {
+        return emptyRingWaitNotifyKey;
     }
 }

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -30,3 +30,4 @@ com.hazelcast.internal.usercodedeployment.impl.UserCodeDeploymentSerializerHook
 com.hazelcast.aggregation.impl.AggregatorDataSerializerHook
 com.hazelcast.projection.impl.ProjectionDataSerializerHook
 com.hazelcast.config.ConfigDataSerializerHook
+com.hazelcast.journal.EventJournalDataSerializerHook

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -43,6 +43,7 @@
                 <xs:element name="durable-executor-service" type="durable-executor-service" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="scheduled-executor-service" type="scheduled-executor-service" minOccurs="0"
                             maxOccurs="unbounded"/>
+                <xs:element name="event-journal" type="event-journal" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="queue" type="queue" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="map" type="map" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="multimap" type="multimap" minOccurs="0" maxOccurs="unbounded"/>
@@ -3148,6 +3149,60 @@
             <xs:annotation>
                 <xs:documentation>
                     True if Hot Restart Persistence is enabled, false otherwise. Only available on Hazelcast Enterprise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="event-journal">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for an event journal. The event journal keeps events related
+                to a specific partition and data structure. For instance, it could keep
+                map or cache add, update, remove, merge events along with the key, old value,
+                new value and so on.
+                This configuration is not tied to a specific data structure and can be reused.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="mapName" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the map to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cacheName" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the cache to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of items in the event journal. If no time-to-live-seconds
+                        is set, the size will always be equal to capacity after the event
+                        journal has been filled. This is because no items are getting retired.
+                        The default value is 10000.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay in the event journal.
+                        Entries that are older than &lt;time-to-live-seconds&gt; are evicted from the journal.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    True if the event journal is enabled, false otherwise.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -206,6 +206,23 @@
 
     </map>
 
+    <!--
+           Configuration for an event journal. The event journal keeps events related
+           to a specific partition and data structure. For instance, it could keep
+           map add, update, remove, merge events along with the key, old value, new value and so on.
+        -->
+    <event-journal enabled="false">
+        <mapName>mapName</mapName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
+
+    <event-journal enabled="false">
+        <cacheName>cacheName</cacheName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
+
     <multimap name="default">
         <backup-count>1</backup-count>
         <value-collection-type>SET</value-collection-type>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -870,8 +870,8 @@ It has the following sub-elements:
     	Adds the partition lost listeners that you created by implementing Hazelcast's PartitionLostListener interface. 
     * <quorum-ref>:
 	Adds the quorum for this map which you configure using the <quorum> element. You should set the <quorum-ref>'s value
-	as the <quorum>'s name. 
- -->    
+	as the <quorum>'s name.
+ -->
     <map name="default">
         <in-memory-format>BINARY</in-memory-format>
         <statistics-enabled>true</statistics-enabled>
@@ -888,54 +888,54 @@ It has the following sub-elements:
         <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
         <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
         <read-backup-data>false</read-backup-data>
-	<hot-restart enabled="false">
-		<fsync>false</fsync>
-	</hot-restart>
-	<map-store enabled="true" initial-mode="LAZY">
-		<class-name>com.hazelcast.examples.DummyStore</class-name>
-		<write-delay-seconds>60</write-delay-seconds>
-		<write-batch-size>1000</write-batch-size>
-		<write-coalescing>true</write-coalescing>
-		<properties>
-    			<property name="jdbc_url">my.jdbc.com</property>
-		</properties>
-	</map-store>
-	<near-cache>
-		<max-size>5000</max-size>
-		<time-to-live-seconds>0</time-to-live-seconds>
-		<max-idle-seconds>60</max-idle-seconds>
-		<eviction-policy>LRU</eviction-policy>
-		<invalidate-on-change>true</invalidate-on-change>
-		<in-memory-format>BINARY</in-memory-format>
-		<cache-local-entries>false</cache-local-entries>
-		<eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
-	</near-cache>
-	<wan-replication-ref name="my-wan-cluster-batch">
-		<merge-policy>com.hazelcast.map.merge.PassThroughMergePolicy</merge-policy>
-		<filters>
-			<filter-impl>com.example.SampleFilter</filter-impl>
-			<filter-impl>com.example.SampleFilter2</filter-impl>
-		</filters>
-		<republishing-enabled>false</republishing-enabled>
-	</wan-replication-ref>
-	<indexes>
-		<index ordered="false">name</index>
-		<index ordered="true">age</index>
-	</indexes>
-	<attributes>
-		<attribute extractor="com.bank.CurrencyExtractor">currency</attribute>
-	</attributes>
-	<entry-listeners>
-		<entry-listener include-value="false" local="false">
-			com.your-package.MyEntryListener
-		</entry-listener>
-	</entry-listeners>
-	<partition-lost-listeners>
-		<partition-lost-listener>
-			com.your-package.YourPartitionLostListener
-		</partition-lost-listener>
-	</partition-lost-listeners>
-	<quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
+        <hot-restart enabled="false">
+            <fsync>false</fsync>
+        </hot-restart>
+        <map-store enabled="true" initial-mode="LAZY">
+            <class-name>com.hazelcast.examples.DummyStore</class-name>
+            <write-delay-seconds>60</write-delay-seconds>
+            <write-batch-size>1000</write-batch-size>
+            <write-coalescing>true</write-coalescing>
+            <properties>
+                <property name="jdbc_url">my.jdbc.com</property>
+            </properties>
+        </map-store>
+        <near-cache>
+            <max-size>5000</max-size>
+            <time-to-live-seconds>0</time-to-live-seconds>
+            <max-idle-seconds>60</max-idle-seconds>
+            <eviction-policy>LRU</eviction-policy>
+            <invalidate-on-change>true</invalidate-on-change>
+            <in-memory-format>BINARY</in-memory-format>
+            <cache-local-entries>false</cache-local-entries>
+            <eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
+        </near-cache>
+        <wan-replication-ref name="my-wan-cluster-batch">
+            <merge-policy>com.hazelcast.map.merge.PassThroughMergePolicy</merge-policy>
+            <filters>
+                <filter-impl>com.example.SampleFilter</filter-impl>
+                <filter-impl>com.example.SampleFilter2</filter-impl>
+            </filters>
+            <republishing-enabled>false</republishing-enabled>
+        </wan-replication-ref>
+        <indexes>
+            <index ordered="false">name</index>
+            <index ordered="true">age</index>
+        </indexes>
+        <attributes>
+            <attribute extractor="com.bank.CurrencyExtractor">currency</attribute>
+        </attributes>
+        <entry-listeners>
+            <entry-listener include-value="false" local="false">
+                com.your-package.MyEntryListener
+            </entry-listener>
+        </entry-listeners>
+        <partition-lost-listeners>
+            <partition-lost-listener>
+                com.your-package.YourPartitionLostListener
+            </partition-lost-listener>
+        </partition-lost-listeners>
+        <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
     </map>
 <!--
     ===== HAZELCAST CONTINUOUS QUERY CACHE CONFIGURATION =====
@@ -1201,25 +1201,68 @@ It has the following sub-elements:
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>
         <eviction size="1000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
-	<wan-replication-ref name="my-wan-cluster-batch">
-	    <merge-policy>com.hazelcast.cache.merge.PassThroughCacheMergePolicy</merge-policy>
-	    <republishing-enabled>true</republishing-enabled>
-	    <filters>
-		<filter-impl>com.example.SampleFilter</filter-impl>
-	    </filters>
-	</wan-replication-ref>
+        <wan-replication-ref name="my-wan-cluster-batch">
+            <merge-policy>com.hazelcast.cache.merge.PassThroughCacheMergePolicy</merge-policy>
+            <republishing-enabled>true</republishing-enabled>
+            <filters>
+                <filter-impl>com.example.SampleFilter</filter-impl>
+            </filters>
+        </wan-replication-ref>
         <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
-	<partition-lost-listeners>
-		<partition-lost-listener>
-			com.your-package.YourPartitionLostListener
-		</partition-lost-listener>
-	</partition-lost-listeners>
+        <partition-lost-listeners>
+            <partition-lost-listener>
+                com.your-package.YourPartitionLostListener
+            </partition-lost-listener>
+        </partition-lost-listeners>
         <merge-policy>com.hazelcast.cache.merge.LatestAccessCacheMergePolicy</merge-policy>
-	<hot-restart enabled="false">
-		<fsync>false</fsync>
-	</hot-restart>
-	<disable-per-entry-invalidation-events>true</disable-per-entry-invalidation-events>
+        <hot-restart enabled="false">
+            <fsync>false</fsync>
+        </hot-restart>
+        <disable-per-entry-invalidation-events>true</disable-per-entry-invalidation-events>
     </cache>
+    <!--
+    ===== HAZELCAST EVENT JOURNAL CONFIGURATION =====
+
+    Configuration element's name is <event-journal>.
+    It has the following attributes and sub-elements:
+    * enabled:
+    	Specifies whether the event journal is enabled.
+    * <mapName>:
+    	Map name to which this configuration applies. This attribute's default value is "default".
+    	Configuration for the event journal with name "default" applies to all maps without
+    	configuration for a specific named map. In another words, if you specify the default
+    	event journal config as enabled then all maps which don't have specific event journal
+    	will be also enabled.
+    * <cacheName>:
+    	Cache name to which this configuration applies. This attribute's default value is "default".
+    	Configuration for the event journal with name "default" applies to all caches without
+    	configuration for a specific named cache. In another words, if you specify the default
+    	event journal config as enabled then all caches which don't have specific event journal
+    	will be also enabled.
+    * <capacity>:
+    * Gets the capacity of the event journal.
+    * The capacity is the total number of items that the event journal can hold at any moment.
+    * The actual number of items contained in the journal can be lower. Its default value is 10000.
+    * <time-to-live-seconds>:
+    * Sets the time to live in seconds.
+    * Time to live is the time the event journal retains items before removing them from the journal.
+    * The events are removed on journal read and write actions, not while the journal is idle.
+    * Time to live can be disabled by setting timeToLiveSeconds to 0. This means that the
+    * events never expire but they can be overwritten when the capacity of the journal is exceeed.
+    * Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Its default value is 0.
+-->
+
+    <event-journal enabled="false">
+        <mapName>default</mapName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
+
+    <event-journal enabled="false">
+        <cacheName>default</cacheName>
+        <capacity>10000</capacity>
+        <time-to-live-seconds>0</time-to-live-seconds>
+    </event-journal>
 
 <!--
     ===== HAZELCAST LIST CONFIGURATION =====

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.function.Predicate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BasicCacheJournalTest extends HazelcastTestSupport {
+    protected HazelcastInstance[] instances;
+    protected CacheManager cacheManager;
+    private static final Random RANDOM = new Random();
+    private static final TruePredicate<EventJournalCacheEvent<String, Integer>> TRUE_PREDICATE = truePredicate();
+    private static final IdentityProjection<EventJournalCacheEvent<String, Integer>> IDENTITY_PROJECTION = identityProjection();
+    private int partitionId;
+
+    @Before
+    public void init() {
+        instances = createInstances();
+        partitionId = 1;
+        cacheManager = createCacheManager();
+        warmUpPartitions(instances);
+    }
+
+    protected CacheManager createCacheManager() {
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(getRandomInstance());
+        return cachingProvider.getCacheManager();
+    }
+
+    protected HazelcastInstance getRandomInstance() {
+        return instances[RANDOM.nextInt(instances.length)];
+    }
+
+    protected HazelcastInstance[] createInstances() {
+        return createHazelcastInstanceFactory(2).newInstances(getConfig());
+    }
+
+    @Override
+    protected Config getConfig() {
+        final Config config = super.getConfig();
+        config.addEventJournalConfig(new EventJournalConfig().setCacheName("default").setEnabled(true));
+        final CacheSimpleConfig nonEvictingCache = new CacheSimpleConfig().setName("cache");
+        nonEvictingCache.getEvictionConfig().setSize(Integer.MAX_VALUE);
+
+        return config.addCacheConfig(nonEvictingCache)
+                     .addCacheConfig(new CacheSimpleConfig().setName("evicting"));
+    }
+
+
+    @Test
+    public void unparkReadOperation() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        assertJournalSize(c, 0);
+
+        final String key = randomPartitionKey();
+        final Integer value = RANDOM.nextInt();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        readFromEventJournal(c, 0, 100, partitionId, TRUE_PREDICATE, IDENTITY_PROJECTION)
+                .andThen(new ExecutionCallback<ReadResultSet<EventJournalCacheEvent<String, Integer>>>() {
+                    @Override
+                    public void onResponse(ReadResultSet<EventJournalCacheEvent<String, Integer>> response) {
+                        assertEquals(1, response.size());
+                        final EventJournalCacheEvent<String, Integer> e = response.get(0);
+
+                        assertEquals(CacheEventType.CREATED, e.getType());
+                        assertEquals(e.getKey(), key);
+                        assertEquals(e.getNewValue(), value);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        t.printStackTrace();
+                    }
+                });
+
+        c.put(key, value);
+        latch.await();
+        assertJournalSize(c, 1);
+    }
+
+    @Test
+    public void receiveAddedEventsWhenPut() throws Exception {
+        final ICache<String, Integer> c = getCache();
+
+        final int count = 100;
+        assertJournalSize(c, 0);
+
+        for (int i = 0; i < count; i++) {
+            c.put(randomPartitionKey(), i);
+        }
+
+        assertJournalSize(c, count);
+        final ReadResultSet<EventJournalCacheEvent<String, Integer>> events = getAllEvents(c, null, null);
+        assertEquals(count, events.size());
+
+        final HashMap<String, Integer> received = new HashMap<String, Integer>();
+        for (EventJournalCacheEvent<String, Integer> e : events) {
+            assertEquals(CacheEventType.CREATED, e.getType());
+            assertNull(e.getOldValue());
+            received.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(getEntries(c), received.entrySet());
+    }
+
+    @Test
+    public void receiveRemoveEventsWhenRemove() throws Exception {
+        final ICache<String, Integer> c = getCache();
+
+        final int count = 100;
+        assertJournalSize(c, 0);
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(count);
+        for (int i = 0; i < count; i++) {
+            final String k = randomPartitionKey();
+            c.put(k, i);
+            initialMap.put(k, i);
+        }
+        assertJournalSize(c, count);
+
+        for (Map.Entry<String, Integer> e : getEntries(c)) {
+            final String key = e.getKey();
+            c.getAndRemove(key);
+        }
+
+        final HashMap<String, Integer> added = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> removed = new HashMap<String, Integer>(count);
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case CREATED:
+                    added.put(e.getKey(), e.getNewValue());
+                    break;
+                case REMOVED:
+                    removed.put(e.getKey(), e.getOldValue());
+                    break;
+            }
+        }
+
+
+        assertEquals(0, c.size());
+        assertJournalSize(c, count * 2);
+        assertEquals(initialMap, added);
+        assertEquals(initialMap, removed);
+    }
+
+    @Test
+    public void receiveUpdateEventsOnMapPut() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        final int count = 100;
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(count);
+        assertJournalSize(c, 0);
+        for (int i = 0; i < count; i++) {
+            final String k = randomPartitionKey();
+            c.put(k, i);
+            initialMap.put(k, i);
+        }
+        assertJournalSize(c, count);
+
+        for (Map.Entry<String, Integer> e : getEntries(c)) {
+            final String key = e.getKey();
+            final Integer newVal = initialMap.get(key) + 100;
+            c.getAndPut(key, newVal);
+        }
+
+        assertJournalSize(c, count * 2);
+
+        final HashMap<String, Integer> updatedFrom = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> updatedTo = new HashMap<String, Integer>(count);
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case UPDATED:
+                    updatedFrom.put(e.getKey(), e.getOldValue());
+                    updatedTo.put(e.getKey(), e.getNewValue());
+                    break;
+            }
+        }
+
+        assertEquals(initialMap, updatedFrom);
+        assertEquals(getEntries(c), updatedTo.entrySet());
+    }
+
+    @Test
+    public void testPredicates() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        final int count = 50;
+        assertJournalSize(c, 0);
+
+        for (int i = 0; i < count; i++) {
+            c.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(c, count);
+
+        final HashMap<String, Integer> evenMap = new HashMap<String, Integer>();
+        final HashMap<String, Integer> oddMap = new HashMap<String, Integer>();
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, new NewValueParityPredicate(0), IDENTITY_PROJECTION)) {
+            assertEquals(CacheEventType.CREATED, e.getType());
+            evenMap.put(e.getKey(), e.getNewValue());
+        }
+
+        for (EventJournalCacheEvent<String, Integer> e : getAllEvents(c, new NewValueParityPredicate(1), IDENTITY_PROJECTION)) {
+            assertEquals(CacheEventType.CREATED, e.getType());
+            oddMap.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(count / 2, evenMap.size());
+        assertEquals(count / 2, oddMap.size());
+
+        for (Entry<String, Integer> e : evenMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 0);
+            assertEquals(c.get(e.getKey()), v);
+        }
+        for (Entry<String, Integer> e : oddMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 1);
+            assertEquals(c.get(e.getKey()), v);
+        }
+    }
+
+    @Test
+    public void testProjection() throws Exception {
+        final ICache<String, Integer> c = getCache();
+        final int count = 50;
+        assertJournalSize(c, 0);
+        for (int i = 0; i < count; i++) {
+            c.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(c, count);
+
+
+        final ReadResultSet<Integer> resultSet = getAllEvents(c, TRUE_PREDICATE, new NewValueIncrementingProjection(100));
+        final ArrayList<Integer> ints = new ArrayList<Integer>(count);
+        for (Integer i : resultSet) {
+            ints.add(i);
+        }
+
+        assertEquals(count, ints.size());
+        for (Entry<String, Integer> e : getEntries(c)) {
+            assertTrue(ints.contains(e.getValue() + 100));
+        }
+    }
+
+    private <K, V> Set<Map.Entry<K, V>> getEntries(ICache<K, V> cache) {
+        final Iterator<Cache.Entry<K, V>> it = cache.iterator();
+        final HashSet<Entry<K, V>> entries = new HashSet<Map.Entry<K, V>>(cache.size());
+        while (it.hasNext()) {
+            final Cache.Entry<K, V> e = it.next();
+            entries.add(new SimpleImmutableEntry<K, V>(e.getKey(), e.getValue()));
+        }
+        return entries;
+    }
+
+    public static class NewValueParityPredicate implements Predicate<EventJournalCacheEvent<String, Integer>>, Serializable {
+        private final int remainder;
+
+        NewValueParityPredicate(int remainder) {
+            this.remainder = remainder;
+        }
+
+        @Override
+        public boolean test(EventJournalCacheEvent<String, Integer> e) {
+            return e.getNewValue() % 2 == remainder;
+        }
+    }
+
+    private static class NewValueIncrementingProjection extends Projection<EventJournalCacheEvent<String, Integer>, Integer> {
+        private final int delta;
+
+        NewValueIncrementingProjection(int delta) {
+            this.delta = delta;
+        }
+
+        @Override
+        public Integer transform(EventJournalCacheEvent<String, Integer> input) {
+            return input.getNewValue() + delta;
+        }
+    }
+
+    private <T> ReadResultSet<T> getAllEvents(ICache<String, Integer> c,
+                                              Predicate<? super EventJournalCacheEvent<String, Integer>> predicate,
+                                              Projection<? super EventJournalCacheEvent<String, Integer>, T> projection) throws Exception {
+        final EventJournalInitialSubscriberState state = subscribeToEventJournal(c, partitionId);
+        return readFromEventJournal(
+                c, state.getOldestSequence(), (int) (state.getNewestSequence() - state.getOldestSequence() + 1),
+                partitionId, predicate, projection).get();
+    }
+
+    private static class TruePredicate<T> implements Predicate<T>, Serializable {
+        @Override
+        public boolean test(T t) {
+            return true;
+        }
+    }
+
+    private static class IdentityProjection<I> extends Projection<I, I> implements Serializable {
+        @Override
+        public I transform(I input) {
+            return input;
+        }
+    }
+
+    private String randomPartitionKey() {
+        return generateKeyForPartition(instances[0], partitionId);
+    }
+
+    private void assertJournalSize(ICache<?, ?> cache, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(cache.getServiceName(), cache.getPrefixedName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, ICache<?, ?> cache, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(cache.getServiceName(), cache.getName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, ObjectNamespace namespace, int size) {
+        HazelcastInstance partitionOwner = null;
+        for (HazelcastInstance instance : instances) {
+            if (getNode(instance).partitionService.getPartition(partitionId).isLocal()) {
+                partitionOwner = instance;
+                break;
+            }
+        }
+
+        final NodeEngineImpl nodeEngine = getNode(partitionOwner).nodeEngine;
+        final RingbufferService rbService = nodeEngine.getService(RingbufferService.SERVICE_NAME);
+        final ConcurrentMap<Integer, Map<ObjectNamespace, RingbufferContainer>> containers = rbService.getContainers();
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (size == 0 && partitionContainers == null) {
+            return;
+        }
+        assertNotNull(partitionContainers);
+        final RingbufferContainer container = partitionContainers.get(namespace);
+        if (size == 0 && container == null) {
+            return;
+        }
+        assertNotNull(container);
+        assertEquals(size, container.size());
+    }
+
+    private <K, V> ICache<K, V> getCache() {
+        return getCache("cache");
+    }
+
+    protected <K, V> ICache<K, V> getCache(String cacheName) {
+        return (ICache<K, V>) cacheManager.getCache(cacheName);
+    }
+
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(Cache<K, V> cache, int partitionId) throws Exception {
+        return ((CacheProxy<K, V>) cache).subscribeToEventJournal(partitionId).get();
+    }
+
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            Cache<K, V> cache,
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+            Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        return ((CacheProxy<K, V>) cache).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+    private static <T> TruePredicate<T> truePredicate() {
+        return new TruePredicate<T>();
+    }
+
+    private static <T> IdentityProjection<T> identityProjection() {
+        return new IdentityProjection<T>();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -81,6 +81,8 @@ class ConfigCompatibilityChecker {
         checkCompatibleConfigs("executor", c1, c2, c1.getExecutorConfigs(), c2.getExecutorConfigs(), new ExecutorConfigChecker());
         checkCompatibleConfigs("durable executor", c1, c2, c1.getDurableExecutorConfigs(), c2.getDurableExecutorConfigs(), new DurableExecutorConfigChecker());
         checkCompatibleConfigs("scheduled executor", c1, c2, c1.getScheduledExecutorConfigs(), c2.getScheduledExecutorConfigs(), new ScheduledExecutorConfigChecker());
+        checkCompatibleConfigs("map event journal", c1, c2, c1.getMapEventJournalConfigs(), c2.getMapEventJournalConfigs(), new MapEventJournalConfigChecker());
+        checkCompatibleConfigs("cache event journal", c1, c2, c1.getCacheEventJournalConfigs(), c2.getCacheEventJournalConfigs(), new CacheEventJournalConfigChecker());
         checkCompatibleConfigs("multimap", c1, c2, c1.getMultiMapConfigs(), c2.getMultiMapConfigs(), new MultimapConfigChecker());
         checkCompatibleConfigs("list", c1, c2, c1.getListConfigs(), c2.getListConfigs(), new ListConfigChecker());
         checkCompatibleConfigs("set", c1, c2, c1.getSetConfigs(), c2.getSetConfigs(), new SetConfigChecker());
@@ -203,6 +205,34 @@ class ConfigCompatibilityChecker {
         @Override
         RingbufferConfig getDefault(Config c) {
             return c.getRingbufferConfig("default");
+        }
+    }
+
+    public static class EventJournalConfigChecker extends ConfigChecker<EventJournalConfig> {
+        @Override
+        boolean check(EventJournalConfig c1, EventJournalConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getMapName(), c2.getMapName())
+                            && nullSafeEqual(c1.getCacheName(), c2.getCacheName())
+                            && nullSafeEqual(c1.getCapacity(), c2.getCapacity())
+                            && nullSafeEqual(c1.getTimeToLiveSeconds(), c2.getTimeToLiveSeconds()));
+        }
+    }
+
+    public static class MapEventJournalConfigChecker extends EventJournalConfigChecker {
+        @Override
+        EventJournalConfig getDefault(Config c) {
+            return c.getMapEventJournalConfig("default");
+        }
+    }
+
+    public static class CacheEventJournalConfigChecker extends EventJournalConfigChecker {
+        @Override
+        EventJournalConfig getDefault(Config c) {
+            return c.getCacheEventJournalConfig("default");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.ConfigCompatibilityChecker.EventJournalConfigChecker;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -238,6 +239,38 @@ public class ConfigXmlGeneratorTest {
         final Config xmlConfig = getNewConfigViaXMLGenerator(config);
 
         ConfigCompatibilityChecker.checkWanConfigs(config.getWanReplicationConfigs(), xmlConfig.getWanReplicationConfigs());
+    }
+
+    @Test
+    public void testMapEventJournal() {
+        final String mapName = "mapName";
+        final EventJournalConfig journalConfig = new EventJournalConfig()
+                .setMapName(mapName)
+                .setEnabled(true)
+                .setCapacity(123)
+                .setTimeToLiveSeconds(321);
+        final Config config = new Config().addEventJournalConfig(journalConfig);
+        final Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        assertTrue(new EventJournalConfigChecker().check(
+                journalConfig,
+                xmlConfig.getMapEventJournalConfig(mapName)));
+    }
+
+    @Test
+    public void testCacheEventJournal() {
+        final String cacheName = "cacheName";
+        final EventJournalConfig journalConfig = new EventJournalConfig()
+                .setCacheName(cacheName)
+                .setEnabled(true)
+                .setCapacity(123)
+                .setTimeToLiveSeconds(321);
+        final Config config = new Config().addEventJournalConfig(journalConfig);
+        final Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        assertTrue(new EventJournalConfigChecker().check(
+                journalConfig,
+                xmlConfig.getCacheEventJournalConfig(cacheName)));
     }
 
     private DiscoveryConfig getDummyDiscoveryConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -944,6 +944,44 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
     }
 
+    @Test
+    public void testMapEventJournalConfig() {
+        final String journalName = "mapName";
+        final String xml = HAZELCAST_START_TAG
+                + "  <event-journal enabled=\"true\">\n" +
+                "        <mapName>" + journalName + "</mapName>\n" +
+                "        <capacity>120</capacity>\n" +
+                "        <time-to-live-seconds>20</time-to-live-seconds>\n" +
+                "    </event-journal>"
+                + HAZELCAST_END_TAG;
+
+        final Config config = buildConfig(xml);
+        final EventJournalConfig journalConfig = config.getMapEventJournalConfig(journalName);
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(120, journalConfig.getCapacity());
+        assertEquals(20, journalConfig.getTimeToLiveSeconds());
+    }
+
+    @Test
+    public void testCacheEventJournalConfig() {
+        final String journalName = "cacheName";
+        final String xml = HAZELCAST_START_TAG
+                + "  <event-journal enabled=\"true\">\n" +
+                "        <cacheName>" + journalName + "</cacheName>\n" +
+                "        <capacity>120</capacity>\n" +
+                "        <time-to-live-seconds>20</time-to-live-seconds>\n" +
+                "    </event-journal>"
+                + HAZELCAST_END_TAG;
+
+        final Config config = buildConfig(xml);
+        final EventJournalConfig journalConfig = config.getCacheEventJournalConfig(journalName);
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(120, journalConfig.getCapacity());
+        assertEquals(20, journalConfig.getTimeToLiveSeconds());
+    }
+
     @Test(expected = InvalidConfigurationException.class)
     public void testParseExceptionIsNotSwallowed() {
         String invalidXml = HAZELCAST_START_TAG + "</hazelcast";

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.ringbuffer.impl.RingbufferContainer;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.function.BiConsumer;
+import com.hazelcast.util.function.Predicate;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BasicMapJournalTest extends HazelcastTestSupport {
+    protected HazelcastInstance[] instances;
+    private static final Random RANDOM = new Random();
+    private static final TruePredicate<EventJournalMapEvent<String, Integer>> TRUE_PREDICATE = truePredicate();
+    private static final IdentityProjection<EventJournalMapEvent<String, Integer>> IDENTITY_PROJECTION = identityProjection();
+    private int partitionId;
+
+    @Before
+    public void init() {
+        instances = createInstances();
+        partitionId = 1;
+        warmUpPartitions(instances);
+    }
+
+    protected HazelcastInstance getRandomInstance() {
+        return instances[RANDOM.nextInt(instances.length)];
+    }
+
+    protected HazelcastInstance[] createInstances() {
+        return createHazelcastInstanceFactory(2).newInstances(getConfig());
+    }
+
+    protected <K, V> IMap<K, V> getMap(String mapName) {
+        return getRandomInstance().getMap(mapName);
+    }
+
+    protected <K, V> EventJournalInitialSubscriberState subscribeToEventJournal(IMap<K, V> map, int partitionId) throws Exception {
+        return ((MapProxyImpl<K, V>) map).subscribeToEventJournal(partitionId).get();
+    }
+
+    protected <K, V, T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            IMap<K, V> map,
+            long startSequence,
+            int maxSize,
+            int partitionId,
+            Predicate<? super EventJournalMapEvent<K, V>> predicate,
+            Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        return ((MapProxyImpl<K, V>) map).readFromEventJournal(startSequence, maxSize, partitionId, predicate, projection);
+    }
+
+
+    @Override
+    protected Config getConfig() {
+        final Config config = super.getConfig();
+        config.addEventJournalConfig(new EventJournalConfig().setMapName("default").setEnabled(true));
+
+        final MapConfig mapConfig = new MapConfig("mappy");
+        final MapConfig expiringMap = new MapConfig("expiring").setTimeToLiveSeconds(1);
+        return config.addMapConfig(mapConfig).addMapConfig(expiringMap);
+    }
+
+    @Test
+    public void unparkReadOperation() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        assertJournalSize(m, 0);
+
+        final String key = randomPartitionKey();
+        final Integer value = RANDOM.nextInt();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        readFromEventJournal(m, 0, 100, partitionId, TRUE_PREDICATE, IDENTITY_PROJECTION)
+                .andThen(new ExecutionCallback<ReadResultSet<EventJournalMapEvent<String, Integer>>>() {
+                    @Override
+                    public void onResponse(ReadResultSet<EventJournalMapEvent<String, Integer>> response) {
+                        assertEquals(1, response.size());
+                        final EventJournalMapEvent<String, Integer> e = response.get(0);
+
+                        assertEquals(EntryEventType.ADDED, e.getType());
+                        assertEquals(e.getKey(), key);
+                        assertEquals(e.getNewValue(), value);
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        t.printStackTrace();
+                    }
+                });
+
+        m.put(key, value);
+        latch.await();
+        assertJournalSize(m, 1);
+    }
+
+    @Test
+    public void receiveAddedEventsWhenPut() throws Exception {
+        final IMap<String, Integer> m = getMap();
+
+        final int count = 100;
+        assertJournalSize(m, 0);
+
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+
+        assertJournalSize(m, count);
+        final ReadResultSet<EventJournalMapEvent<String, Integer>> events = getAllEvents(m, null, null);
+        assertEquals(count, events.size());
+
+        final HashMap<String, Integer> received = new HashMap<String, Integer>();
+        for (EventJournalMapEvent<String, Integer> e : events) {
+            assertEquals(EntryEventType.ADDED, e.getType());
+            assertNull(e.getOldValue());
+            received.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(m.entrySet(), received.entrySet());
+    }
+
+    @Test
+    public void receiveExpirationEventsWhenPutWithTtl() throws Exception {
+        final String mapName = "mappy";
+        final IMap<String, Integer> m = getMap(mapName);
+        testExpiration(mapName, new BiConsumer<String, Integer>() {
+            @Override
+            public void accept(String k, Integer i) {
+                m.put(k, i, 1, TimeUnit.SECONDS);
+            }
+        });
+    }
+
+    @Test
+    public void receiveExpirationEventsWhenPutOnExpiringMap() throws Exception {
+        final String mapName = "expiring";
+        final IMap<String, Integer> m = getMap(mapName);
+        testExpiration(mapName, new BiConsumer<String, Integer>() {
+            @Override
+            public void accept(String k, Integer i) {
+                m.put(k, i);
+            }
+        });
+    }
+
+    @Test
+    public void receiveRemoveEventsWhenRemove() throws Exception {
+        final IMap<String, Integer> m = getMap();
+
+        final int count = 100;
+        assertJournalSize(m, 0);
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(m, count);
+
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(m);
+        for (String key : m.keySet()) {
+            m.remove(key);
+        }
+
+        final HashMap<String, Integer> added = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> removed = new HashMap<String, Integer>(count);
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case ADDED:
+                    added.put(e.getKey(), e.getNewValue());
+                    break;
+                case REMOVED:
+                    removed.put(e.getKey(), e.getOldValue());
+                    break;
+            }
+        }
+
+
+        assertEquals(0, m.size());
+        assertJournalSize(m, count * 2);
+        assertEquals(initialMap, added);
+        assertEquals(initialMap, removed);
+    }
+
+    @Test
+    public void receiveUpdateEventsOnMapPut() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        final int count = 100;
+        assertJournalSize(m, 0);
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        final HashMap<String, Integer> initialMap = new HashMap<String, Integer>(m);
+        assertJournalSize(m, count);
+
+        for (String key : m.keySet()) {
+            final Integer newVal = initialMap.get(key) + 100;
+            m.put(key, newVal);
+        }
+        assertJournalSize(m, count * 2);
+
+        final HashMap<String, Integer> updatedFrom = new HashMap<String, Integer>(count);
+        final HashMap<String, Integer> updatedTo = new HashMap<String, Integer>(count);
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, TRUE_PREDICATE, IDENTITY_PROJECTION)) {
+            switch (e.getType()) {
+                case UPDATED:
+                    updatedFrom.put(e.getKey(), e.getOldValue());
+                    updatedTo.put(e.getKey(), e.getNewValue());
+                    break;
+            }
+        }
+
+        assertEquals(initialMap, updatedFrom);
+        assertEquals(m.entrySet(), updatedTo.entrySet());
+    }
+
+    @Test
+    public void testPredicates() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        final int count = 50;
+        assertJournalSize(m, 0);
+
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(m, count);
+
+        final HashMap<String, Integer> evenMap = new HashMap<String, Integer>();
+        final HashMap<String, Integer> oddMap = new HashMap<String, Integer>();
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, new NewValueParityPredicate(0), IDENTITY_PROJECTION)) {
+            assertEquals(EntryEventType.ADDED, e.getType());
+            evenMap.put(e.getKey(), e.getNewValue());
+        }
+
+        for (EventJournalMapEvent<String, Integer> e : getAllEvents(m, new NewValueParityPredicate(1), IDENTITY_PROJECTION)) {
+            assertEquals(EntryEventType.ADDED, e.getType());
+            oddMap.put(e.getKey(), e.getNewValue());
+        }
+
+        assertEquals(count / 2, evenMap.size());
+        assertEquals(count / 2, oddMap.size());
+
+        for (Entry<String, Integer> e : evenMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 0);
+            assertEquals(m.get(e.getKey()), v);
+        }
+        for (Entry<String, Integer> e : oddMap.entrySet()) {
+            final Integer v = e.getValue();
+            assertTrue(v % 2 == 1);
+            assertEquals(m.get(e.getKey()), v);
+        }
+    }
+
+    @Test
+    public void testProjection() throws Exception {
+        final IMap<String, Integer> m = getMap();
+        final int count = 50;
+        assertJournalSize(m, 0);
+        for (int i = 0; i < count; i++) {
+            m.put(randomPartitionKey(), i);
+        }
+        assertJournalSize(m, count);
+
+
+        final ReadResultSet<Integer> ints = getAllEvents(m, TRUE_PREDICATE, new NewValueIncrementingProjection(100));
+        assertEquals(count, ints.size());
+        final Collection<Integer> values = m.values();
+        for (Integer v : ints) {
+            assertTrue(values.contains(v - 100));
+        }
+    }
+
+    private static class NewValueIncrementingProjection extends Projection<EventJournalMapEvent<String, Integer>, Integer> {
+        private final int delta;
+
+        NewValueIncrementingProjection(int delta) {
+            this.delta = delta;
+        }
+
+        @Override
+        public Integer transform(EventJournalMapEvent<String, Integer> input) {
+            return input.getNewValue() + delta;
+        }
+    }
+
+    public static class NewValueParityPredicate implements Predicate<EventJournalMapEvent<String, Integer>>, Serializable {
+        private final int remainder;
+
+        NewValueParityPredicate(int remainder) {
+            this.remainder = remainder;
+        }
+
+        @Override
+        public boolean test(EventJournalMapEvent<String, Integer> e) {
+            return e.getNewValue() % 2 == remainder;
+        }
+    }
+
+    private void testExpiration(String mapName, BiConsumer<String, Integer> mutationFn) throws Exception {
+        final IMap<String, Integer> m = getMap(mapName);
+        final int count = 2;
+        assertJournalSize(m, 0);
+
+        for (int i = 0; i < count; i++) {
+            final String k = randomPartitionKey();
+            mutationFn.accept(k, i);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertJournalSize(partitionId, m, count * 2);
+                final ReadResultSet<EventJournalMapEvent<String, Integer>> set = getAllEvents(m, null, null);
+                assertEquals(count * 2, set.size());
+                final HashMap<String, Integer> added = new HashMap<String, Integer>();
+                final HashMap<String, Integer> evicted = new HashMap<String, Integer>();
+                for (EventJournalMapEvent<String, Integer> e : set) {
+                    if (EntryEventType.ADDED.equals(e.getType())) {
+                        added.put(e.getKey(), e.getNewValue());
+                    } else if (EntryEventType.EVICTED.equals(e.getType())) {
+                        evicted.put(e.getKey(), e.getOldValue());
+                    }
+                }
+                assertEquals(added, evicted);
+            }
+        });
+    }
+
+    private <T> ReadResultSet<T> getAllEvents(IMap<String, Integer> m,
+                                              Predicate<? super EventJournalMapEvent<String, Integer>> predicate,
+                                              Projection<? super EventJournalMapEvent<String, Integer>, T> projection) throws Exception {
+        final EventJournalInitialSubscriberState state = subscribeToEventJournal(m, partitionId);
+        return readFromEventJournal(
+                m, state.getOldestSequence(), (int) (state.getNewestSequence() - state.getOldestSequence() + 1),
+                partitionId, predicate, projection).get();
+    }
+
+
+    private static class TruePredicate<T> implements Predicate<T>, Serializable {
+        @Override
+        public boolean test(T t) {
+            return true;
+        }
+    }
+
+    private static class IdentityProjection<I> extends Projection<I, I> implements Serializable {
+        @Override
+        public I transform(I input) {
+            return input;
+        }
+    }
+
+    private String randomPartitionKey() {
+        return generateKeyForPartition(instances[0], partitionId);
+    }
+
+    private void assertJournalSize(DistributedObject object, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(object.getServiceName(), object.getName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, DistributedObject object, int size) {
+        assertJournalSize(partitionId, new DistributedObjectNamespace(object.getServiceName(), object.getName()), size);
+    }
+
+    private void assertJournalSize(int partitionId, ObjectNamespace namespace, int size) {
+        HazelcastInstance partitionOwner = null;
+        for (HazelcastInstance instance : instances) {
+            if (getNode(instance).partitionService.getPartition(partitionId).isLocal()) {
+                partitionOwner = instance;
+                break;
+            }
+        }
+
+        final Node node = getNode(partitionOwner);
+        final NodeEngineImpl nodeEngine = node.nodeEngine;
+        final RingbufferService rbService = nodeEngine.getService(RingbufferService.SERVICE_NAME);
+        final ConcurrentMap<Integer, Map<ObjectNamespace, RingbufferContainer>> containers = rbService.getContainers();
+        final Map<ObjectNamespace, RingbufferContainer> partitionContainers = containers.get(partitionId);
+        if (size == 0 && partitionContainers == null) {
+            return;
+        }
+        assertNotNull(partitionContainers);
+        final RingbufferContainer container = partitionContainers.get(namespace);
+        if (size == 0 && container == null) {
+            return;
+        }
+        assertNotNull(container);
+        assertEquals(size, container.size());
+    }
+
+    private <K, V> IMap<K, V> getMap() {
+        return getMap("mappy");
+    }
+
+    private static <T> TruePredicate<T> truePredicate() {
+        return new TruePredicate<T>();
+    }
+
+    private static <T> IdentityProjection<T> identityProjection() {
+        return new IdentityProjection<T>();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.test.TestEnvironment;
 
@@ -115,6 +116,21 @@ public class SamplingSerializationService implements InternalSerializationServic
         byte[] bytes =  delegate.toBytes(obj, leftPadding, insertPartitionHash);
         sampleObject(obj, bytes);
         return bytes;
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type) {
+        return toData(obj);
+    }
+
+    @Override
+    public <B extends Data> B toData(Object obj, DataType type, PartitioningStrategy strategy) {
+        return toData(obj, strategy);
+    }
+
+    @Override
+    public <B extends Data> B convertData(Data data, DataType type) {
+        return (B) data;
     }
 
     @Override


### PR DESCRIPTION
Add event journal for tracking mutation events on map and cache.
The events are written in a ringbuffer (event journal) and
can be read from MapProxyImpl, CacheProxy, ClientMapProxy and
ClientCacheProxy.
The reading is done by first subscribing to the stream and
then calling the read method.

Depends on:
https://github.com/hazelcast/hazelcast-client-protocol/pull/87
https://github.com/hazelcast/hazelcast-client-protocol/pull/88