### PR TITLE
Utility methods for cluster version conditions in distributed objects

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
@@ -30,6 +30,9 @@ public final class Versions {
      */
     public static final Version V3_9 = Version.of(3, 9);
 
+    public static final Version PREVIOUS_CLUSTER_VERSION = V3_8;
+    public static final Version CURRENT_CLUSTER_VERSION = V3_9;
+
     private Versions() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.version.Version;
 
 /**
  * Abstract DistributedObject implementation. Useful to provide basic functionality.
@@ -170,5 +171,55 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
     @Override
     public String toString() {
         return getClass().getName() + '{' + "service=" + getServiceName() + ", name=" + getName() + '}';
+    }
+
+    boolean isClusterVersionLessThan(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isLessThan(version);
+    }
+
+    boolean isClusterVersionUnknownOrLessThan(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isUnknownOrLessThan(version);
+    }
+
+    boolean isClusterVersionLessOrEqual(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isLessOrEqual(version);
+    }
+
+    boolean isClusterVersionUnknownLessOrEqual(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isUnknownLessOrEqual(version);
+    }
+
+    boolean isClusterVersionGreaterThan(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isGreaterThan(version);
+    }
+
+    boolean isClusterVersionUnknownOrGreaterThan(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isUnknownOrGreaterThan(version);
+    }
+
+    boolean isClusterVersionGreaterOrEqual(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isGreaterOrEqual(version);
+    }
+
+    boolean isClusterVersionUnknownGreaterOrEqual(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isUnknownGreaterOrEqual(version);
+    }
+
+    boolean isClusterVersionEqualTo(Version version) {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isEqualTo(version);
+    }
+
+    boolean isClusterVersionUnknown() {
+        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        return clusterVersion.isUnknown();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/AbstractDistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/AbstractDistributedObjectTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.cluster.Versions.CURRENT_CLUSTER_VERSION;
+import static com.hazelcast.internal.cluster.Versions.PREVIOUS_CLUSTER_VERSION;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractDistributedObjectTest extends HazelcastTestSupport {
+
+    private static final Version NEXT_MINOR_VERSION =
+            Version.of(CURRENT_CLUSTER_VERSION.getMajor(), CURRENT_CLUSTER_VERSION.getMinor() + 1);
+
+    private AbstractDistributedObject object;
+
+    @Before
+    public void setup() {
+        HazelcastInstance instance = createHazelcastInstance();
+        object = (AbstractDistributedObject) instance.getMap("test");
+    }
+
+    @Test
+    public void testClusterVersionIsNotUknown() {
+        assertFalse(object.isClusterVersionUnknown());
+    }
+
+    @Test
+    public void testClusterVersion_isEqualTo_currentVersion() {
+        assertTrue(object.isClusterVersionEqualTo(CURRENT_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isGreaterOrEqual_currentVersion() {
+        assertTrue(object.isClusterVersionGreaterOrEqual(CURRENT_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isUnknownGreaterOrEqual_currentVersion() {
+        assertTrue(object.isClusterVersionUnknownGreaterOrEqual(CURRENT_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isGreaterThan_previousVersion() {
+        assertTrue(object.isClusterVersionGreaterThan(PREVIOUS_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isUnknownGreaterThan_previousVersion() {
+        assertTrue(object.isClusterVersionUnknownOrGreaterThan(PREVIOUS_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isLessOrEqual_currentVersion() {
+        assertTrue(object.isClusterVersionLessOrEqual(CURRENT_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isUnknownLessOrEqual_currentVersion() {
+        assertTrue(object.isClusterVersionUnknownLessOrEqual(CURRENT_CLUSTER_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isLessThan_nextMinorVersion() {
+        assertTrue(object.isClusterVersionLessThan(NEXT_MINOR_VERSION));
+    }
+
+    @Test
+    public void testClusterVersion_isUnknownOrLessThan_nextMinorVersion() {
+        assertTrue(object.isClusterVersionUnknownOrLessThan(NEXT_MINOR_VERSION));
+    }
+
+}


### PR DESCRIPTION
Adds cluster version condition checks in `AbstractDistributedObject`, useful for gating user calls depending on current cluster version.