### PR TITLE
Add local statistics for ReliableTopic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/monitor/MemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/MemberState.java
@@ -38,6 +38,8 @@ public interface MemberState extends JsonSerializable {
 
     LocalTopicStats getLocalTopicStats(String topicName);
 
+    LocalTopicStats getReliableLocalTopicStats(String reliableTopicName);
+
     LocalReplicatedMapStats getLocalReplicatedMapStats(String replicatedMapName);
 
     LocalExecutorStats getLocalExecutorStats(String executorName);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
@@ -51,6 +51,14 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         return totalPublishes;
     }
 
+    /**
+     * Increment the number of locally published messages. The count can be local
+     * to the member or local to a single proxy (whereas there are many proxies
+     * on one member).
+     *
+     * @see com.hazelcast.topic.impl.TopicService
+     * @see com.hazelcast.topic.impl.reliable.ReliableTopicService
+     */
     public void incrementPublishes() {
         TOTAL_PUBLISHES.incrementAndGet(this);
     }
@@ -60,6 +68,14 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
         return totalReceivedMessages;
     }
 
+    /**
+     * Increment the number of locally received messages. The count can be local
+     * to the member or local to a single listener (whereas there are many listeners
+     * on one member).
+     *
+     * @see com.hazelcast.topic.impl.TopicService
+     * @see com.hazelcast.topic.impl.reliable.ReliableMessageListenerRunner
+     */
     public void incrementReceives() {
         TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -58,6 +58,7 @@ public class MemberStateImpl implements MemberState {
     private Map<String, LocalMultiMapStats> multiMapStats = new HashMap<String, LocalMultiMapStats>();
     private Map<String, LocalQueueStats> queueStats = new HashMap<String, LocalQueueStats>();
     private Map<String, LocalTopicStats> topicStats = new HashMap<String, LocalTopicStats>();
+    private Map<String, LocalTopicStats> reliableTopicStats = new HashMap<String, LocalTopicStats>();
     private Map<String, LocalExecutorStats> executorStats = new HashMap<String, LocalExecutorStats>();
     private Map<String, LocalReplicatedMapStats> replicatedMapStats = new HashMap<String, LocalReplicatedMapStats>();
     private Map<String, LocalCacheStats> cacheStats = new HashMap<String, LocalCacheStats>();
@@ -102,6 +103,11 @@ public class MemberStateImpl implements MemberState {
     @Override
     public LocalTopicStats getLocalTopicStats(String topicName) {
         return topicStats.get(topicName);
+    }
+
+    @Override
+    public LocalTopicStats getReliableLocalTopicStats(String reliableTopicName) {
+        return reliableTopicStats.get(reliableTopicName);
     }
 
     @Override
@@ -151,6 +157,10 @@ public class MemberStateImpl implements MemberState {
 
     public void putLocalTopicStats(String name, LocalTopicStats localTopicStats) {
         topicStats.put(name, localTopicStats);
+    }
+
+    public void putLocalReliableTopicStats(String name, LocalTopicStats localTopicStats) {
+        reliableTopicStats.put(name, localTopicStats);
     }
 
     public void putLocalExecutorStats(String name, LocalExecutorStats localExecutorStats) {
@@ -250,6 +260,7 @@ public class MemberStateImpl implements MemberState {
         serializeMap(root, "replicatedMapStats", replicatedMapStats);
         serializeMap(root, "queueStats", queueStats);
         serializeMap(root, "topicStats", topicStats);
+        serializeMap(root, "reliableTopicStats", reliableTopicStats);
         serializeMap(root, "executorStats", executorStats);
         serializeMap(root, "cacheStats", cacheStats);
         serializeMap(root, "wanStats", wanStats);
@@ -312,6 +323,11 @@ public class MemberStateImpl implements MemberState {
             LocalTopicStatsImpl stats = new LocalTopicStatsImpl();
             stats.fromJson(next.getValue().asObject());
             topicStats.put(next.getName(), stats);
+        }
+        for (JsonObject.Member next : getObject(json, "reliableTopicStats")) {
+            LocalTopicStatsImpl stats = new LocalTopicStatsImpl();
+            stats.fromJson(next.getValue().asObject());
+            reliableTopicStats.put(next.getName(), stats);
         }
         for (JsonObject.Member next : getObject(json, "executorStats")) {
             LocalExecutorStatsImpl stats = new LocalExecutorStatsImpl();
@@ -385,6 +401,7 @@ public class MemberStateImpl implements MemberState {
                 + ", replicatedMapStats=" + replicatedMapStats
                 + ", queueStats=" + queueStats
                 + ", topicStats=" + topicStats
+                + ", reliableTopicStats=" + reliableTopicStats
                 + ", executorStats=" + executorStats
                 + ", cacheStats=" + cacheStats
                 + ", memoryStats=" + memoryStats

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.topic.impl;
 
+import com.hazelcast.config.TopicConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -28,6 +29,13 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.locks.Lock;
 
+/**
+ * ITopic publication operation used when global ordering is enabled
+ * (all nodes listening to the same topic get their messages in the same order).
+ *
+ * @see TotalOrderedTopicProxy
+ * @see TopicConfig#isGlobalOrderingEnabled()
+ */
 public class PublishOperation extends AbstractNamedOperation
         implements IdentifiedDataSerializable {
 
@@ -41,6 +49,13 @@ public class PublishOperation extends AbstractNamedOperation
         this.message = message;
     }
 
+    /**
+     * {@inheritDoc}
+     * Increments the local statistics for the number of published
+     * messages.
+     *
+     * @throws Exception
+     */
     @Override
     public void beforeRun() throws Exception {
         TopicService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
@@ -21,6 +21,12 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.spi.NodeEngine;
 
+/**
+ * Topic proxy used when global ordering is disabled (nodes get
+ * the messages in the order that the messages are published).
+ *
+ * @param <E> the type of message in this topic
+ */
 public class TopicProxy<E> extends TopicProxySupport implements ITopic<E> {
 
     public TopicProxy(String name, NodeEngine nodeEngine, TopicService service) {

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -86,6 +86,12 @@ public abstract class TopicProxySupport extends AbstractDistributedObject<TopicS
         return topicService.getLocalTopicStats(name);
     }
 
+    /**
+     * Publishes the message and increases the local statistics
+     * for the number of published messages.
+     *
+     * @param message the message to be published
+     */
     public void publishInternal(Object message) {
         topicStats.incrementPublishes();
         topicService.publishMessage(name, message, multithreaded);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -139,10 +139,22 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
         return getOrPutSynchronized(statsMap, name, statsMap, localTopicStatsConstructorFunction);
     }
 
+    /**
+     * Increments the number of published messages on the ITopic
+     * with the name {@code topicName}.
+     *
+     * @param topicName the name of the {@link ITopic}
+     */
     public void incrementPublishes(String topicName) {
         getLocalTopicStats(topicName).incrementPublishes();
     }
 
+    /**
+     * Increments the number of received messages on the ITopic
+     * with the name {@code topicName}.
+     *
+     * @param topicName the name of the {@link ITopic}
+     */
     public void incrementReceivedMessages(String topicName) {
         getLocalTopicStats(topicName).incrementReceives();
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -20,7 +20,13 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 
-public class TotalOrderedTopicProxy extends TopicProxy {
+/**
+ * Topic proxy used when global ordering is enabled (all nodes listening to
+ * the same topic get their messages in the same order).
+ *
+ * @param <E> the type of message in this topic
+ */
+public class TotalOrderedTopicProxy<E> extends TopicProxy<E> {
 
     private final int partitionId;
 
@@ -30,7 +36,7 @@ public class TotalOrderedTopicProxy extends TopicProxy {
     }
 
     @Override
-    public void publish(Object message) {
+    public void publish(E message) {
         Operation operation = new PublishOperation(getName(), toData(message))
                 .setPartitionId(partitionId);
         InternalCompletableFuture f = invokeOnPartition(operation);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerRunner.java
@@ -113,6 +113,13 @@ class ReliableMessageListenerRunner<E> implements ExecutionCallback<ReadResultSe
         next();
     }
 
+    /**
+     * Processes the message by increasing the local topic stats and
+     * calling the user supplied listener.
+     *
+     * @param message the reliable topic message
+     * @throws Throwable
+     */
     private void process(ReliableTopicMessage message) throws Throwable {
         proxy.localTopicStats.incrementReceives();
         listener.onMessage(toMessage(message));

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -51,7 +51,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * The serverside {@link com.hazelcast.core.ITopic} implementation for reliable topics.
  *
- * @param <E>
+ * @param <E> type of item contained in the topic
  */
 public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTopicService> implements ITopic<E> {
 
@@ -62,7 +62,12 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     final Executor executor;
     final ConcurrentMap<String, ReliableMessageListenerRunner> runnersMap
             = new ConcurrentHashMap<String, ReliableMessageListenerRunner>();
-    final LocalTopicStatsImpl localTopicStats = new LocalTopicStatsImpl();
+
+    /**
+     * Local statistics for this reliable topic, including
+     * messages received on and published through this topic.
+     */
+    final LocalTopicStatsImpl localTopicStats;
     final ReliableTopicConfig topicConfig;
     final TopicOverloadPolicy overloadPolicy;
 
@@ -81,6 +86,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
         this.executor = initExecutor(nodeEngine, topicConfig);
         this.thisAddress = nodeEngine.getThisAddress();
         this.overloadPolicy = topicConfig.getTopicOverloadPolicy();
+        this.localTopicStats = service.getLocalTopicStats(name);
 
         for (ListenerConfig listenerConfig : topicConfig.getMessageListenerConfigs()) {
             addMessageListener(listenerConfig);

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
@@ -47,6 +47,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         hz.getMultiMap("trial").put(2, 2);
         hz.getQueue("trial").offer(3);
         hz.getTopic("trial").publish("Hello");
+        hz.getReliableTopic("trial").publish("Hello");
         hz.getReplicatedMap("trial").put(3, 3);
         hz.getExecutorService("trial");
 
@@ -58,6 +59,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         assertContains(instanceNames, "m:trial");
         assertContains(instanceNames, "q:trial");
         assertContains(instanceNames, "t:trial");
+        assertContains(instanceNames, "rt:trial");
         assertContains(instanceNames, "r:trial");
         assertContains(instanceNames, "e:trial");
     }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -99,6 +99,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         memberState.putLocalMultiMapStats("multiMapStats", new LocalMultiMapStatsImpl());
         memberState.putLocalQueueStats("queueStats", new LocalQueueStatsImpl());
         memberState.putLocalTopicStats("topicStats", new LocalTopicStatsImpl());
+        memberState.putLocalReliableTopicStats("reliableTopicStats", new LocalTopicStatsImpl());
         memberState.putLocalExecutorStats("executorStats", new LocalExecutorStatsImpl());
         memberState.putLocalReplicatedMapStats("replicatedMapStats", replicatedMapStats);
         memberState.putLocalCacheStats("cacheStats", new LocalCacheStatsImpl(cacheStatistics));
@@ -118,6 +119,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         assertNotNull(deserialized.getLocalMultiMapStats("multiMapStats").toString());
         assertNotNull(deserialized.getLocalQueueStats("queueStats").toString());
         assertNotNull(deserialized.getLocalTopicStats("topicStats").toString());
+        assertNotNull(deserialized.getReliableLocalTopicStats("reliableTopicStats").toString());
         assertNotNull(deserialized.getLocalExecutorStats("executorStats").toString());
         assertNotNull(deserialized.getLocalReplicatedMapStats("replicatedMapStats").toString());
         assertEquals(1, deserialized.getLocalReplicatedMapStats("replicatedMapStats").getPutOperationCount());


### PR DESCRIPTION
Collect and track statistics for all reliable topic proxies on a local
member. The statistics are destroyed when the proxy is destroyed.