### PR TITLE
Cleanup of some client map tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
@@ -19,26 +19,38 @@ package com.hazelcast.client.map;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelTest.class})
-public class ClientMapPartitionIteratorTest extends AbstractMapPartitionIteratorTest {
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractClientMapTest extends HazelcastTestSupport {
+
+    protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    protected HazelcastInstance client;
+
+    protected HazelcastInstance member1;
+    protected HazelcastInstance member2;
 
     @Before
-    public void setup() {
+    public final void startHazelcastInstances() {
         Config config = getConfig();
         ClientConfig clientConfig = getClientConfig();
 
-        factory = new TestHazelcastFactory();
-        server = factory.newHazelcastInstance(config);
-        client = factory.newHazelcastClient(clientConfig);
+        member1 = hazelcastFactory.newHazelcastInstance(config);
+        member2 = hazelcastFactory.newHazelcastInstance(config);
+
+        client = hazelcastFactory.newHazelcastClient(clientConfig);
+    }
+
+    @After
+    public final void stopHazelcastInstances() {
+        hazelcastFactory.terminateAll();
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapPartitionIteratorTest.java
@@ -16,30 +16,32 @@
 
 package com.hazelcast.client.map;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.proxy.ClientMapProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
+import static java.util.Arrays.asList;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractMapPartitionIteratorTest extends HazelcastTestSupport {
 
-    @Parameterized.Parameter
+    @Parameter
     public boolean prefetchValues;
 
-    @Parameterized.Parameters(name = "prefetchValues:{0}")
+    @Parameters(name = "prefetchValues:{0}")
     public static Iterable<Object[]> parameters() {
-        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+        return asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
     }
 
     protected TestHazelcastFactory factory;
@@ -98,6 +100,10 @@ public abstract class AbstractMapPartitionIteratorTest extends HazelcastTestSupp
             Map.Entry entry = iterator.next();
             assertEquals(value, entry.getValue());
         }
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 
     private <K, V> ClientMapProxy<K, V> getMapProxy() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapQueryPartitionIteratorTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.map;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.proxy.ClientMapProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
@@ -47,7 +48,6 @@ public abstract class AbstractMapQueryPartitionIteratorTest extends HazelcastTes
     public void teardown() {
         factory.terminateAll();
     }
-
 
     @Test(expected = NoSuchElementException.class)
     public void test_next_Throws_Exception_On_EmptyPartition() throws Exception {
@@ -116,7 +116,6 @@ public abstract class AbstractMapQueryPartitionIteratorTest extends HazelcastTes
         assertTrue(iterator.hasNext());
     }
 
-
     @Test
     public void test_with_projection_and_true_predicate() throws Exception {
         final ClientMapProxy<String, String> proxy = getMapProxy();
@@ -154,7 +153,6 @@ public abstract class AbstractMapQueryPartitionIteratorTest extends HazelcastTes
         for (Map.Entry<String, Integer> i : projected) {
             assertTrue(i.getValue() % 2 == 0);
         }
-
 
         final Collection<Integer> actualValues = intMap.values();
         assertEquals(actualValues.size() / 2, projected.size());
@@ -198,6 +196,10 @@ public abstract class AbstractMapQueryPartitionIteratorTest extends HazelcastTes
             String val = iterator.next();
             assertEquals(value, val);
         }
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 
     private <K, V> ClientMapProxy<K, V> getMapProxy() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
@@ -16,9 +16,6 @@
 
 package com.hazelcast.client.map;
 
-import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.ReadOnly;
 import com.hazelcast.map.AbstractEntryProcessor;
@@ -30,11 +27,8 @@ import com.hazelcast.query.impl.FalsePredicate;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -48,33 +42,9 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientEntryProcessorTest extends HazelcastTestSupport {
+public class ClientEntryProcessorTest extends AbstractClientMapTest {
 
     private static final String MAP_NAME = "default";
-
-    private HazelcastInstance client;
-
-    private HazelcastInstance member1;
-    private HazelcastInstance member2;
-
-    @Before
-    public void setUp() throws Exception {
-        Config config = getConfig();
-
-        TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-        member1 = hazelcastFactory.newHazelcastInstance(config);
-        member2 = hazelcastFactory.newHazelcastInstance(config);
-
-        client = hazelcastFactory.newHazelcastClient();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        client.shutdown();
-
-        member1.shutdown();
-        member2.shutdown();
-    }
 
     @Test
     public void test_executeOnEntries_updatesValue_onOwnerAndBackupPartition() {
@@ -112,7 +82,6 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
         assertEquals("value", member1Value);
     }
 
-
     @Test
     public void test_executeOnEntries_updatesValue_with_TruePredicate() {
         String member1Key = generateKeyOwnedBy(member1);
@@ -128,7 +97,6 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
         assertEquals("newValue", member1Value);
     }
 
-
     @Test
     public void test_executeOnEntriesWithPredicate_usesIndexes_whenIndexesAvailable() {
         IMap<Integer, Integer> map = client.getMap("test");
@@ -140,7 +108,6 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
 
         IndexedTestPredicate predicate = new IndexedTestPredicate();
         map.executeOnEntries(new EP(), predicate);
-
 
         assertTrue("isIndexed method of IndexAwarePredicate should be called", IndexedTestPredicate.INDEX_CALLED.get());
     }
@@ -156,19 +123,19 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
     }
 
     public static final class EP extends AbstractEntryProcessor {
+
         @Override
         public Object process(Map.Entry entry) {
             return null;
         }
     }
 
-
     /**
      * This predicate is used to check whether or not {@link IndexAwarePredicate#isIndexed} method is called.
      */
     private static class IndexedTestPredicate implements IndexAwarePredicate {
 
-        public static final AtomicBoolean INDEX_CALLED = new AtomicBoolean(false);
+        static final AtomicBoolean INDEX_CALLED = new AtomicBoolean(false);
 
         @Override
         public Set<QueryableEntry> filter(QueryContext queryContext) {
@@ -187,12 +154,11 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
         }
     }
 
-
     public static class ValueUpdater extends AbstractEntryProcessor {
 
         private final String newValue;
 
-        public ValueUpdater(String newValue) {
+        ValueUpdater(String newValue) {
             this.newValue = newValue;
         }
 
@@ -207,7 +173,7 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
 
         private final String newValue;
 
-        public ValueUpdaterReadOnly(String newValue) {
+        ValueUpdaterReadOnly(String newValue) {
             this.newValue = newValue;
         }
 
@@ -222,6 +188,4 @@ public class ClientEntryProcessorTest extends HazelcastTestSupport {
             return null;
         }
     }
-
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -16,12 +16,9 @@
 
 package com.hazelcast.client.map;
 
-import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.MapInterceptor;
@@ -30,11 +27,8 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,65 +51,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientMapBasicTest extends HazelcastTestSupport {
-
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
-    private HazelcastInstance client;
-
-    private HazelcastInstance member1;
-    private HazelcastInstance member2;
-
-    private static class DelayGetRemoveMapInterceptor
-            implements MapInterceptor, Serializable {
-        @Override
-        public Object interceptGet(Object value) {
-            sleepMillis(1);
-            return value;
-        }
-
-        @Override
-        public void afterGet(Object value) {
-
-        }
-
-        @Override
-        public Object interceptPut(Object oldValue, Object newValue) {
-            sleepMillis(1);
-            return newValue;
-        }
-
-        @Override
-        public void afterPut(Object value) {
-
-        }
-
-        @Override
-        public Object interceptRemove(Object removedValue) {
-            sleepMillis(1);
-            return removedValue;
-        }
-
-        @Override
-        public void afterRemove(Object value) {
-
-        }
-    }
-
-    @Before
-    public void setup() {
-        Config config = getConfig();
-
-        member1 = hazelcastFactory.newHazelcastInstance(config);
-        member2 = hazelcastFactory.newHazelcastInstance(config);
-
-        client = hazelcastFactory.newHazelcastClient();
-    }
-
-    @After
-    public void tearDown() {
-        hazelcastFactory.terminateAll();
-    }
+public class ClientMapBasicTest extends AbstractClientMapTest {
 
     @Test
     public void testClientGetMap() {
@@ -1270,6 +1206,39 @@ public class ClientMapBasicTest extends HazelcastTestSupport {
     public void testLocalKeySet_WithPredicate() {
         IMap<String, String> map = client.getMap(randomString());
         map.localKeySet(new FalsePredicate());
+    }
+
+    private static class DelayGetRemoveMapInterceptor implements MapInterceptor, Serializable {
+
+        @Override
+        public Object interceptGet(Object value) {
+            sleepMillis(1);
+            return value;
+        }
+
+        @Override
+        public void afterGet(Object value) {
+        }
+
+        @Override
+        public Object interceptPut(Object oldValue, Object newValue) {
+            sleepMillis(1);
+            return newValue;
+        }
+
+        @Override
+        public void afterPut(Object value) {
+        }
+
+        @Override
+        public Object interceptRemove(Object removedValue) {
+            sleepMillis(1);
+            return removedValue;
+        }
+
+        @Override
+        public void afterRemove(Object value) {
+        }
     }
 
     private static class EmptyEntryListener implements EntryListener<String, String> {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapEvictAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapEvictAllTest.java
@@ -16,17 +16,12 @@
 
 package com.hazelcast.client.map;
 
-import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryAdapter;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,22 +34,11 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientMapEvictAllTest extends HazelcastTestSupport {
-
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
-    @After
-    public void tearDown() {
-        hazelcastFactory.terminateAll();
-    }
+public class ClientMapEvictAllTest extends AbstractClientMapTest {
 
     @Test
     public void evictAll_firesEvent() throws Exception {
         final String mapName = randomMapName();
-        Config config = getConfig();
-        hazelcastFactory.newHazelcastInstance(config);
-        hazelcastFactory.newHazelcastInstance(config);
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         final IMap<Object, Object> map = client.getMap(mapName);
         final CountDownLatch evictedEntryCount = new CountDownLatch(3);
         map.addEntryListener(new EntryAdapter<Object, Object>() {
@@ -80,9 +64,6 @@ public class ClientMapEvictAllTest extends HazelcastTestSupport {
     @Test
     public void evictAll_firesOnlyOneEvent() throws Exception {
         final String mapName = randomMapName();
-        Config config = getConfig();
-        hazelcastFactory.newHazelcastInstance(config);
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         final IMap<Object, Object> map = client.getMap(mapName);
         final CountDownLatch eventCount = new CountDownLatch(2);
         map.addEntryListener(new EntryAdapter<Object, Object>() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -67,8 +67,10 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
     @Test
     public void testListenerRegistrations() throws Exception {
         Config config = getConfig();
+        ClientConfig clientConfig = getClientConfig();
+
         HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance(config);
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final String mapName = randomMapName();
         IMap<Object, Object> map = client.getMap(mapName);
@@ -96,11 +98,14 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
 
     @Test
     public void testFutureGetCalledInCallback() {
-        hazelcastFactory.newHazelcastInstance();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        Config config = getConfig();
+        ClientConfig clientConfig = getClientConfig();
+
+        hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<Integer, Integer> map = client.getMap("map");
-        final ICompletableFuture<Integer> future = (ICompletableFuture<Integer>) map.getAsync(1);
+        final ICompletableFuture<Integer> future = map.getAsync(1);
         final CountDownLatch latch = new CountDownLatch(1);
         future.andThen(new ExecutionCallback<Integer>() {
             public void onResponse(Integer response) {
@@ -122,10 +127,11 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
     @Category(NightlyTest.class)
     public void testOperationNotBlockingAfterClusterShutdown() throws InterruptedException {
         Config config = getConfig();
+
         HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance(config);
 
-        ClientConfig clientConfig = new ClientConfig();
+        ClientConfig clientConfig = getClientConfig();
         clientConfig.setExecutorPoolSize(1);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "10");
@@ -160,7 +166,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance(config);
 
-        ClientConfig clientConfig = new ClientConfig();
+        ClientConfig clientConfig = getClientConfig();
         clientConfig.setExecutorPoolSize(1);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "10");
@@ -194,7 +200,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
 
-        final ClientConfig clientConfig = new ClientConfig();
+        final ClientConfig clientConfig = getClientConfig();
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final IMap<Integer, Integer> map = client.getMap("map");
@@ -218,7 +224,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
 
-        final ClientConfig clientConfig = new ClientConfig();
+        final ClientConfig clientConfig = getClientConfig();
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final IMap<Integer, Integer> map = client.getMap("map");
@@ -235,7 +241,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         Collection<Integer> values = map.values(predicate);
         assertEquals(pageSize, values.size());
 
-        /**
+        /*
          * There may be cases when the server may return a list of entries larger than the requested page size, in this case
          * the client should not put any anchor into the list that is on a page greater than the requested page. The case occurs
          * when multiple members exist in the cluster. E.g.:
@@ -316,7 +322,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
 
-        final ClientConfig clientConfig = new ClientConfig();
+        final ClientConfig clientConfig = getClientConfig();
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final IMap<Integer, Integer> map = client.getMap("map");
@@ -334,7 +340,6 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         assertEquals(pageSize, values.size());
     }
 
-
     @Test
     @Category(NightlyTest.class)
     public void testNoOperationTimeoutException_whenUserCodeLongRunning() {
@@ -350,6 +355,10 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         String value = randomString();
         map.put(key, value);
         assertEquals(value, map.executeOnKey(key, sleepyProcessor));
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 
     static class SleepyProcessor implements EntryProcessor, Serializable {
@@ -375,6 +384,5 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         public EntryBackupProcessor getBackupProcessor() {
             return null;
         }
-
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.map;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
@@ -79,7 +80,7 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
 
         breakMe.set(true);
 
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
         client.getMap(mapName);
     }
 
@@ -91,7 +92,7 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
 
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
         final IMap<Object, Object> map = client.getMap(mapName);
         populateMap(map, 1000);
         map.evictAll();
@@ -107,7 +108,7 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         String name = randomString();
         int keysInMapStore = 10000;
 
-        Config config = new Config();
+        Config config = getConfig();
         MapConfig mapConfig = config.getMapConfig(name);
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true);
@@ -116,7 +117,7 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         mapConfig.setMapStoreConfig(mapStoreConfig);
         hazelcastFactory.newHazelcastInstance(config);
 
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
         IMap<Integer, Integer> map = client.getMap(name);
 
         //load specific keys
@@ -137,13 +138,17 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
         final IMap<Object, Object> map = client.getMap(mapName);
         populateMap(map, 1000);
         map.evictAll();
         map.loadAll(true);
 
         assertEquals(1000, map.size());
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 
     private Config createNewConfig(String mapName) {
@@ -174,17 +179,8 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         }
     }
 
-    private static void closeResources(HazelcastInstance... instances) {
-        if (instances == null) {
-            return;
-        }
-        for (HazelcastInstance instance : instances) {
-            instance.shutdown();
-        }
-    }
-
-
     private static class SimpleStore implements MapStore {
+
         private ConcurrentMap store = new ConcurrentHashMap();
 
         @Override
@@ -200,17 +196,14 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
                 final Object value = entry.getValue();
                 store(key, value);
             }
-
         }
 
         @Override
         public void delete(Object key) {
-
         }
 
         @Override
         public void deleteAll(Collection keys) {
-
         }
 
         @Override
@@ -261,5 +254,4 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
             return false;
         }
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryLiteMemberTest.java
@@ -17,11 +17,11 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.MapLiteMemberTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -30,11 +30,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientMapQueryLiteMemberTest {
+public class ClientMapQueryLiteMemberTest extends HazelcastTestSupport {
 
     private TestHazelcastFactory factory;
 
@@ -43,8 +41,8 @@ public class ClientMapQueryLiteMemberTest {
     @Before
     public void setUp() {
         factory = new TestHazelcastFactory();
-        factory.newHazelcastInstance();
-        factory.newHazelcastInstance(new Config().setLiteMember(true));
+        factory.newHazelcastInstance(getConfig());
+        factory.newHazelcastInstance(getConfig().setLiteMember(true));
         HazelcastInstance client = factory.newHazelcastClient();
         map = client.getMap(randomMapName());
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryPartitionIteratorTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -31,9 +30,8 @@ public class ClientMapQueryPartitionIteratorTest extends AbstractMapQueryPartiti
 
     @Before
     public void setup() {
-        Config config = getConfig();
         factory = new TestHazelcastFactory();
-        server = factory.newHazelcastInstance(config);
-        client = factory.newHazelcastClient();
+        server = factory.newHazelcastInstance(getConfig());
+        client = factory.newHazelcastClient(getClientConfig());
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapRemoveAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapRemoveAllTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.Predicate;
@@ -53,15 +52,15 @@ public class ClientMapRemoveAllTest extends HazelcastTestSupport {
     private HazelcastInstance client;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         factory = new TestHazelcastFactory();
-        factory.newInstances(new Config(), NODE_COUNT);
+        factory.newInstances(getConfig(), NODE_COUNT);
 
         client = factory.newHazelcastClient();
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         factory.shutdownAll();
     }
 
@@ -114,6 +113,7 @@ public class ClientMapRemoveAllTest extends HazelcastTestSupport {
     }
 
     private static final class OddFinderPredicate implements Predicate<Integer, Integer> {
+
         @Override
         public boolean apply(Map.Entry<Integer, Integer> mapEntry) {
             return mapEntry.getKey() % 2 != 0;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
@@ -69,7 +69,7 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        nodeConfig = new Config();
+        nodeConfig = getConfig();
         MapConfig mapConfig = new MapConfig();
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true);
@@ -136,7 +136,7 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
     public void mapSize_After_MapStore_OperationQueue_OverFlow() throws Exception {
         int maxCapacity = 1000;
 
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY.getName(), String.valueOf(maxCapacity));
 
         MapConfig mapConfig = new MapConfig();
@@ -183,7 +183,7 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
     public void mapStore_OperationQueue_AtMaxCapacity() {
         int maxCapacity = 1000;
 
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY.getName(), String.valueOf(maxCapacity));
 
         MapConfig mapConfig = new MapConfig();
@@ -220,7 +220,7 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
 
     @Test
     public void destroyMap_configuredWithMapStore() {
-        Config config = new Config();
+        Config config = getConfig();
         MapConfig mapConfig = new MapConfig();
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -100,7 +100,7 @@ public class ClientMapTest extends HazelcastTestSupport {
 
         server = hazelcastFactory.newHazelcastInstance(config);
 
-        ClientConfig clientConfig = new ClientConfig();
+        ClientConfig clientConfig = getClientConfig();
         clientConfig.getSerializationConfig()
                 .addPortableFactory(TestSerializationConstants.PORTABLE_FACTORY_ID, new PortableFactory() {
                     public Portable create(int classId) {
@@ -118,7 +118,7 @@ public class ClientMapTest extends HazelcastTestSupport {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testIssue537() throws InterruptedException {
+    public void testIssue537() {
         final CountDownLatch latch = new CountDownLatch(2);
         final CountDownLatch nullLatch = new CountDownLatch(2);
 
@@ -156,7 +156,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testSerializationServiceNullClassLoaderProblem() throws Exception {
+    public void testSerializationServiceNullClassLoaderProblem() {
         IMap<Integer, SampleTestObjects.PortableEmployee> map = client.getMap("test");
 
         // If the classloader is null the following call throws NullPointerException
@@ -164,7 +164,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testContains() throws Exception {
+    public void testContains() {
         IMap<String, String> map = createMap();
         fillMap(map);
 
@@ -211,7 +211,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testFlush() throws InterruptedException {
+    public void testFlush() {
         flushMapStore.latch = new CountDownLatch(1);
         IMap<Long, String> map = client.getMap("flushMap");
         map.put(1L, "value");
@@ -371,7 +371,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutTtl() throws Exception {
+    public void testPutTtl() {
         final IMap<String, String> map = createMap();
         map.put("key1", "value1", 1, TimeUnit.SECONDS);
         assertNotNull(map.get("key1"));
@@ -384,14 +384,14 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutIfAbsent() throws Exception {
+    public void testPutIfAbsent() {
         IMap<String, String> map = createMap();
         assertNull(map.putIfAbsent("key1", "value1"));
         assertEquals("value1", map.putIfAbsent("key1", "value3"));
     }
 
     @Test
-    public void testPutIfAbsentTtl() throws Exception {
+    public void testPutIfAbsentTtl() {
         final IMap<String, String> map = createMap();
         assertNull(map.putIfAbsent("key1", "value1", 1, TimeUnit.SECONDS));
         assertEquals("value1", map.putIfAbsent("key1", "value3", 1, TimeUnit.SECONDS));
@@ -406,7 +406,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testSet() throws Exception {
+    public void testSet() {
         final IMap<String, String> map = createMap();
         map.set("key1", "value1");
         assertEquals("value1", map.get("key1"));
@@ -426,7 +426,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutTransient() throws InterruptedException {
+    public void testPutTransient() throws Exception {
         transientMapStore.latch = new CountDownLatch(1);
         IMap<Long, String> map = client.getMap("putTransientMap");
         map.putTransient(3L, "value1", 100, TimeUnit.SECONDS);
@@ -531,7 +531,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testReplace() throws Exception {
+    public void testReplace() {
         IMap<String, String> map = createMap();
         assertNull(map.replace("key1", "value1"));
         map.put("key1", "value1");
@@ -545,7 +545,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testExecuteOnKey() throws Exception {
+    public void testExecuteOnKey() {
         IMap<Integer, Integer> map = createMap();
         map.put(1, 1);
         assertEquals(2, map.executeOnKey(1, new IncrementerEntryProcessor()));
@@ -601,7 +601,7 @@ public class ClientMapTest extends HazelcastTestSupport {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testListener() throws InterruptedException {
+    public void testListener() throws Exception {
         IMap<String, String> map = createMap();
         final CountDownLatch latch1Add = new CountDownLatch(5);
         final CountDownLatch latch1Remove = new CountDownLatch(2);
@@ -634,7 +634,7 @@ public class ClientMapTest extends HazelcastTestSupport {
         map.addEntryListener(listener1, false);
         map.addEntryListener(listener2, "key3", true);
 
-        Thread.sleep(1000);
+        sleepSeconds(1);
 
         map.put("key1", "value1");
         map.put("key2", "value2");
@@ -653,7 +653,7 @@ public class ClientMapTest extends HazelcastTestSupport {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testPredicateListenerWithPortableKey() throws InterruptedException {
+    public void testPredicateListenerWithPortableKey() throws Exception {
         IMap<Portable, Integer> tradeMap = createMap();
 
         final AtomicInteger atomicInteger = new AtomicInteger(0);
@@ -709,7 +709,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testExecuteOnKeys() throws Exception {
+    public void testExecuteOnKeys() {
         String name = randomString();
         IMap<Integer, Integer> map = client.getMap(name);
         IMap<Integer, Integer> map2 = client.getMap(name);
@@ -760,7 +760,7 @@ public class ClientMapTest extends HazelcastTestSupport {
      */
     @Test
     @SuppressWarnings({"deprecation", "unchecked"})
-    public void testEntryListener() throws InterruptedException {
+    public void testEntryListener() throws Exception {
         CountDownLatch gateAdd = new CountDownLatch(3);
         CountDownLatch gateRemove = new CountDownLatch(1);
         CountDownLatch gateEvict = new CountDownLatch(1);
@@ -801,7 +801,7 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testMapStatistics() throws Exception {
+    public void testMapStatistics() {
         String name = randomString();
         IMap<Integer, Integer> map = client.getMap(name);
 
@@ -823,7 +823,7 @@ public class ClientMapTest extends HazelcastTestSupport {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testEntryListenerWithPredicateOnDeleteOperation() throws Exception {
+    public void testEntryListenerWithPredicateOnDeleteOperation() {
         IMap<String, String> serverMap = server.getMap("A");
         IMap<String, String> clientMap = client.getMap("A");
 
@@ -838,6 +838,10 @@ public class ClientMapTest extends HazelcastTestSupport {
         serverMap.put("A", "B");
         clientMap.delete("A");
         assertOpenEventually(latch, 10);
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 
     private <K, V> IMap<K, V> createMap() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -26,6 +26,7 @@ import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
@@ -38,7 +39,7 @@ import static java.lang.String.valueOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-public abstract class ClientMapUnboundReturnValuesTestSupport {
+public abstract class ClientMapUnboundReturnValuesTestSupport extends HazelcastTestSupport {
 
     protected static final int PARTITION_COUNT = 271;
 
@@ -125,7 +126,7 @@ public abstract class ClientMapUnboundReturnValuesTestSupport {
     }
 
     private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), valueOf(partitionCount));
         config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT.getName(), valueOf(limit));
         config.setProperty(GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK.getName(), valueOf(preCheckTrigger));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
@@ -75,7 +75,7 @@ public class ClientMapWANExceptionTest extends HazelcastTestSupport {
 
     @Override
     protected Config getConfig() {
-        Config config = new Config();
+        Config config = super.getConfig();
         WanReplicationConfig wanConfig = new WanReplicationConfig();
         wanConfig.setName("dummyWan");
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientWriteBehindFlushTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientWriteBehindFlushTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.map;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
@@ -56,7 +57,7 @@ public class ClientWriteBehindFlushTest extends HazelcastTestSupport {
     private HazelcastInstance member3;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         MapStoreWithCounter mapStore = new MapStoreWithCounter<Integer, String>();
         mapStoreConfig.setImplementation(mapStore).setWriteDelaySeconds(3000);
@@ -69,18 +70,17 @@ public class ClientWriteBehindFlushTest extends HazelcastTestSupport {
         member2 = hazelcastFactory.newHazelcastInstance(config);
         member3 = hazelcastFactory.newHazelcastInstance(config);
 
-        client = hazelcastFactory.newHazelcastClient();
+        client = hazelcastFactory.newHazelcastClient(getClientConfig());
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         client.shutdown();
 
         member1.shutdown();
         member2.shutdown();
         member3.shutdown();
     }
-
 
     @Test
     @Ignore //https://github.com/hazelcast/hazelcast/issues/7492
@@ -115,6 +115,10 @@ public class ClientWriteBehindFlushTest extends HazelcastTestSupport {
         hazelcastFactory.shutdownAll();
     }
 
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
+    }
+
     protected Config newMapStoredConfig(MapStore store, int writeDelaySeconds) {
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true);
@@ -138,5 +142,4 @@ public class ClientWriteBehindFlushTest extends HazelcastTestSupport {
             }
         });
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapPartitionIteratorTest.java
@@ -29,9 +29,10 @@ import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class DummyClientMapPartitionIteratorTest extends AbstractMapPartitionIteratorTest {
 
@@ -46,14 +47,15 @@ public class DummyClientMapPartitionIteratorTest extends AbstractMapPartitionIte
         client = factory.newHazelcastClient(getClientConfig(server));
     }
 
-    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+    private ClientConfig getClientConfig(HazelcastInstance instance) {
         Address address = instance.getCluster().getLocalMember().getAddress();
         String addressString = address.getHost() + ":" + address.getPort();
-        ClientConfig clientConfig = new ClientConfig();
-        ClientNetworkConfig networkConfig = new ClientNetworkConfig();
-        networkConfig.setSmartRouting(false);
-        networkConfig.addAddress(addressString);
-        clientConfig.setNetworkConfig(networkConfig);
-        return clientConfig;
+
+        ClientNetworkConfig networkConfig = new ClientNetworkConfig()
+                .setSmartRouting(false)
+                .addAddress(addressString);
+
+        return getClientConfig()
+                .setNetworkConfig(networkConfig);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapQueryPartitionIteratorTest.java
@@ -44,14 +44,15 @@ public class DummyClientMapQueryPartitionIteratorTest extends AbstractMapQueryPa
         client = factory.newHazelcastClient(getClientConfig(server));
     }
 
-    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+    private ClientConfig getClientConfig(HazelcastInstance instance) {
         Address address = instance.getCluster().getLocalMember().getAddress();
         String addressString = address.getHost() + ":" + address.getPort();
-        ClientConfig clientConfig = new ClientConfig();
-        ClientNetworkConfig networkConfig = new ClientNetworkConfig();
-        networkConfig.setSmartRouting(false);
-        networkConfig.addAddress(addressString);
-        clientConfig.setNetworkConfig(networkConfig);
-        return clientConfig;
+
+        ClientNetworkConfig networkConfig = new ClientNetworkConfig()
+                .setSmartRouting(false)
+                .addAddress(addressString);
+
+        return getClientConfig()
+                .setNetworkConfig(networkConfig);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.client.map;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.logging.ILogger;
@@ -54,9 +54,8 @@ public class MapMemoryUsageStressTest extends HazelcastTestSupport {
 
     @Before
     public void launchHazelcastServer() {
-        Config config = getConfig();
-        hazelcastFactory.newHazelcastInstance(config);
-        client = hazelcastFactory.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance(getConfig());
+        client = hazelcastFactory.newHazelcastClient(getClientConfig());
     }
 
     @After
@@ -80,6 +79,10 @@ public class MapMemoryUsageStressTest extends HazelcastTestSupport {
         assertJoinable(MINUTES.toSeconds(30), threads);
         assertEqualsStringFormat("Expected %d errors, but got %d (" + errorList + ")", 0, errors.get());
         assertTrue(format("Expected the counter to be <= 0, but was %d", counter.get()), counter.get() <= 0);
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 
     private class StressThread extends Thread {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -51,21 +52,19 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MapPreconditionsTest {
+public class MapPreconditionsTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    private HazelcastInstance client;
-    private HazelcastInstance server;
     private IMap<Object, Object> map;
 
     @Before
-    public void setUp() throws Exception {
-        Config config = new Config();
+    public void setUp() {
+        Config config = getConfig();
         // Default minimum is 100000 * 1.5f
         config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT.getName(), "1");
-        server = hazelcastFactory.newHazelcastInstance(config);
-        client = hazelcastFactory.newHazelcastClient();
+        hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         map = client.getMap("trial");
     }
@@ -635,36 +634,30 @@ public class MapPreconditionsTest {
         int mapClearedCalled;
         int mapEvictedCalled;
 
-
         @Override
         public void entryAdded(EntryEvent event) {
             entryAddedCalled++;
         }
-
 
         @Override
         public void entryEvicted(EntryEvent event) {
             entryEvictedCalled++;
         }
 
-
         @Override
         public void entryRemoved(EntryEvent event) {
             entryRemovedCalled++;
         }
-
 
         @Override
         public void entryUpdated(EntryEvent event) {
             entryUpdatedCalled++;
         }
 
-
         @Override
         public void mapCleared(MapEvent event) {
             mapClearedCalled++;
         }
-
 
         @Override
         public void mapEvicted(MapEvent event) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/SimpleClientMapInterceptorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/SimpleClientMapInterceptorTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -37,7 +38,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class SimpleClientMapInterceptorTest {
+public class SimpleClientMapInterceptorTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     private HazelcastInstance client;
@@ -46,7 +47,7 @@ public class SimpleClientMapInterceptorTest {
 
     @Before
     public void setup() {
-        Config config = new Config();
+        Config config = getConfig();
         config.getSerializationConfig().addPortableFactory(PortableHelpersFactory.ID, new PortableHelpersFactory());
         hazelcastFactory.newHazelcastInstance(config);
         hazelcastFactory.newHazelcastInstance(config);
@@ -78,7 +79,6 @@ public class SimpleClientMapInterceptorTest {
         map.put(7, "Hong Kong");
 
         map.remove(1);
-
 
         try {
             map.remove(2);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
@@ -72,14 +72,14 @@ public class ClientMapNearCacheStaleReadTest extends HazelcastTestSupport {
     private HazelcastInstance client;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestHazelcastFactory factory = new TestHazelcastFactory();
         valuePut = new AtomicInteger(0);
         stop = new AtomicBoolean(false);
         failed = new AtomicBoolean(false);
         assertionViolationCount = new AtomicInteger(0);
 
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), "2");
         member = factory.newHazelcastInstance(config);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -47,8 +47,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,6 +65,7 @@ import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAG
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -70,16 +73,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapNearCacheTest extends NearCacheTestSupport {
 
-    @Parameterized.Parameter
+    @Parameter
     public boolean batchInvalidationEnabled;
 
-    @Parameterized.Parameters(name = "batchInvalidationEnabled:{0}")
+    @Parameters(name = "batchInvalidationEnabled:{0}")
     public static Iterable<Object[]> parameters() {
-        return Arrays.asList(new Object[]{TRUE}, new Object[]{FALSE});
+        return asList(new Object[]{TRUE}, new Object[]{FALSE});
     }
 
     protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
@@ -1272,7 +1275,7 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     protected Config newConfig() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(MAP_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), String.valueOf(batchInvalidationEnabled));
         return config;
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/MapNearCacheInvalidationFromClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/MapNearCacheInvalidationFromClientTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -36,9 +37,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
-import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -46,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MapNearCacheInvalidationFromClientTest {
+public class MapNearCacheInvalidationFromClientTest extends HazelcastTestSupport {
 
     private String mapName;
 
@@ -243,7 +241,7 @@ public class MapNearCacheInvalidationFromClientTest {
         NearCacheConfig nearCacheConfig = new NearCacheConfig()
                 .setInvalidateOnChange(true);
 
-        Config config = new Config()
+        Config config = getConfig()
                 .setLiteMember(liteMember)
                 .setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), "true")
                 .setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), "5")

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -160,7 +160,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
     }
 
     protected Config createConfig() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "271");
         config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), "true");
         config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), Integer.toString(INVALIDATION_BATCH_SIZE));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -63,7 +63,7 @@ public class InvalidationMetadataDistortionTest extends NearCacheTestSupport {
     }
 
     protected Config createConfig() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "271");
         config.setProperty(GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), "true");
         config.setProperty(GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), "10");

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
@@ -16,13 +16,14 @@
 
 package com.hazelcast.client.map.impl.query;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SampleTestObjects;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -39,7 +40,7 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientQueryAdvancedTest {
+public class ClientQueryAdvancedTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
@@ -48,14 +49,14 @@ public class ClientQueryAdvancedTest {
         hazelcastFactory.terminateAll();
     }
 
-
+    /**
+     * Test for issue #5807.
+     */
     @Test
     public void queryIndexedComparableField_whenEqualsPredicateWithNullValueIsUsed_thenConverterUsesNullObject() {
-        //issue 5807
-        Config config = getConfig();
-        hazelcastFactory.newHazelcastInstance(config);
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
-        final IMap<Integer, SampleTestObjects.Value> map = client.getMap("default");
+        hazelcastFactory.newHazelcastInstance(getConfig());
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(getClientConfig());
+        IMap<Integer, SampleTestObjects.Value> map = client.getMap("default");
 
         map.addIndex("type", false);
 
@@ -65,13 +66,13 @@ public class ClientQueryAdvancedTest {
         map.put(1, valueWithoutNull);
         map.put(2, valueWithNull);
 
-        final Predicate nullPredicate = equal("type", null);
-        final Collection<SampleTestObjects.Value> emptyFieldValues = map.values(nullPredicate);
+        Predicate nullPredicate = equal("type", null);
+        Collection<SampleTestObjects.Value> emptyFieldValues = map.values(nullPredicate);
         assertThat(emptyFieldValues, hasSize(1));
         assertThat(emptyFieldValues, contains(valueWithNull));
     }
 
-    protected Config getConfig() {
-        return new Config();
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheBasicTest.java
@@ -87,7 +87,7 @@ public class ClientQueryCacheBasicTest extends HazelcastTestSupport {
     // setup a map with 2 query caches, same predicate, one includes values, the other excludes values
     @Before
     public void setup() {
-        Config config = new Config();
+        Config config = getConfig();
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.addQueryCacheConfig(TEST_MAP_NAME, new QueryCacheConfig(QUERY_CACHE_NAME)

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheClientContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheClientContextTest.java
@@ -58,7 +58,7 @@ public class ClientQueryCacheClientContextTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        Config config = new Config();
+        Config config = getConfig();
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.addQueryCacheConfig(MAP_NAME_1, newQueryCacheConfig(QUERY_CACHE_1));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheDestroyResourcesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheDestroyResourcesTest.java
@@ -65,7 +65,7 @@ public class ClientQueryCacheDestroyResourcesTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        Config config = new Config();
+        Config config = getConfig();
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.addQueryCacheConfig(MAP_NAME_1, newQueryCacheConfig(QUERY_CACHE_NAME_1));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheEventLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheEventLostListenerTest.java
@@ -48,15 +48,15 @@ public class ClientQueryCacheEventLostListenerTest extends HazelcastTestSupport 
     private HazelcastInstance node;
 
     @Before
-    public void setUp() throws Exception {
-        Config config = new Config();
+    public void setUp() {
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "1");
 
         node = factory.newHazelcastInstance(config);
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         factory.shutdownAll();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheIndexTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheIndexTest.java
@@ -56,7 +56,7 @@ public class ClientQueryCacheIndexTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "1");
 
         factory = new TestHazelcastFactory();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheRecoveryUponEventLossTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheRecoveryUponEventLossTest.java
@@ -57,7 +57,7 @@ public class ClientQueryCacheRecoveryUponEventLossTest extends HazelcastTestSupp
     public void testForceConsistency() {
         String mapName = randomMapName("map");
         String queryCacheName = randomMapName("cache");
-        Config config = new Config();
+        Config config = getConfig();
 
         config.setProperty(PARTITION_COUNT.getName(), "1");
         factory.newHazelcastInstance(config);


### PR DESCRIPTION
Added a `getClientConfig()` method for tests, which are extended in HZ
Enterprise. Also made sure that member nodes are using `getConfig()`, not
`new Config()`, to enabled configuration override in Hazelcast Enterprise.

This PR is needed to fix the extensive logging of weak group password for EE tests. We need an override-able client config for those tests.