### PR TITLE
Allow use of Key & Trust stores for Management Center config

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MCMutualAuthConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MCMutualAuthConfig.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Properties;
+
+/**
+ * Management Center mutual authentication configuration.
+ * Config required to setup custom key & trust stores for the outgoing connections of the member towards the Management Center.
+ * A custom SSLContextFactory can also be provided for special needs.
+ */
+public final class MCMutualAuthConfig {
+
+    private boolean enabled;
+    private String factoryClassName;
+    private Object factoryImplementation;
+    private Properties properties = new Properties();
+
+    /**
+     * Returns the name of the implementation class.
+     * <p>
+     * Class can either be an  {@link com.hazelcast.nio.ssl.SSLContextFactory}.
+     *
+     * @return the name implementation class
+     */
+    public String getFactoryClassName() {
+        return factoryClassName;
+    }
+
+    /**
+     * Sets the name for the implementation class.
+     * <p>
+     * Class can either be an  {@link com.hazelcast.nio.ssl.SSLContextFactory}.
+     *
+     * @param factoryClassName the name implementation class
+     */
+    public MCMutualAuthConfig setFactoryClassName(String factoryClassName) {
+        this.factoryClassName = factoryClassName;
+        return this;
+    }
+
+    /**
+     * Returns if this configuration is enabled.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables and disables this configuration.
+     *
+     * @param enabled {@code true} to enable, {@code false} to disable
+     */
+    public MCMutualAuthConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Sets the implementation object.
+     * <p>
+     * Object must be instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory}.
+     *
+     * @param factoryImplementation the implementation object
+     * @return this MCMutualAuthConfig instance
+     */
+    public MCMutualAuthConfig setFactoryImplementation(Object factoryImplementation) {
+        this.factoryImplementation = factoryImplementation;
+        return this;
+    }
+
+    /**
+     * Returns the factory implementation object.
+     * <p>
+     * Object is instance of an {@link com.hazelcast.nio.ssl.SSLContextFactory}
+     * @return the factory implementation object
+     */
+    public Object getFactoryImplementation() {
+        return factoryImplementation;
+    }
+
+    /**
+     * Sets a property.
+     *
+     * @param name  the name of the property to set
+     * @param value the value of the property to set
+     * @return the updated MCMutualAuthConfig
+     * @throws NullPointerException if name or value is {@code null}
+     */
+    public MCMutualAuthConfig setProperty(String name, String value) {
+        properties.put(name, value);
+        return this;
+    }
+
+    /**
+     * Gets a property.
+     *
+     * @param name the name of the property to get
+     * @return the value of the property, null if not found
+     * @throws NullPointerException if name is {@code null}
+     */
+    public String getProperty(String name) {
+        return properties.getProperty(name);
+    }
+
+    /**
+     * Gets all properties.
+     *
+     * @return the properties
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    /**
+     * Sets the properties.
+     *
+     * @param properties the properties to set
+     * @return the updated MCMutualAuthConfig
+     * @throws IllegalArgumentException if properties is {@code null}
+     */
+    public MCMutualAuthConfig setProperties(Properties properties) {
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+        this.properties = properties;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "MCMutualAuthConfig{"
+                + "className='" + factoryClassName + '\''
+                + ", enabled=" + enabled
+                + ", implementation=" + factoryImplementation
+                + ", properties=" + properties
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Contains the configuration for a Management Center.
  */
@@ -28,6 +30,8 @@ public class ManagementCenterConfig {
     private String url;
 
     private int updateInterval = UPDATE_INTERVAL;
+
+    private MCMutualAuthConfig mutualAuthConfig;
 
     public ManagementCenterConfig() {
     }
@@ -101,8 +105,37 @@ public class ManagementCenterConfig {
         return this;
     }
 
+
+    /**
+     * Sets the management center mutual auth config
+     *
+     * @param mutualAuthConfig  the mutual auth config
+     * @return the updated ManagementCenterConfig
+     * @throws NullPointerException if mutualAuthConfig {@code null}
+     */
+    public ManagementCenterConfig setMutualAuthConfig(MCMutualAuthConfig mutualAuthConfig) {
+        checkNotNull(mutualAuthConfig);
+        this.mutualAuthConfig = mutualAuthConfig;
+        return this;
+    }
+
+    /**
+     * Gets a property.
+     *
+     * @return the value of the property, null if not found
+     * @throws NullPointerException if name is {@code null}
+     */
+    public MCMutualAuthConfig getMutualAuthConfig() {
+        return mutualAuthConfig;
+    }
+
     @Override
     public String toString() {
-        return "ManagementCenterConfig{enabled=" + enabled + ", url='" + url + "', updateInterval=" + updateInterval + '}';
+        return "ManagementCenterConfig{"
+                + "enabled=" + enabled
+                + ", url='" + url + "'"
+                + ", updateInterval=" + updateInterval
+                + ", mcMutualAuthConfig=" + mutualAuthConfig
+                + "}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -32,6 +32,7 @@ import com.hazelcast.internal.cluster.ClusterVersionListener;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
+import com.hazelcast.internal.management.ManagementCenterConnectionFactory;
 import com.hazelcast.internal.networking.ChannelFactory;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelOutboundHandler;
@@ -334,5 +335,10 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public TimedMemberStateFactory createTimedMemberStateFactory(HazelcastInstanceImpl instance) {
         return new TimedMemberStateFactory(instance);
+    }
+
+    @Override
+    public ManagementCenterConnectionFactory getManagementCenterConnectionFactory() {
+        return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -22,6 +22,7 @@ import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
+import com.hazelcast.internal.management.ManagementCenterConnectionFactory;
 import com.hazelcast.internal.networking.ChannelFactory;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelOutboundHandler;
@@ -233,6 +234,8 @@ public interface NodeExtension {
      * @return {@link TimedMemberStateFactory}
      */
     TimedMemberStateFactory createTimedMemberStateFactory(HazelcastInstanceImpl instance);
+
+    ManagementCenterConnectionFactory getManagementCenterConnectionFactory();
 
     /** Returns a byte array processor for incoming data on the Multicast joiner */
     ByteArrayProcessor createMulticastInputProcessor(IOService ioService);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterConnectionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterConnectionFactory.java
@@ -14,26 +14,20 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.ssl;
+package com.hazelcast.internal.management;
 
-import javax.net.ssl.SSLContext;
-import java.util.Properties;
+import com.hazelcast.config.MCMutualAuthConfig;
 
-/**
- * Factory class for creating {@link javax.net.ssl.SSLContext}
- */
-public interface SSLContextFactory {
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
 
-    /**
-     * Initializes this class with config from {@link com.hazelcast.config.SSLConfig}
-     *
-     * @param properties properties form config
-     * @throws Exception
-     */
-    void init(Properties properties) throws Exception;
+public interface ManagementCenterConnectionFactory {
 
-    /**
-     * @return SSLContext
-     */
-    SSLContext getSSLContext();
+    void init(MCMutualAuthConfig config)
+            throws Exception;
+
+    URLConnection openConnection(URL url)
+            throws IOException;
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/BasicSSLContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/BasicSSLContextFactory.java
@@ -39,4 +39,5 @@ public class BasicSSLContextFactory extends SSLEngineFactorySupport implements S
     public SSLContext getSSLContext() {
         return sslContext;
     }
+
 }

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -2070,6 +2070,25 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
+    <xs:complexType name="mutual-auth">
+        <xs:all>
+            <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the com.hazelcast.nio.ssl.SSLContextFactory implementation class.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable this mutual-auth configuration, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
     <xs:complexType name="item-listener">
         <xs:simpleContent>
             <xs:extension base="listener-base">
@@ -2150,26 +2169,32 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
-    <xs:complexType name="management-center">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional">
-                    <xs:annotation>
-                        <xs:documentation>
-                            True to enable management center, false to disable.
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="update-interval" type="xs:integer" default="3" use="optional">
-                    <xs:annotation>
-                        <xs:documentation>
-                            The time frequency (in seconds) for which Management Center will take
-                            information from the Hazelcast cluster.
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-            </xs:extension>
-        </xs:simpleContent>
+    <xs:complexType name="management-center" mixed="true">
+        <xs:sequence minOccurs="0">
+            <xs:element name="url" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Management Center endpoint/URL.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mutual-auth" type="mutual-auth" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable management center, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="update-interval" type="xs:integer" default="3" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The time frequency (in seconds) for which Management Center will take
+                    information from the Hazelcast cluster.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="services">
         <xs:sequence>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -65,6 +65,36 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
+    public void testManagementCenterConfigGenerator() {
+        ManagementCenterConfig managementCenterConfig = new ManagementCenterConfig()
+                .setEnabled(true)
+                .setUpdateInterval(8)
+                .setUrl("http://foomybar.ber")
+                .setMutualAuthConfig(
+                        new MCMutualAuthConfig()
+                            .setEnabled(true)
+                            .setProperty("keyStore", "/tmp/foo_keystore")
+                            .setProperty("keyStorePassword", "myp@ss1")
+                            .setProperty("trustStore", "/tmp/foo_truststore")
+                            .setProperty("trustStorePassword", "myp@ss2")
+                );
+
+        Config config = new Config()
+                .setManagementCenterConfig(managementCenterConfig);
+
+        Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        ManagementCenterConfig xmlManCenterConfig = xmlConfig.getManagementCenterConfig();
+        assertEquals(managementCenterConfig.isEnabled(), xmlManCenterConfig.isEnabled());
+        assertEquals(managementCenterConfig.getUpdateInterval(), xmlManCenterConfig.getUpdateInterval());
+        assertEquals(managementCenterConfig.getUrl(), xmlManCenterConfig.getUrl());
+        assertEquals(managementCenterConfig.getMutualAuthConfig().isEnabled(), xmlManCenterConfig.getMutualAuthConfig().isEnabled());
+        assertEquals(managementCenterConfig.getMutualAuthConfig().getFactoryClassName(), xmlManCenterConfig.getMutualAuthConfig().getFactoryClassName());
+        assertEquals(managementCenterConfig.getMutualAuthConfig().getProperty("keyStore"), xmlManCenterConfig.getMutualAuthConfig().getProperty("keyStore"));
+        assertEquals(managementCenterConfig.getMutualAuthConfig().getProperty("trustStore"), xmlManCenterConfig.getMutualAuthConfig().getProperty("trustStore"));
+    }
+
+    @Test
     public void testReplicatedMapConfigGenerator() {
         ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig()
                 .setName("replicated-map-name")

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -480,6 +480,30 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testManagementCenterConfigComplex() {
+        String xml = HAZELCAST_START_TAG
+                + "<management-center enabled=\"true\">"
+                + "<url>wowUrl</url>"
+                + "<mutual-auth enabled=\"true\">"
+                + "<properties>"
+                + "<property name=\"keyStore\">/tmp/foo_keystore</property>"
+                + "<property name=\"trustStore\">/tmp/foo_truststore</property>"
+                + "</properties>"
+                + "</mutual-auth>"
+                + "</management-center>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertTrue(manCenterCfg.isEnabled());
+        assertEquals("wowUrl", manCenterCfg.getUrl());
+        assertTrue(manCenterCfg.getMutualAuthConfig().isEnabled());
+        assertEquals("/tmp/foo_keystore", manCenterCfg.getMutualAuthConfig().getProperty("keyStore"));
+        assertEquals("/tmp/foo_truststore", manCenterCfg.getMutualAuthConfig().getProperty("trustStore"));
+    }
+
+    @Test
     public void testNullManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center>"
@@ -530,6 +554,24 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
         assertFalse(manCenterCfg.isEnabled());
         assertEquals("http://localhost:8080/mancenter", manCenterCfg.getUrl());
+    }
+
+    @Test
+    public void testManagementCenterConfigComplexDisabledMutualAuth() {
+        String xml = HAZELCAST_START_TAG
+                + "<management-center enabled=\"true\">"
+                + "<url>wowUrl</url>"
+                + "<mutual-auth enabled=\"false\">"
+                + "</mutual-auth>"
+                + "</management-center>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertTrue(manCenterCfg.isEnabled());
+        assertEquals("wowUrl", manCenterCfg.getUrl());
+        assertFalse(manCenterCfg.getMutualAuthConfig().isEnabled());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -22,6 +22,7 @@ import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
+import com.hazelcast.internal.management.ManagementCenterConnectionFactory;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.networking.ChannelFactory;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
@@ -189,6 +190,11 @@ public class SamplingNodeExtension implements NodeExtension {
     @Override
     public TimedMemberStateFactory createTimedMemberStateFactory(HazelcastInstanceImpl instance) {
         return nodeExtension.createTimedMemberStateFactory(instance);
+    }
+
+    @Override
+    public ManagementCenterConnectionFactory getManagementCenterConnectionFactory() {
+        return nodeExtension.getManagementCenterConnectionFactory();
     }
 
     @Override

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -42,7 +42,16 @@
     </group>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <instance-name>dummy</instance-name>
-    <management-center enabled="true" update-interval="5">http://mywebserver:8080</management-center>
+    <management-center enabled="true" update-interval="5">
+        <url>http://mywebserver:8080</url>
+        <mutual-auth enabled="true">
+            <factory-class-name>com.hazelcast.examples.MySSLContextFactory</factory-class-name>
+            <properties>
+                <property name="foo">bar</property>
+            </properties>
+        </mutual-auth>
+    </management-center>
+
     <properties>
         <property name="foo">bar</property>
     </properties>


### PR DESCRIPTION
Support for custom properties in management center config, to allow end-users to provide key & trust stores when needed for mutual-auth between members and MC.

This change makes Management Center config more complex, and some additional logic was put in the Config builder from the XML to handle both old/new scenarios. Please keep that in mind during review.

Example of old:
```<management-center enabled="true" update-interval="2">http://localhost:8080/mancenter</management-center>```

Example of new:
```
<management-center enabled="true" update-interval="8">
    <url>http://foomybar.ber</url>
    <mutual-auth enabled="true">
        <properties>
            <property name="keyStore">/tmp/foo_keystore</property>
            <property name="trustStorePassword">****</property>
            <property name="trustStore">/tmp/foo_truststore</property>
            <property name="keyStorePassword">****</property>
        </properties>
    </mutual-auth>
</management-center>
```

Also, SPI `SSLContextFactory`, originally deprecated for 3.9, is now restored back to full duty to support the change. /cc @pveentjer 

Relevant MC PR: https://github.com/hazelcast/management-center/pull/457
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/1525
