### PR TITLE
Fixed object identity issue in ReplicatedMap when using OBJECT in-memory format

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ReplicatedMapCustomClassesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ReplicatedMapCustomClassesTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.replicatedmap;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.nio.serialization.ClassDefinition;
+import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ReplicatedMapCustomClassesTest extends HazelcastTestSupport {
+
+    @Parameters(name = "replicatedMapFormat:{0} withEqualsAndHashCode:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean withEqualsAndHashCode;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private ReplicatedMap<CustomKey, CustomValue> map;
+
+    @Before
+    public void setUp() {
+        Config config = getConfig();
+        config.getReplicatedMapConfig("default")
+                .setInMemoryFormat(inMemoryFormat);
+        prepareSerializationConfig(config.getSerializationConfig());
+
+        ClientConfig clientConfig = new ClientConfig();
+        prepareSerializationConfig(clientConfig.getSerializationConfig());
+
+        hazelcastFactory.newHazelcastInstance(config);
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+
+        map = client.getReplicatedMap("default");
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Test
+    public void whenCustomClassKeyIsUsed_thenPutAndGetShouldWorkProperly() {
+        CustomKey key = new CustomKey(withEqualsAndHashCode);
+        CustomValue value = new CustomValue(withEqualsAndHashCode);
+
+        map.put(key, value);
+        CustomValue result = map.get(key);
+
+        assertNotNull("The result from map.get(key) should never be null", result);
+        if (withEqualsAndHashCode) {
+            assertEquals(value, result);
+        } else {
+            assertEquals(value.getClass(), result.getClass());
+            assertFalse(result.executeEqualsAndHashCode);
+        }
+    }
+
+    private static void prepareSerializationConfig(SerializationConfig serializationConfig) {
+        ClassDefinition keyClassDefinition = new ClassDefinitionBuilder(CustomKey.FACTORY_ID, CustomKey.CLASS_ID)
+                .addBooleanField("b").build();
+        serializationConfig.addClassDefinition(keyClassDefinition);
+
+        ClassDefinition valueClassDefinition = new ClassDefinitionBuilder(CustomValue.FACTORY_ID, CustomValue.CLASS_ID)
+                .addBooleanField("b").build();
+        serializationConfig.addClassDefinition(valueClassDefinition);
+
+        serializationConfig.addPortableFactory(CustomKey.FACTORY_ID, new PortableFactory() {
+            @Override
+            public Portable create(int classId) {
+                return new CustomKey();
+            }
+        });
+        serializationConfig.addPortableFactory(CustomValue.FACTORY_ID, new PortableFactory() {
+            @Override
+            public Portable create(int classId) {
+                return new CustomValue();
+            }
+        });
+    }
+
+    private static class CustomKey extends CustomClass {
+
+        private static int FACTORY_ID = 1;
+        private static int CLASS_ID = 1;
+
+        CustomKey() {
+        }
+
+        CustomKey(boolean executeEqualsAndHashCode) {
+            super(executeEqualsAndHashCode);
+        }
+
+        @Override
+        public int getFactoryId() {
+            return FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return CLASS_ID;
+        }
+    }
+
+    private static class CustomValue extends CustomClass {
+
+        private static int FACTORY_ID = 2;
+        private static int CLASS_ID = 2;
+
+        CustomValue() {
+        }
+
+        CustomValue(boolean executeEqualsAndHashCode) {
+            super(executeEqualsAndHashCode);
+        }
+
+        @Override
+        public int getFactoryId() {
+            return FACTORY_ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return CLASS_ID;
+        }
+    }
+
+    private static abstract class CustomClass implements Portable {
+
+        boolean executeEqualsAndHashCode;
+
+        CustomClass() {
+        }
+
+        CustomClass(boolean executeEqualsAndHashCode) {
+            this.executeEqualsAndHashCode = executeEqualsAndHashCode;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeBoolean("b", executeEqualsAndHashCode);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            executeEqualsAndHashCode = reader.readBoolean("b");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!executeEqualsAndHashCode) {
+                return super.equals(o);
+            }
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CustomClass)) {
+                return false;
+            }
+
+            CustomClass that = (CustomClass) o;
+            return that.executeEqualsAndHashCode;
+        }
+
+        @Override
+        public int hashCode() {
+            if (!executeEqualsAndHashCode) {
+                return super.hashCode();
+            }
+            return 1;
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -97,11 +97,11 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
                 {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 0, 0), newInt(0, 1, 0), BINARY, OBJECT, false},
 
                 // FIXME: we should not serialize the value twice
-                {GET, newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
-                {GET, newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
+                {GET, newInt(1, 1, 1), newInt(0, 0, 0), newInt(1, 1, 1), newInt(1, 1, 1), OBJECT, null, null},
+                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, true},
+                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 2, 0), newInt(1, 1, 1), OBJECT, BINARY, false},
+                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, true},
+                {GET, newInt(1, 1, 0), newInt(0, 0, 0), newInt(1, 1, 0), newInt(1, 1, 0), OBJECT, OBJECT, false},
         });
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -75,8 +75,8 @@ public class ReplicateUpdateOperation extends AbstractSerializableOperation impl
             }
             return;
         }
