### PR TITLE
Add missing Versioned markers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -24,13 +24,14 @@ import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
 import static com.hazelcast.internal.cluster.impl.operations.VersionedClusterOperation.isGreaterOrEqualV39;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-public final class HeartbeatOp extends AbstractClusterOperation {
+public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
 
     private MembersViewMetadata senderMembersViewMetadata;
     private String targetUuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOp.java
@@ -22,12 +22,13 @@ import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
 import static com.hazelcast.internal.cluster.impl.operations.VersionedClusterOperation.isGreaterOrEqualV39;
 
-public class MasterConfirmationOp extends AbstractClusterOperation {
+public class MasterConfirmationOp extends AbstractClusterOperation implements Versioned {
 
     private static final String NON_AVAILABLE_UUID = "n/a";
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ReplicaSyncResponse.java
@@ -29,6 +29,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -60,7 +61,8 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
  */
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class ReplicaSyncResponse extends AbstractPartitionOperation
-        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringPassiveState {
+        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation,
+        AllowedDuringPassiveState, Versioned {
 
     private Collection<Operation> operations;
     private ServiceNamespace namespace;


### PR DESCRIPTION
Normally on OSS side, input/output `getVersion()` returns codebase version
regardless of class being marked as `Versioned`.
But on EE, `getVersion()` returns cluster version for `Versioned` classes,
returns `UNKNOWN` otherwise.

That's why this issue didn't happen on OSS tests.