### PR TITLE
Fixed Near Cache preloader when Near Cache stores keys by-reference

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.map.impl.nearcache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
@@ -42,12 +43,12 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 
 @RunWith(Parameterized.class)
@@ -58,22 +59,35 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
     private final File storeFile = new File("nearCache-" + defaultNearCache + ".store").getAbsoluteFile();
     private final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
 
-    @Parameter
-    public boolean invalidationOnChange;
-
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
-    @Parameters(name = "invalidationOnChange:{0}")
+    @Parameters(name = "format:{0} invalidationOnChange:{1} serializeKeys:{2}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
-                {false},
-                {true},
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, false, true},
+                {InMemoryFormat.BINARY, false, false},
+                {InMemoryFormat.BINARY, true, true},
+                {InMemoryFormat.BINARY, true, false},
+
+                {InMemoryFormat.OBJECT, false, true},
+                {InMemoryFormat.OBJECT, false, false},
+                {InMemoryFormat.OBJECT, true, true},
+                {InMemoryFormat.OBJECT, true, false},
         });
     }
 
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean invalidationOnChange;
+
+    @Parameter(value = 2)
+    public boolean serializeKeys;
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
     @Before
     public void setUp() {
-        nearCacheConfig = getNearCacheConfig(invalidationOnChange, KEY_COUNT, storeFile.getParent());
+        nearCacheConfig = getNearCacheConfig(inMemoryFormat, serializeKeys, invalidationOnChange, KEY_COUNT,
+                storeFile.getParent());
     }
 
     @After

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.monitor.NearCacheStats;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InitializingObject;
 
 /**
@@ -138,7 +137,7 @@ public interface NearCache<K, V> extends InitializingObject {
     /**
      * Executes the Near Cache pre-loader on the given {@link DataStructureAdapter}.
      */
-    void preload(DataStructureAdapter<Data, ?> adapter);
+    void preload(DataStructureAdapter<Object, ?> adapter);
 
     /**
      * Stores the keys of the Near Cache.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.nearcache;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.nearcache.impl.invalidation.StaleReadDetector;
 import com.hazelcast.monitor.NearCacheStats;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InitializingObject;
 
 /**
@@ -115,7 +114,7 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
     /**
      * Loads the keys into the Near Cache.
      */
