### PR TITLE
Added EXECUTE_ON_ENTRIES methods to DataStructureAdapter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.adapter;
 
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.query.Predicate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.cache.integration.CompletionListener;
@@ -61,6 +62,10 @@ public interface DataStructureAdapter<K, V> {
     Object executeOnKey(K key, com.hazelcast.map.EntryProcessor entryProcessor);
 
     Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor);
+
+    Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor);
+
+    Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor, Predicate predicate);
 
     boolean containsKey(K key);
 
@@ -106,6 +111,8 @@ public interface DataStructureAdapter<K, V> {
         INVOKE("invoke", Object.class, EntryProcessor.class, Object[].class),
         EXECUTE_ON_KEY("executeOnKey", Object.class, com.hazelcast.map.EntryProcessor.class),
         EXECUTE_ON_KEYS("executeOnKeys", Set.class, com.hazelcast.map.EntryProcessor.class),
+        EXECUTE_ON_ENTRIES("executeOnEntries", com.hazelcast.map.EntryProcessor.class),
+        EXECUTE_ON_ENTRIES_WITH_PREDICATE("executeOnEntries", com.hazelcast.map.EntryProcessor.class, Predicate.class),
         CONTAINS_KEY("containsKey", Object.class),
         LOAD_ALL("loadAll", boolean.class),
         LOAD_ALL_WITH_KEYS("loadAll", Set.class, boolean.class),

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.adapter;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.query.Predicate;
 
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
@@ -109,6 +110,18 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     @MethodNotAvailable
     public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor, Predicate predicate) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
 
 import javax.cache.integration.CompletionListener;
@@ -112,6 +113,16 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     @Override
     public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
         return map.executeOnKeys(keys, entryProcessor);
+    }
+
+    @Override
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor) {
+        return map.executeOnEntries(entryProcessor);
+    }
+
+    @Override
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor, Predicate predicate) {
+        return map.executeOnEntries(entryProcessor, predicate);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.adapter;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.query.Predicate;
 
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
@@ -118,6 +119,18 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     @MethodNotAvailable
     public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor, Predicate predicate) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.transaction.TransactionContext;
 
 import javax.cache.integration.CompletionListener;
@@ -29,6 +30,7 @@ import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class TransactionalMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
 
     private final HazelcastInstance hazelcastInstance;
@@ -145,6 +147,18 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     @Override
     @MethodNotAvailable
     public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnEntries(com.hazelcast.map.EntryProcessor entryProcessor, Predicate predicate) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheConfiguration;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -215,6 +216,16 @@ public class ICacheDataStructureAdapterTest extends HazelcastTestSupport {
     public void testExecuteOnKeys() {
         Set<Integer> keys = new HashSet<Integer>(singleton(23));
         adapter.executeOnKeys(keys, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnEntries() {
+        adapter.executeOnEntries(new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnEntriesWithPredicate() {
+        adapter.executeOnEntries(new IMapReplaceEntryProcessor("value", "newValue"), TruePredicate.INSTANCE);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.adapter;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -145,6 +146,16 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
     public void testExecuteOnKeys() {
         Set<Integer> keys = new HashSet<Integer>(singleton(23));
         adapter.executeOnKeys(keys, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnEntries() {
+        adapter.executeOnEntries(new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnEntriesWithPredicate() {
+        adapter.executeOnEntries(new IMapReplaceEntryProcessor("value", "newValue"), TruePredicate.INSTANCE);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.adapter;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -170,6 +171,16 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
     public void testExecuteOnKeys() {
         Set<Integer> keys = new HashSet<Integer>(singleton(23));
         adapter.executeOnKeys(keys, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnEntries() {
+        adapter.executeOnEntries(new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnEntriesWithPredicate() {
+        adapter.executeOnEntries(new IMapReplaceEntryProcessor("value", "newValue"), TruePredicate.INSTANCE);
     }
 
     @Test


### PR DESCRIPTION
We are missing Near Cache tests for these methods, so the first step is to add them to the `DataStructureAdapter`.