### PR TITLE
Apply join fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -939,6 +939,14 @@ public class MembershipManager {
                     return;
                 }
 
+                MemberImpl localMember = clusterService.getLocalMember();
+                if (!newMembersView.containsMember(localMember.getAddress(), localMember.getUuid())) {
+                    // local member uuid is changed because of force start or split brain merge...
+                    logger.fine("Ignoring decided members view after mastership claim: " + newMembersView
+                            + ", because current local member: " + localMember + " not in decided members view.");
+                    return;
+                }
+
                 updateMembers(newMembersView);
                 clusterService.getClusterHeartbeatManager().resetMemberMasterConfirmations();
                 clusterService.getClusterJoinManager().reset();


### PR DESCRIPTION
* After mastership claim is done, check if local uuid is still the same. It might be changed because of force start or split brain merge
* Send explicit suspicion on heartbeat when not joined if sender is known to be version 3.9

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1155