### PR TITLE
Introduces config-permission in hazelcast-spring xsd

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -2280,6 +2280,7 @@
                         <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="cache-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
+                        <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/SecureApplicationContextTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/SecureApplicationContextTest.java
@@ -162,6 +162,11 @@ public class SecureApplicationContextTest {
                     String[] actualActions = permConfig.getActions().toArray(new String[0]);
                     assertArrayEquals(expectedActions, actualActions);
                     break;
+                case CONFIG:
+                    assertEquals("dev", permConfig.getPrincipal());
+                    assertEquals(1, permConfig.getEndpoints().size());
+                    assertEquals("127.0.0.1", permConfig.getEndpoints().iterator().next());
+                    break;
             }
         }
     }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
@@ -118,6 +118,11 @@
                         <hz:action>destroy</hz:action>
                     </hz:actions>
                 </hz:cache-permission>
+                <hz:config-permission principal="dev">
+                    <hz:endpoints>
+                        <hz:endpoint>127.0.0.1</hz:endpoint>
+                    </hz:endpoints>
+                </hz:config-permission>
             </hz:client-permissions>
             <hz:security-interceptors>
                 <hz:interceptor class-name="com.hazelcast.spring.security.DummySecurityInterceptor"

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -50,6 +50,7 @@ import java.util.Properties;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
+import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1751,6 +1752,22 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         Config config = buildConfig(xml);
         PermissionConfig expected = new PermissionConfig(CACHE, "/hz/cachemanager1/cache1", "dev");
         expected.addAction("create").addAction("destroy").addAction("add").addAction("remove");
+        assertPermissionConfig(expected, config);
+    }
+
+    @Test
+    public void testConfigPermission() {
+        String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
+                + "  <client-permissions>"
+                + "    <config-permission principal=\"dev\">"
+                + "       <endpoints><endpoint>127.0.0.1</endpoint></endpoints>"
+                + "    </config-permission>\n"
+                + "  </client-permissions>"
+                + SECURITY_END_TAG + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        PermissionConfig expected = new PermissionConfig(CONFIG, "*", "dev");
+        expected.getEndpoints().add("127.0.0.1");
         assertPermissionConfig(expected, config);
     }
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -674,6 +674,11 @@
                     <action>remove</action>
                 </actions>
             </cache-permission>
+            <config-permission principal="dev">
+                <endpoints>
+                    <endpoint>127.0.0.1</endpoint>
+                </endpoints>
+            </config-permission>
         </client-permissions>
     </security>
 


### PR DESCRIPTION
Also adds test for config-permission in `hazelcast-config-3.9.xsd`

Fixes #10835 