-        Object key = store.marshall(dataKey);
-        Object value = store.marshall(dataValue);
+        Object key = store.marshallKey(dataKey);
+        Object value = store.marshallValue(dataValue);
         if (isRemove) {
             store.removeWithVersion(key, updateVersion);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -72,8 +72,8 @@ public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperat
 
             return;
         }
-        Object key = store.marshall(dataKey);
-        Object value = store.marshall(dataValue);
+        Object key = store.marshallKey(dataKey);
+        Object value = store.marshallValue(dataValue);
         if (isRemove) {
             store.removeWithVersion(key, updateVersion);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -60,8 +60,8 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractSerializableOp
                 .getReplicatedRecordStore(name, true, getPartitionId());
         InternalReplicatedMapStorage<K, V> newStorage = new InternalReplicatedMapStorage<K, V>();
         for (RecordMigrationInfo record : recordSet) {
-            K key = (K) store.marshall(record.getKey());
-            V value = (V) store.marshall(record.getValue());
+            K key = (K) store.marshallKey(record.getKey());
+            V value = (V) store.marshallValue(record.getValue());
             ReplicatedRecord<K, V> replicatedRecord = buildReplicatedRecord(key, value, record.getTtl());
             ReplicatedRecord oldRecord = store.getReplicatedRecord(key);
             if (oldRecord != null) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -83,6 +83,16 @@ public abstract class AbstractBaseReplicatedRecordStore<K, V> implements Replica
         return name;
     }
 
+    @Override
+    public Object unmarshallKey(Object key) {
+        return key == null ? null : nodeEngine.toObject(key);
+    }
+
+    @Override
+    public Object marshallKey(Object key) {
+        return nodeEngine.toData(key);
+    }
+
     public LocalReplicatedMapStatsImpl getStats() {
         return replicatedMapService.getLocalMapStatsImpl(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/DataReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/DataReplicatedRecordStore.java
@@ -34,12 +34,12 @@ public class DataReplicatedRecordStore extends AbstractReplicatedRecordStore<Dat
     }
 
     @Override
-    public Object unmarshall(Object object) {
-        return object == null ? null : nodeEngine.toObject(object);
+    public Object unmarshallValue(Object value) {
+        return value == null ? null : nodeEngine.toObject(value);
     }
 
     @Override
-    public Object marshall(Object object) {
-        return nodeEngine.toData(object);
+    public Object marshallValue(Object value) {
+        return nodeEngine.toData(value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
@@ -80,8 +80,8 @@ class EntrySetIteratorFactory<K, V> implements IteratorFactory<K, V, Map.Entry<K
                 throw new NoSuchElementException();
             }
 
-            key = recordStore.unmarshall(key);
-            value = recordStore.unmarshall(value);
+            key = recordStore.unmarshallKey(key);
+            value = recordStore.unmarshallValue(value);
             return new AbstractMap.SimpleEntry<K, V>((K) key, (V) value);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -77,7 +77,7 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
                 throw new NoSuchElementException();
             }
 
-            key = recordStore.unmarshall(key);
+            key = recordStore.unmarshallValue(key);
             return (K) key;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ObjectReplicatedRecordStorage.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ObjectReplicatedRecordStorage.java
@@ -32,12 +32,12 @@ public class ObjectReplicatedRecordStorage<K, V> extends AbstractReplicatedRecor
     }
 
     @Override
-    public Object unmarshall(Object key) {
-        return nodeEngine.toObject(key);
+    public Object unmarshallValue(Object value) {
+        return nodeEngine.toObject(value);
     }
 
     @Override
-    public Object marshall(Object key) {
-        return nodeEngine.toObject(key);
+    public Object marshallValue(Object value) {
+        return nodeEngine.toObject(value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
@@ -70,9 +70,13 @@ public interface ReplicatedRecordStore {
 
     boolean isEmpty();
 
-    Object unmarshall(Object key);
+    Object unmarshallKey(Object key);
 
-    Object marshall(Object key);
+    Object marshallKey(Object key);
+
+    Object unmarshallValue(Object value);
+
+    Object marshallValue(Object value);
 
     void destroy();
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
@@ -77,7 +77,7 @@ class ValuesIteratorFactory<K, V> implements IteratorFactory<K, V, V> {
                 throw new NoSuchElementException();
             }
 
-            value = recordStore.unmarshall(value);
+            value = recordStore.unmarshallValue(value);
             return (V) value;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
@@ -101,12 +101,12 @@ public class AbstractBaseReplicatedRecordStoreTest extends HazelcastTestSupport 
         }
 
         @Override
-        public Object unmarshall(Object key) {
+        public Object unmarshallValue(Object key) {
             return key;
         }
 
         @Override
-        public Object marshall(Object key) {
+        public Object marshallValue(Object key) {
             return key;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -624,13 +624,23 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Object unmarshall(Object key) {
+        public Object unmarshallKey(Object key) {
             return key;
         }
 
         @Override
-        public Object marshall(Object key) {
+        public Object marshallKey(Object key) {
             return key;
+        }
+
+        @Override
+        public Object unmarshallValue(Object value) {
+            return value;
+        }
+
+        @Override
+        public Object marshallValue(Object value) {
+            return value;
         }
 
         @Override


### PR DESCRIPTION
* added test for `ReplicatedMap` with custom key/value classes
* fixed key marshalling in `ReplicatedMap` (always store serialized keys)