### PR TITLE
Fixed Near Cache key object identity issue

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -39,6 +39,7 @@ import javax.cache.expiry.ExpiryPolicy;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -221,11 +222,11 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         }
 
         int keysSize = keys.size();
-        List<Data> dataKeys = new ArrayList<Data>(keys.size());
+        List<Data> dataKeys = new LinkedList<Data>();
         List<Object> resultingKeyValuePairs = new ArrayList<Object>(keysSize * 2);
         getAllInternal(keys, dataKeys, expiryPolicy, resultingKeyValuePairs, startNanos);
 
-        Map<K, V> result = createHashMap(keys.size());
+        Map<K, V> result = createHashMap(keysSize);
         for (int i = 0; i < resultingKeyValuePairs.size(); ) {
             K key = toObject(resultingKeyValuePairs.get(i++));
             V value = toObject(resultingKeyValuePairs.get(i++));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1043,7 +1043,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     protected void getAllInternal(Set<K> keys, Map<Integer, List<Data>> partitionToKeyData, List<Object> resultingKeyValuePairs) {
         if (partitionToKeyData.isEmpty()) {
-            fillPartitionToKeyData(keys, partitionToKeyData, null);
+            fillPartitionToKeyData(keys, partitionToKeyData, null, null);
         }
         List<Future<ClientMessage>> futures = new ArrayList<Future<ClientMessage>>(partitionToKeyData.size());
         for (Map.Entry<Integer, List<Data>> entry : partitionToKeyData.entrySet()) {
@@ -1069,7 +1069,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         }
     }
 
-    protected void fillPartitionToKeyData(Set<K> keys, Map<Integer, List<Data>> partitionToKeyData, Map<Object, Data> keyMap) {
+    protected void fillPartitionToKeyData(Set<K> keys, Map<Integer, List<Data>> partitionToKeyData, Map<Object, Data> keyMap,
+                                          Map<Data, Object> reverseKeyMap) {
         ClientPartitionService partitionService = getContext().getPartitionService();
         for (K key : keys) {
             Data keyData = toData(key);
@@ -1082,6 +1083,9 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             keyList.add(keyData);
             if (keyMap != null) {
                 keyMap.put(key, keyData);
+            }
+            if (reverseKeyMap != null) {
+                reverseKeyMap.put(keyData, key);
             }
         }
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -149,13 +149,13 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null, null},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true, INVALIDATE},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true, CACHE_ON_UPDATE},
-                {GET_ALL, newInt(1, 1, 0), newInt(0, 1, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false, INVALIDATE},
+                {GET_ALL, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false, INVALIDATE},
                 {GET_ALL, newInt(1, 0, 0), newInt(0, 0, 0), newInt(2, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false, CACHE_ON_UPDATE},
 
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null, null},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true, INVALIDATE},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(2, 0, 0), OBJECT, OBJECT, false, true, CACHE_ON_UPDATE},
-                {GET_ALL, newInt(1, 1, 0), newInt(0, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false, INVALIDATE},
+                {GET_ALL, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false, INVALIDATE},
                 {GET_ALL, newInt(1, 0, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, false, false, CACHE_ON_UPDATE},
         });
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -117,7 +117,7 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
 
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
-                {GET_ALL, newInt(1, 1, 0), newInt(0, 1, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {GET_ALL, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
 
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -96,11 +96,11 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
                 {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, true},
                 {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
 
-                {GET, newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
+                {GET, newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, null, null},
+                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, BINARY, true},
+                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, BINARY, false},
+                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, true},
+                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 0, 0), newInt(1, 0, 0), OBJECT, OBJECT, false},
         });
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -76,6 +76,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -331,7 +332,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
         }
 
         int keysSize = keys.size();
-        List<Data> dataKeys = new ArrayList<Data>(keysSize);
+        List<Data> dataKeys = new LinkedList<Data>();
         List<Object> resultingKeyValuePairs = new ArrayList<Object>(keysSize * 2);
         getAllInternal(keys, dataKeys, resultingKeyValuePairs);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -117,11 +117,11 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
 
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, null, null, null},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, true},
-                {GET_ALL, newInt(1, 1, 0), newInt(0, 1, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
+                {GET_ALL, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 1), BINARY, BINARY, true, false},
 
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null, null},
                 {GET_ALL, newInt(1, 1, 1), newInt(0, 1, 1), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, true},
-                {GET_ALL, newInt(1, 1, 0), newInt(0, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
+                {GET_ALL, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false, false},
         });
     }
 


### PR DESCRIPTION
* removed the key lookup map where possible by directly acquiring Near Cache reservations
* added a reverse key lookup map, so Near Cache population doesn't rely on `equals()/hashCode()` to find the reservation ID
* switched key collection to `LinkedList` due to better O(1) on `remove()`
* adapted the serialization count tests to test both scenarios:
  * key/value classes which do not provide custom `equals()/hashCode() methods
  * key/value classes which provide custom `equals()/hashCode()` methods

The key is to omit a `toObject(keyData)` call, which generates a cloned key object, which might not match the original object in the reservation list. I could remove the `keyMap` in two proxies, so the costs are the same (even a bit smaller, that map only contains keys which are not served from the Near Cache!).