### PR TITLE
Anti-entropy task should run after startup is completed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -443,7 +443,8 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
     private class SyncReplicaVersionTask implements Runnable {
         @Override
         public void run() {
-            if (!node.nodeEngine.isRunning() || !partitionService.isReplicaSyncAllowed()) {
+            if (!node.nodeEngine.isRunning() || !node.getNodeExtension().isStartCompleted()
+                    || !partitionService.isReplicaSyncAllowed()) {
                 return;
             }
 


### PR DESCRIPTION
Normally, startup will be completed when node starts, but in Hot Restart
case, startup completes after Hot Restart process ends.