### PR TITLE
Fix transactional queue offer/take leak

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -100,7 +100,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
     }
 
 
-    public QueueContainer(String name, QueueConfig config, NodeEngine nodeEngine, QueueService service) throws Exception {
+    public QueueContainer(String name, QueueConfig config, NodeEngine nodeEngine, QueueService service) {
         this(name);
         setConfig(config, nodeEngine, service);
     }
@@ -160,9 +160,12 @@ public class QueueContainer implements IdentifiedDataSerializable {
     //TX Poll
 
     /**
-     * Retrieves and removes the head of the queue and loads the data from the queue store if the data is not stored in-memory
-     * and the queue store is configured and enabled. If the queue is empty returns an item which was previously reserved with
-     * the {@code reservedOfferId} by invoking {@code {@link #txnOfferReserve(String)}}.
+     * Tries to obtain an item by removing the head of the
+     * queue or removing an item previously reserved by invoking
+     * {@link #txnOfferReserve(String)} with {@code reservedOfferId}.
+     * <p>
+     * If the queue item does not have data in-memory it will load the
+     * data from the queue store if the queue store is configured and enabled.
      *
      * @param reservedOfferId the ID of the reserved item to be returned if the queue is empty
      * @param transactionId   the transaction ID for which this poll is invoked
@@ -190,13 +193,27 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return item;
     }
 
+    /**
+     * Makes a reservation for a poll operation. Should be executed as
+     * a part of the prepare phase for a transactional queue poll
+     * on the partition backup replica.
+     * The ID of the item being polled is determined by the partition
+     * owner.
+     *
+     * @param itemId        the ID of the reserved item to be polled
+     * @param transactionId the transaction ID
+     * @see #txnPollReserve(long, String)
+     * @see com.hazelcast.collection.impl.txnqueue.operations.TxnReservePollOperation
+     */
     public void txnPollBackupReserve(long itemId, String transactionId) {
         QueueItem item = getBackupMap().remove(itemId);
-        if (item == null) {
-            logger.warning("Backup reserve failed, itemId: " + itemId + " is not found");
+        if (item != null) {
+            txMap.put(itemId, new TxQueueItem(item).setPollOperation(true).setTransactionId(transactionId));
             return;
         }
-        txMap.put(itemId, new TxQueueItem(item).setPollOperation(true).setTransactionId(transactionId));
+        if (txMap.remove(itemId) == null) {
+            logger.warning("Poll backup reserve failed, itemId: " + itemId + " is not found");
+        }
     }
 
     public Data txnCommitPoll(long itemId) {
@@ -230,13 +247,15 @@ public class QueueContainer implements IdentifiedDataSerializable {
     }
 
     /**
-     * Rolls back the effects of the {@link #txnPollReserve(long, String)}. The {@code backup} parameter defines whether
-     * this item was stored on a backup queue or a primary queue. Also adds a queue item with the {@code itemId} to the backup
-     * map if the {@code backup} parameter is true or the queue.
+     * Rolls back the effects of the {@link #txnPollReserve(long, String)}.
+     * The {@code backup} parameter defines whether this item was stored
+     * on a backup queue or a primary queue.
+     * It will return the item to the queue or backup map if it wasn't
+     * offered as a part of the transaction.
      * Cancels the queue eviction if one is scheduled.
      *
      * @param itemId the ID of the item which was polled in a transaction
-     * @param backup if this item was
+     * @param backup if this is the primary or the backup replica for this queue
      * @return if there was any polled item with the {@code itemId} inside a transaction
      */
     public boolean txnRollbackPoll(long itemId, boolean backup) {
@@ -277,9 +296,9 @@ public class QueueContainer implements IdentifiedDataSerializable {
      * @return the ID of the reserved item
      */
     public long txnOfferReserve(String transactionId) {
-        TxQueueItem item = new TxQueueItem(this, nextId(), null).setTransactionId(transactionId).setPollOperation(false);
-        txMap.put(item.getItemId(), item);
-        return item.getItemId();
+        final long itemId = nextId();
+        txnOfferReserveInternal(itemId, transactionId);
+        return itemId;
     }
 
     /**
@@ -290,23 +309,32 @@ public class QueueContainer implements IdentifiedDataSerializable {
      * @param itemId        the ID of the item being reserved
      */
     public void txnOfferBackupReserve(long itemId, String transactionId) {
-        QueueItem item = new QueueItem(this, itemId, null);
-        Object o = txMap.put(itemId, new TxQueueItem(item).setPollOperation(false).setTransactionId(transactionId));
+        final TxQueueItem o = txnOfferReserveInternal(itemId, transactionId);
         if (o != null) {
             logger.severe("txnOfferBackupReserve operation-> Item exists already at txMap for itemId: " + itemId);
         }
     }
 
+    /** Add a reservation for an item with {@code itemId} offered in transaction with {@code transactionId} */
+    private TxQueueItem txnOfferReserveInternal(long itemId, String transactionId) {
+        final TxQueueItem item = new TxQueueItem(this, itemId, null)
+                .setTransactionId(transactionId)
+                .setPollOperation(false);
+        return txMap.put(itemId, item);
+    }
+
     /**
-     * Sets the data of a reserved item and commits the change so it can be visible outside a transaction. The commit means
-     * that the item is offered to the queue if {@code backup} is false or saved into a backup map if {@code backup} is true.
+     * Sets the data of a reserved item and commits the change so it can be
+     * visible outside a transaction.
+     * The commit means that the item is offered to the queue if
+     * {@code backup} is false or saved into a backup map if {@code backup} is {@code true}.
      * This is because a node can hold backups for queues on other nodes.
      * Cancels the queue eviction if one is scheduled.
      *
      * @param itemId the ID of the reserved item
      * @param data   the data to be associated with the reserved item
      * @param backup if the item is to be offered to the underlying queue or stored as a backup
-     * @return true if the commit succeeded
+     * @return {@code true} if the commit succeeded
      * @throws TransactionException if there is no reserved item with the {@code itemId}
      */
     public boolean txnCommitOffer(long itemId, Data data, boolean backup) {
@@ -415,6 +443,14 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return item.getItemId();
     }
 
+    /**
+     * Offers the item to the backup map. If the memory limit
+     * has been achieved the item data will not be kept in-memory.
+     * Executed on the backup replica
+     *
+     * @param data   the item data
+     * @param itemId the item ID as determined by the primary replica
+     */
     public void offerBackup(Data data, long itemId) {
         QueueItem item = new QueueItem(this, itemId, null);
         if (!store.isEnabled() || store.getMemoryLimit() > getItemQueue().size()) {
@@ -456,6 +492,14 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return map;
     }
 
+    /**
+     * Offers the items to the backup map in bulk. If the memory limit
+     * has been achieved the item data will not be kept in-memory.
+     * Executed on the backup replica
+     *
+     * @param dataMap the map from item ID to queue item
+     * @see #offerBackup(Data, long)
+     */
     public void addAllBackup(Map<Long, Data> dataMap) {
         for (Map.Entry<Long, Data> entry : dataMap.entrySet()) {
             QueueItem item = new QueueItem(this, entry.getKey(), null);
@@ -511,6 +555,13 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return item;
     }
 
+    /**
+     * Polls an item on the backup replica. The item ID is predetermined
+     * when executing the poll operation on the partition owner.
+     * Executed on the backup replica
+     *
+     * @param itemId the item ID as determined by the primary replica
+     */
     public void pollBackup(long itemId) {
         QueueItem item = getBackupMap().remove(itemId);
         if (item != null) {
@@ -583,6 +634,15 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return txMap.size();
     }
 
+    /**
+     * Returns the number of queue items contained on this
+     * backup replica. A transaction might temporarily reserve
+     * a poll operation by removing an item from this map.
+     * If the transaction is committed, the map will remain the same.
+     * If the transaction is aborted, the item is returned to the map.
+     *
+     * @return the number of items on this backup replica
+     */
     public int backupSize() {
         return getBackupMap().size();
     }
@@ -638,6 +698,12 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return -1;
     }
 
+    /**
+     * Removes a queue item from the backup map. This should
+     * be executed on the backup replica.
+     *
+     * @param itemId the queue item ID
+     */
     public void removeBackup(long itemId) {
         getBackupMap().remove(itemId);
     }
@@ -690,7 +756,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
      * the retain parameter is true, it will remove items which are not in the dataList (retaining the items which are in the
      * list). If the retain parameter is false, it will remove items which are in the dataList (retaining all other items which
      * are not in the list).
-     *
+     * <p>
      * Note: this method will trigger store load.
      *
      * @param dataList the list of items which are to be retained in the queue or which are to be removed from the queue
@@ -809,6 +875,14 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return (getItemQueue().size() + delta) <= config.getMaxSize();
     }
 
+    /**
+     * Returns the item queue on the partition owner. This method
+     * will also move the items from the backup map if this
+     * member has been promoted from a backup replica to the
+     * partition owner and clear the backup map.
+     *
+     * @return the item queue
+     */
     public Deque<QueueItem> getItemQueue() {
         if (itemQueue == null) {
             itemQueue = new LinkedList<QueueItem>();
@@ -827,7 +901,16 @@ public class QueueContainer implements IdentifiedDataSerializable {
         return itemQueue;
     }
 
-    Map<Long, QueueItem> getBackupMap() {
+    /**
+     * Return the map containing queue items when this instance is
+     * a backup replica.
+     * The map contains both items that are parts of different
+     * transactions and items which have already been committed
+     * to the queue.
+     *
+     * @return backup replica map from item ID to queue item
+     */
+    private Map<Long, QueueItem> getBackupMap() {
         if (backupMap == null) {
             backupMap = new HashMap<Long, QueueItem>();
             if (itemQueue != null) {
@@ -858,6 +941,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
         this.store = QueueStoreWrapper.create(name, storeConfig, serializationService, classLoader);
     }
 
+    /** Returns the next ID that can be used for uniquely identifying queue items */
     long nextId() {
         return ++idGenerator;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -123,7 +123,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         reset();
     }
 
-    public QueueContainer getOrCreateContainer(final String name, boolean fromBackup) throws Exception {
+    public QueueContainer getOrCreateContainer(final String name, boolean fromBackup) {
         QueueContainer container = containerMap.get(name);
         if (container != null) {
             return container;
@@ -265,9 +265,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     }
 
     /**
-     * Returns the local queue statistics for the given name and partition ID. If this node is the owner for the partition,
-     * returned stats contain {@link LocalQueueStats#getOwnedItemCount()}, otherwise it contains
-     * {@link LocalQueueStats#getBackupItemCount()}.
+     * Returns the local queue statistics for the given name and
+     * partition ID. If this node is the owner for the partition,
+     * returned stats contain {@link LocalQueueStats#getOwnedItemCount()},
+     * otherwise it contains {@link LocalQueueStats#getBackupItemCount()}.
      *
      * @param name        the name of the queue for which the statistics are returned
      * @param partitionId the partition ID for which the statistics are returned

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -54,7 +54,9 @@ public abstract class TransactionalQueueProxySupport<E>
     protected final int partitionId;
     protected final QueueConfig config;
 
+    /** The list of items offered to the transactional queue */
     private final LinkedList<QueueItem> offeredQueue = new LinkedList<QueueItem>();
+    /** The IDs of the items modified by the transaction, either added or removed from the queue */
     private final Set<Long> itemIdSet = new HashSet<Long>();
 
     TransactionalQueueProxySupport(NodeEngine nodeEngine, QueueService service, String name, Transaction tx) {
@@ -93,6 +95,19 @@ public abstract class TransactionalQueueProxySupport<E>
         }
     }
 
+    /**
+     * Tries to accomodate one more item in the queue in addition to the
+     * already offered items. If it succeeds by getting an item ID, it will
+     * add the item to the
+     * Makes a reservation for a {@link TransactionalQueue#offer} operation
+     * and adds the commit operation to the transaction log.
+     *
+     * @param data    the serialised item being offered
+     * @param timeout the wait timeout in milliseconds for the offer reservation
+     * @return {@code true} if the item reservation was made
+     * @see TxnReserveOfferOperation
+     * @see TxnOfferOperation
+     */
     boolean offerInternal(Data data, long timeout) {
         TxnReserveOfferOperation operation
                 = new TxnReserveOfferOperation(name, timeout, offeredQueue.size(), tx.getTxnId());

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
@@ -31,9 +31,11 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Offer operation for the Transactional Queue.
+ * Transaction commit operation for a queue offer, executed on the primary replica.
+ *
+ * @see com.hazelcast.core.TransactionalQueue#offer(Object)
+ * @see TxnReserveOfferOperation
  */
-
 public class TxnOfferOperation extends BaseTxnQueueOperation implements Notifier, MutatingOperation {
 
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
@@ -27,7 +27,14 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Reserve offer backup operation for the transactional queue.
+ * Transaction prepare operation for a queue offer, executed on the backup replica.
+ * <p>
+ * Adds the item ID to the collection of IDs offered by a transaction.
+ * The check if the queue can accomodate for all items offered in a
+ * transaction is done on the partition owner.
+ *
+ * @see TxnReserveOfferOperation
+ * @see com.hazelcast.core.TransactionalQueue#offer(Object)
  */
 public class TxnReserveOfferBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.txnqueue.operations;
 import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.operations.QueueOperation;
+import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
@@ -27,7 +28,10 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Reserve poll backup operation for the transactional queue.
+ * Transaction prepare operation for a queue poll, executed on the backup replica.
+ *
+ * @see TransactionalQueue#poll
+ * @see TxnPollOperation
  */
 public class TxnReservePollBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.QueueItem;
 import com.hazelcast.collection.impl.queue.operations.QueueBackupAwareOperation;
+import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BlockingOperation;
@@ -30,7 +31,13 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Reserve poll operation for the transactional queue.
+ * Transaction prepare operation for a queue poll, executed on the primary replica.
+ * <p>
+ * The operation can also wait until there is at least one item reserved or the
+ * wait timeout has elapsed.
+ *
+ * @see TransactionalQueue#poll
+ * @see TxnPollOperation
  */
 public class TxnReservePollOperation extends QueueBackupAwareOperation implements BlockingOperation, MutatingOperation {
 


### PR DESCRIPTION
The transactional queue offer adds an item to the transactional map
but the offer/poll operation expects the item to be in the
(committed) backup map, logs a warning if it is not there and leaves
the uncommitted item as a leak.
This fix checks the transactional map on the backup as well and removes
the reserved item.

Also added some javadoc and removed checked exception on queue
container instantiation.

Fixes : https://github.com/hazelcast/hazelcast/issues/10867