### PR TITLE
Keep broadcasting group password to support RU

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -656,7 +656,7 @@ public class Node {
 
     public ConfigCheck createConfigCheck() {
         String joinerType = joiner == null ? "" : joiner.getType();
-        return new ConfigCheck(config, joinerType);
+        return new ConfigCheck(config, joinerType, clusterService.getClusterVersion());
     }
 
     public void join() {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
@@ -20,16 +20,27 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -47,6 +58,80 @@ public class ConfigCheckTest {
         ConfigCheck configCheck2 = new ConfigCheck(config2, "joiner");
 
         assertIsCompatibleFalse(configCheck1, configCheck2);
+    }
+
+    @Test
+    public void whenGroupPasswordDifferent_thenJoin() {
+        Config config1 = new Config();
+        config1.getGroupConfig().setName("foo");
+        config1.getGroupConfig().setPassword("Here");
+
+        Config config2 = new Config();
+        config2.getGroupConfig().setName("foo");
+        config2.getGroupConfig().setPassword("There");
+
+        ConfigCheck configCheck1 = new ConfigCheck(config1, "joiner");
+        ConfigCheck configCheck2 = new ConfigCheck(config2, "joiner");
+
+        assertIsCompatibleTrue(configCheck1, configCheck2);
+    }
+
+    @Test
+    public void testGroupPasswordLeak_whenVersionUnknow()
+            throws IOException {
+        final Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig()
+               .setEnabled(true).setMulticastTimeoutSeconds(3);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
+
+        final AtomicBoolean leaked = new AtomicBoolean(false);
+
+        ObjectDataOutput odo = mock(ObjectDataOutput.class);
+
+        ConfigCheck configCheck = new ConfigCheck(config, "multicast");
+        configCheck.writeData(odo);
+
+
+        ArgumentCaptor<String> captor =  ArgumentCaptor.forClass(String.class);
+        verify(odo, times(7)).writeUTF(captor.capture());
+        List<String> values = captor.getAllValues();
+        if (values.contains(config.getGroupConfig().getPassword())) {
+            leaked.set(true);
+        }
+
+        assertEquals(true, leaked.get());
+    }
+
+    @Test
+    public void testGroupPasswordNotLeak_whenVersionAboveThreeNine() {
+        final Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig()
+              .setEnabled(true).setMulticastTimeoutSeconds(3);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
+
+        final AtomicBoolean leaked = new AtomicBoolean(false);
+
+        ObjectDataOutput odo = mock(ObjectDataOutput.class);
+
+        try {
+            ConfigCheck configCheck = new ConfigCheck(config, "multicast", Version.of(3, 9));
+            configCheck.writeData(odo);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        try {
+            ArgumentCaptor<String> captor =  ArgumentCaptor.forClass(String.class);
+            verify(odo, times(7)).writeUTF(captor.capture());
+            List<String> values = captor.getAllValues();
+            if (values.contains(config.getGroupConfig().getPassword())) {
+                leaked.set(true);
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        assertEquals("Password leaked in output stream.", false, leaked.get());
     }
 
     @Test


### PR DESCRIPTION
Relax previous feature to prevent group password leak. Original implementation here (https://github.com/hazelcast/hazelcast/pull/10376)
We now still send the password when cluster version is unknown or less than 3.9, allowing clusters to be formed between 3.8, 3.8.1 and >= 3.9 members. (>=3.8.2 were already working due to a patch)

This will eventually be removed in 4.0 altogether.
Fixing hazelcast/hazelcast-enterprise#1492