### PR TITLE
Changed serialize-keys default for Near Cache from true to false

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
@@ -364,7 +364,7 @@
     <xs:complexType name="near-cache">
         <xs:all>
             <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
-            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
             <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -136,7 +136,7 @@
         <eviction-policy>LFU</eviction-policy>
         <invalidate-on-change>true</invalidate-on-change>
         <in-memory-format>OBJECT</in-memory-format>
-        <serialize-keys>false</serialize-keys>
+        <serialize-keys>true</serialize-keys>
         <local-update-policy>INVALIDATE</local-update-policy>
     </near-cache>
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
@@ -134,7 +134,7 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
         ICache<Object, String> memberCache = member.getCacheManager().getCache(
                 CacheUtil.getPrefixedCacheName(DEFAULT_CACHE_NAME, null, null));
 
-        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(
+        NearCache<Object, String> nearCache = nearCacheManager.getNearCache(
                 cacheManager.getCacheNameWithPrefix(DEFAULT_CACHE_NAME));
 
         testContext = new NearCacheTestContext(client, member, cacheManager, memberCacheManager, nearCacheManager, cache,

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTestSupport.java
@@ -33,7 +33,6 @@ import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.monitor.NearCacheStats;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -117,8 +116,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
         //noinspection unchecked
         ICache<Object, String> cache = cacheManager.createCache(cacheName, cacheConfig);
-
-        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheManager.getCacheNameWithPrefix(cacheName));
+        NearCache<Object, String> nearCache = nearCacheManager.getNearCache(cacheManager.getCacheNameWithPrefix(cacheName));
 
         return new NearCacheTestContext(client, cacheManager, nearCacheManager, cache, nearCache);
     }
@@ -150,7 +148,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         NearCacheTestContext nearCacheTestContext = createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            assertNull(nearCacheTestContext.nearCache.get(nearCacheTestContext.serializationService.toData(i)));
+            assertNull(nearCacheTestContext.nearCache.get(i));
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
@@ -160,8 +158,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             String expectedValue = generateValueFromKey(i);
-            Data keyData = nearCacheTestContext.serializationService.toData(i);
-            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(i));
         }
     }
 
@@ -173,8 +170,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             String expectedValue = generateValueFromKey(i);
-            Data keyData = nearCacheTestContext.serializationService.toData(i);
-            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(i));
         }
     }
 
@@ -193,10 +189,9 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
         for (int i = 0; i < 10 * DEFAULT_RECORD_COUNT; i++) {
             String expectedValue = generateValueFromKey(i);
-            Data keyData = nearCacheTestContext.serializationService.toData(i);
             Future future = nearCacheTestContext.cache.putAsync(i, expectedValue);
             future.get();
-            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(i));
         }
     }
 
@@ -219,8 +214,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertEquals(value, nearCacheTestContext2.nearCache.get(keyData));
+                    assertEquals(value, nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -237,8 +231,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertNull(nearCacheTestContext2.nearCache.get(keyData));
+                    assertNull(nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -251,8 +244,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertEquals(value, nearCacheTestContext2.nearCache.get(keyData));
+                    assertEquals(value, nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -287,7 +279,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
             String key = entry.getKey();
             String exceptedValue = entry.getValue();
-            String actualValue = nearCacheTestContext1.nearCache.get(nearCacheTestContext1.serializationService.toData(key));
+            String actualValue = nearCacheTestContext1.nearCache.get(key);
             assertEquals(exceptedValue, actualValue);
         }
 
@@ -312,8 +304,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext1.serializationService.toData(key);
-                    assertNull(nearCacheTestContext1.nearCache.get(keyData));
+                    assertNull(nearCacheTestContext1.nearCache.get(key));
                 }
             });
         }
