### PR TITLE
Make event journal read operation non-blocking

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -557,8 +557,9 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V> {
             Predicate<? super EventJournalCacheEvent<K, V>> predicate,
             Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
         final SerializationService ss = getSerializationService();
+        // minSize is ignored on member side
         final ClientMessage request = CacheEventJournalReadCodec.encodeRequest(
-                nameWithPrefix, startSequence, 1, maxSize, ss.toData(predicate), ss.toData(projection));
+                nameWithPrefix, startSequence, 0, maxSize, ss.toData(predicate), ss.toData(projection));
         final ClientInvocationFuture fut = new ClientInvocation(getClient(), request, partitionId).invoke();
         return new ClientDelegatingFuture<ReadResultSet<T>>(fut, ss, eventJournalReadResponseDecoder);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1679,8 +1679,9 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
             Projection<? super EventJournalMapEvent<K, V>, T> projection) {
         final SerializationService ss = getSerializationService();
+        // minSize is ignored on member side
         final ClientMessage request = MapEventJournalReadCodec.encodeRequest(
-                name, startSequence, 1, maxSize, ss.toData(predicate), ss.toData(projection));
+                name, startSequence, 0, maxSize, ss.toData(predicate), ss.toData(projection));
         final ClientInvocationFuture fut = new ClientInvocation(getClient(), request, partitionId).invoke();
         return new ClientDelegatingFuture<ReadResultSet<T>>(fut, ss, eventJournalReadResponseDecoder);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -413,7 +413,7 @@ public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> {
             Predicate<? super EventJournalCacheEvent<K, V>> predicate,
             Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
         final CacheEventJournalReadOperation<K, V, T> op = new CacheEventJournalReadOperation<K, V, T>(
-                nameWithPrefix, startSequence, 1, maxSize, predicate, projection);
+                nameWithPrefix, startSequence, maxSize, predicate, projection);
         op.setPartitionId(partitionId);
         return getNodeEngine().getOperationService().invokeOnPartition(op);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
@@ -30,11 +30,9 @@ import java.io.IOException;
 
 /**
  * Reads from the cache event journal in batches. You may specify the start sequence,
- * the minumum required number of items in the response, the maximum number of items
- * in the response, a predicate that the events should pass and a projection to
- * apply to the events in the journal.
- * If the event journal currently contains less events than the required minimum, the
- * call will wait until it has sufficient items.
+ * the maximum number of items in the response, a predicate that the events should
+ * pass and a projection to apply to the events in the journal.
+ * If the event journal currently contains no events, the response will be empty.
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  *
@@ -49,10 +47,10 @@ public class CacheEventJournalReadOperation<K, V, T> extends EventJournalReadOpe
     public CacheEventJournalReadOperation() {
     }
 
-    public CacheEventJournalReadOperation(String cacheName, long startSequence, int minSize, int maxSize,
+    public CacheEventJournalReadOperation(String cacheName, long startSequence, int maxSize,
                                           Predicate<? super EventJournalCacheEvent<K, V>> predicate,
                                           Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
-        super(cacheName, startSequence, minSize, maxSize);
+        super(cacheName, startSequence, maxSize);
         this.predicate = predicate;
         this.projection = projection;
     }
@@ -96,6 +94,6 @@ public class CacheEventJournalReadOperation<K, V, T> extends EventJournalReadOpe
     @Override
     protected ReadResultSetImpl<InternalEventJournalCacheEvent, T> createResultSet() {
         return new CacheEventJournalReadResultSetImpl<K, V, T>(
-                minSize, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
+                0, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
@@ -38,11 +38,9 @@ import java.util.List;
 
 /**
  * Reads from the cache event journal in batches. You may specify the start sequence,
- * the minumum required number of items in the response, the maximum number of items
- * in the response, a predicate that the events should pass and a projection to
- * apply to the events in the journal.
- * If the event journal currently contains less events than the required minimum, the
- * call will wait until it has sufficient items.
+ * the maximum number of items in the response, a predicate that the events should
+ * pass and a projection to apply to the events in the journal.
+ * If the event journal currently contains no events, the response will be empty.
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  *
@@ -70,7 +68,7 @@ public class CacheEventJournalReadTask<K, V, T>
                 = serializationService.toObject(parameters.projection);
         final Predicate<? super EventJournalCacheEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);
         return new CacheEventJournalReadOperation<K, V, T>(parameters.name,
-                parameters.startSequence, parameters.minSize, parameters.maxSize, predicate, projection);
+                parameters.startSequence, parameters.maxSize, predicate, projection);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
@@ -38,11 +38,9 @@ import java.util.List;
 
 /**
  * Reads from the map event journal in batches. You may specify the start sequence,
- * the minumum required number of items in the response, the maximum number of items
- * in the response, a predicate that the events should pass and a projection to
- * apply to the events in the journal.
- * If the event journal currently contains less events than the required minimum, the
- * call will wait until it has sufficient items.
+ * the maximum number of items in the response, a predicate that the events should
+ * pass and a projection to apply to the events in the journal.
+ * If the event journal currently contains no events, the response will be empty.
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  *
@@ -67,7 +65,7 @@ public class MapEventJournalReadTask<K, V, T>
         final Projection<? super EventJournalMapEvent<K, V>, T> projection = serializationService.toObject(parameters.projection);
         final Predicate<? super EventJournalMapEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);
         return new MapEventJournalReadOperation<K, V, T>(parameters.name,
-                parameters.startSequence, parameters.minSize, parameters.maxSize, predicate, projection);
+                parameters.startSequence, parameters.maxSize, predicate, projection);
     }
 
     @Override
@@ -77,7 +75,6 @@ public class MapEventJournalReadTask<K, V, T>
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        // we are not deserializing the whole content, only the enclosing portable. The actual items remain un
         final ReadResultSetImpl resultSet = nodeEngine.getSerializationService().toObject(response);
         final List<Data> items = new ArrayList<Data>(resultSet.size());
         final long[] seqs = new long[resultSet.size()];

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.WaitNotifyKey;
 
 /**
  * The event journal is a container for events related to a data structure.
@@ -95,16 +94,6 @@ public interface EventJournal<E> {
      * @throws IllegalStateException if there is no event journal configured for this object
      */
     boolean isNextAvailableSequence(ObjectNamespace namespace, int partitionId, long sequence);
