### PR TITLE
Do not register merge barrier for non-running members

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/MergeBarrier.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/MergeBarrier.java
@@ -3,6 +3,7 @@ package com.hazelcast.test;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.LifecycleService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,8 +26,11 @@ class MergeBarrier {
         MergeCountingListener mergeCountingListener = new MergeCountingListener();
 
         for (HazelcastInstance instance : instances) {
-            String registeration = instance.getLifecycleService().addLifecycleListener(mergeCountingListener);
-            registrations.put(instance, registeration);
+            LifecycleService lifecycleService = instance.getLifecycleService();
+            if (lifecycleService.isRunning()) {
+                String registeration = lifecycleService.addLifecycleListener(mergeCountingListener);
+                registrations.put(instance, registeration);
+            }
         }
     }
 


### PR DESCRIPTION
It could be a test terminated an instance on its own.
In this case we should not register this instance into
the MergeBarrier.

Fixes failing `SplitBrainUpgradeCase4Test` in EE. 