### PR TITLE
Do not cache BuildInfo / Version in static fields

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -595,11 +595,11 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             UsernamePasswordCredentials cr = (UsernamePasswordCredentials) credentials;
             clientMessage = ClientAuthenticationCodec
                     .encodeRequest(cr.getUsername(), cr.getPassword(), uuid, ownerUuid, asOwner, ClientTypes.JAVA,
-                            serializationVersion, BuildInfoProvider.BUILD_INFO.getVersion());
+                            serializationVersion, BuildInfoProvider.getBuildInfo().getVersion());
         } else {
             Data data = ss.toData(credentials);
             clientMessage = ClientAuthenticationCustomCodec.encodeRequest(data, uuid, ownerUuid,
-                    asOwner, ClientTypes.JAVA, serializationVersion, BuildInfoProvider.BUILD_INFO.getVersion());
+                    asOwner, ClientTypes.JAVA, serializationVersion, BuildInfoProvider.getBuildInfo().getVersion());
         }
         return clientMessage;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -216,7 +216,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         GroupConfig groupConfig = config.getGroupConfig();
         String loggingType = config.getProperty(GroupProperty.LOGGING_TYPE.getName());
         loggingService = new ClientLoggingService(groupConfig.getName(),
-                loggingType, BuildInfoProvider.BUILD_INFO, instanceName);
+                loggingType, BuildInfoProvider.getBuildInfo(), instanceName);
         ClassLoader classLoader = config.getClassLoader();
         clientExtension = createClientInitializer(classLoader);
         clientExtension.beforeStart(this);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -81,7 +81,7 @@ public final class LifecycleServiceImpl implements LifecycleService {
                 }
             }
         }
-        buildInfo = BuildInfoProvider.BUILD_INFO;
+        buildInfo = BuildInfoProvider.getBuildInfo();
         fireLifecycleEvent(STARTING);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
