### PR TITLE
IOBalancer: Change misleading logging message

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -139,7 +139,12 @@ public class IOBalancer {
             if (logger.isFinestEnabled()) {
                 long min = loadImbalance.minimumEvents;
                 long max = loadImbalance.maximumEvents;
-                logger.finest("No imbalance has been detected. Max. events: " + max + " Min events: " + min + ".");
+                if (max == Long.MIN_VALUE) {
+                    logger.finest("There is at most 1 handler associated with each thread. "
+                            + "There is nothing to balance");
+                } else {
+                    logger.finest("No imbalance has been detected. Max. events: " + max + " Min events: " + min + ".");
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #10840
When each thread has at most 1 handler assigned then max value
is kept at its initial setting - Long.MIN_VALUE.