-
-    /**
-     * Return the {@link WaitNotifyKey} for objects waiting and notifying on the event journal.
-     *
-     * @param namespace   the object namespace
-     * @param partitionId the partition ID of the entries in the journal
-     * @return the key for a wait notify object
-     * @throws IllegalStateException if there is no event journal configured for this object
-     */
-    WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId);
 
     /**
      * Reads events from the journal in batches. It will read up to

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
@@ -30,11 +30,9 @@ import java.io.IOException;
 
 /**
  * Reads from the map event journal in batches. You may specify the start sequence,
- * the minumum required number of items in the response, the maximum number of items
- * in the response, a predicate that the events should pass and a projection to
- * apply to the events in the journal.
- * If the event journal currently contains less events than the required minimum, the
- * call will wait until it has sufficient items.
+ * the maximum number of items in the response, a predicate that the events should
+ * pass and a projection to apply to the events in the journal.
+ * If the event journal currently contains no events, the response will be empty.
  * The predicate, filter and projection may be {@code null} in which case all elements are returned
  * and no projection is applied.
  *
@@ -50,10 +48,10 @@ public class MapEventJournalReadOperation<K, V, T> extends EventJournalReadOpera
     public MapEventJournalReadOperation() {
     }
 
-    public MapEventJournalReadOperation(String mapName, long startSequence, int minSize, int maxSize,
+    public MapEventJournalReadOperation(String mapName, long startSequence, int maxSize,
                                         Predicate<? super EventJournalMapEvent<K, V>> predicate,
                                         Projection<? super EventJournalMapEvent<K, V>, T> projection) {
-        super(mapName, startSequence, minSize, maxSize);
+        super(mapName, startSequence, maxSize);
         this.predicate = predicate;
         this.projection = projection;
     }
@@ -61,7 +59,7 @@ public class MapEventJournalReadOperation<K, V, T> extends EventJournalReadOpera
     @Override
     protected ReadResultSetImpl<InternalEventJournalMapEvent, T> createResultSet() {
         return new MapEventJournalReadResultSetImpl<K, V, T>(
-                minSize, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
+                0, maxSize, getNodeEngine().getSerializationService(), predicate, projection);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -969,7 +969,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
             com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
             Projection<? super EventJournalMapEvent<K, V>, T> projection) {
         final MapEventJournalReadOperation<K, V, T> op = new MapEventJournalReadOperation<K, V, T>(
-                name, startSequence, 1, maxSize, predicate, projection);
+                name, startSequence, maxSize, predicate, projection);
         op.setPartitionId(partitionId);
         return operationService.invokeOnPartition(op);
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -27,9 +27,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.ringbuffer.StaleSequenceException;
-import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
@@ -50,7 +48,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * it is null to save space.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class RingbufferContainer<T> implements IdentifiedDataSerializable, Notifier, Versioned {
+public class RingbufferContainer<T> implements IdentifiedDataSerializable, Versioned {
 
     private static final long TTL_DISABLED = 0;
 
@@ -584,15 +582,5 @@ public class RingbufferContainer<T> implements IdentifiedDataSerializable, Notif
     @Override
     public int getId() {
         return RingbufferDataSerializerHook.RINGBUFFER_CONTAINER;
-    }
-
-    @Override
-    public boolean shouldNotify() {
-        return true;
-    }
-
-    @Override
-    public WaitNotifyKey getNotifiedKey() {
-        return emptyRingWaitNotifyKey;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
@@ -116,39 +116,6 @@ public class BasicMapJournalTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void unparkReadOperation() throws Exception {
-        final IMap<String, Integer> m = getMap();
-        assertJournalSize(m, 0);
-
-        final String key = randomPartitionKey();
-        final Integer value = RANDOM.nextInt();
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        readFromEventJournal(m, 0, 100, partitionId, TRUE_PREDICATE, IDENTITY_PROJECTION)
-                .andThen(new ExecutionCallback<ReadResultSet<EventJournalMapEvent<String, Integer>>>() {
-                    @Override
-                    public void onResponse(ReadResultSet<EventJournalMapEvent<String, Integer>> response) {
-                        assertEquals(1, response.size());
-                        final EventJournalMapEvent<String, Integer> e = response.get(0);
-
-                        assertEquals(EntryEventType.ADDED, e.getType());
-                        assertEquals(e.getKey(), key);
-                        assertEquals(e.getNewValue(), value);
-                        latch.countDown();
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        t.printStackTrace();
-                    }
-                });
-
-        m.put(key, value);
-        latch.await();
-        assertJournalSize(m, 1);
-    }
-
-    @Test
     public void receiveAddedEventsWhenPut() throws Exception {
         final IMap<String, Integer> m = getMap();
 


### PR DESCRIPTION
If there are no events the read operation would block until there is
at least one event. With this change the operation never blocks and
returns an empty response if there are no events.

Because of this, the RingbufferContainer no longer needs to implement
 Notifier.

We will not change the client protocol at this point even though it
is sending a minSize parameter which is no longer used.