@@ -49,7 +49,7 @@ public class ClientExecutionServiceImplTest {
         String name = "ClientExecutionServiceImplTest";
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         HazelcastProperties properties = new HazelcastProperties(new Config());
-        ClientLoggingService loggingService = new ClientLoggingService(name, "jdk", BuildInfoProvider.BUILD_INFO, name);
+        ClientLoggingService loggingService = new ClientLoggingService(name, "jdk", BuildInfoProvider.getBuildInfo(), name);
 
         executionService = new ClientExecutionServiceImpl(name, classLoader, properties, 1, loggingService);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -210,7 +210,7 @@ public abstract class AbstractXmlConfigHelper {
     }
 
     protected String getReleaseVersion() {
-        BuildInfo buildInfo = BuildInfoProvider.BUILD_INFO;
+        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
         return buildInfo.getVersion().substring(0, 3);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
@@ -37,8 +37,7 @@ public class BuildInfo {
     private final boolean enterprise;
     private final byte serializationVersion;
     private final BuildInfo upstreamBuildInfo;
-
-    private JetBuildInfo jetBuildInfo;
+    private final JetBuildInfo jetBuildInfo;
 
     public BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
                      byte serializationVersion) {
@@ -47,6 +46,12 @@ public class BuildInfo {
 
     public BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
                      byte serializationVersion, BuildInfo upstreamBuildInfo) {
+        this(version, build, revision, buildNumber, enterprise, serializationVersion, upstreamBuildInfo,
+                null);
+    }
+
+    private BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
+                     byte serializationVersion, BuildInfo upstreamBuildInfo, JetBuildInfo jetBuildInfo) {
         this.version = version;
         this.build = build;
         this.revision = revision;
@@ -54,6 +59,13 @@ public class BuildInfo {
         this.enterprise = enterprise;
         this.serializationVersion = serializationVersion;
         this.upstreamBuildInfo = upstreamBuildInfo;
+        this.jetBuildInfo = jetBuildInfo;
+    }
+
+    private BuildInfo(BuildInfo buildInfo, JetBuildInfo jetBuildInfo) {
+        this(buildInfo.getVersion(), buildInfo.getBuild(), buildInfo.getRevision(), buildInfo.getBuildNumber(),
+                buildInfo.isEnterprise(), buildInfo.getSerializationVersion(), buildInfo.getUpstreamBuildInfo(),
+                jetBuildInfo);
     }
 
     public String getRevision() {
@@ -91,8 +103,8 @@ public class BuildInfo {
         return jetBuildInfo;
     }
 
-    void setJetBuildInfo(JetBuildInfo jetBuildInfo) {
-        this.jetBuildInfo = jetBuildInfo;
+    BuildInfo withJetBuildInfo(JetBuildInfo jetBuildInfo) {
+        return new BuildInfo(this, jetBuildInfo);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -32,42 +32,52 @@ import static com.hazelcast.util.EmptyStatement.ignore;
  */
 public final class BuildInfoProvider {
 
-    /**
-     * Use this in production code to obtain the BuildInfo already parsed when this class was first loaded.
-     * Its properties will not change at runtime.
-     */
-    public static final BuildInfo BUILD_INFO;
-
     public static final String HAZELCAST_INTERNAL_OVERRIDE_VERSION = "hazelcast.internal.override.version";
+    private static final String HAZELCAST_INTERNAL_OVERRIDE_BUILD = "hazelcast.build";
 
     private static final ILogger LOGGER;
+    private static final BuildInfo BUILD_INFO_CACHE;
 
     static {
         LOGGER = Logger.getLogger(BuildInfoProvider.class);
-        BUILD_INFO = getBuildInfo();
+        BUILD_INFO_CACHE = populateBuildInfoCache();
     }
 
     private BuildInfoProvider() {
     }
 
+    private static BuildInfo populateBuildInfoCache() {
+        return getBuildInfoInternalVersion(Overrides.DISABLED);
+    }
+
     /**
      * Parses {@code hazelcast-runtime.properties} for {@code BuildInfo}; also checks for overrides in System.properties.
-     * Use this method to obtain and cache a {@code BuildInfo} object or from test code that needs to re-parse properties
-     * on each invocation.
+     * Never cache result of this method in a static context - as it can change due versions overriding - this method
+     * already does caching whenever it's possible - i.e. when overrides is disabled.
      *
      * @return the parsed BuildInfo
      */
     public static BuildInfo getBuildInfo() {
+        if (Overrides.isEnabled()) {
+            // never use cache when override is enabled -> we need to re-parse everything
+            Overrides overrides = Overrides.fromProperties();
+            return getBuildInfoInternalVersion(overrides);
+        }
+
+        return BUILD_INFO_CACHE;
+    }
+
+    private static BuildInfo getBuildInfoInternalVersion(Overrides overrides) {
         // If you have a compilation error at GeneratedBuildProperties then run 'mvn clean install'
         // the GeneratedBuildProperties class is generated at a compile-time
-        BuildInfo buildInfo = readBuildPropertiesClass(GeneratedBuildProperties.class, null);
+        BuildInfo buildInfo = readBuildPropertiesClass(GeneratedBuildProperties.class, null, overrides);
         try {
             Class<?> enterpriseClass = BuildInfoProvider.class.getClassLoader()
                     .loadClass("com.hazelcast.instance.GeneratedEnterpriseBuildProperties");
             if (enterpriseClass.getClassLoader() == BuildInfoProvider.class.getClassLoader()) {
                 //only read the enterprise properties if there were loaded by the same classloader
                 //as BuildInfoProvider and not e.g. a parent classloader.
-                buildInfo = readBuildPropertiesClass(enterpriseClass, buildInfo);
+                buildInfo = readBuildPropertiesClass(enterpriseClass, buildInfo, overrides);
             }
         } catch (ClassNotFoundException e) {
             ignore(e);
@@ -105,7 +115,7 @@ public final class BuildInfoProvider {
         return runtimeProperties;
     }
 
-    private static BuildInfo readBuildPropertiesClass(Class<?> clazz, BuildInfo upstreamBuildInfo) {
+    private static BuildInfo readBuildPropertiesClass(Class<?> clazz, BuildInfo upstreamBuildInfo, Overrides overrides) {
         String version = readStaticStringField(clazz, "VERSION");
         String build = readStaticStringField(clazz, "BUILD");
         String revision = readStaticStringField(clazz, "REVISION");
@@ -119,22 +129,7 @@ public final class BuildInfoProvider {
 
         String serialVersionString = readStaticStringField(clazz, "SERIALIZATION_VERSION");
         byte serialVersion = Byte.parseByte(serialVersionString);
-        return overrideBuildInfo(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
-    }
-
-    private static BuildInfo overrideBuildInfo(String version, String build, String revision, int buildNumber,
-                                               boolean enterprise, byte serialVersion, BuildInfo upstreamBuildInfo) {
-        Integer hazelcastBuild = Integer.getInteger("hazelcast.build", -1);
-        if (hazelcastBuild != -1) {
-            build = String.valueOf(hazelcastBuild);
-            buildNumber = hazelcastBuild;
-        }
-        String overridingVersion = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
-        if (overridingVersion != null) {
-            LOGGER.info("Overriding hazelcast version with system property value " + overridingVersion);
-            version = overridingVersion;
-        }
-        return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
+        return overrides.apply(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
     }
 
     //todo: move elsewhere
@@ -146,6 +141,44 @@ public final class BuildInfoProvider {
             throw new HazelcastException(e);
         } catch (IllegalAccessException e) {
             throw new HazelcastException(e);
+        }
+    }
+
+    private static final class Overrides {
+        private static final Overrides DISABLED = new Overrides(null, -1);
+
+        private String version;
+        private int buildNo;
+
+        private Overrides(String version, int build) {
+            this.version = version;
+            this.buildNo = build;
+        }
+
+        private BuildInfo apply(String version, String build, String revision, int buildNumber,
+                                boolean enterprise, byte serialVersion, BuildInfo upstreamBuildInfo) {
+            if (buildNo != -1) {
+                build = String.valueOf(buildNo);
+                buildNumber = buildNo;
+            }
+            if (this.version != null) {
+                LOGGER.info("Overriding hazelcast version with system property value " + this.version);
+                version = this.version;
+            }
+            return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
+
+        }
+
+        private static boolean isEnabled() {
+            return System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_BUILD) != null
+                    || System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION) != null;
+        }
+
+        private static Overrides fromProperties() {
+            String version = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
+            int build = Integer.getInteger(HAZELCAST_INTERNAL_OVERRIDE_BUILD, -1);
+
+            return new Overrides(version, build);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -84,20 +84,19 @@ public final class BuildInfoProvider {
         }
 
         Properties jetProperties = loadPropertiesFromResource("jet-runtime.properties");
-        setJetProperties(jetProperties, buildInfo);
-        return buildInfo;
+        return withJetProperties(jetProperties, buildInfo);
     }
 
-    static void setJetProperties(Properties properties, BuildInfo buildInfo) {
+    private static BuildInfo withJetProperties(Properties properties, BuildInfo buildInfo) {
         if (properties.isEmpty()) {
-            return;
+            return buildInfo;
         }
         String version = properties.getProperty("jet.version");
         String build = properties.getProperty("jet.build");
         String revision = properties.getProperty("jet.git.revision");
 
         JetBuildInfo jetBuildInfo = new JetBuildInfo(version, build, revision);
-        buildInfo.setJetBuildInfo(jetBuildInfo);
+        return buildInfo.withJetBuildInfo(jetBuildInfo);
     }
 
     private static Properties loadPropertiesFromResource(String resourceName) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -150,7 +150,7 @@ public final class ConfigValidator {
      * @param inMemoryFormat supplied inMemoryFormat
      */
     private static void checkNotNative(InMemoryFormat inMemoryFormat) {
-        if (inMemoryFormat == NATIVE && !BuildInfoProvider.BUILD_INFO.isEnterprise()) {
+        if (inMemoryFormat == NATIVE && !BuildInfoProvider.getBuildInfo().isEnterprise()) {
             throw new IllegalArgumentException("NATIVE storage format is supported in Hazelcast Enterprise only."
                     + " Make sure you have Hazelcast Enterprise JARs on your classpath!");
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
  */
 public class BuildInfoPlugin extends DiagnosticsPlugin {
 
-    private final BuildInfo buildInfo = BuildInfoProvider.BUILD_INFO;
+    private final BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
 
     public BuildInfoPlugin(NodeEngineImpl nodeEngine) {
         super(nodeEngine.getLogger(BuildInfoPlugin.class));

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -37,7 +38,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DATA_SERIALIZABLE;
 
 /**
@@ -54,8 +54,8 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
     public static final byte EE_FLAG = 1 << 1;
 
     private static final String FACTORY_ID = "com.hazelcast.DataSerializerHook";
-    private static final Version VERSION = Version.of(BUILD_INFO.getVersion());
 
+    private final Version version = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
     private final Int2ObjectHashMap<DataSerializableFactory> factories = new Int2ObjectHashMap<DataSerializableFactory>();
 
     DataSerializableSerializer(Map<Integer, ? extends DataSerializableFactory> dataSerializableFactories,
@@ -113,7 +113,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
 
     private DataSerializable readInternal(ObjectDataInput in, Class aClass)
             throws IOException {
-        setInputVersion(in, VERSION);
+        setInputVersion(in, version);
         DataSerializable ds = null;
         if (null != aClass) {
             try {
@@ -184,7 +184,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
     public void write(ObjectDataOutput out, DataSerializable obj) throws IOException {
         // If you ever change the way this is serialized think about to change
         // BasicOperationService::extractOperationCallId
-        setOutputVersion(out, VERSION);
+        setOutputVersion(out, version);
         final boolean identified = obj instanceof IdentifiedDataSerializable;
         out.writeBoolean(identified);
         if (identified) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -85,7 +85,7 @@ public class DefaultSerializationServiceBuilder implements SerializationServiceB
 
     @Override
     public SerializationServiceBuilder setVersion(byte version) {
-        byte maxVersion = BuildInfoProvider.BUILD_INFO.getSerializationVersion();
+        byte maxVersion = BuildInfoProvider.getBuildInfo().getSerializationVersion();
         if (version > maxVersion) {
             throw new IllegalArgumentException(
                     "Configured serialization version is higher than the max supported version: " + maxVersion);

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastInternalOSGiService.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastInternalOSGiService.java
@@ -31,9 +31,9 @@ public interface HazelcastInternalOSGiService
      * Default ID for {@link HazelcastInternalOSGiService} instance
      */
     String DEFAULT_ID =
-            BuildInfoProvider.BUILD_INFO.getVersion()
+            BuildInfoProvider.getBuildInfo().getVersion()
             + "#"
-            + (BuildInfoProvider.BUILD_INFO.isEnterprise() ? "EE" : "OSS");
+            + (BuildInfoProvider.getBuildInfo().isEnterprise() ? "EE" : "OSS");
 
     /**
      * Default group name to be used when grouping is not disabled with

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -736,7 +736,7 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty SERIALIZATION_VERSION
             = new HazelcastProperty("hazelcast.serialization.version",
-            BuildInfoProvider.BUILD_INFO.getSerializationVersion());
+            BuildInfoProvider.getBuildInfo().getSerializationVersion());
 
     /**
      * Override cluster version to use while node is not yet member of a cluster. The cluster version assumed before joining

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -48,7 +48,7 @@ public class ClientMessageSplitAndBuildTest {
         int FRAME_SIZE = 50;
         String s = UUID.randomUUID().toString();
         final ClientMessage expectedClientMessage = ClientAuthenticationCodec.encodeRequest(s, s, s, s, true, s, (byte) 1,
-                BuildInfoProvider.BUILD_INFO.getVersion());
+                BuildInfoProvider.getBuildInfo().getVersion());
         expectedClientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
         List<ClientMessage> subFrames = ClientMessageSplitter.getSubFrames(FRAME_SIZE, expectedClientMessage);
         ClientMessageChannelInboundHandler clientMessageReadHandler = new ClientMessageChannelInboundHandler(
@@ -70,7 +70,7 @@ public class ClientMessageSplitAndBuildTest {
         int FRAME_SIZE = 50;
         String s = UUID.randomUUID().toString();
         ClientMessage clientMessage = ClientAuthenticationCodec.encodeRequest(s, s, s, s, true, s, (byte) 1,
-                BuildInfoProvider.BUILD_INFO.getVersion());
+                BuildInfoProvider.getBuildInfo().getVersion());
         clientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
         List<ClientMessage> subFrames = ClientMessageSplitter.getSubFrames(FRAME_SIZE, clientMessage);
 
@@ -91,7 +91,7 @@ public class ClientMessageSplitAndBuildTest {
         for (int id = 0; id < NUMBER_OF_MESSAGES; id++) {
             String s = UUID.randomUUID().toString();
             ClientMessage expectedClientMessage = ClientAuthenticationCodec.encodeRequest(s, s, s, s, true, s, (byte) 1,
-                    BuildInfoProvider.BUILD_INFO.getVersion());
+                    BuildInfoProvider.getBuildInfo().getVersion());
             expectedClientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
             expectedClientMessage.setCorrelationId(id);
 
@@ -129,7 +129,7 @@ public class ClientMessageSplitAndBuildTest {
     public void splitAndBuild_whenMessageIsAlreadySmallerThanFrameSize() throws Exception {
         String s = UUID.randomUUID().toString();
         final ClientMessage expectedClientMessage = ClientAuthenticationCodec.encodeRequest(s, s, s, s, true, s, (byte) 1,
-                BuildInfoProvider.BUILD_INFO.getVersion());
+                BuildInfoProvider.getBuildInfo().getVersion());
         expectedClientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
         List<ClientMessage> subFrames = ClientMessageSplitter.getSubFrames(expectedClientMessage.getFrameLength() + 1, expectedClientMessage);
         ClientMessageChannelInboundHandler clientMessageReadHandler = new ClientMessageChannelInboundHandler(

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/RawProtocolAuthenticationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/RawProtocolAuthenticationTest.java
@@ -102,7 +102,7 @@ public class RawProtocolAuthenticationTest {
         String pass = GroupConfig.DEFAULT_GROUP_PASSWORD;
 
         final ClientMessage authMessage = ClientAuthenticationCodec.encodeRequest(username, pass, null, null,
-                true, ClientTypes.JAVA, InternalSerializationService.VERSION_1, BuildInfoProvider.BUILD_INFO.getVersion());
+                true, ClientTypes.JAVA, InternalSerializationService.VERSION_1, BuildInfoProvider.getBuildInfo().getVersion());
         authMessage.setCorrelationId(1).addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
 
         final ClientProtocolBuffer byteBuffer = authMessage.buffer();
@@ -135,7 +135,7 @@ public class RawProtocolAuthenticationTest {
 
         final ClientMessage authMessage = ClientAuthenticationCodec
                 .encodeRequest(username, pass, null, null, true, ClientTypes.JAVA, InternalSerializationService.VERSION_1,
-                        BuildInfoProvider.BUILD_INFO.getVersion());
+                        BuildInfoProvider.getBuildInfo().getVersion());
         authMessage.setCorrelationId(1).addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
 
         final ClientProtocolBuffer byteBuffer = authMessage.buffer();
@@ -168,7 +168,7 @@ public class RawProtocolAuthenticationTest {
 
         final ClientMessage authMessage = ClientAuthenticationCodec
                 .encodeRequest(username, pass, null, null, true, ClientTypes.JAVA, (byte) 0,
-                        BuildInfoProvider.BUILD_INFO.getVersion());
+                        BuildInfoProvider.getBuildInfo().getVersion());
         authMessage.setCorrelationId(1).addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
 
         final ClientProtocolBuffer byteBuffer = authMessage.buffer();
@@ -201,7 +201,7 @@ public class RawProtocolAuthenticationTest {
 
         final ClientMessage authMessage = ClientAuthenticationCodec
                 .encodeRequest(username, pass, null, null, true, ClientTypes.JAVA, (byte) 0,
-                        BuildInfoProvider.BUILD_INFO.getVersion());
+                        BuildInfoProvider.getBuildInfo().getVersion());
         authMessage.setCorrelationId(1).addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
 
         //set invalid message size

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -126,25 +126,4 @@ public class BuildInfoProviderTest extends HazelcastTestSupport {
         assertEquals("99.99.99", buildInfo.getVersion());
         System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
     }
-
-    @Test
-    public void testJetBuildInfo() {
-        Properties properties = new Properties();
-        properties.setProperty("jet.version", "1.0");
-        properties.setProperty("jet.build", "1486562404303");
-        properties.setProperty("jet.git.revision", "a252185d2d39c8ed5ef2596e889307d396a239cc");
-
-        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
-        BuildInfoProvider.setJetProperties(properties, buildInfo);
-
-        JetBuildInfo jetBuildInfo = buildInfo.getJetBuildInfo();
-
-        assertEquals("1.0", jetBuildInfo.getVersion());
-        assertEquals("1486562404303", jetBuildInfo.getBuild());
-        assertEquals("a252185d2d39c8ed5ef2596e889307d396a239cc", jetBuildInfo.getRevision());
-
-        assertContains(jetBuildInfo.toString(), "1.0");
-        assertContains(jetBuildInfo.toString(), "1486562404303");
-        assertContains(jetBuildInfo.toString(), "a252185d2d39c8ed5ef2596e889307d396a239cc");
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
@@ -44,7 +44,6 @@ import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -93,7 +92,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
     @Test
     public void test_joinRequestAllowed_whenSameVersion()
             throws UnknownHostException {
-        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), node.getVersion(),
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BuildInfoProvider.getBuildInfo().getBuildNumber(), node.getVersion(),
                 new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
         nodeExtension.validateJoinRequest(joinRequest);
     }
@@ -103,7 +102,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
             throws UnknownHostException {
         MemberVersion otherPatchVersion = MemberVersion
                 .of(node.getVersion().getMajor(), node.getVersion().getMinor(), node.getVersion().getPatch() + 1);
-        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), otherPatchVersion,
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BuildInfoProvider.getBuildInfo().getBuildNumber(), otherPatchVersion,
                 new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
         nodeExtension.validateJoinRequest(joinRequest);
     }
@@ -113,7 +112,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
             throws UnknownHostException {
         MemberVersion otherPatchVersion = MemberVersion
                 .of(node.getVersion().getMajor(), node.getVersion().getMinor() + 1, node.getVersion().getPatch());
-        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), otherPatchVersion,
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BuildInfoProvider.getBuildInfo().getBuildNumber(), otherPatchVersion,
                 new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
         expected.expect(VersionMismatchException.class);
         nodeExtension.validateJoinRequest(joinRequest);
@@ -124,7 +123,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
             throws UnknownHostException {
         MemberVersion otherPatchVersion = MemberVersion
                 .of(node.getVersion().getMajor() + 1, node.getVersion().getMinor(), node.getVersion().getPatch());
-        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), otherPatchVersion,
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BuildInfoProvider.getBuildInfo().getBuildNumber(), otherPatchVersion,
                 new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
         expected.expect(VersionMismatchException.class);
         nodeExtension.validateJoinRequest(joinRequest);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -184,7 +184,7 @@ public class RestClusterTest extends HazelcastTestSupport {
         HazelcastTestSupport.waitInstanceForSafeState(instance);
         String result = String.format("{\"status\":\"success\",\"response\":\"[%s]\n%s\n%s\"}",
                 instance.getCluster().getLocalMember().toString(),
-                BuildInfoProvider.BUILD_INFO.getVersion(),
+                BuildInfoProvider.getBuildInfo().getVersion(),
                 System.getProperty("java.version"));
         assertEquals(result, communicator.listClusterNodes("dev", "dev-pass"));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.Address;
@@ -35,7 +36,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -44,7 +44,7 @@ public class ClusterDataSerializationTest {
 
     private static final SerializationService SERIALIZATION_SERVICE = new DefaultSerializationServiceBuilder().build();
     private static final ClusterStateChange<MemberVersion> VERSION_CLUSTER_STATE_CHANGE = ClusterStateChange.from(MemberVersion.of(
-            BUILD_INFO.getVersion()));
+            BuildInfoProvider.getBuildInfo().getVersion()));
     private static final ClusterStateChange<ClusterState> CLUSTER_STATE_CHANGE = ClusterStateChange.from(ClusterState.FROZEN);
 
     @Test
@@ -103,7 +103,7 @@ public class ClusterDataSerializationTest {
         attributes.put("b", "b");
         attributes.put("c", new Address("127.0.0.1", 5999));
         MemberInfo memberInfo = new MemberInfo(new Address("127.0.0.1", 5071), UUID.randomUUID().toString(), attributes,
-                false, MemberVersion.of(BUILD_INFO.getVersion()));
+                false, MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion()));
 
         Data serialized = SERIALIZATION_SERVICE.toData(memberInfo);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -61,8 +61,8 @@ public class ClusterStateManagerTest {
 
     private static final String TXN = "txn";
     private static final String ANOTHER_TXN = "another-txn";
-    private static final MemberVersion CURRENT_NODE_VERSION = MemberVersion.of(BuildInfoProvider.BUILD_INFO.getVersion());
-    private static final Version CURRENT_CLUSTER_VERSION = Version.of(BuildInfoProvider.BUILD_INFO.getVersion());
+    private static final MemberVersion CURRENT_NODE_VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
+    private static final Version CURRENT_CLUSTER_VERSION = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
 
     private final Node node = mock(Node.class);
     private final InternalPartitionService partitionService = mock(InternalPartitionService.class);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class MemberMapTest {
 
-    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.BUILD_INFO.getVersion());
+    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
 
     @Test(expected = AssertionError.class)
     @RequireAssertEnabled

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
@@ -57,7 +57,7 @@ public class MemberSelectingIteratorTest extends HazelcastTestSupport {
     @Before
     public void before()
             throws Exception {
-        MemberVersion version = new MemberVersion(BuildInfoProvider.BUILD_INFO.getVersion());
+        MemberVersion version = new MemberVersion(BuildInfoProvider.getBuildInfo().getVersion());
         thisMember = new MemberImpl(new Address("localhost", 5701), version, true, newUnsecureUuidString(), null, true);
         matchingMember = new MemberImpl(new Address("localhost", 5702), version, false, newUnsecureUuidString(), null, true);
         matchingMember2 = new MemberImpl(new Address("localhost", 5703), version, false, newUnsecureUuidString(), null, true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/BuildInfoPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/BuildInfoPluginTest.java
@@ -52,7 +52,7 @@ public class BuildInfoPluginTest extends AbstractDiagnosticsPluginTest {
     public void test() throws IOException {
         plugin.run(logWriter);
 
-        BuildInfo buildInfo = BuildInfoProvider.BUILD_INFO;
+        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
 
         assertContains("BuildNumber=" + buildInfo.getBuildNumber());
         assertContains("Build=" + buildInfo.getBuild());

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
@@ -61,7 +61,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class PartitionStateGeneratorTest {
 
-    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.BUILD_INFO.getVersion());
+    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
     private static final boolean PRINT_STATE = false;
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStoreAdapter;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.map.AbstractEntryProcessor;
 import com.hazelcast.map.impl.MapService;
@@ -47,7 +48,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
-import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
@@ -179,7 +179,7 @@ public class NearCacheTestSupport extends HazelcastTestSupport {
         // the Near Cache is filled, we should see some memory costs now
         assertTrue("The Near Cache is filled, there should be some owned entry memory costs",
                 getNearCacheStats(map).getOwnedEntryMemoryCost() > 0);
-        if (isMember && !BUILD_INFO.isEnterprise()) {
+        if (isMember && !BuildInfoProvider.getBuildInfo().isEnterprise()) {
             // the heap costs are just calculated on member on-heap maps
             assertTrue("The Near Cache is filled, there should be some heap costs", map.getLocalMapStats().getHeapCost() > 0);
         }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.SimpleMemberImpl;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
@@ -66,7 +67,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -570,7 +570,7 @@ public class SerializationTest extends HazelcastTestSupport {
         VersionedDataSerializable object = new VersionedDataSerializable();
         ss.toData(object);
         assertEquals("ObjectDataOutput.getVersion should be equal to member version",
-                Version.of(BUILD_INFO.getVersion()), object.getVersion());
+                Version.of(BuildInfoProvider.getBuildInfo().getVersion()), object.getVersion());
     }
 
     @Test
@@ -579,7 +579,7 @@ public class SerializationTest extends HazelcastTestSupport {
         VersionedDataSerializable object = new VersionedDataSerializable();
         VersionedDataSerializable otherObject = ss.toObject(ss.toData(object));
         assertEquals("ObjectDataInput.getVersion should be equal to member version",
-                Version.of(BUILD_INFO.getVersion()), otherObject.getVersion());
+                Version.of(BuildInfoProvider.getBuildInfo().getVersion()), otherObject.getVersion());
     }
 
     private static final class DynamicProxyTestClassLoader extends ClassLoader {

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -59,7 +59,7 @@ public class MockIOService implements IOService {
     public volatile PacketHandler packetHandler;
 
     public MockIOService(int port, ChannelFactory channelFactory) throws Exception {
-        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.BUILD_INFO);
+        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
         serverSocketChannel = ServerSocketChannel.open();
         ServerSocket serverSocket = serverSocketChannel.socket();
         serverSocket.setReuseAddress(true);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -69,7 +69,7 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
         addressB = new Address("127.0.0.1", 5702);
         addressC = new Address("127.0.0.1", 5703);
 
-        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.BUILD_INFO);
+        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
         logger = loggingService.getLogger(TcpIpConnection_AbstractTest.class);
 
         metricsRegistryA = newMetricsRegistry();

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class MemberGroupFactoryTest {
 
-    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.BUILD_INFO.getVersion());
+    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
 
     @Test
     public void testHostAwareMemberGroupFactoryCreateMemberGroups() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -93,7 +93,7 @@ import static org.mockito.Mockito.when;
 @Category(QuickTest.class)
 public class DiscoverySpiTest extends HazelcastTestSupport {
 
-    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.BUILD_INFO.getVersion());
+    private static final MemberVersion VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
     private static final ILogger LOGGER = Logger.getLogger(DiscoverySpiTest.class);
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/DumpBuildInfoOnFailureRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DumpBuildInfoOnFailureRule.java
@@ -1,0 +1,28 @@
+package com.hazelcast.test;
+
+import com.hazelcast.instance.BuildInfoProvider;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class DumpBuildInfoOnFailureRule implements TestRule {
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    printBuildInfo(description);
+                    throw t;
+                }
+            }
+        };
+    }
+
+    private void printBuildInfo(Description description) {
+        System.out.println("BuildInfo right after " + description.getDisplayName() + ": "
+                + BuildInfoProvider.getBuildInfo());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1212,7 +1212,7 @@ public abstract class HazelcastTestSupport {
 
     @SuppressWarnings("unchecked")
     private static TestHazelcastInstanceFactory createHazelcastInstanceFactory0(Integer nodeCount) {
-        if (isRunningCompatibilityTest() && BuildInfoProvider.BUILD_INFO.isEnterprise()) {
+        if (isRunningCompatibilityTest() && BuildInfoProvider.getBuildInfo().isEnterprise()) {
             try {
                 String className = "com.hazelcast.test.CompatibilityTestHazelcastInstanceFactory";
                 Class<? extends TestHazelcastInstanceFactory> compatibilityTestFactoryClass

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -74,7 +74,6 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.partition.TestPartitionUtils.getPartitionServiceState;
 import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
@@ -97,6 +96,9 @@ public abstract class HazelcastTestSupport {
 
     @Rule
     public JitterRule jitterRule = new JitterRule();
+
+    @Rule
+    public DumpBuildInfoOnFailureRule dumpInfoRule = new DumpBuildInfoOnFailureRule();
 
     static {
         ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 120);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -80,7 +80,7 @@ public class MockNodeContext implements NodeContext {
      * @return {@code NodeExtension} suitable for sampling serialized objects in OSS or EE environment
      */
     private NodeExtension constructSamplingNodeExtension(Node node) {
-        if (BuildInfoProvider.BUILD_INFO.isEnterprise()) {
+        if (BuildInfoProvider.getBuildInfo().isEnterprise()) {
             try {
                 Class<? extends NodeExtension> klass = (Class<? extends NodeExtension>)
                         Class.forName("com.hazelcast.test.compatibility.SamplingEnterpriseNodeExtension");


### PR DESCRIPTION
We have a version overriding mechanism and when services are caching
BuildVersion/Version in a static field then tests are not truly
independent -> when the cache initialized whilst the override is
active then it stays like that for all remaining tests.

We should always follow these rules:
1. services should never cache the `BuildInfo` in a static field.
   caching in a non-static field is OK

2. the (public) `BUILD_INFO` field should be removed
   from `BuildInfoProvider` - services should always
   use the `getBuildInfo()` method

3. the `BuildInfoProvider::getBuildInfo` can do its own internal caching
   when no override is set then a cache can be used. this is the only
   place where the `BuildInfo` can be stored into a static field.

Also services should not cache Version in a static field - for the same
reasons

Fixes https://github.com/hazelcast/hazelcast/issues/10897