### PR TITLE
ProgressMonitor added into bouncing tests support

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -120,6 +120,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * </ol>
  */
 public class BounceMemberRule implements TestRule {
+    public static final long STALENESS_DETECTOR_DISABLED = -1;
 
     private static final ILogger LOGGER = Logger.getLogger(BounceMemberRule.class);
 
@@ -128,6 +129,7 @@ public class BounceMemberRule implements TestRule {
     // amount of time wait for test task futures to complete after test duration has passed
     private static final int TEST_TASK_TIMEOUT_SECONDS = 30;
     private static final int DEFAULT_BOUNCING_INTERVAL_SECONDS = 2;
+    private static final long DEFAULT_MAXIMUM_STALE_SECONDS = STALENESS_DETECTOR_DISABLED;
 
     private final BounceTestConfiguration bounceTestConfig;
     private final AtomicBoolean testRunning = new AtomicBoolean();
@@ -135,6 +137,7 @@ public class BounceMemberRule implements TestRule {
     private final AtomicReferenceArray<HazelcastInstance> members;
     private final AtomicReferenceArray<HazelcastInstance> testDrivers;
     private final int bouncingIntervalSeconds;
+    private final StalenessDetector stalenessDetector;
 
     private volatile TestHazelcastInstanceFactory factory;
 
@@ -147,6 +150,7 @@ public class BounceMemberRule implements TestRule {
         this.members = new AtomicReferenceArray<HazelcastInstance>(bounceTestConfig.getClusterSize());
         this.testDrivers = new AtomicReferenceArray<HazelcastInstance>(bounceTestConfig.getDriverCount());
         this.bouncingIntervalSeconds = bounceTestConfig.getBouncingIntervalSeconds();
+        stalenessDetector = new StalenessDetector(bounceTestConfig.getMaximumStaleSeconds());
     }
 
     /**
@@ -246,7 +250,9 @@ public class BounceMemberRule implements TestRule {
         Future[] futures = new Future[tasks.length];
         taskExecutor = Executors.newFixedThreadPool(tasks.length);
         for (int i = 0; i < tasks.length; i++) {
-            futures[i] = taskExecutor.submit(tasks[i]);
+            Runnable task = tasks[i];
+            stalenessDetector.registerTask(task);
+            futures[i] = taskExecutor.submit(task);
         }
 
         // let the test run for test duration or until failed or finished, whichever comes first
@@ -258,6 +264,12 @@ public class BounceMemberRule implements TestRule {
                     break;
                 }
                 sleepSeconds(1);
+                try {
+                    stalenessDetector.assertProgress();
+                } catch (AssertionError e) {
+                    testRunning.set(false);
+                    throw e;
+                }
             }
             if (currentTimeMillis() >= deadline) {
                 LOGGER.info("Test deadline reached, tearing down");
@@ -441,6 +453,7 @@ public class BounceMemberRule implements TestRule {
         private DriverType testDriverType;
         private boolean useTerminate;
         private int bouncingIntervalSeconds = DEFAULT_BOUNCING_INTERVAL_SECONDS;
+        private long maximumStaleSeconds = DEFAULT_MAXIMUM_STALE_SECONDS;
 
         private Builder(Config memberConfig) {
             this.memberConfig = memberConfig;
@@ -471,7 +484,7 @@ public class BounceMemberRule implements TestRule {
                 }
             }
             return new BounceMemberRule(new BounceTestConfiguration(clusterSize, testDriverType, memberConfig,
-                    driversCount, driverFactory, useTerminate, bouncingIntervalSeconds));
+                    driversCount, driverFactory, useTerminate, bouncingIntervalSeconds, maximumStaleSeconds));
         }
 
         public Builder clusterSize(int clusterSize) {
@@ -491,6 +504,11 @@ public class BounceMemberRule implements TestRule {
 
         public Builder bouncingIntervalSeconds(int bouncingIntervalSeconds) {
             this.bouncingIntervalSeconds = bouncingIntervalSeconds;
+            return this;
+        }
+
+        public Builder maximumStalenessSeconds(int maximumStalenessSeconds) {
+            this.maximumStaleSeconds = maximumStalenessSeconds;
             return this;
         }
 
@@ -534,10 +552,12 @@ public class BounceMemberRule implements TestRule {
                         members.get(i).shutdown();
                     }
                     nextInstance = i % divisor + 1;
-                    sleepSeconds(bouncingIntervalSeconds);
-
+                    sleepSecondsWhenRunning(bouncingIntervalSeconds);
+                    if (!testRunning.get()) {
+                        break;
+                    }
                     members.set(i, factory.newHazelcastInstance(bounceTestConfig.getMemberConfig()));
-                    sleepSeconds(bouncingIntervalSeconds);
+                    sleepSecondsWhenRunning(bouncingIntervalSeconds);
                     // move to next member
                     i = nextInstance;
                 }
@@ -548,12 +568,26 @@ public class BounceMemberRule implements TestRule {
         }
     }
 
+    private void sleepSecondsWhenRunning(int seconds) {
+        long deadLine = System.nanoTime() + SECONDS.toNanos(seconds);
+        while (System.nanoTime() < deadLine && testRunning.get()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
     /**
      * Wraps a {@code Runnable} to be executed repeatedly until testRunning becomes false or an exception is thrown
      * which sets the test as failed.
      */
-    private final class TestTaskRunable implements Runnable {
+    final class TestTaskRunable implements Runnable {
         private final Runnable task;
+        private volatile long lastIterationStartedTimestamp;
+        private volatile Thread currentThread;
 
         public TestTaskRunable(Runnable task) {
             this.task = task;
@@ -563,12 +597,30 @@ public class BounceMemberRule implements TestRule {
         public void run() {
             while (testRunning.get()) {
                 try {
+                    lastIterationStartedTimestamp = System.nanoTime();
+                    currentThread = Thread.currentThread();
                     task.run();
                 } catch (Throwable t) {
                     testFailed.set(true);
                     rethrow(t);
                 }
             }
+        }
+
+        public long getLastIterationStartedTimestamp() {
+            return lastIterationStartedTimestamp;
+        }
+
+        public Thread getCurrentThreadOrNull() {
+            return currentThread;
+        }
+
+
+        @Override
+        public String toString() {
+            return "TestTaskRunable{" +
+                    "task=" + task +
+                    '}';
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleStalenessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleStalenessTest.java
@@ -1,0 +1,55 @@
+package com.hazelcast.test.bounce;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BounceMemberRuleStalenessTest extends HazelcastTestSupport {
+    private static final int MAXIMUM_STALENESS_SECONDS = 5;
+
+    // an intentionally long interval to test the failure is declared quickly
+    // even when a bouncing interval is long
+    private static final int BOUNCING_INTERVAL_SECONDS = 120;
+
+    @Rule
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(new Config())
+            .clusterSize(2)
+            .maximumStalenessSeconds(MAXIMUM_STALENESS_SECONDS)
+            .bouncingIntervalSeconds(BOUNCING_INTERVAL_SECONDS)
+            .build();
+
+    @Test
+    public void stalenessIsDetected() {
+        long startTime = System.nanoTime();
+        try {
+            bounceMemberRule.testRepeatedly(1, new Runnable() {
+                @Override
+                public void run() {
+                    sleepAtLeastMillis(10000);
+                }
+            }, 120);
+
+            fail("The Bouncing Rule should detect a staleness!");
+        } catch (AssertionError ae) {
+            long detectionDurationSeconds = NANOSECONDS.toSeconds(System.nanoTime() - startTime);
+            assertTrue("Staleness detector was too slow to detect stale. "
+                    + "Maximum configured staleness in seconds: " + MAXIMUM_STALENESS_SECONDS
+                    + " and it took " + detectionDurationSeconds + " seconds to detect staleness",
+                    detectionDurationSeconds < BOUNCING_INTERVAL_SECONDS * 4);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceTestConfiguration.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceTestConfiguration.java
@@ -30,6 +30,7 @@ public class BounceTestConfiguration {
     private final DriverFactory driverFactory;
     private final boolean useTerminate;
     private final int bouncingIntervalSeconds;
+    private final long maximumStaleSeconds;
 
     /**
      * Indicates whether the test will be driven by member or client HazelcastInstances
@@ -51,7 +52,7 @@ public class BounceTestConfiguration {
 
     BounceTestConfiguration(int clusterSize, DriverType driverType,
                             Config memberConfig, int driverCount, DriverFactory driverFactory, boolean useTerminate,
-                            int bouncingIntervalSeconds) {
+                            int bouncingIntervalSeconds, long maximumStaleSeconds) {
         this.clusterSize = clusterSize;
         this.driverType = driverType;
         this.memberConfig = memberConfig;
@@ -59,6 +60,7 @@ public class BounceTestConfiguration {
         this.driverFactory = driverFactory;
         this.useTerminate = useTerminate;
         this.bouncingIntervalSeconds = bouncingIntervalSeconds;
+        this.maximumStaleSeconds = maximumStaleSeconds;
     }
 
     public int getClusterSize() {
@@ -87,5 +89,9 @@ public class BounceTestConfiguration {
 
     public int getBouncingIntervalSeconds() {
         return bouncingIntervalSeconds;
+    }
+
+    public long getMaximumStaleSeconds() {
+        return maximumStaleSeconds;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/StalenessDetector.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/StalenessDetector.java
@@ -1,0 +1,75 @@
+package com.hazelcast.test.bounce;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.test.bounce.BounceMemberRule.STALENESS_DETECTOR_DISABLED;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class StalenessDetector {
+    private final long maximumStaleNanos;
+    private final List<BounceMemberRule.TestTaskRunable> tasks = new ArrayList<BounceMemberRule.TestTaskRunable>();
+
+    public StalenessDetector(long maximumStaleSeconds) {
+        this.maximumStaleNanos = maximumStaleSeconds == STALENESS_DETECTOR_DISABLED
+                ? maximumStaleSeconds
+                : SECONDS.toNanos(maximumStaleSeconds);
+    }
+
+    public void registerTask(Runnable task) {
+        if (maximumStaleNanos == STALENESS_DETECTOR_DISABLED) {
+            return;
+        }
+        if (task instanceof BounceMemberRule.TestTaskRunable) {
+            tasks.add((BounceMemberRule.TestTaskRunable)task);
+        } else {
+            throw new UnsupportedOperationException("Staleness checking is enabled only for automatically repeated tests");
+        }
+    }
+
+    public void assertProgress() {
+        long now = System.nanoTime();
+        for (BounceMemberRule.TestTaskRunable task : tasks) {
+            long lastIterationStartedTimestamp = task.getLastIterationStartedTimestamp();
+            if (lastIterationStartedTimestamp == 0) {
+                //the tasks haven't started yet
+                continue;
+            }
+            long currentStaleNanos = now - lastIterationStartedTimestamp;
+            if (currentStaleNanos > maximumStaleNanos) {
+                onStalenessDetected(task, currentStaleNanos);
+            }
+        }
+    }
+
+    private void onStalenessDetected(BounceMemberRule.TestTaskRunable task, long currentStaleNanos) {
+        // this could seems redundant as the Hazelcast JUnit runner will also take threadumps
+        // however in this case we are doing the threaddump before declaring a test failure
+        // and stopping Hazelcast instances -> there is a higher chance we will actually
+        // record something useful.
+        long currentStaleSeconds = NANOSECONDS.toSeconds(currentStaleNanos);
+        long maximumStaleSeconds = NANOSECONDS.toSeconds(maximumStaleNanos);
+        StringBuilder sb = new StringBuilder("Stalling task detected: ")
+                .append(task).append('\n')
+                .append("Maximum staleness allowed (in seconds): ").append(maximumStaleSeconds).append('\n')
+                .append(", Current staleness detected (in seconds): ").append(currentStaleSeconds).append('\n');
+        Thread taskThread = task.getCurrentThreadOrNull();
+        appendStackTrace(taskThread, sb);
+        throw new AssertionError(sb.toString());
+    }
+
+    private void appendStackTrace(Thread thread, StringBuilder sb) {
+        if (thread == null) {
+            sb.append("The task has no thread currently assigned!");
+            return;
+        }
+
+        sb.append("Assigned thread: ").append(thread).append(", Stacktrace: \n");
+        StackTraceElement[] stackTraces = thread.getStackTrace();
+        for (StackTraceElement stackTraceElement : stackTraces) {
+            sb.append("**").append(stackTraceElement).append('\n');
+        }
+        sb.append("**********");
+    }
+}


### PR DESCRIPTION
The bouncing tests print this in regular intervals:
`18:27:12,625 INFO |doNotThrowExceptionWhenMemberIsGone| - [ProgressDetector] doNotThrowExceptionWhenMemberIsGone - Aggregated progress: 98509 operations. Throughput in last 5002 ms: 11597 ops / second. Maximum latency: 1115 ms `

This is always enabled.

The rule can also detect stuck tasks and automatically declare an error
This part is disabled by default.

Example usage:
```java
    @Rule
    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(new Config())
            .clusterSize(2)
            .maximumStalenessSeconds(10)
            .build();
```