-    void loadKeys(DataStructureAdapter<Data, ?> adapter);
+    void loadKeys(DataStructureAdapter<Object, ?> adapter);
 
     /**
      * Persists the key set of the Near Cache.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -178,7 +178,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     }
 
     @Override
-    public void preload(DataStructureAdapter<Data, ?> adapter) {
+    public void preload(DataStructureAdapter<Object, ?> adapter) {
         nearCacheRecordStore.loadKeys(adapter);
         preloadDone = true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -53,9 +53,8 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
         super(nearCacheConfig, serializationService, classLoader);
 
         NearCachePreloaderConfig preloaderConfig = nearCacheConfig.getPreloaderConfig();
-        this.nearCachePreloader = preloaderConfig.isEnabled()
-                ? new NearCachePreloader<K>(name, preloaderConfig, nearCacheStats, serializationService)
-                : null;
+        this.nearCachePreloader = preloaderConfig.isEnabled() ? new NearCachePreloader<K>(name, preloaderConfig, nearCacheStats,
+                serializationService, nearCacheConfig.isSerializeKeys()) : null;
     }
 
     @Override
@@ -121,7 +120,7 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     }
 
     @Override
-    public void loadKeys(DataStructureAdapter<Data, ?> adapter) {
+    public void loadKeys(DataStructureAdapter<Object, ?> adapter) {
         if (nearCachePreloader != null) {
             nearCachePreloader.loadKeys(adapter);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -34,8 +34,14 @@ import org.junit.rules.ExpectedException;
 
 import java.io.File;
 
+import static com.hazelcast.internal.nearcache.AbstractNearCachePreloaderTest.KeyType.INTEGER;
+import static com.hazelcast.internal.nearcache.AbstractNearCachePreloaderTest.KeyType.STRING;
+import static com.hazelcast.internal.nearcache.NearCacheRecord.READ_PERMITTED;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getNearCacheKey;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getRecordFromNearCache;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getValueFromNearCache;
 import static com.hazelcast.nio.IOUtil.deleteQuietly;
 import static com.hazelcast.nio.IOUtil.getFileFromResources;
 import static java.lang.String.format;
@@ -62,7 +68,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    protected static final int TEST_TIMEOUT = 120000;
+    protected static final int TEST_TIMEOUT = 300000;
     protected static final int KEY_COUNT = 10023;
 
     protected final String defaultNearCache = randomName();
@@ -121,31 +127,18 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     @Test(timeout = TEST_TIMEOUT)
     @Category(SlowTest.class)
-    public void testStoreAndLoad_withIntegerKeys_withInMemoryFormatBinary() {
-        storeAndLoad(2342, KeyType.INTEGER, InMemoryFormat.BINARY);
+    public void testStoreAndLoad_withIntegerKeys() {
+        storeAndLoad(2342, INTEGER);
     }
 
     @Test(timeout = TEST_TIMEOUT)
     @Category(SlowTest.class)
-    public void testStoreAndLoad_withIntegerKeys_withInMemoryFormatObject() {
-        storeAndLoad(2342, KeyType.INTEGER, InMemoryFormat.OBJECT);
-    }
-
-    @Test(timeout = TEST_TIMEOUT)
-    @Category(SlowTest.class)
-    public void testStoreAndLoad_withStringKeys_withInMemoryFormatBinary() {
-        storeAndLoad(4223, KeyType.STRING, InMemoryFormat.BINARY);
-    }
-
-    @Test(timeout = TEST_TIMEOUT)
-    @Category(SlowTest.class)
-    public void testStoreAndLoad_withStringKeys_withInMemoryFormatObject() {
-        storeAndLoad(4223, KeyType.STRING, InMemoryFormat.OBJECT);
+    public void testStoreAndLoad_withStringKeys() {
+        storeAndLoad(4223, STRING);
     }
 
     @SuppressWarnings("WeakerAccess")
-    protected void storeAndLoad(int keyCount, KeyType keyType, InMemoryFormat inMemoryFormat) {
-        nearCacheConfig.setInMemoryFormat(inMemoryFormat);
+    protected void storeAndLoad(int keyCount, KeyType keyType) {
         nearCacheConfig.getPreloaderConfig()
                 .setStoreInitialDelaySeconds(3)
                 .setStoreIntervalSeconds(1);
@@ -165,6 +158,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
         // wait until the pre-loading is done, then check for the Near Cache size
         assertNearCachePreloadDoneEventually(clientContext);
         assertNearCacheSizeEventually(clientContext, keyCount);
+        assertNearCacheContent(clientContext, keyCount, keyType);
     }
 
     @Test(timeout = TEST_TIMEOUT)
@@ -186,19 +180,19 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
     @Test(timeout = TEST_TIMEOUT)
     @Category(SlowTest.class)
     public void testCreateStoreFile_withStringKey() {
-        createStoreFile(KEY_COUNT, KeyType.STRING);
+        createStoreFile(KEY_COUNT, STRING);
     }
 
     @Test(timeout = TEST_TIMEOUT)
     @Category(SlowTest.class)
     public void testCreateStoreFile_withIntegerKey() {
-        createStoreFile(KEY_COUNT, KeyType.INTEGER);
+        createStoreFile(KEY_COUNT, INTEGER);
     }
 
     @Test(timeout = TEST_TIMEOUT)
     @Category(SlowTest.class)
     public void testCreateStoreFile_withEmptyNearCache() {
-        createStoreFile(0, KeyType.INTEGER);
+        createStoreFile(0, INTEGER);
     }
 
     private void createStoreFile(int keyCount, KeyType keyType) {
@@ -224,7 +218,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
         NearCacheTestContext<Object, String, NK, NV> context = createContext(true);
 
         // assure that the pre-loader is working on the first client
-        populateNearCache(context, KEY_COUNT, KeyType.INTEGER);
+        populateNearCache(context, KEY_COUNT, INTEGER);
         waitForNearCachePersistence(context, 3);
         assertLastNearCachePersistence(context, getStoreFile(), KEY_COUNT);
 
@@ -236,35 +230,35 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
     @Test
     public void testPreloadNearCache_withIntegerKeys() {
-        preloadNearCache(preloadDir10kInt, 10000, false);
+        preloadNearCache(preloadDir10kInt, 10000, INTEGER);
     }
 
     @Test
     public void testPreloadNearCache_withStringKeys() {
-        preloadNearCache(preloadDir10kString, 10000, true);
+        preloadNearCache(preloadDir10kString, 10000, STRING);
     }
 
     @Test
     public void testPreloadNearCache_withEmptyFile() {
-        preloadNearCache(preloadDirEmpty, 0, false);
+        preloadNearCache(preloadDirEmpty, 0, INTEGER);
     }
 
     @Test
     public void testPreloadNearCache_withInvalidMagicBytes() {
-        preloadNearCache(preloadDirInvalidMagicBytes, 0, false);
+        preloadNearCache(preloadDirInvalidMagicBytes, 0, INTEGER);
     }
 
     @Test
     public void testPreloadNearCache_withInvalidFileFormat() {
-        preloadNearCache(preloadDirInvalidFileFormat, 0, false);
+        preloadNearCache(preloadDirInvalidFileFormat, 0, INTEGER);
     }
 
     @Test
     public void testPreloadNearCache_withNegativeFileFormat() {
-        preloadNearCache(preloadDirNegativeFileFormat, 0, false);
+        preloadNearCache(preloadDirNegativeFileFormat, 0, INTEGER);
     }
 
-    private void preloadNearCache(File preloaderDir, int keyCount, boolean useStringKey) {
+    private void preloadNearCache(File preloaderDir, int keyCount, KeyType keyType) {
         nearCacheConfig
                 .setName("defaultNearCache")
                 .getPreloaderConfig().setDirectory(preloaderDir.getAbsolutePath());
@@ -272,7 +266,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
         // populate the member side data structure, so we have the values to populate the client side Near Cache
         for (int i = 0; i < keyCount; i++) {
-            Object key = useStringKey ? "key-" + i : i;
+            Object key = createKey(keyType, i);
             context.dataAdapter.put(key, "value-" + i);
         }
 
@@ -282,9 +276,11 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
         // wait until the pre-loading is done, then check for the Near Cache size
         assertNearCachePreloadDoneEventually(clientContext);
         assertNearCacheSizeEventually(clientContext, keyCount);
+        assertNearCacheContent(clientContext, keyCount, keyType);
     }
 
-    protected NearCacheConfig getNearCacheConfig(boolean invalidationOnChange, int maxSize, String preloaderDir) {
+    protected NearCacheConfig getNearCacheConfig(InMemoryFormat inMemoryFormat, boolean serializeKeys,
+                                                 boolean invalidationOnChange, int maxSize, String preloaderDir) {
         EvictionConfig evictionConfig = new EvictionConfig()
                 .setMaximumSizePolicy(MaxSizePolicy.ENTRY_COUNT)
                 .setSize(maxSize)
@@ -292,6 +288,8 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
         NearCacheConfig nearCacheConfig = createNearCacheConfig(InMemoryFormat.BINARY, true)
                 .setName(defaultNearCache)
+                .setInMemoryFormat(inMemoryFormat)
+                .setSerializeKeys(serializeKeys)
                 .setInvalidateOnChange(invalidationOnChange)
                 .setEvictionConfig(evictionConfig);
 
@@ -358,5 +356,21 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
                 assertTrue(clientContext.nearCache.isPreloadDone());
             }
         });
+    }
+
+    private static void assertNearCacheContent(NearCacheTestContext<?, ?, ?, ?> context, int keyCount, KeyType keyType) {
+        for (int i = 0; i < keyCount; i++) {
+            Object key = createKey(keyType, i);
+            Object nearCacheKey = getNearCacheKey(context, key);
+
+            String value = context.serializationService.toObject(getValueFromNearCache(context, nearCacheKey));
+            assertEquals("value-" + i, value);
+
+            NearCacheRecord record = getRecordFromNearCache(context, nearCacheKey);
+            if (record != null) {
+                assertEquals(format("The NearCacheRecord for key %d should be READ_PERMITTED (%s)", i, record),
+                        READ_PERMITTED, record.getRecordState());
+            }
+        }
     }
 }


### PR DESCRIPTION
* added optional de-serialization of Near Cache keys in preloader
* added tests for Near Cache content in `AbstractNearCachePreloaderTest`
* added serializeKeys configuration to `AbstractNearCachePreloaderTest`
* added in-memory-format configuration to `AbstractNearCachePreloaderTest`
