### PR TITLE
Any unfinished callback will be counted as one invocation.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
-import static com.hazelcast.util.Preconditions.isNotNull;
 
 public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessage> {
 
@@ -78,9 +77,12 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
 
     @Override
     public void andThen(ExecutionCallback<ClientMessage> callback) {
-        isNotNull(callback, "callback");
-
         super.andThen(new InternalDelegatingExecutionCallback(callback));
+    }
+
+    @Override
+    public void andThen(ExecutionCallback<ClientMessage> callback, Executor executor) {
+        super.andThen(new InternalDelegatingExecutionCallback(callback), executor);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -88,17 +88,17 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
      *                              otherwise execution result will be in {@link com.hazelcast.nio.serialization.Data} format
      * @param <T>                   type of the execution result which is passed to {@link ExecutionCallback#onResponse}
      */
-    public <T> void andThenInternal(final ExecutionCallback<T> callback, boolean shouldDeserializeData) {
+    public <T> void andThenInternal(ExecutionCallback<T> callback, boolean shouldDeserializeData) {
         future.andThen(new DelegatingExecutionCallback<T>(callback, shouldDeserializeData));
     }
 
     @Override
-    public void andThen(final ExecutionCallback<V> callback) {
+    public void andThen(ExecutionCallback<V> callback) {
         future.andThen(new DelegatingExecutionCallback<V>(callback, true), userExecutor);
     }
 
     @Override
-    public void andThen(final ExecutionCallback<V> callback, Executor executor) {
+    public void andThen(ExecutionCallback<V> callback, Executor executor) {
         future.andThen(new DelegatingExecutionCallback<V>(callback, true), executor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -206,7 +206,7 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
     }
 
     @Override
-    public final void andThen(ExecutionCallback<V> callback, Executor executor) {
+    public void andThen(ExecutionCallback<V> callback, Executor executor) {
         isNotNull(callback, "callback");
         isNotNull(executor, "executor");
 


### PR DESCRIPTION
They will cause any invocation to get HazelcastOverLoadException to
prevent OOME.

fixes https://github.com/hazelcast/hazelcast/issues/10630