### PR TITLE
[BACKPORT] Send cause of error if changeClusterVersion fails

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -172,14 +172,9 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
                 res = response(ResponseType.FORBIDDEN);
             } else {
-                Version version;
-                try {
-                    version = Version.of(versionParam);
-                    clusterService.changeClusterVersion(version);
-                    res = response(ResponseType.SUCCESS, "version", clusterService.getClusterVersion().toString());
-                } catch (Exception ex) {
-                    res = response(ResponseType.FAIL, "version", clusterService.getClusterVersion().toString());
-                }
+                Version version = Version.of(versionParam);
+                clusterService.changeClusterVersion(version);
+                res = response(ResponseType.SUCCESS, "version", clusterService.getClusterVersion().toString());
             }
         } catch (Throwable throwable) {
             logger.warning("Error occurred while changing cluster version", throwable);


### PR DESCRIPTION
Management Center currently gets no feedback about the cause of an
error during changeClusterVersion operation. With this change, it gets
the exception message.

(cherry picked from commit b2c8eb8)

Backport of #10751 