### PR TITLE
Thread leak testing fixes

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -16,6 +16,8 @@
 
 package classloading;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.test.jitter.JitterThread;
 
 import java.util.Arrays;
@@ -30,6 +32,12 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 public final class ThreadLeakTestUtils {
+
+    private static final ILogger LOGGER = Logger.getLogger(ThreadLeakTestUtils.class);
+
+    static {
+        LOGGER.info("Initializing Logger (required for thread leak tests).");
+    }
 
     /**
      * List of whitelisted classes of threads, which are allowed to be not joinable.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingConnectionManager.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
@@ -39,7 +40,8 @@ public class FirewallingConnectionManager implements ConnectionManager, PacketHa
 
     private final ConnectionManager delegate;
     private final Set<Address> blockedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
-    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService scheduledExecutor
+            = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryImpl("FirewallingConnectionManager"));
     private final PacketHandler packetHandler;
 
     private volatile PacketFilter droppingPacketFilter;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -776,16 +776,16 @@ public abstract class HazelcastTestSupport {
 
     public static void assertJoinable(long timeoutSeconds, Thread... threads) {
         try {
-            long remainingTimeout = TimeUnit.SECONDS.toNanos(timeoutSeconds);
+            long remainingTimeout = TimeUnit.SECONDS.toMillis(timeoutSeconds);
             for (Thread thread : threads) {
-                long start = System.nanoTime();
+                long start = System.currentTimeMillis();
                 thread.join(remainingTimeout);
 
                 if (thread.isAlive()) {
                     fail("Timeout waiting for thread " + thread.getName() + " to terminate");
                 }
 
-                long duration = System.nanoTime() - start;
+                long duration = System.currentTimeMillis() - start;
                 remainingTimeout -= duration;
                 if (remainingTimeout <= 0) {
                     fail("Timeout waiting for thread " + thread.getName() + " to terminate");


### PR DESCRIPTION
- Fixes HazelcastTestSupport.assertJoinable, `Thread.join()` expects milliseconds timeout, not nanoseconds.  
- ThreadLeakTestUtils initializes logger factory. Log4j2 creates its own shutdown hook threads, by initializing logger initially we force them to be created beforehand. This is required to be able to detect thread leaks.
- Add explicit thread names to test connection managers

Fixes https://github.com/hazelcast/hazelcast/issues/10699
Fixes  #10655