### PR TITLE
Fixed MetricsRenderer class hierarchy problem

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.ClientType;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.metrics.renderers.StringRenderer;
+import com.hazelcast.internal.metrics.Gauge;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -346,11 +346,11 @@ public class Statistics {
                 "runtime.totalMemory", "runtime.uptime", "runtime.usedMemory", "executionService.userExecutorQueueSize",
         };
 
-        private final Map<String, StringRenderer> allMetrics = new HashMap<String, StringRenderer>(statisticNames.length);
+        private final Map<String, Gauge> allMetrics = new HashMap<String, Gauge>(statisticNames.length);
 
         PeriodicStatistics(final MetricsRegistry metricsRegistry) {
             for (String name : statisticNames) {
-                allMetrics.put(name, metricsRegistry.newStringRendererGauge(name));
+                allMetrics.put(name, metricsRegistry.newGauge(name));
             }
         }
 
@@ -370,7 +370,7 @@ public class Statistics {
                 addStat(stats, "credentials.principal", credentials.getPrincipal());
             }
 
-            for (Map.Entry<String, StringRenderer> entry : allMetrics.entrySet()) {
+            for (Map.Entry<String, Gauge> entry : allMetrics.entrySet()) {
                 stats.append(STAT_SEPARATOR).append(entry.getKey()).append(KEY_VALUE_SEPARATOR);
                 entry.getValue().render(stats);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/DoubleGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/DoubleGauge.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.internal.metrics;
 
-import com.hazelcast.internal.metrics.renderers.StringRenderer;
-
 /**
- * A DoubleGauge is {link Metric} where a particular double value is read instantaneous. E.g. the current os load.
+ * A DoubleGauge is {link Gauge} where a particular double value is read instantaneous. E.g. the current os load.
  *
  * {@link LongGauge}
  */
-public interface DoubleGauge extends Metric, StringRenderer {
+public interface DoubleGauge extends Gauge {
 
     /**
      * Reads the current available value as a double.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Gauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Gauge.java
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.metrics.renderers;
+package com.hazelcast.internal.metrics;
 
-public interface StringRenderer {
+/**
+ * A Gauge is {@link Metric} where a particular value is read instantaneous. E.g. the current size of the
+ * pending operations queue.
+ *
+ * The Gauge interface has not methods for retrieving the actual value, because it depends on the type of
+ * value to read.
+ *
+ * @see LongGauge
+ * @see DoubleGauge
+ */
+public interface Gauge extends Metric {
+
     /**
-     * The interface is used to fill a StringBuilder buffer with the current value of a probe.
+     * Renders the value from the gauge.
      *
-     * @param stringBuilder the string builder to be filled
+     * @param stringBuilder the {@link StringBuilder} to write to.
      */
     void render(StringBuilder stringBuilder);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/LongGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/LongGauge.java
@@ -16,15 +16,13 @@
 
 package com.hazelcast.internal.metrics;
 
-import com.hazelcast.internal.metrics.renderers.StringRenderer;
-
 /**
- * A LongGauge is {@link Metric} where a particular long value is read instantaneous. E.g. the current size of the
+ * A LongGauge is {@link Gauge} where a particular long value is read instantaneous. E.g. the current size of the
  * pending operations queue.
  *
  * {@link DoubleGauge}
  */
-public interface LongGauge extends Metric, StringRenderer {
+public interface LongGauge extends Gauge {
 
     /**
      * Reads the current available value as a long.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.metrics;
 
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
-import com.hazelcast.internal.metrics.renderers.StringRenderer;
 
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +58,7 @@ public interface MetricsRegistry {
     ProbeLevel minimumLevel();
 
     /**
-     * Creates a LongGauge for a given metric name.
+     * Creates a {@link LongGauge} for a given metric name.
      *
      * If no gauge exists for the name, it will be created but no probe is set. The reason to do so is that you don't want to
      * depend on the order of registration. Perhaps you want to read out e.g. operations.count gauge, but the OperationService
@@ -77,7 +76,7 @@ public interface MetricsRegistry {
     LongGauge newLongGauge(String name);
 
     /**
-     * Creates a DoubleProbe for a given metric name.
+     * Creates a {@link DoubleGauge} for a given metric name.
      *
      * @param name name of the metric
      * @return the create DoubleGauge
@@ -87,14 +86,15 @@ public interface MetricsRegistry {
     DoubleGauge newDoubleGauge(String name);
 
     /**
-     * Creates a String probe for a given metric name.
+     * Creates a {@link Gauge} for a given metric name.
      *
      * @param name name of the metric
-     * @return the created gauge which implements the StringRenderer.
+     * @return the created gauge
      * @throws NullPointerException if name is null.
-     * @see #newLongGauge(String)#newDoubleGauge(String)
+     * @see #newLongGauge(String)
+     * @see #newDoubleGauge(String)
      */
-    StringRenderer newStringRendererGauge(String name);
+    Gauge newGauge(String name);
 
     /**
      * Gets a set of all current probe names.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -24,8 +24,8 @@ import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.internal.metrics.Gauge;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
-import com.hazelcast.internal.metrics.renderers.StringRenderer;
 import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
@@ -231,7 +231,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     }
 
     @Override
-    public StringRenderer newStringRendererGauge(final String name) {
+    public Gauge newGauge(final String name) {
         checkNotNull(name, "name can't be null");
 
         ProbeInstance probeInstance = getProbeInstance(name);


### PR DESCRIPTION
The Gauge interface is introduced as parent of the Long/Double-Gauge and adds
the ability to render the value. This provides a proper class hierarchy.