### PR TITLE
[BACKPORT] Fix transactional queue offer/take leak

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -124,7 +124,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         reset();
     }
 
-    public QueueContainer getOrCreateContainer(final String name, boolean fromBackup) throws Exception {
+    public QueueContainer getOrCreateContainer(final String name, boolean fromBackup) {
         QueueContainer container = containerMap.get(name);
         if (container != null) {
             return container;
@@ -266,9 +266,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     }
 
     /**
-     * Returns the local queue statistics for the given name and partition ID. If this node is the owner for the partition,
-     * returned stats contain {@link LocalQueueStats#getOwnedItemCount()}, otherwise it contains
-     * {@link LocalQueueStats#getBackupItemCount()}.
+     * Returns the local queue statistics for the given name and
+     * partition ID. If this node is the owner for the partition,
+     * returned stats contain {@link LocalQueueStats#getOwnedItemCount()},
+     * otherwise it contains {@link LocalQueueStats#getBackupItemCount()}.
      *
      * @param name        the name of the queue for which the statistics are returned
      * @param partitionId the partition ID for which the statistics are returned

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -52,7 +52,10 @@ public abstract class TransactionalQueueProxySupport extends TransactionalDistri
     protected final String name;
     protected final int partitionId;
     protected final QueueConfig config;
+
+    /** The list of items offered to the transactional queue */
     private final LinkedList<QueueItem> offeredQueue = new LinkedList<QueueItem>();
+    /** The IDs of the items modified by the transaction, either added or removed from the queue */
     private final Set<Long> itemIdSet = new HashSet<Long>();
 
     protected TransactionalQueueProxySupport(NodeEngine nodeEngine, QueueService service, String name,
@@ -69,6 +72,19 @@ public abstract class TransactionalQueueProxySupport extends TransactionalDistri
         }
     }
 
+    /**
+     * Tries to accomodate one more item in the queue in addition to the
+     * already offered items. If it succeeds by getting an item ID, it will
+     * add the item to the
+     * Makes a reservation for a {@link TransactionalQueue#offer} operation
+     * and adds the commit operation to the transaction log.
+     *
+     * @param data    the serialised item being offered
+     * @param timeout the wait timeout in milliseconds for the offer reservation
+     * @return {@code true} if the item reservation was made
+     * @see TxnReserveOfferOperation
+     * @see TxnOfferOperation
+     */
     public boolean offerInternal(Data data, long timeout) {
         TxnReserveOfferOperation operation
                 = new TxnReserveOfferOperation(name, timeout, offeredQueue.size(), tx.getTxnId());

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
@@ -31,9 +31,11 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Offer operation for the Transactional Queue.
+ * Transaction commit operation for a queue offer, executed on the primary replica.
+ *
+ * @see com.hazelcast.core.TransactionalQueue#offer(Object)
+ * @see TxnReserveOfferOperation
  */
-
 public class TxnOfferOperation extends BaseTxnQueueOperation implements Notifier, MutatingOperation {
 
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
@@ -27,7 +27,14 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Reserve offer backup operation for the transactional queue.
+ * Transaction prepare operation for a queue offer, executed on the backup replica.
+ * <p>
+ * Adds the item ID to the collection of IDs offered by a transaction.
+ * The check if the queue can accomodate for all items offered in a
+ * transaction is done on the partition owner.
+ *
+ * @see TxnReserveOfferOperation
+ * @see com.hazelcast.core.TransactionalQueue#offer(Object)
  */
 public class TxnReserveOfferBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.impl.txnqueue.operations;
 import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.operations.QueueOperation;
+import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
@@ -27,7 +28,10 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Reserve poll backup operation for the transactional queue.
+ * Transaction prepare operation for a queue poll, executed on the backup replica.
+ *
+ * @see TransactionalQueue#poll
+ * @see TxnPollOperation
  */
 public class TxnReservePollBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.QueueItem;
 import com.hazelcast.collection.impl.queue.operations.QueueBackupAwareOperation;
+import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BlockingOperation;
@@ -30,7 +31,13 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 /**
- * Reserve poll operation for the transactional queue.
+ * Transaction prepare operation for a queue poll, executed on the primary replica.
+ * <p>
+ * The operation can also wait until there is at least one item reserved or the
+ * wait timeout has elapsed.
+ *
+ * @see TransactionalQueue#poll
+ * @see TxnPollOperation
  */
 public class TxnReservePollOperation extends QueueBackupAwareOperation implements BlockingOperation, MutatingOperation {
 


### PR DESCRIPTION
The transactional queue offer adds an item to the transactional map
but the offer/poll operation expects the item to be in the
(committed) backup map, logs a warning if it is not there and leaves
the uncommitted item as a leak.
This fix checks the transactional map on the backup as well and removes
the reserved item.

Also added some javadoc and removed checked exception on queue
container instantiation.

Fixes : https://github.com/hazelcast/hazelcast/issues/10867

(cherry picked from commit 82f1a5c)