### PR TITLE
[3.9 EA] Disable dynamic index creation from within PostJoinMapOp

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -155,13 +155,14 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
                     // global-index
                     Indexes indexes = mapContainer.getIndexes();
                     indexes.addOrGetIndex(indexInfo.attributeName, indexInfo.ordered);
-                } else {
+                } //else {
                     // partitioned-index
-                    for (PartitionContainer partitionContainer : mapServiceContext.getPartitionContainers()) {
-                        final Indexes indexes = mapContainer.getIndexes(partitionContainer.getPartitionId());
-                        indexes.addOrGetIndex(indexInfo.attributeName, indexInfo.ordered);
-                    }
-                }
+//                    https://github.com/hazelcast/hazelcast/issues/10841
+//                    for (PartitionContainer partitionContainer : mapServiceContext.getPartitionContainers()) {
+//                        final Indexes indexes = mapContainer.getIndexes(partitionContainer.getPartitionId());
+//                        indexes.addOrGetIndex(indexInfo.attributeName, indexInfo.ordered);
+//                    }
+//                }
             }
         }
         for (InterceptorInfo interceptorInfo : interceptorInfoList) {


### PR DESCRIPTION
Port of https://github.com/hazelcast/hazelcast/pull/10842 into 3.9 EA release branch. 

See https://github.com/hazelcast/hazelcast/issues/10841
for details.

(cherry picked from commit 9d85b4c)