### PR TITLE
Prevented thread dump on assumeThat() mismatch

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -22,6 +22,7 @@ import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.runners.statements.RunAfters;
@@ -350,12 +351,15 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             try {
                 next.evaluate();
             } catch (Throwable e) {
-                System.err.println("THREAD DUMP FOR TEST FAILURE: \"" + e.getMessage() + "\" at \"" + method.getName() + "\"\n");
-                try {
-                    System.err.println(generateThreadDump());
-                } catch (Throwable t) {
-                    System.err.println("Unable to get thread dump!");
-                    e.printStackTrace();
+                if (!isJUnitAssumeException(e)) {
+                    System.err.println("THREAD DUMP FOR TEST FAILURE: \"" + e.getMessage()
+                            + "\" at \"" + method.getName() + "\"\n");
+                    try {
+                        System.err.println(generateThreadDump());
+                    } catch (Throwable t) {
+                        System.err.println("Unable to get thread dump!");
+                        e.printStackTrace();
+                    }
                 }
                 errors.add(e);
             } finally {
@@ -368,6 +372,10 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
                 }
             }
             MultipleFailureException.assertEmpty(errors);
+        }
+
+        private boolean isJUnitAssumeException(Throwable e) {
+            return e instanceof AssumptionViolatedException;
         }
     }
 


### PR DESCRIPTION
(cherry picked from commit 57db0e9)

Backport of https://github.com/hazelcast/hazelcast/pull/10561

After backporting the Near Cache tests, we should also backport this small PR, to prevent huge log files due to automatically skipped Near Cache tests.

Motivation:
> With this change the size of the com.hazelcast.map.impl.tx.TxnMapNearCacheBasicTest-output.txt should shrink from about 19.7 MB to 952 KB.