### PR TITLE
Prevented premature removal of near cached entries

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -806,12 +806,12 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         public void beforeListenerRegister() {
             nearCache.clear();
             getRepairingTask().deregisterHandler(nameWithPrefix);
+            repairingHandler = getRepairingTask().registerAndGetHandler(nameWithPrefix, nearCache);
         }
 
         @Override
         public void onListenerRegister() {
             nearCache.clear();
-            repairingHandler = getRepairingTask().registerAndGetHandler(nameWithPrefix, nearCache);
         }
 
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcher.java
@@ -19,15 +19,12 @@ package com.hazelcast.client.cache.impl.nearcache.invalidation;
 
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.CacheAssignAndGetUuidsCodec;
-import com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec;
-import com.hazelcast.client.impl.protocol.codec.MapAssignAndGetUuidsCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec.ResponseParameters;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataFetcher;
-import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -35,11 +32,6 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec.decodeResponse;
 import static com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec.encodeRequest;
@@ -61,6 +53,14 @@ public class ClientCacheMetaDataFetcher extends MetaDataFetcher {
     }
 
     @Override
+    protected void extractAndPopulateResult(InternalCompletableFuture future, ResultHolder resultHolder) throws Exception {
+        ClientMessage message = ((ClientMessage) future.get(ASYNC_RESULT_WAIT_TIMEOUT_MINUTES, MINUTES));
+        ResponseParameters response = decodeResponse(message);
+
+        resultHolder.populate(response.partitionUuidList, response.namePartitionSequenceList);
+    }
+
+    @Override
     protected List<InternalCompletableFuture> scanMembers(List<String> names) {
         Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
         List<InternalCompletableFuture> futures = new ArrayList<InternalCompletableFuture>(members.size());
@@ -79,33 +79,5 @@ public class ClientCacheMetaDataFetcher extends MetaDataFetcher {
         }
 
         return futures;
-    }
-
-    @Override
-    protected void process(InternalCompletableFuture future, ConcurrentMap<String, RepairingHandler> handlers) {
-        try {
-            CacheFetchNearCacheInvalidationMetadataCodec.ResponseParameters response = extractResponse(future);
-            repairUuids(response.partitionUuidList, handlers);
-            repairSequences(response.namePartitionSequenceList, handlers);
-        } catch (Exception e) {
-            if (logger.isWarningEnabled()) {
-                logger.warning("Cant fetch invalidation meta-data [" + e.getMessage() + "]");
-            }
-        }
-    }
-
-    private CacheFetchNearCacheInvalidationMetadataCodec.ResponseParameters extractResponse(InternalCompletableFuture future)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        ClientMessage message = ((ClientMessage) future.get(1, MINUTES));
-        return decodeResponse(message);
-    }
-
-    @Override
-    public List<Map.Entry<Integer, UUID>> assignAndGetUuids() throws Exception {
-        ClientMessage request = MapAssignAndGetUuidsCodec.encodeRequest();
-        ClientInvocation invocation = new ClientInvocation(clientImpl, request);
-        CacheAssignAndGetUuidsCodec.ResponseParameters responseParameters
-                = CacheAssignAndGetUuidsCodec.decodeResponse(invocation.invoke().get());
-        return responseParameters.partitionUuidList;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcher.java
@@ -19,14 +19,12 @@ package com.hazelcast.client.map.impl.nearcache.invalidation;
 
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.MapAssignAndGetUuidsCodec;
-import com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec;
+import com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec.ResponseParameters;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataFetcher;
-import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -34,11 +32,6 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec.decodeResponse;
 import static com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec.encodeRequest;
@@ -60,6 +53,14 @@ public class ClientMapMetaDataFetcher extends MetaDataFetcher {
     }
 
     @Override
+    protected void extractAndPopulateResult(InternalCompletableFuture future, ResultHolder resultHolder) throws Exception {
+        ClientMessage message = ((ClientMessage) future.get(ASYNC_RESULT_WAIT_TIMEOUT_MINUTES, MINUTES));
+        ResponseParameters response = decodeResponse(message);
+
+        resultHolder.populate(response.partitionUuidList, response.namePartitionSequenceList);
+    }
+
+    @Override
     protected List<InternalCompletableFuture> scanMembers(List<String> names) {
         Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
         List<InternalCompletableFuture> futures = new ArrayList<InternalCompletableFuture>(members.size());
@@ -78,33 +79,5 @@ public class ClientMapMetaDataFetcher extends MetaDataFetcher {
         }
 
         return futures;
-    }
-
-    @Override
-    protected void process(InternalCompletableFuture future, ConcurrentMap<String, RepairingHandler> handlers) {
-        try {
-            MapFetchNearCacheInvalidationMetadataCodec.ResponseParameters response = extractResponse(future);
-            repairUuids(response.partitionUuidList, handlers);
-            repairSequences(response.namePartitionSequenceList, handlers);
-        } catch (Exception e) {
-            if (logger.isWarningEnabled()) {
-                logger.warning("Cant fetch invalidation meta-data [" + e.getMessage() + "]");
-            }
-        }
-    }
-
-    private MapFetchNearCacheInvalidationMetadataCodec.ResponseParameters extractResponse(InternalCompletableFuture future)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        ClientMessage message = ((ClientMessage) future.get(1, MINUTES));
-        return decodeResponse(message);
-    }
-
-    @Override
-    public List<Map.Entry<Integer, UUID>> assignAndGetUuids() throws Exception {
-        ClientMessage request = MapAssignAndGetUuidsCodec.encodeRequest();
-        ClientInvocation invocation = new ClientInvocation(clientImpl, request);
-        MapAssignAndGetUuidsCodec.ResponseParameters responseParameters
-                = MapAssignAndGetUuidsCodec.decodeResponse(invocation.invoke().get());
-        return responseParameters.partitionUuidList;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -709,12 +709,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         public void beforeListenerRegister() {
             nearCache.clear();
             getRepairingTask().deregisterHandler(name);
+            repairingHandler = getRepairingTask().registerAndGetHandler(name, nearCache);
         }
 
         @Override
         public void onListenerRegister() {
             nearCache.clear();
-            repairingHandler = getRepairingTask().registerAndGetHandler(name, nearCache);
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheReconciliationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheReconciliationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl.nearcache.invalidation;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.map.impl.nearcache.invalidation.MemberMapReconciliationTest.assertStats;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.String.valueOf;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheReconciliationTest extends HazelcastTestSupport {
+
+    private static final String CACHE_NAME = "test";
+    private static final int RECONCILIATION_INTERVAL_SECONDS = 3;
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final ClientConfig clientConfig = new ClientConfig();
+    private final CacheConfig cacheConfig = new CacheConfig();
+
+    private Cache serverCache;
+    private Cache clientCache;
+
+    @Before
+    public void setUp() throws Exception {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(CACHE_NAME);
+        nearCacheConfig.setInvalidateOnChange(true);
+
+        clientConfig.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
+        clientConfig.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", valueOf(RECONCILIATION_INTERVAL_SECONDS));
+        clientConfig.setProperty("hazelcast.invalidation.min.reconciliation.interval.seconds", valueOf(RECONCILIATION_INTERVAL_SECONDS));
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        cacheConfig.getEvictionConfig()
+                .setMaximumSizePolicy(ENTRY_COUNT)
+                .setSize(MAX_VALUE);
+
+        Config config = new Config();
+        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), valueOf(Integer.MAX_VALUE));
+        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), valueOf(Integer.MAX_VALUE));
+
+        HazelcastInstance server = factory.newHazelcastInstance(config);
+
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(server);
+        CacheManager serverCacheManager = provider.getCacheManager();
+
+        serverCache = serverCacheManager.createCache(CACHE_NAME, cacheConfig);
+
+        clientCache = createCacheFromNewClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    private Cache createCacheFromNewClient() {
+        HazelcastClientProxy client = (HazelcastClientProxy) factory.newHazelcastClient(clientConfig);
+        CachingProvider clientCachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+
+        CacheManager cacheManager = clientCachingProvider.getCacheManager();
+        Cache cache = cacheManager.createCache(CACHE_NAME, cacheConfig);
+
+        assert cache instanceof NearCachedClientCacheProxy;
+
+        return cache;
+    }
+
+    @Test
+    public void test_reconciliation_does_not_cause_premature_removal() throws Exception {
+        int total = 100;
+        for (int i = 0; i < total; i++) {
+            serverCache.put(i, i);
+        }
+
+        for (int i = 0; i < total; i++) {
+            clientCache.get(i);
+        }
+
+        Cache cacheFromNewClient = createCacheFromNewClient();
+        for (int i = 0; i < total; i++) {
+            cacheFromNewClient.get(i);
+        }
+
+        NearCacheStats nearCacheStats = ((ICache) cacheFromNewClient).getLocalCacheStatistics().getNearCacheStatistics();
+        assertStats(nearCacheStats, total, 0, total);
+
+        sleepSeconds(2 * RECONCILIATION_INTERVAL_SECONDS);
+
+        for (int i = 0; i < total; i++) {
+            cacheFromNewClient.get(i);
+        }
+
+        assertStats(nearCacheStats, total, total, total);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapReconciliationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapReconciliationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache.invalidation;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.proxy.NearCachedClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.impl.nearcache.invalidation.MemberMapReconciliationTest.assertStats;
+import static java.lang.String.valueOf;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapReconciliationTest extends HazelcastTestSupport {
+
+    private static final String MAP_NAME = "test";
+    private static final int RECONCILIATION_INTERVAL_SECONDS = 3;
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final ClientConfig clientConfig = new ClientConfig();
+
+    private IMap serverMap;
+    private IMap clientMap;
+
+    @Before
+    public void setUp() throws Exception {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(MAP_NAME);
+        nearCacheConfig.setInvalidateOnChange(true);
+
+        clientConfig.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
+        clientConfig.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", valueOf(RECONCILIATION_INTERVAL_SECONDS));
+        clientConfig.setProperty("hazelcast.invalidation.min.reconciliation.interval.seconds", valueOf(RECONCILIATION_INTERVAL_SECONDS));
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        Config config = new Config();
+        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), valueOf(Integer.MAX_VALUE));
+        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), valueOf(Integer.MAX_VALUE));
+
+        HazelcastInstance server = factory.newHazelcastInstance(config);
+        serverMap = server.getMap(MAP_NAME);
+
+        clientMap = createMapFromNewClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    private IMap createMapFromNewClient() {
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        IMap map = client.getMap(MAP_NAME);
+
+        assert map instanceof NearCachedClientMapProxy;
+
+        return map;
+    }
+
+    @Test
+    public void test_reconciliation_does_not_cause_premature_removal() throws Exception {
+        int total = 100;
+        for (int i = 0; i < total; i++) {
+            serverMap.put(i, i);
+        }
+
+        for (int i = 0; i < total; i++) {
+            clientMap.get(i);
+        }
+
+        IMap mapFromNewClient = createMapFromNewClient();
+        for (int i = 0; i < total; i++) {
+            mapFromNewClient.get(i);
+        }
+
+        NearCacheStats nearCacheStats = mapFromNewClient.getLocalMapStats().getNearCacheStats();
+        assertStats(nearCacheStats, total, 0, total);
+
+        sleepSeconds(2 * RECONCILIATION_INTERVAL_SECONDS);
+
+        for (int i = 0; i < total; i++) {
+            mapFromNewClient.get(i);
+        }
+
+        assertStats(nearCacheStats, total, total, total);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
@@ -166,10 +166,8 @@ public class CacheGetInvalidationMetaDataOperation extends Operation implements 
 
         Map<Integer, UUID> partitionUuids = new HashMap<Integer, UUID>(ownedPartitionIds.size());
         for (Integer partitionId : ownedPartitionIds) {
-            UUID uuid = metaDataGenerator.getUuidOrNull(partitionId);
-            if (uuid != null) {
-                partitionUuids.put(partitionId, uuid);
-            }
+            UUID uuid = metaDataGenerator.getOrCreateUuid(partitionId);
+            partitionUuids.put(partitionId, uuid);
         }
         return partitionUuids;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataContainer.java
@@ -78,6 +78,10 @@ public final class MetaDataContainer {
         return sequence;
     }
 
+    public void setSequence(long sequence) {
+        SEQUENCE.set(this, sequence);
+    }
+
     public boolean casSequence(long currentSequence, long nextSequence) {
         return SEQUENCE.compareAndSet(this, currentSequence, nextSequence);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataFetcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataFetcher.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.InternalCompletableFuture;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,26 +35,42 @@ import java.util.concurrent.ConcurrentMap;
  */
 public abstract class MetaDataFetcher {
 
+    protected static final int ASYNC_RESULT_WAIT_TIMEOUT_MINUTES = 1;
+
     protected final ILogger logger;
 
     public MetaDataFetcher(ILogger logger) {
         this.logger = logger;
     }
 
+    protected abstract void extractAndPopulateResult(InternalCompletableFuture future, ResultHolder resultHolder)
+            throws Exception;
+
     protected abstract List<InternalCompletableFuture> scanMembers(List<String> names);
 
-    protected abstract void process(InternalCompletableFuture future, ConcurrentMap<String, RepairingHandler> handlers);
+    public final void init(RepairingHandler handler) throws Exception {
+        ResultHolder resultHolder = new ResultHolder();
+        List<InternalCompletableFuture> futures = scanMembers(Collections.singletonList(handler.getName()));
+        for (InternalCompletableFuture future : futures) {
+            extractAndPopulateResult(future, resultHolder);
 
-    /**
-     * Gets or assigns partition UUIDs before start of {@link RepairingTask} and returns a list of partition ID,
-     * partition UUID pairs.
-     * <p>
-     * This method is likely to be called only one time during the life-cycle of a client.
-     *
-     * @return list of partition ID, partition UUID pairs for initialization
-     * @throws Exception possible exceptions raised by remote calls
-     */
-    protected abstract Collection<Map.Entry<Integer, UUID>> assignAndGetUuids() throws Exception;
+            initUuid(resultHolder.partitionUuidList, handler);
+            initSequence(resultHolder.namePartitionSequenceList, handler);
+        }
+    }
+
+    public final void process(InternalCompletableFuture future, ConcurrentMap<String, RepairingHandler> handlers) {
+        try {
+            ResultHolder resultHolder = new ResultHolder();
+            extractAndPopulateResult(future, resultHolder);
+            repairUuids(resultHolder.partitionUuidList, handlers);
+            repairSequences(resultHolder.namePartitionSequenceList, handlers);
+        } catch (Exception e) {
+            if (logger.isWarningEnabled()) {
+                logger.warning("Can't fetch invalidation meta-data [" + e.getMessage() + "]");
+            }
+        }
+    }
 
     public final void fetchMetadata(ConcurrentMap<String, RepairingHandler> handlers) {
         if (handlers.isEmpty()) {
@@ -83,6 +100,16 @@ public abstract class MetaDataFetcher {
         }
     }
 
+    protected void initUuid(Collection<Map.Entry<Integer, UUID>> uuids, RepairingHandler handler) {
+        for (Map.Entry<Integer, UUID> entry : uuids) {
+
+            int partitionID = entry.getKey();
+            UUID partitionUuid = entry.getValue();
+
+            handler.initUuid(partitionID, partitionUuid);
+        }
+    }
+
     protected void repairSequences(Collection<Map.Entry<String, List<Map.Entry<Integer, Long>>>> namePartitionSequenceList,
                                    ConcurrentMap<String, RepairingHandler> handlers) {
         for (Map.Entry<String, List<Map.Entry<Integer, Long>>> entry : namePartitionSequenceList) {
@@ -90,6 +117,36 @@ public abstract class MetaDataFetcher {
                 RepairingHandler repairingHandler = handlers.get(entry.getKey());
                 repairingHandler.checkOrRepairSequence(subEntry.getKey(), subEntry.getValue(), true);
             }
+        }
+    }
+
+    protected void initSequence(Collection<Map.Entry<String, List<Map.Entry<Integer, Long>>>> namePartitionSequenceList,
+                                RepairingHandler handler) {
+        for (Map.Entry<String, List<Map.Entry<Integer, Long>>> entry : namePartitionSequenceList) {
+            for (Map.Entry<Integer, Long> subEntry : entry.getValue()) {
+                int partitionID = subEntry.getKey();
+                long partitionSequence = subEntry.getValue();
+                handler.initSequence(partitionID, partitionSequence);
+            }
+        }
+    }
+
+    protected static class ResultHolder {
+        private Collection<Map.Entry<String, List<Map.Entry<Integer, Long>>>> namePartitionSequenceList;
+        private Collection<Map.Entry<Integer, UUID>> partitionUuidList;
+
+        public void populate(Collection<Map.Entry<Integer, UUID>> partitionUuidList,
+                             Collection<Map.Entry<String, List<Map.Entry<Integer, Long>>>> namePartitionSequenceList) {
+            this.namePartitionSequenceList = namePartitionSequenceList;
+            this.partitionUuidList = partitionUuidList;
+        }
+
+        public Collection<Map.Entry<String, List<Map.Entry<Integer, Long>>>> getNamePartitionSequenceList() {
+            return namePartitionSequenceList;
+        }
+
+        public Collection<Map.Entry<Integer, UUID>> getPartitionUuidList() {
+            return partitionUuidList;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingHandler.java
@@ -24,18 +24,17 @@ import com.hazelcast.spi.serialization.SerializationService;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static java.lang.String.format;
 
 /**
  * Handler used on Near Cache side. Observes local and remote invalidations and registers relevant
  * data to {@link MetaDataContainer}s.
- *
+ * <p>
  * Used to repair Near Cache in the event of missed invalidation events or partition uuid changes.
  * Here repairing is done by making relevant Near Cache data unreachable.
  * To make stale data unreachable {@link StaleReadDetectorImpl} is used.
- *
+ * <p>
  * An instance of this class is created per Near Cache and can concurrently be used by many threads.
  *
  * @see StaleReadDetectorImpl
@@ -71,12 +70,6 @@ public final class RepairingHandler {
             metaData[partition] = new MetaDataContainer();
         }
         return metaData;
-    }
-
-    public void initUnknownUuids(AtomicReferenceArray<UUID> partitionUuids) {
-        for (int partition = 0; partition < partitionCount; partition++) {
-            metaDataContainers[partition].casUuid(null, partitionUuids.get(partition));
-        }
     }
 
     public MetaDataContainer getMetaDataContainer(int partition) {
@@ -212,5 +205,15 @@ public final class RepairingHandler {
                 + "name='" + name + '\''
                 + ", localUuid='" + localUuid + '\''
                 + '}';
+    }
+
+    public void initUuid(int partitionID, UUID partitionUuid) {
+        MetaDataContainer metaData = getMetaDataContainer(partitionID);
+        metaData.setUuid(partitionUuid);
+    }
+
+    public void initSequence(int partitionID, long partitionSequence) {
+        MetaDataContainer metaData = getMetaDataContainer(partitionID);
+        metaData.setSequence(partitionSequence);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -275,6 +275,7 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
                 }
                 if (staleReadDetector.isStaleRead(key, record)) {
                     remove(key);
+                    nearCacheStats.incrementMisses();
                     return null;
                 }
                 if (isRecordExpired(record)) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
@@ -75,7 +75,7 @@ public class RepairingTaskTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void whenReconciliationIntervalSecondsIsNotZeroButSmallerThanThresholdValue_thenThrowException() {
-        int thresholdValue = (int) MIN_RECONCILIATION_INTERVAL_SECONDS;
+        int thresholdValue = Integer.parseInt(MIN_RECONCILIATION_INTERVAL_SECONDS.getDefaultValue());
         Config config = getConfigWithReconciliationInterval(getInt(1, thresholdValue));
         newRepairingTask(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapReconciliationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapReconciliationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache.invalidation;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static java.lang.String.valueOf;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberMapReconciliationTest extends HazelcastTestSupport {
+
+    private static final String MAP_NAME = "test";
+    private static final int RECONCILIATION_INTERVAL_SECONDS = 3;
+
+    private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
+    private final Config config = new Config();
+
+    private IMap serverMap;
+    private IMap nearCachedServerMap;
+
+    @Before
+    public void setUp() throws Exception {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(MAP_NAME);
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setCacheLocalEntries(true);
+
+        config.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
+        config.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", valueOf(RECONCILIATION_INTERVAL_SECONDS));
+        config.setProperty("hazelcast.invalidation.min.reconciliation.interval.seconds", valueOf(RECONCILIATION_INTERVAL_SECONDS));
+        config.setProperty(MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), valueOf(Integer.MAX_VALUE));
+        config.setProperty(MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), valueOf(Integer.MAX_VALUE));
+        config.getMapConfig(MAP_NAME).setNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance server = factory.newHazelcastInstance(config);
+        serverMap = server.getMap(MAP_NAME);
+
+        nearCachedServerMap = nearCachedMapFromNewServer();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    private IMap nearCachedMapFromNewServer() {
+        HazelcastInstance server = factory.newHazelcastInstance(config);
+        IMap map = server.getMap(MAP_NAME);
+
+        assert map instanceof NearCachedMapProxyImpl;
+
+        return map;
+    }
+
+    @Test
+    public void test_reconciliation_does_not_cause_premature_removal() throws Exception {
+        int total = 100;
+        for (int i = 0; i < total; i++) {
+            serverMap.put(i, i);
+        }
+
+        for (int i = 0; i < total; i++) {
+            nearCachedServerMap.get(i);
+        }
+
+        IMap nearCachedMapFromNewServer = nearCachedMapFromNewServer();
+        for (int i = 0; i < total; i++) {
+            nearCachedMapFromNewServer.get(i);
+        }
+
+        NearCacheStats nearCacheStats = nearCachedMapFromNewServer.getLocalMapStats().getNearCacheStats();
+
+        assertStats(nearCacheStats, total, 0, total);
+
+        sleepSeconds(2 * RECONCILIATION_INTERVAL_SECONDS);
+
+        for (int i = 0; i < total; i++) {
+            nearCachedMapFromNewServer.get(i);
+        }
+
+        assertStats(nearCacheStats, total, total, total);
+    }
+
+    public static void assertStats(NearCacheStats nearCacheStats, int ownedEntryCount, int expectedHits, int expectedMisses) {
+        assertEquals("not expected ownedEntryCount", ownedEntryCount, nearCacheStats.getOwnedEntryCount());
+        assertEquals("not expected expectedHits", expectedHits, nearCacheStats.getHits());
+        assertEquals("not expected expectedMisses", expectedMisses, nearCacheStats.getMisses());
+    }
+}


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/10913
__Fix:__
When initializing a near cached map, get also latest partition-sequences beside partition-uuids.