### PR TITLE
Allow arguments in test constructors when they are parametrized

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
@@ -76,16 +76,16 @@ public class ClientBackpressureBouncingTest extends HazelcastTestSupport {
         });
     }
 
-    public long backoff;
-
     @Rule
     public BounceMemberRule bounceMemberRule;
 
     private InvocationCheckingThread checkingThread;
 
+    private long backoff;
+
     public ClientBackpressureBouncingTest(int backoffTimeoutMillis) {
         this.backoff = backoffTimeoutMillis;
-        bounceMemberRule = BounceMemberRule
+        this.bounceMemberRule = BounceMemberRule
                 .with(new Config())
                 .driverFactory(new MultiSocketClientDriverFactory(
                         new ClientConfig()

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
@@ -77,19 +76,23 @@ public class ClientBackpressureBouncingTest extends HazelcastTestSupport {
         });
     }
 
-    @Parameter
     public long backoff;
 
     @Rule
-    public BounceMemberRule bounceMemberRule = BounceMemberRule
-            .with(new Config())
-            .driverFactory(new MultiSocketClientDriverFactory(
-                    new ClientConfig()
-                            .setProperty(MAX_CONCURRENT_INVOCATIONS.getName(), valueOf(MAX_CONCURRENT_INVOCATION_CONFIG))
-                            .setProperty(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS.getName(), valueOf(backoff))
-            )).build();
+    public BounceMemberRule bounceMemberRule;
 
     private InvocationCheckingThread checkingThread;
+
+    public ClientBackpressureBouncingTest(int backoffTimeoutMillis) {
+        this.backoff = backoffTimeoutMillis;
+        bounceMemberRule = BounceMemberRule
+                .with(new Config())
+                .driverFactory(new MultiSocketClientDriverFactory(
+                        new ClientConfig()
+                                .setProperty(MAX_CONCURRENT_INVOCATIONS.getName(), valueOf(MAX_CONCURRENT_INVOCATION_CONFIG))
+                                .setProperty(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS.getName(), valueOf(backoff))
+                )).build();
+    }
 
     @After
     public void tearDown() {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
@@ -92,6 +92,14 @@ public abstract class AbstractParameterizedHazelcastClassRunner extends BlockJUn
         return getTestClass().getOnlyConstructor().newInstance(fParameters);
     }
 
+    @Override
+    protected void validateConstructor(List<Throwable> errors) {
+        validateOnlyOneConstructor(errors);
+        if (fieldsAreAnnotated() || !isParameterized) {
+            validateZeroArgConstructor(errors);
+        }
+    }
+
     private Object createTestUsingFieldInjection() throws Exception {
         List<FrameworkField> annotatedFieldsByParameter = getAnnotatedFieldsByParameter();
         if (annotatedFieldsByParameter.size() != fParameters.length) {


### PR DESCRIPTION
Also fixes ClientBackpressureBouncingTest

See commit messages for details. 