### PR TITLE
Added EXECUTE_ON_ENTRIES Near Cache tests and fixed Near Cache map proxy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -494,7 +494,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         } finally {
             for (int i = 0; i < resultingKeyValuePairs.size(); i += 2) {
                 Data key = resultingKeyValuePairs.get(i);
-                invalidateNearCache(key);
+                invalidateNearCache(serializeKeys ? key : toObject(key));
             }
         }
     }


### PR DESCRIPTION
The `NearCachedMapProxyImpl` used the wrong key type to invalidate keys when `serializeKeys` is `false`.