### PR TITLE
[BACKPORT] Fix for class cast exception when running on mule

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -426,14 +426,15 @@ public final class ServiceLoader {
                     // this can happen in application containers - different Hazelcast JARs are loaded
                     // by different classloaders.
                     LOGGER.fine("There appears to be a classloading conflict. "
-                            + "Class " + className + " loaded by " + candidate.getClassLoader() + " does not "
-                            + "implement " + expectedType.getClass().getName() + " loaded by "
-                            + expectedType.getClass().getClassLoader());
+                            + "Class " + className + " loaded by " + candidate.getClassLoader() + " implements "
+                            + expectedType.getName() + " from its own class loader, but it does not implement "
+                            + expectedType.getName() + " loaded by " + expectedType.getClassLoader());
                 } else {
-                    // ok, the class does not implement interface with the expected name. it's probably
-                    // an error in hook implementation -> let's fail fast
-                    throw new ClassCastException("Class " + className + " does not implement "
-                            + expectedType.getName());
+                    //the class does not implement interface with the expected name.
+                    LOGGER.fine("There appears to be a classloading conflict. "
+                            + "Class " + className + " loaded by " + candidate.getClassLoader() + " does not "
+                            + "implement an interface with name " + expectedType.getName() + " in both class loaders."
+                            + "the interface currently loaded by " + expectedType.getClassLoader());
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -67,7 +67,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         assertFalse(iterator.hasNext());
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void testFailFastWhenHookDoesNotImplementExpectedInteface() {
         Class<?> otherInterface = newInterface("com.hazelcast.internal.serialization.DifferentInterface");
         ClassLoader otherClassloader = otherInterface.getClassLoader();
@@ -79,7 +79,7 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         Set<ServiceLoader.ServiceDefinition> definitions = singleton(definition);
         ServiceLoader.ClassIterator<PortableHook> iterator = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
 
-        iterator.hasNext();
+        assertFalse(iterator.hasNext());
     }
 
     @Test


### PR DESCRIPTION
ClassCastException was there to check whether the hooks listed in META-INF
are actually implements relevant interface or not.
An example to related interface is PortableHook.
Since hook classes are moved to another package in 3.6, now it is hitting this exception and
causing instance to fail fast unnecessarily.
To fix the issue we had to gave up on fail fast behaviour. Exception converted
to log to warn the user.

Fixes #10706