### PR TITLE
Switching to byte-based io balancing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java
@@ -32,8 +32,12 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 public abstract class AbstractHandler
         implements SelectionHandler, MigratableHandler {
 
+    protected static final int LOAD_BALANCING_HANDLE = 0;
+    protected static final int LOAD_BALANCING_BYTE = 1;
+    protected static final int LOAD_BALANCING_FRAME = 2;
+
     // for the time being we configure using a int until we have decided which load strategy to use.
-    protected static final int LOAD_TYPE = Integer.getInteger("io.load", 0);
+    protected static final int LOAD_TYPE = Integer.getInteger("hazelcast.io.load", LOAD_BALANCING_BYTE);
 
     @Probe(name = "handleCount")
     protected final SwCounter handleCount = newSwCounter();

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
@@ -69,11 +69,11 @@ public final class NioChannelReader extends AbstractHandler {
     @Override
     public long getLoad() {
         switch (LOAD_TYPE) {
-            case 0:
+            case LOAD_BALANCING_HANDLE:
                 return handleCount.get();
-            case 1:
+            case LOAD_BALANCING_BYTE:
                 return bytesRead.get();
-            case 2:
+            case LOAD_BALANCING_FRAME:
                 return normalFramesRead.get() + priorityFramesRead.get();
             default:
                 throw new RuntimeException();

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
@@ -89,11 +89,11 @@ public final class NioChannelWriter extends AbstractHandler implements Runnable 
     @Override
     public long getLoad() {
         switch (LOAD_TYPE) {
-            case 0:
+            case LOAD_BALANCING_HANDLE:
                 return handleCount.get();
-            case 1:
+            case LOAD_BALANCING_BYTE:
                 return bytesWritten.get() + priorityFramesWritten.get();
-            case 2:
+            case LOAD_BALANCING_FRAME:
                 return normalFramesWritten.get() + priorityFramesWritten.get();
             default:
                 throw new RuntimeException();


### PR DESCRIPTION
In the past we did it 'handle' based but under certain conditions it doesn't
provide the right input for balancing. Byte based doesn't seem to have the
drawbacks.

In most cases nothing will change.