### PR TITLE
Test testNoOperationTimeoutException_whenUserCodeLongRunning may sometime fail - issue #10400

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -336,14 +336,16 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
 
 
     @Test
+    @Category(NightlyTest.class)
     public void testNoOperationTimeoutException_whenUserCodeLongRunning() {
         Config config = getConfig();
-        config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "2000");
+        long callTimeoutMillis = SECONDS.toMillis(10);
+        config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), String.valueOf(callTimeoutMillis));
         hazelcastFactory.newHazelcastInstance(config);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Object, Object> map = client.getMap(randomMapName());
-        SleepyProcessor sleepyProcessor = new SleepyProcessor(SECONDS.toMillis(10));
+        SleepyProcessor sleepyProcessor = new SleepyProcessor(2 * callTimeoutMillis);
         String key = randomString();
         String value = randomString();
         map.put(key, value);


### PR DESCRIPTION
Increased the insufficient timeout time for the call timeout in the testNoOperationTimeoutException_whenUserCodeLongRunning test and marked the test as a NightlyTest. Assuming that 10 seconds will hopefully be enough even when there is gc pause. Total test duration is 2 * 10 = 20 seconds.

Fixes issue https://github.com/hazelcast/hazelcast/issues/10400