### PR TITLE
Constructor validation in JUnit runner more lenient

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
@@ -95,7 +95,7 @@ public abstract class AbstractParameterizedHazelcastClassRunner extends BlockJUn
     @Override
     protected void validateConstructor(List<Throwable> errors) {
         validateOnlyOneConstructor(errors);
-        if (fieldsAreAnnotated() || !isParameterized) {
+        if (fieldsAreAnnotated()) {
             validateZeroArgConstructor(errors);
         }
     }


### PR DESCRIPTION
Fixes #10678
Credits for analysis go to @Donnerbart 

Reasoning:
the isParametrized is initialized after the validateContructor() is called
This is given by an unfortunate design of JUnit runners. Even the out-of-the-box
runners are not checking the isParametrized

For details see David's explanation at:
https://github.com/hazelcast/hazelcast/issues/10678#issuecomment-306436024