@@ -338,8 +329,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertEquals(value, nearCacheTestContext2.nearCache.get(keyData));
+                    assertEquals(value, nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -356,8 +346,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertNull(nearCacheTestContext2.nearCache.get(keyData));
+                    assertNull(nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -404,8 +393,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertNull(nearCacheTestContext2.nearCache.get(keyData));
+                    assertNull(nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -430,8 +418,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertEquals(value, nearCacheTestContext2.nearCache.get(keyData));
+                    assertEquals(value, nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -445,8 +432,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertNull(nearCacheTestContext2.nearCache.get(keyData));
+                    assertNull(nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -460,7 +446,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         NearCacheTestContext nearCacheTestContext = createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            assertNull(nearCacheTestContext.nearCache.get(nearCacheTestContext.serializationService.toData(i)));
+            assertNull(nearCacheTestContext.nearCache.get(i));
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
@@ -469,9 +455,8 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            Data keyData = nearCacheTestContext.serializationService.toData(i);
             // check if same reference to verify data coming from Near Cache
-            assertSame(nearCacheTestContext.cache.get(i), nearCacheTestContext.nearCache.get(keyData));
+            assertSame(nearCacheTestContext.cache.get(i), nearCacheTestContext.nearCache.get(i));
         }
     }
 
@@ -497,8 +482,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertEquals(value, nearCacheTestContext2.nearCache.get(keyData));
+                    assertEquals(value, nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }
@@ -532,8 +516,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    Data keyData = nearCacheTestContext2.serializationService.toData(key);
-                    assertNull(nearCacheTestContext2.nearCache.get(keyData));
+                    assertNull(nearCacheTestContext2.nearCache.get(key));
                 }
             });
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/NearCacheTestContext.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/NearCacheTestContext.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**
@@ -38,11 +37,11 @@ public class NearCacheTestContext {
     protected final NearCacheManager nearCacheManager;
     protected final ICache<Object, String> cache;
     protected final ICache<Object, String> memberCache;
-    protected final NearCache<Data, String> nearCache;
+    protected final NearCache<Object, String> nearCache;
 
     NearCacheTestContext(HazelcastClientProxy client, HazelcastClientCacheManager cacheManager,
                          NearCacheManager nearCacheManager, ICache<Object, String> cache,
-                         NearCache<Data, String> nearCache) {
+                         NearCache<Object, String> nearCache) {
         this.client = client;
         this.member = null;
         this.serializationService = client.getSerializationService();
@@ -58,7 +57,7 @@ public class NearCacheTestContext {
                          HazelcastClientCacheManager cacheManager, HazelcastServerCacheManager memberCacheManager,
                          NearCacheManager nearCacheManager,
                          ICache<Object, String> cache, ICache<Object, String> memberCache,
-                         NearCache<Data, String> nearCache) {
+                         NearCache<Object, String> nearCache) {
         this.client = client;
         this.member = member;
         this.serializationService = client.getSerializationService();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -250,7 +250,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("LFU", nearCacheConfig.getEvictionPolicy());
         assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertTrue(nearCacheConfig.isInvalidateOnChange());
-        assertFalse(nearCacheConfig.isSerializeKeys());
+        assertTrue(nearCacheConfig.isSerializeKeys());
         assertEquals(InMemoryFormat.OBJECT, nearCacheConfig.getInMemoryFormat());
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapRecordStateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapRecordStateStressTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
 import com.hazelcast.internal.nearcache.NearCacheRecordStore;
 import com.hazelcast.internal.nearcache.impl.DefaultNearCache;
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -133,7 +131,7 @@ public class ClientMapRecordStateStressTest extends HazelcastTestSupport {
             thread.join();
         }
 
-        assertFinalRecordStateIsReadPermitted(clientMap, getSerializationService(member));
+        assertFinalRecordStateIsReadPermitted(clientMap);
     }
 
     private NearCacheConfig newNearCacheConfig() {
@@ -142,14 +140,13 @@ public class ClientMapRecordStateStressTest extends HazelcastTestSupport {
                 .setInvalidateOnChange(true);
     }
 
-    private static void assertFinalRecordStateIsReadPermitted(IMap clientMap, InternalSerializationService serializationService) {
+    private static void assertFinalRecordStateIsReadPermitted(IMap clientMap) {
         NearCachedClientMapProxy proxy = (NearCachedClientMapProxy) clientMap;
         DefaultNearCache nearCache = (DefaultNearCache) proxy.getNearCache().unwrap(DefaultNearCache.class);
         NearCacheRecordStore nearCacheRecordStore = nearCache.getNearCacheRecordStore();
 
         for (int i = 0; i < KEY_SPACE; i++) {
-            Data key = serializationService.toData(i);
-            NearCacheRecord record = nearCacheRecordStore.getRecord(key);
+            NearCacheRecord record = nearCacheRecordStore.getRecord(i);
 
             if (record != null) {
                 assertEquals(record.toString(), READ_PERMITTED, record.getRecordState());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheStatsStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheStatsStressTest.java
@@ -51,12 +51,13 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class NearCacheStatsStressTest extends HazelcastTestSupport {
 
-    final int keySpace = 1000;
-    final TestHazelcastFactory factory = new TestHazelcastFactory();
-    final AtomicBoolean stop = new AtomicBoolean(false);
+    private static final int KEY_SPACE = 1000;
 
-    InternalSerializationService ss;
-    NearCache nearCache;
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final AtomicBoolean stop = new AtomicBoolean(false);
+
+    private InternalSerializationService ss;
+    private NearCache<Object, Object> nearCache;
 
     @Before
     public void setUp() throws Exception {
@@ -107,18 +108,15 @@ public class NearCacheStatsStressTest extends HazelcastTestSupport {
         }
     }
 
-    private Data getKeyData() {
-        return ss.toData(getInt(keySpace));
-    }
-
     class Put implements Runnable {
         @Override
         public void run() {
             while (!stop.get()) {
-                Data keyData = getKeyData();
-                long reservationId = nearCache.tryReserveForUpdate(keyData, keyData);
+                Object key = getInt(KEY_SPACE);
+                Data keyData = ss.toData(key);
+                long reservationId = nearCache.tryReserveForUpdate(key, keyData);
                 if (reservationId != NOT_RESERVED) {
-                    nearCache.tryPublishReserved(keyData, keyData, reservationId, false);
+                    nearCache.tryPublishReserved(key, keyData, reservationId, false);
                 }
             }
         }
@@ -128,8 +126,8 @@ public class NearCacheStatsStressTest extends HazelcastTestSupport {
         @Override
         public void run() {
             while (!stop.get()) {
-                Data keyData = getKeyData();
-                nearCache.remove(keyData);
+                Object key = getInt(KEY_SPACE);
+                nearCache.remove(key);
             }
         }
     }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -2527,7 +2527,7 @@
             <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
         <xs:attribute name="in-memory-format" type="in-memory-format" use="optional" default="BINARY"/>
-        <xs:attribute name="serialize-keys" use="optional" type="parameterized-boolean" default="true"/>
+        <xs:attribute name="serialize-keys" use="optional" type="parameterized-boolean" default="false"/>
         <xs:attribute name="invalidate-on-change" use="optional" type="parameterized-boolean" default="true"/>
         <xs:attribute name="time-to-live-seconds" use="optional" type="xs:string" default="0"/>
         <xs:attribute name="max-idle-seconds" use="optional" type="xs:string" default="0"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -92,7 +92,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     private String name = "default";
     private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
-    private boolean serializeKeys = true;
+    private boolean serializeKeys;
     private boolean invalidateOnChange = true;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private int maxIdleSeconds = DEFAULT_MAX_IDLE_SECONDS;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -111,6 +111,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     @Override
     public V get(K key) {
         checkNotNull(key, "key cannot be null on get!");
+        checkKeyFormat(key);
 
         return nearCacheRecordStore.get(key);
     }
@@ -118,6 +119,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     @Override
     public void put(K key, Data keyData, V value) {
         checkNotNull(key, "key cannot be null on put!");
+        checkKeyFormat(key);
 
         nearCacheRecordStore.doEvictionIfRequired();
 
@@ -127,9 +129,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     @Override
     public boolean remove(K key) {
         checkNotNull(key, "key cannot be null on remove!");
-        if (!serializeKeys) {
-            checkNotInstanceOf(Data.class, key, "key cannot be of type Data!");
-        }
+        checkKeyFormat(key);
 
         return nearCacheRecordStore.remove(key);
     }
@@ -219,6 +219,12 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     public NearCacheRecordStore<K, V> getNearCacheRecordStore() {
         return nearCacheRecordStore;
+    }
+
+    private void checkKeyFormat(K key) {
+        if (!serializeKeys) {
+            checkNotInstanceOf(Data.class, key, "key cannot be of type Data!");
+        }
     }
 
     private class ExpirationTask implements Runnable {

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -2411,14 +2411,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
                 <xs:annotation>
                     <xs:documentation>
                         Defines if the Near Cache keys should be serialized or not.
                         Keys should be serialized if they are mutable and need to be cloned via serialization.
                         NOTE: It's not supported to disable key serialization with in-memory-format NATIVE.
                         This setting will have no effect in that case.
-                        Default value is true.
+                        Default value is false.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLiteMemberTest.java
@@ -184,15 +184,15 @@ public class NearCacheLiteMemberTest {
     public static void testPutAll(HazelcastInstance instance, HazelcastInstance lite, String mapName) {
         IMap<Object, Object> map = instance.getMap(mapName);
         IMap<Object, Object> liteMap = lite.getMap(mapName);
-        NearCachedMapProxyImpl proxy = (NearCachedMapProxyImpl) liteMap;
-        NearCache liteNearCache = proxy.getNearCache();
+        NearCachedMapProxyImpl<Object, Object> proxy = (NearCachedMapProxyImpl<Object, Object>) liteMap;
+        NearCache<Object, Object> liteNearCache = proxy.getNearCache();
         SerializationService serializationService = ((SerializationServiceSupport) instance).getSerializationService();
         int count = 100;
 
         // fill the Near Cache with the same data as below so we can detect when it is emptied
         for (int i = 0; i < count; i++) {
             Data keyData = serializationService.toData(i);
-            liteNearCache.put(keyData, keyData, i);
+            liteNearCache.put(i, keyData, i);
         }
         final NearCacheStats stats = liteNearCache.getNearCacheStats();
         assertEquals(100, stats.getOwnedEntryCount());
@@ -476,13 +476,12 @@ public class NearCacheLiteMemberTest {
         return ((NearCachedMapProxyImpl<Data, Object>) map).getNearCache();
     }
 
-    private static void assertNullNearCacheEntryEventually(final HazelcastInstance instance, String mapName, Object key) {
+    private static void assertNullNearCacheEntryEventually(final HazelcastInstance instance, String mapName, final Object key) {
         final NearCache<Object, Object> nearCache = getNearCache(instance, mapName);
-        final Data keyData = toData(instance, key);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertNull(toObject(instance, nearCache.get(keyData)));
+                assertNull(toObject(instance, nearCache.get(key)));
             }
         });
     }


### PR DESCRIPTION
Last part of the requirements: change the default to `store keys by-reference`

I changed the default and reversed the XML tests to test for the non-default value. I also added two more asserts on the Near Cache which fail if a `Data` key is submitted when we expect an `Object` key. This should help us to find all tests which need to be adapted. All known tests have been adapted so far.

Depends on https://github.com/hazelcast/hazelcast/pull/10714