### PR TITLE
Introduces operation sequence in post join operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PostJoinAwareOperation;
 import com.hazelcast.spi.exception.ServiceNotFoundException;
 
 import java.io.IOException;
@@ -32,8 +33,12 @@ import java.util.List;
 
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 import static com.hazelcast.cache.impl.JCacheDetector.isJCacheAvailable;
+import static com.hazelcast.spi.PostJoinAwareOperation.Sequence.POST_JOIN_OPS_SEQUENCE;
 
-public class PostJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
+public class PostJoinCacheOperation extends Operation implements IdentifiedDataSerializable,
+                                                                 PostJoinAwareOperation {
+
+    private static final int SEQUENCE = POST_JOIN_OPS_SEQUENCE.get(PostJoinCacheOperation.class);
 
     private List<CacheConfig> configs = new ArrayList<CacheConfig>();
 
@@ -98,5 +103,10 @@ public class PostJoinCacheOperation extends Operation implements IdentifiedDataS
     @Override
     public int getId() {
         return CacheDataSerializerHook.CACHE_POST_JOIN;
+    }
+
+    @Override
+    public int getSequence() {
+        return SEQUENCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.PostJoinAwareOperation;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -28,7 +29,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class PostJoinClientOperation extends AbstractClientOperation {
+import static com.hazelcast.spi.PostJoinAwareOperation.Sequence.POST_JOIN_OPS_SEQUENCE;
+
+public class PostJoinClientOperation extends AbstractClientOperation implements PostJoinAwareOperation {
+
+    private static final int SEQUENCE = POST_JOIN_OPS_SEQUENCE.get(PostJoinClientOperation.class);
 
     private Map<String, String> mappings;
 
@@ -100,5 +105,10 @@ public class PostJoinClientOperation extends AbstractClientOperation {
     @Override
     public int getId() {
         return ClientDataSerializerHook.POST_JOIN;
+    }
+
+    @Override
+    public int getSequence() {
+        return SEQUENCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -37,6 +37,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PostJoinAwareOperation;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -47,7 +48,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class PostJoinMapOperation extends Operation implements IdentifiedDataSerializable {
+import static com.hazelcast.spi.PostJoinAwareOperation.Sequence.POST_JOIN_OPS_SEQUENCE;
+
+public class PostJoinMapOperation extends Operation implements IdentifiedDataSerializable,
+                                                               PostJoinAwareOperation {
+
+    private static final int SEQUENCE = POST_JOIN_OPS_SEQUENCE.get(PostJoinMapOperation.class);
 
     private List<MapIndexInfo> indexInfoList = new LinkedList<MapIndexInfo>();
     private List<InterceptorInfo> interceptorInfoList = new LinkedList<InterceptorInfo>();
@@ -56,6 +62,11 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     @Override
     public String getServiceName() {
         return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    public int getSequence() {
+        return SEQUENCE;
     }
 
     public void addMapIndex(MapServiceContext mapServiceContext, MapContainer mapContainer) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareOperation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.cache.impl.operation.PostJoinCacheOperation;
+import com.hazelcast.client.impl.operations.PostJoinClientOperation;
+import com.hazelcast.map.impl.operation.PostJoinMapOperation;
+import com.hazelcast.spi.impl.eventservice.impl.operations.PostJoinRegistrationOperation;
+import com.hazelcast.spi.impl.proxyservice.impl.operations.PostJoinProxyOperation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An interface to be implemented by post join {@link Operation}s, indicating the sequence in which
+ * the post join operation must be applied.
+ *
+ * @see PostJoinAwareService#getPostJoinOperation()
+ */
+public interface PostJoinAwareOperation {
+
+    /**
+     * @return unique sequence number for applying this post join operation. Operations with a lower sequence
+     * will be applied before ones with a higher sequence.
+     */
+    int getSequence();
+
+    /**
+     * Sequence of post join aware operations
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    final class Sequence {
+        public static final Map<Class<? extends Operation>, Integer> POST_JOIN_OPS_SEQUENCE;
+
+        static {
+            HashMap<Class<? extends Operation>, Integer> postJoinOpsSequence = new HashMap<Class<? extends Operation>, Integer>();
+            postJoinOpsSequence.put(PostJoinCacheOperation.class, 0);
+            postJoinOpsSequence.put(PostJoinRegistrationOperation.class, 1);
+            postJoinOpsSequence.put(PostJoinClientOperation.class, 2);
+            postJoinOpsSequence.put(PostJoinProxyOperation.class, 3);
+            postJoinOpsSequence.put(PostJoinMapOperation.class, 4);
+            POST_JOIN_OPS_SEQUENCE = postJoinOpsSequence;
+        }
+
+        private Sequence() {
+
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/PostJoinRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/PostJoinRegistrationOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PostJoinAwareOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
@@ -29,7 +30,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class PostJoinRegistrationOperation extends Operation implements IdentifiedDataSerializable {
+import static com.hazelcast.spi.PostJoinAwareOperation.Sequence.POST_JOIN_OPS_SEQUENCE;
+
+public class PostJoinRegistrationOperation extends Operation implements IdentifiedDataSerializable,
+                                                                        PostJoinAwareOperation {
+
+    private static final int SEQUENCE = POST_JOIN_OPS_SEQUENCE.get(PostJoinRegistrationOperation.class);
 
     private Collection<Registration> registrations;
 
@@ -92,5 +98,10 @@ public class PostJoinRegistrationOperation extends Operation implements Identifi
     @Override
     public int getId() {
         return SpiDataSerializerHook.POST_JOIN_REGISTRATION;
+    }
+
+    @Override
+    public int getSequence() {
+        return SEQUENCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationutil/PostJoinAwareOperationComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationutil/PostJoinAwareOperationComparator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationutil;
+
+import com.hazelcast.nio.serialization.SerializableByConvention;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PostJoinAwareOperation;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * Sorts {@link PostJoinAwareOperation}s by sequence number.
+ */
+@SerializableByConvention
+public class PostJoinAwareOperationComparator<T extends Operation & PostJoinAwareOperation>
+        implements Comparator<T>, Serializable {
+
+    @Override
+    public int compare(T o1, T o2) {
+        if (o1.equals(o2)) {
+            return 0;
+        }
+
+        // since the two operations are not equal, never return equality even when their sequence numbers collide
+        return o1.getSequence() < o2.getSequence() ? -1
+                : 1;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PostJoinAwareOperation;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyInfo;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyRegistry;
@@ -33,7 +34,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class PostJoinProxyOperation extends Operation implements IdentifiedDataSerializable {
+import static com.hazelcast.spi.PostJoinAwareOperation.Sequence.POST_JOIN_OPS_SEQUENCE;
+
+public class PostJoinProxyOperation extends Operation implements IdentifiedDataSerializable,
+                                                                 PostJoinAwareOperation {
+
+    private static final int SEQUENCE = POST_JOIN_OPS_SEQUENCE.get(PostJoinProxyOperation.class);
 
     private Collection<ProxyInfo> proxies;
 
@@ -42,6 +48,11 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
 
     public PostJoinProxyOperation(Collection<ProxyInfo> proxies) {
         this.proxies = proxies;
+    }
+
+    @Override
+    public int getSequence() {
+        return SEQUENCE;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/PostJoinAwareOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/PostJoinAwareOperationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Constructor;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.spi.PostJoinAwareOperation.Sequence.POST_JOIN_OPS_SEQUENCE;
+import static com.hazelcast.test.ReflectionsHelper.REFLECTIONS;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PostJoinAwareOperationTest {
+
+    @Test
+    public void testAllPostJoinAwareOperation_haveSequenceDefinedInMap()
+            throws Exception {
+        Set<Class<? extends PostJoinAwareOperation>> postJoinAwareOps = REFLECTIONS.getSubTypesOf(PostJoinAwareOperation.class);
+        for (Class<? extends PostJoinAwareOperation> op : postJoinAwareOps) {
+            PostJoinAwareOperation operationInstance = ClassLoaderUtil.newInstance(op, null, op.getName());
+            assertEquals(format("%s.getSequence() returned an unexpected value", op.getName()),
+                    (int) POST_JOIN_OPS_SEQUENCE.get(op), operationInstance.getSequence());
+        }
+    }
+
+    @Test
+    public void testEachPostJoinAwareOperation_haveUniqueSequence() {
+        Set<Class<? extends PostJoinAwareOperation>> postJoinAwareOps = REFLECTIONS.getSubTypesOf(PostJoinAwareOperation.class);
+        Set<Integer> definedSequences = new HashSet<Integer>();
+        for (Integer sequence : POST_JOIN_OPS_SEQUENCE.values()) {
+            definedSequences.add(sequence);
+        }
+        assertEquals(postJoinAwareOps.size(), definedSequences.size());
+    }
+
+}


### PR DESCRIPTION
As described in https://github.com/hazelcast/hazelcast/issues/10727#issuecomment-312855582 dynamically created `CacheConfig`s (via `CacheManager.createCache(.., CacheConfig)`) must be added to a new member's known configs via `PostJoinCacheOperation` before `PostJoinProxyOperation` is executed.

Fixes #10727 