### PR TITLE
Use `find*Config` methods to get ringbuffer config for event journal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -154,7 +154,7 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
                     + nodeEngine.getLocalMember());
         }
         final String cacheSimpleName = cacheConfig.getName();
-        final EventJournalConfig config = nodeEngine.getConfig().getCacheEventJournalConfig(cacheSimpleName);
+        final EventJournalConfig config = nodeEngine.getConfig().findCacheEventJournalConfig(cacheSimpleName);
         if (config == null || !config.isEnabled()) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -130,7 +130,7 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
 
     @Override
     public EventJournalConfig getEventJournalConfig(ObjectNamespace namespace) {
-        return nodeEngine.getConfig().getMapEventJournalConfig(namespace.getObjectName());
+        return nodeEngine.getConfig().findMapEventJournalConfig(namespace.getObjectName());
     }
 
     @Override


### PR DESCRIPTION
The `get*Config` methods add a new configuration based on the "default"
if there is no config with an equivalent name. In a scenario where
maps with different names are requested, the number of configs then
increases and pattern matching on these slows down the event journal
initialisation. Switching to `find*Config` causes the overhead of
config lookup to remain constant.