### PR TITLE
Need a helper to track client lifecycle states

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -32,6 +32,7 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Helper class for the user to track the lifecycle state of the client.
@@ -94,8 +95,8 @@ public class ClientStateListener
                 return false;
             }
 
-            if (!connectedCondition.await(timeout, unit)) {
-                return false;
+            long duration = unit.toNanos(timeout);
+            while ((duration = connectedCondition.awaitNanos(duration)) > 0) {
             }
 
             return currentState.equals(CLIENT_CONNECTED);
@@ -112,7 +113,7 @@ public class ClientStateListener
      */
     public void awaitConnected()
             throws InterruptedException {
-        awaitConnected(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        awaitConnected(Long.MAX_VALUE, MILLISECONDS);
     }
 
     /**
@@ -132,8 +133,8 @@ public class ClientStateListener
                 return true;
             }
 
-            if (!disconnectedCondition.await(timeout, unit)) {
-                return false;
+            long duration = unit.toNanos(timeout);
+            while ((duration = disconnectedCondition.awaitNanos(duration)) > 0) {
             }
 
             if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
@@ -154,7 +155,7 @@ public class ClientStateListener
      */
     public void awaitDisconnected()
             throws InterruptedException {
-        awaitDisconnected(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        awaitDisconnected(Long.MAX_VALUE, MILLISECONDS);
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -34,11 +34,11 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
 
 /**
- * Implementation of helper class for the user to track the lifecycle state of the client.
+ * Helper class for the user to track the lifecycle state of the client.
  * The user will instantiate this listener and it will be registered to the client configuration.
  * If the provided client config is not used while instantiating the client, this helper class
- * will not work as expected. It is the user's responsibility to instantiate the client with the same
- * ClientConfig.
+ * will not be useful. It is the user's responsibility to instantiate the client with the same
+ * ClientConfig which was used to instantiate this helper.
  */
 public class ClientStateListener
         implements LifecycleListener {
@@ -64,7 +64,8 @@ public class ClientStateListener
             currentState = event.getState();
             if (currentState.equals(CLIENT_CONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
                 connectedCondition.signalAll();
-            } else if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+            } else if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState
+                    .equals(SHUTDOWN)) {
                 disconnectedCondition.signalAll();
             }
         } finally {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.util;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
+
+/**
+ * Implementation of helper class for the user to track the lifecycle state of the client.
+ * The user will instantiate this listener and it will be registered to the client configuration.
+ * If the provided client config is not used while instantiating the client, this helper class
+ * will not work as expected. It is the user's responsibility to instantiate the client with the same
+ * ClientConfig.
+ */
+public class ClientStateListener
+        implements LifecycleListener {
+    private LifecycleEvent.LifecycleState currentState = STARTING;
+
+    private final Lock lock = new ReentrantLock();
+    private final Condition connectedCondition = lock.newCondition();
+    private final Condition disconnectedCondition = lock.newCondition();
+
+    /**
+     * Registers this instance with the provided client configuration
+     *
+     * @param clientConfig The client configuration to which this listener will be registered
+     */
+    ClientStateListener(ClientConfig clientConfig) {
+        clientConfig.addListenerConfig(new ListenerConfig(this));
+    }
+
+    @Override
+    public void stateChanged(LifecycleEvent event) {
+        lock.lock();
+        try {
+            currentState = event.getState();
+            if (event.getState().equals(CLIENT_CONNECTED)) {
+                connectedCondition.signalAll();
+            } else if (event.getState().equals(CLIENT_DISCONNECTED)) {
+                disconnectedCondition.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits until the client is connected to cluster or the timeout expires.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the time unit of the {@code timeout} argument
+     * @return true if the client is connected to the cluster.
+     * @throws InterruptedException
+     */
+    public boolean awaitConnected(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        lock.lock();
+        try {
+            if (currentState.equals(CLIENT_CONNECTED)) {
+                return true;
+            }
+
+            if (currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                return false;
+            }
+
+            return connectedCondition.await(timeout, unit);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits until the client is connected to cluster.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @throws InterruptedException
+     */
+    public void awaitConnected()
+            throws InterruptedException {
+        lock.lock();
+        try {
+            if (currentState.equals(CLIENT_CONNECTED)) {
+                return;
+            }
+
+            if (currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                return;
+            }
+
+            connectedCondition.await();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     *
+     * Waits until the client is disconnected from the cluster or the timeout expires.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the time unit of the {@code timeout} argument
+     * @return true if the client is disconnected to the cluster.
+     * @throws InterruptedException
+     */
+    public boolean awaitDisconnected(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        lock.lock();
+        try {
+            if (currentState.equals(CLIENT_DISCONNECTED)) {
+                return true;
+            }
+
+            if (currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                return false;
+            }
+
+            return disconnectedCondition.await(timeout, unit);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits until the client is disconnected from the cluster.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @throws InterruptedException
+     */
+    public void awaitDisconnected()
+            throws InterruptedException {
+        lock.lock();
+        try {
+            if (currentState.equals(CLIENT_DISCONNECTED)) {
+                return;
+            }
+
+            if (currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                return;
+            }
+
+            disconnectedCondition.await();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     *
+     * @return true if the client is connected.
+     */
+    public boolean isConnected() {
+        lock.lock();
+        try {
+            return currentState.equals(CLIENT_CONNECTED);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     *
+     * @return true if the client is shutdown.
+     */
+    public boolean isShutdown() {
+        lock.lock();
+        try {
+            return currentState.equals(SHUTDOWN);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     *
+     * @return true if the client is started.
+     */
+    public boolean isStarted() {
+        lock.lock();
+        try {
+            return currentState.equals(STARTED) || currentState.equals(CLIENT_CONNECTED) || currentState
+                    .equals(CLIENT_DISCONNECTED);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     *
+     * @return The current lifecycle state of the client.
+     */
+    public LifecycleEvent.LifecycleState getCurrentState() {
+        lock.lock();
+        try {
+            return currentState;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -96,7 +96,8 @@ public class ClientStateListener
             }
 
             long duration = unit.toNanos(timeout);
-            while ((duration = connectedCondition.awaitNanos(duration)) > 0) {
+            while (duration > 0) {
+                duration = connectedCondition.awaitNanos(duration);
             }
 
             return currentState.equals(CLIENT_CONNECTED);
@@ -134,7 +135,8 @@ public class ClientStateListener
             }
 
             long duration = unit.toNanos(timeout);
-            while ((duration = disconnectedCondition.awaitNanos(duration)) > 0) {
+            while (duration > 0) {
+                duration = disconnectedCondition.awaitNanos(duration);
             }
 
             if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -49,19 +49,6 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    private class StateTrackingListener implements LifecycleListener {
-        private volatile LifecycleEvent.LifecycleState latestState = STARTING;
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            latestState = event.getState();
-        }
-
-        LifecycleEvent.LifecycleState getLatestState() {
-            return latestState;
-        }
-    }
-
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.util;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.FutureUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.ASYNC;
+import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.OFF;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientStateListenerTest extends ClientTestSupport{
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testWithUnusedClientConfig()
+            throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+
+        assertFalse(listener.awaitConnected(1, MILLISECONDS));
+
+        assertFalse(listener.awaitDisconnected(1, MILLISECONDS));
+
+        assertFalse(listener.isConnected());
+
+        assertFalse(listener.isShutdown());
+
+        assertFalse(listener.isStarted());
+
+        assertEquals(STARTING, listener.getCurrentState());
+    }
+
+    @Test
+    public void testClientASYNCStartConnected() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+        clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
+
+        hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig);
+
+        assertTrue(listener.awaitConnected(5, SECONDS));
+
+        assertFalse(listener.awaitDisconnected(1, MILLISECONDS));
+
+        assertTrue(listener.isConnected());
+
+        assertFalse(listener.isShutdown());
+
+        assertTrue(listener.isStarted());
+
+        assertEquals(CLIENT_CONNECTED, listener.getCurrentState());
+    }
+
+    @Test
+    public void testClientReconnecModeAsyncConnected() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+        clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig);
+
+        hazelcastInstance.shutdown();
+
+        assertTrue(listener.awaitDisconnected(5, SECONDS));
+
+        assertFalse(listener.isConnected());
+
+        assertFalse(listener.isShutdown());
+
+        assertTrue(listener.isStarted());
+
+        assertEquals(CLIENT_DISCONNECTED, listener.getCurrentState());
+
+        hazelcastFactory.newHazelcastInstance();
+
+        assertTrue(listener.awaitConnected(5, SECONDS));
+
+        assertTrue(listener.isConnected());
+
+        assertFalse(listener.isShutdown());
+
+        assertTrue(listener.isStarted());
+
+        assertEquals(CLIENT_CONNECTED, listener.getCurrentState());
+    }
+
+    @Test
+    public void testClientReconnecModeAsyncConnectedMultipleThreads() throws InterruptedException {
+        int numThreads = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+        ClientConfig clientConfig = new ClientConfig();
+        final ClientStateListener listener = new ClientStateListener(clientConfig);
+        clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig);
+
+        hazelcastInstance.shutdown();
+
+        List<Future> futures = new ArrayList<Future>(numThreads);
+        for (int i = 0; i < numThreads; i++) {
+            futures.add(executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        assertTrue(listener.awaitDisconnected(5, SECONDS));
+                    } catch (InterruptedException e) {
+                        fail("Should not be interrupted");
+                    }
+
+                    assertFalse(listener.isConnected());
+
+                    assertFalse(listener.isShutdown());
+
+                    assertTrue(listener.isStarted());
+
+                    assertEquals(CLIENT_DISCONNECTED, listener.getCurrentState());
+                }
+            }));
+        }
+
+        FutureUtil.waitWithDeadline(futures, 10, SECONDS);
+        assertTrue(FutureUtil.allDone(futures));
+
+        hazelcastFactory.newHazelcastInstance();
+
+        futures.clear();
+        for (int i = 0; i < numThreads; i++) {
+            futures.add(executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        listener.awaitConnected(5, SECONDS);
+                    } catch (InterruptedException e) {
+                        fail("Should not be interrupted");
+                    }
+
+                    assertTrue(listener.isConnected());
+
+                    assertFalse(listener.isShutdown());
+
+                    assertTrue(listener.isStarted());
+
+                    assertEquals(CLIENT_CONNECTED, listener.getCurrentState());
+                }
+            }));
+        }
+
+        FutureUtil.waitWithDeadline(futures, 10, SECONDS);
+        assertTrue(FutureUtil.allDone(futures));
+    }
+
+    @Test
+    public void testClientReconnecModeOffDisconnected() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+        clientConfig.getConnectionStrategyConfig().setReconnectMode(OFF);
+
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig);
+
+        hazelcastInstance.shutdown();
+
+        hazelcastFactory.newHazelcastInstance();
+
+        assertTrue(listener.awaitDisconnected(2, SECONDS));
+
+        assertFalse(listener.isConnected());
+
+        assertFalse(listener.isStarted());
+
+        assertEquals(SHUTDOWN, listener.getCurrentState());
+    }
+
+    @Test
+    public void testClientConnectedWithTimeout() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+
+        hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig);
+        assertTrue(listener.awaitConnected(1, MILLISECONDS));
+
+        assertFalse(listener.awaitDisconnected(1, MILLISECONDS));
+
+        assertTrue(listener.isConnected());
+
+        assertFalse(listener.isShutdown());
+
+        assertTrue(listener.isStarted());
+
+        assertEquals(CLIENT_CONNECTED, listener.getCurrentState());
+    }
+
+    @Test
+    public void testClientConnectedWithoutTimeout() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+
+        hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig);
+
+        listener.awaitConnected();
+
+        assertEquals(CLIENT_CONNECTED, listener.getCurrentState());
+
+        assertTrue(listener.isConnected());
+
+        assertTrue(listener.isStarted());
+
+        assertFalse(listener.awaitDisconnected(1, MILLISECONDS));
+
+        assertFalse(listener.isShutdown());
+    }
+
+    @Test
+    public void testClientDisconnectedWithTimeout() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+
+        hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig).shutdown();
+
+        assertFalse(listener.awaitConnected(1, MILLISECONDS));
+
+        assertTrue(listener.awaitDisconnected(1, MILLISECONDS));
+
+        assertFalse(listener.isConnected());
+
+        assertTrue(listener.isShutdown());
+
+        assertFalse(listener.isStarted());
+
+        assertEquals(SHUTDOWN, listener.getCurrentState());
+    }
+
+    @Test
+    public void testClientDisconnectedWithoutTimeout() throws InterruptedException {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientStateListener listener = new ClientStateListener(clientConfig);
+
+        hazelcastFactory.newHazelcastInstance();
+
+        hazelcastFactory.newHazelcastClient(clientConfig).shutdown();
+
+        listener.awaitDisconnected();
+
+        assertFalse(listener.awaitConnected(1, MILLISECONDS));
+
+        assertFalse(listener.isConnected());
+
+        assertTrue(listener.isShutdown());
+
+        assertFalse(listener.isStarted());
+
+        assertEquals(SHUTDOWN, listener.getCurrentState());
+    }
+
+}


### PR DESCRIPTION
We needed a helper utility class to track the connected and disconnected states of the client with the introduction of  the new async client connection strategy. The user needs to instantiate the client with the same client config which is used to instantiate the helper ClientStateListener to use it correctly.