### PR TITLE
Fixes Config assertions in OSGi test considering dynamic config changes

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
@@ -272,11 +272,11 @@ public class HazelcastOSGiServiceTest extends HazelcastTestSupport {
 
         HazelcastOSGiInstance osgiInstance = service.newHazelcastInstance(config);
         assertNotNull(osgiInstance);
-        assertEquals(config, osgiInstance.getConfig());
+        assertEquals(config.getInstanceName(), osgiInstance.getConfig().getInstanceName());
 
         HazelcastInstance instance = osgiInstance.getDelegatedInstance();
         assertNotNull(instance);
-        assertEquals(config, instance.getConfig());
+        assertEquals(config.getInstanceName(), instance.getConfig().getInstanceName());
     }
 
     @Test
@@ -455,11 +455,11 @@ public class HazelcastOSGiServiceTest extends HazelcastTestSupport {
 
         HazelcastOSGiInstance osgiInstance = service.getHazelcastInstanceByName(INSTANCE_NAME);
         assertNotNull(osgiInstance);
-        assertEquals(config, osgiInstance.getConfig());
+        assertEquals(config.getInstanceName(), osgiInstance.getConfig().getInstanceName());
 
         HazelcastInstance instance = osgiInstance.getDelegatedInstance();
         assertNotNull(instance);
-        assertEquals(config, instance.getConfig());
+        assertEquals(config.getInstanceName(), instance.getConfig().getInstanceName());
     }
 
     @Test


### PR DESCRIPTION
Since #10757 was merged, `HazelcastOSGiServiceTest.newInstanceRetrievedSuccessfullyWithConfiguration` & `HazelcastOSGiServiceTest.instanceRetrievedSuccessfullyWithItsName` have been failing due to asserting object equality of `Config` object used to create an instance with `hazelcastInstance.getConfig()`. Instead, equality should be asserted only on the configured `instanceName`.