### PR TITLE
Ringbuffer should adjust headSeq while setting tailSeq due to capacity

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -298,6 +298,10 @@ public class RingbufferContainer<T> implements IdentifiedDataSerializable, Notif
 
         if (sequenceId > tailSequence()) {
             ringbuffer.setTailSequence(sequenceId);
+
+            if (ringbuffer.size() > ringbuffer.getCapacity()) {
+                ringbuffer.setHeadSequence(ringbuffer.tailSequence() - ringbuffer.getCapacity() + 1);
+            }
         }
         if (sequenceId < headSequence()) {
             ringbuffer.setHeadSequence(sequenceId);

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -59,7 +59,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
 
     protected HazelcastInstance[] instances;
     protected IAtomicLong atomicLong;
-    private Ringbuffer<String> ringbuffer;
+    protected Ringbuffer<String> ringbuffer;
     private Config config;
     private HazelcastInstance local;
     private String name;
@@ -103,6 +103,8 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
                 .setTimeToLiveSeconds(10));
         config.addRingBufferConfig(new RingbufferConfig("readOne_staleSequence*").setCapacity(5));
         config.addRingBufferConfig(new RingbufferConfig("readOne_futureSequence*").setCapacity(5));
+        config.addRingBufferConfig(new RingbufferConfig("sizeShouldNotExceedCapacity_whenPromotedFromBackup*")
+                .setCapacity(10));
 
         instances = newInstances(config);
         local = instances[0];

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicDistributedTest.java
@@ -21,8 +21,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -31,5 +34,17 @@ public class RingbufferBasicDistributedTest extends RingbufferAbstractTest {
     @Override
     protected HazelcastInstance[] newInstances(Config config) {
         return createHazelcastInstanceFactory(2).newInstances(config);
+    }
+
+    @Test
+    public void sizeShouldNotExceedCapacity_whenPromotedFromBackup() {
+        for (int i = 0; i < 100; i++) {
+            ringbuffer.add(randomString());
+        }
+
+        waitAllForSafeState(instances);
+        instances[instances.length - 1].getLifecycleService().terminate();
+
+        assertEquals(ringbuffer.capacity(), ringbuffer.size());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/10774