### PR TITLE
afterRun() doesn't always get invoked properly for cache operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractBackupCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractBackupCacheOperation.java
@@ -54,5 +54,6 @@ abstract class AbstractBackupCacheOperation extends AbstractCacheOperation {
         if (cache != null) {
             afterRunInternal();
         }
+        super.afterRun();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryProcessorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryProcessorOperation.java
@@ -108,6 +108,7 @@ public class CacheEntryProcessorOperation
                 wanEventPublisher.publishWanReplicationRemove(name, key);
             }
         }
+        super.afterRun();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndRemoveOperation.java
@@ -49,6 +49,7 @@ public class CacheGetAndRemoveOperation
                 wanEventPublisher.publishWanReplicationRemove(name, key);
             }
         }
+        super.afterRun();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
@@ -61,6 +61,7 @@ public class CacheGetAndReplaceOperation
                     getNodeEngine().getSerializationService().toData(backupRecord.getValue()), backupRecord);
             wanEventPublisher.publishWanReplicationUpdate(name, entryView);
         }
+        super.afterRun();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
@@ -65,6 +65,7 @@ public class CachePutIfAbsentOperation
                 wanEventPublisher.publishWanReplicationUpdate(name, entryView);
             }
         }
+        super.afterRun();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
@@ -71,6 +71,7 @@ public class CachePutOperation
             CacheWanEventPublisher publisher = cacheService.getCacheWanEventPublisher();
             publisher.publishWanReplicationUpdate(name, entryView);
         }
+        super.afterRun();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
@@ -60,6 +60,7 @@ public class CacheRemoveOperation
                 wanEventPublisher.publishWanReplicationRemove(name, key);
             }
         }
+        super.afterRun();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
@@ -72,6 +72,7 @@ public class CacheReplaceOperation
                 wanEventPublisher.publishWanReplicationUpdate(name, entryView);
             }
         }
+        super.afterRun();
     }
 
     @Override


### PR DESCRIPTION
making sure beforeRun and afterRun are always invoked in the proper order