### PR TITLE
Refactor ringbuffer container creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -204,8 +204,10 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
      */
     private RingbufferContainer<InternalEventJournalCacheEvent> getRingbufferOrFail(ObjectNamespace namespace, int partitionId) {
         final RingbufferService ringbufferService = getRingbufferService();
-        if (ringbufferService.hasContainer(partitionId, namespace)) {
-            return ringbufferService.getContainer(partitionId, namespace, null);
+        final RingbufferContainer<InternalEventJournalCacheEvent> container =
+                ringbufferService.getContainerOrNull(partitionId, namespace);
+        if (container != null) {
+            return container;
         }
 
         final EventJournalConfig config = getEventJournalConfig(namespace);
@@ -233,8 +235,10 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
      */
     private RingbufferContainer<InternalEventJournalCacheEvent> getRingbufferOrNull(ObjectNamespace namespace, int partitionId) {
         final RingbufferService ringbufferService = getRingbufferService();
-        if (ringbufferService.hasContainer(partitionId, namespace)) {
-            return ringbufferService.getContainer(partitionId, namespace, null);
+        final RingbufferContainer<InternalEventJournalCacheEvent> container =
+                ringbufferService.getContainerOrNull(partitionId, namespace);
+        if (container != null) {
+            return container;
         }
 
         final EventJournalConfig config = getEventJournalConfig(namespace);
@@ -245,7 +249,7 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
                                                                                                int partitionId,
                                                                                                EventJournalConfig config) {
         final RingbufferConfig ringbufferConfig = toRingbufferConfig(config);
-        return getRingbufferService().getContainer(partitionId, namespace, ringbufferConfig);
+        return getRingbufferService().getOrCreateContainer(partitionId, namespace, ringbufferConfig);
     }
 
     private RingbufferService getRingbufferService() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -171,16 +171,17 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
     private RingbufferContainer<InternalEventJournalMapEvent> getRingbufferOrNull(ObjectNamespace namespace, int partitionId) {
         final RingbufferService service = getRingbufferService();
         final RingbufferConfig ringbufferConfig;
-        if (service.hasContainer(partitionId, namespace)) {
-            ringbufferConfig = null;
-        } else {
-            final EventJournalConfig config = getEventJournalConfig(namespace);
-            if (config == null || !config.isEnabled()) {
-                return null;
-            }
-            ringbufferConfig = toRingbufferConfig(config);
+        final RingbufferContainer<InternalEventJournalMapEvent> container = service.getContainerOrNull(partitionId, namespace);
+        if (container != null) {
+            return container;
         }
-        return service.getContainer(partitionId, namespace, ringbufferConfig);
+
+        final EventJournalConfig config = getEventJournalConfig(namespace);
+        if (config == null || !config.isEnabled()) {
+            return null;
+        }
+        ringbufferConfig = toRingbufferConfig(config);
+        return service.getOrCreateContainer(partitionId, namespace, ringbufferConfig);
     }
 
     private RingbufferService getRingbufferService() {

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -62,11 +62,11 @@ public abstract class AbstractRingBufferOperation extends Operation
 
     /**
      * Returns an {@link RingbufferContainer} or creates a new one if necessary by calling
-     * {@link RingbufferService#getContainer(int, ObjectNamespace, RingbufferConfig)}.
+     * {@link RingbufferService#getOrCreateContainer(int, ObjectNamespace, RingbufferConfig)}.
      * Also calls the {@link RingbufferContainer#cleanup()} before returning
      * the container. This will currently remove any expired items.
      *
-     * @return the ring buffer container
+     * @return the ringbuffer container
      */
     RingbufferContainer getRingBufferContainer() {
         if (ringbuffer != null) {
@@ -74,9 +74,11 @@ public abstract class AbstractRingBufferOperation extends Operation
         }
         final RingbufferService service = getService();
         final ObjectNamespace ns = RingbufferService.getRingbufferNamespace(name);
-        final boolean isContainerCreated = service.hasContainer(getPartitionId(), ns);
-        final RingbufferContainer ringbuffer = service.getContainer(getPartitionId(), ns,
-                isContainerCreated ? null : service.getRingbufferConfig(name));
+
+        RingbufferContainer ringbuffer = service.getContainerOrNull(getPartitionId(), ns);
+        if (ringbuffer == null) {
+            ringbuffer = service.getOrCreateContainer(getPartitionId(), ns, service.getRingbufferConfig(name));
+        }
 
         ringbuffer.cleanup();
         this.ringbuffer = ringbuffer;

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
@@ -59,11 +59,11 @@ public class RingbufferServiceTest extends HazelcastTestSupport {
     public void reset() {
         final String foo = "foo";
         final String bar = "bar";
-        service.getContainer(
+        service.getOrCreateContainer(
                 service.getRingbufferPartitionId(foo),
                 RingbufferService.getRingbufferNamespace(foo),
                 service.getRingbufferConfig(foo));
-        service.getContainer(
+        service.getOrCreateContainer(
                 service.getRingbufferPartitionId(bar),
                 RingbufferService.getRingbufferNamespace(bar),
                 service.getRingbufferConfig(bar));

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
@@ -49,7 +49,7 @@ public class RingbufferTTLTest extends HazelcastTestSupport {
         ringbuffer = hz.getRingbuffer(name);
 
         RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(
+        ringbufferContainer = ringbufferService.getOrCreateContainer(
                 ringbufferService.getRingbufferPartitionId(name),
                 RingbufferService.getRingbufferNamespace(name),
                 ringbufferConfig);

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
@@ -69,7 +69,7 @@ public class GenericOperationTest extends HazelcastTestSupport {
         ringbuffer = hz.getRingbuffer(name);
 
         ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(
+        ringbufferContainer = ringbufferService.getOrCreateContainer(
                 ringbufferService.getRingbufferPartitionId(name),
                 RingbufferService.getRingbufferNamespace(name),
                 rbConfig);

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -66,7 +66,7 @@ public class ReadManyOperationTest extends HazelcastTestSupport {
         ringbuffer = hz.getRingbuffer(name);
 
         ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(
+        ringbufferContainer = ringbufferService.getOrCreateContainer(
                 ringbufferService.getRingbufferPartitionId(name),
                 RingbufferService.getRingbufferNamespace(name),
                 rbConfig);

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperationTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
@@ -64,7 +63,7 @@ public class ReadOneOperationTest extends HazelcastTestSupport {
         ringbuffer = hz.getRingbuffer(name);
 
         ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-        ringbufferContainer = ringbufferService.getContainer(
+        ringbufferContainer = ringbufferService.getOrCreateContainer(
                 ringbufferService.getRingbufferPartitionId(name),
                 RingbufferService.getRingbufferNamespace(name),
                 rbConfig);


### PR DESCRIPTION
The ringbuffer container creation can run into a NPE if the container
is being destroyed simultaneously. This is because of a
check-then-act paradigm : the code checks if there is a container
created and skips config lookup in that case. The problem is that the
container might have been destroyed after the check.
The fix uses a different approach and always calls the ringbuffer
get-or-create method with a non-null argument.
Also renamed some methods to reflect their usage and added javadoc.

Fixes https://github.com/hazelcast/hazelcast/issues/10772