### PR TITLE
Introduces support for pre-join operations per service

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -61,7 +61,7 @@ import com.hazelcast.cache.impl.operation.CacheReplaceOperation;
 import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperationFactory;
-import com.hazelcast.cache.impl.operation.PostJoinCacheOperation;
+import com.hazelcast.cache.impl.operation.OnJoinCacheOperation;
 import com.hazelcast.cache.impl.record.CacheDataRecord;
 import com.hazelcast.cache.impl.record.CacheObjectRecord;
 import com.hazelcast.client.impl.protocol.task.cache.CacheAssignAndGetUuidsOperation;
@@ -376,7 +376,7 @@ public final class CacheDataSerializerHook
         };
         constructors[CACHE_POST_JOIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PostJoinCacheOperation();
+                return new OnJoinCacheOperation();
             }
         };
         constructors[CACHE_DATA_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.exception.ServiceNotFoundException;
 
+import javax.cache.configuration.Configuration;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +34,14 @@ import java.util.List;
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 import static com.hazelcast.cache.impl.JCacheDetector.isJCacheAvailable;
 
-public class PostJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
+/**
+ * Operation executed on joining members so they become aware of {@link CacheConfig}s dynamically created via
+ * {@link javax.cache.CacheManager#createCache(String, Configuration)}. Depending on the cluster version, this operation
+ * is executed either as a post-join operation (when cluster version is < 3.9) or as a pre-join operation (since 3.9), to
+ * resolve a race between the {@link CacheConfig} becoming available in the joining member and creation of a
+ * {@link com.hazelcast.cache.ICache} proxy.
+ */
+public class OnJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
 
     private List<CacheConfig> configs = new ArrayList<CacheConfig>();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -38,7 +38,7 @@ import com.hazelcast.internal.cluster.impl.operations.MemberAttributeChangedOp;
 import com.hazelcast.internal.cluster.impl.operations.MembersUpdateOp;
 import com.hazelcast.internal.cluster.impl.operations.MemberRemoveOperation;
 import com.hazelcast.internal.cluster.impl.operations.MergeClustersOp;
-import com.hazelcast.internal.cluster.impl.operations.PostJoinOp;
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.MasterResponseOp;
 import com.hazelcast.internal.cluster.impl.operations.ShutdownNodeOp;
@@ -228,7 +228,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         };
         constructors[POST_JOIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PostJoinOp();
+                return new OnJoinOp();
             }
         };
         constructors[ROLLBACK_CLUSTER_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -31,7 +31,7 @@ import com.hazelcast.internal.cluster.impl.operations.GroupMismatchOp;
 import com.hazelcast.internal.cluster.impl.operations.JoinRequestOp;
 import com.hazelcast.internal.cluster.impl.operations.MasterResponseOp;
 import com.hazelcast.internal.cluster.impl.operations.MembersUpdateOp;
-import com.hazelcast.internal.cluster.impl.operations.PostJoinOp;
+import com.hazelcast.internal.cluster.impl.operations.OnJoinOp;
 import com.hazelcast.internal.cluster.impl.operations.WhoisMasterOp;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -640,13 +641,12 @@ public class ClusterJoinManager {
                 }
 
                 // send members update back to node trying to join again...
-                Operation[] postJoinOps = nodeEngine.getPostJoinOperations();
-                boolean isPostJoinOperation = postJoinOps != null && postJoinOps.length > 0;
-                PostJoinOp postJoinOp = isPostJoinOperation ? new PostJoinOp(postJoinOps) : null;
+                OnJoinOp preJoinOp = preparePreJoinOps();
+                OnJoinOp postJoinOp = preparePostJoinOp();
                 PartitionRuntimeState partitionRuntimeState = node.getPartitionService().createPartitionState();
 
                 Operation op = new FinalizeJoinOp(member.getUuid(),
-                        clusterService.getMembershipManager().createMembersView(), postJoinOp,
+                        clusterService.getMembershipManager().createMembersView(), preJoinOp, postJoinOp,
                         clusterClock.getClusterTime(), clusterService.getClusterId(),
                         clusterClock.getClusterStartTime(), clusterStateManager.getState(),
                         clusterService.getClusterVersion(), partitionRuntimeState, false);
@@ -722,9 +722,8 @@ public class ClusterJoinManager {
 
                 // post join operations must be lock free, that means no locks at all:
                 // no partition locks, no key-based locks, no service level locks!
-                Operation[] postJoinOps = nodeEngine.getPostJoinOperations();
-                boolean createPostJoinOperation = (postJoinOps != null && postJoinOps.length > 0);
-                PostJoinOp postJoinOp = (createPostJoinOperation ? new PostJoinOp(postJoinOps) : null);
+                OnJoinOp preJoinOp = preparePreJoinOps();
+                OnJoinOp postJoinOp = preparePostJoinOp();
 
                 if (!clusterService.updateMembers(newMembersView, node.getThisAddress(), clusterService.getThisUuid())) {
                     return;
@@ -735,7 +734,7 @@ public class ClusterJoinManager {
                 PartitionRuntimeState partitionRuntimeState = partitionService.createPartitionState();
                 for (MemberInfo member : joiningMembers.values()) {
                     long startTime = clusterClock.getClusterStartTime();
-                    Operation op = new FinalizeJoinOp(member.getUuid(), newMembersView, postJoinOp, time,
+                    Operation op = new FinalizeJoinOp(member.getUuid(), newMembersView, preJoinOp, postJoinOp, time,
                             clusterService.getClusterId(), startTime, clusterStateManager.getState(),
                             clusterService.getClusterVersion(), partitionRuntimeState, true);
                     op.setCallerUuid(clusterService.getThisUuid());
@@ -758,6 +757,20 @@ public class ClusterJoinManager {
         } finally {
             clusterServiceLock.unlock();
         }
+    }
+
+    private OnJoinOp preparePostJoinOp() {
+        Operation[] postJoinOps = nodeEngine.getPostJoinOperations();
+        boolean createPostJoinOperation = (postJoinOps != null && postJoinOps.length > 0);
+        return (createPostJoinOperation ? new OnJoinOp(postJoinOps) : null);
+    }
+
+    private OnJoinOp preparePreJoinOps() {
+        Operation[] preJoinOps = null;
+        if (clusterService.getClusterVersion().isGreaterOrEqual(V3_9)) {
+            preJoinOps = nodeEngine.getPreJoinOperations();
+        }
+        return (preJoinOps != null && preJoinOps.length > 0) ? new OnJoinOp(preJoinOps) : null;
     }
 
     private void persistJoinedMemberUuids(Collection<MemberInfo> joinedMembers) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
@@ -32,15 +32,15 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
 import static com.hazelcast.util.Preconditions.checkNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-public class PostJoinOp
+public class OnJoinOp
         extends AbstractJoinOperation implements UrgentSystemOperation {
 
     private Operation[] operations;
 
-    public PostJoinOp() {
+    public OnJoinOp() {
     }
 
-    public PostJoinOp(final Operation... ops) {
+    public OnJoinOp(final Operation... ops) {
         for (Operation op : ops) {
             checkNotNull(op, "op can't be null");
             checkNegative(op.getPartitionId(), "Post join operation can not have a partition ID!");

--- a/hazelcast/src/main/java/com/hazelcast/spi/PreJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PreJoinAwareService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Services which need to perform operations on a joining member just before the member is set as joined must implement
+ * this interface. These operations are executed on the joining member before it is set as joined, in contrast to
+ * {@link PostJoinAwareService#getPostJoinOperation()}s which are executed on the joining member after it is set as joined.
+ * The practical outcome is that pre-join operations are already executed before the {@link com.hazelcast.core.HazelcastInstance}
+ * is returned to the caller, while post-join operations may be still executing.
+ *
+ * @since 3.9
+ */
+public interface PreJoinAwareService {
+
+    /**
+     * An operation to be executed on the joining member before it is set as joined. As is the case with
+     * {@link PostJoinAwareService#getPostJoinOperation()}s, no partition locks, no key-based locks, no service level
+     * locks, no database interaction are allowed. Additionally, a pre-join operation is executed while the cluster
+     * lock is being held on the joining member, so it is important that the operation finishes quickly and does not
+     * interact with other locks.
+     *
+     * The {@link Operation#getPartitionId()} method should return a negative value.
+     * This means that the operations should not implement {@link PartitionAwareOperation}.
+     * <p>
+     * Pre join operations should return response, which may also be a {@code null} response.
+     *
+     * @return an operation to be executed on joining member before it is set as joined. Can be {@code null}.
+     */
+    Operation getPreJoinOperation();
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
@@ -43,13 +43,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Test whether PostJoinCacheOperation logs warning, fails or succeeds under different JCache API availability
+ * Test whether OnJoinCacheOperation logs warning, fails or succeeds under different JCache API availability
  * in classpath.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JCacheDetector.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class PostJoinCacheOperationTest {
+public class OnJoinCacheOperationTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -72,10 +72,10 @@ public class PostJoinCacheOperationTest {
         // node engine returns mock CacheService
         when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenReturn(mock(ICacheService.class));
 
-        PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
-        postJoinCacheOperation.setNodeEngine(nodeEngine);
+        OnJoinCacheOperation onJoinCacheOperation = new OnJoinCacheOperation();
+        onJoinCacheOperation.setNodeEngine(nodeEngine);
 
-        postJoinCacheOperation.run();
+        onJoinCacheOperation.run();
 
         verify(nodeEngine).getConfigClassLoader();
         verify(nodeEngine).getService(CacheService.SERVICE_NAME);
@@ -87,15 +87,15 @@ public class PostJoinCacheOperationTest {
     public void test_cachePostJoinOperationSucceeds_whenJCacheNotAvailable_noCacheConfigs() throws Exception {
         when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(false);
 
-        PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
-        postJoinCacheOperation.setNodeEngine(nodeEngine);
+        OnJoinCacheOperation onJoinCacheOperation = new OnJoinCacheOperation();
+        onJoinCacheOperation.setNodeEngine(nodeEngine);
 
-        postJoinCacheOperation.run();
+        onJoinCacheOperation.run();
 
         verify(nodeEngine).getConfigClassLoader();
         // verify a warning was logged
         verify(logger).warning(anyString());
-        // verify CacheService instance was not requested in PostJoinCacheOperation.run
+        // verify CacheService instance was not requested in OnJoinCacheOperation.run
         verify(nodeEngine, never()).getService(CacheService.SERVICE_NAME);
     }
 
@@ -106,13 +106,13 @@ public class PostJoinCacheOperationTest {
         // node engine throws HazelcastException due to missing CacheService
         when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenThrow(new HazelcastException("CacheService not found"));
 
-        // some CacheConfigs are added in the PostJoinCacheOperation (so JCache is actually in use in the rest of the cluster)
-        PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
-        postJoinCacheOperation.addCacheConfig(new CacheConfig("test"));
-        postJoinCacheOperation.setNodeEngine(nodeEngine);
+        // some CacheConfigs are added in the OnJoinCacheOperation (so JCache is actually in use in the rest of the cluster)
+        OnJoinCacheOperation onJoinCacheOperation = new OnJoinCacheOperation();
+        onJoinCacheOperation.addCacheConfig(new CacheConfig("test"));
+        onJoinCacheOperation.setNodeEngine(nodeEngine);
 
         expectedException.expect(HazelcastException.class);
-        postJoinCacheOperation.run();
+        onJoinCacheOperation.run();
 
         verify(nodeEngine).getConfigClassLoader();
         verify(nodeEngine).getService(CacheService.SERVICE_NAME);


### PR DESCRIPTION
Some operations sent to a joining member may have to be completed before a new `HazelcastInstance` is returned to the user, in order to avoid race of user actions with operations executed by `PostJoinOp`. A service can declare it supplies such operations by implementing new interface `PreJoinAwareService` (operations to be executed on the joining member before the node is set as joined).
`CacheService` is currently sending a `PostJoinCacheOperation` to make the new member aware of its dynamic `CacheConfig`s, however this is racey with `PostJoinProxyOperation` and a user attempting to obtain a `Cache` proxy immediately after `Hazelcast.newHazelcastInstance()` returns. This issue is resolved in this PR by having `CacheService` deliver `CacheConfig` as a pre-join operation (when operating at cluster version 3.9).