### PR TITLE
Fixes 2 Networking diagnostics problems

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
@@ -51,10 +51,10 @@ public final class NioChannelReader extends AbstractHandler {
     private ChannelInboundHandler inboundHandler;
     private volatile long lastReadTime;
 
-    private long bytesReadLastPublish;
-    private long normalFramesReadLastPublish;
-    private long priorityFramesReadLastPublish;
-    private long handleCountLastPublish;
+    private volatile long bytesReadLastPublish;
+    private volatile long normalFramesReadLastPublish;
+    private volatile long priorityFramesReadLastPublish;
+    private volatile long handleCountLastPublish;
 
     public NioChannelReader(
             NioChannel channel,


### PR DESCRIPTION
1: the fields containing the statistics on the io threads are now volatile so they can be read
by any thread.

2: the channel wasn't stored on the channels-set; so it wasn't possible to publish the fields.