### PR TITLE
Added missing invalidation listener in Near Cache preloader tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -181,6 +181,10 @@ public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloade
                 .setNearCacheAdapter(new ICacheDataStructureAdapter<K, V>(clientCache))
                 .setNearCache(nearCache)
                 .setNearCacheManager(nearCacheManager)
-                .setCacheManager(cacheManager);
+                .setCacheManager(cacheManager)
+                // FIXME: the JCache doesn't send invalidation on CREATED entries, so this will crash some tests
+                // see AbstractCacheRecordStore.doPutRecord()
+                //.setInvalidationListener(createInvalidationEventHandler(clientCache))
+                ;
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static com.hazelcast.client.map.impl.nearcache.ClientMapInvalidationListener.createInvalidationEventHandler;
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -182,6 +183,7 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
                 .setNearCacheInstance(client)
                 .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(clientMap))
                 .setNearCache(nearCache)
-                .setNearCacheManager(nearCacheManager);
+                .setNearCacheManager(nearCacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(clientMap));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -36,6 +36,7 @@ import java.io.File;
 
 import static com.hazelcast.internal.nearcache.AbstractNearCachePreloaderTest.KeyType.INTEGER;
 import static com.hazelcast.internal.nearcache.AbstractNearCachePreloaderTest.KeyType.STRING;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheInvalidations;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheRecord;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
@@ -269,6 +270,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
             Object key = createKey(keyType, i);
             context.dataAdapter.put(key, "value-" + i);
         }
+        assertNearCacheInvalidations(context, keyCount);
 
         // start the client which will kick off the Near Cache pre-loader
         NearCacheTestContext<Object, String, NK, NV> clientContext = createClientContext();
@@ -303,7 +305,11 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
     private void populateNearCache(NearCacheTestContext<Object, String, NK, NV> context, int keyCount, KeyType keyType) {
         for (int i = 0; i < keyCount; i++) {
             Object key = createKey(keyType, i);
-            context.nearCacheAdapter.put(key, "value-" + i);
+            context.dataAdapter.put(key, "value-" + i);
+        }
+        assertNearCacheInvalidations(context, keyCount);
+        for (int i = 0; i < keyCount; i++) {
+            Object key = createKey(keyType, i);
             context.nearCacheAdapter.get(key);
         }
     }


### PR DESCRIPTION
There is a race between the population of the backing data structure, which sends out invalidation events, and the population of the Near Cache. If the invalidations are processed too late, the already populated Near Cache is invalidated again. This is only done in IMap, not ICache, which explain why only the map tests are affected.

We already fixed this in the Near Cache basic tests, by adding an invalidation listener, which waits after the population of the backing data structure, before populating the Near Cache. This should also be applied for the preloader tests.

See https://github.com/hazelcast/hazelcast/pull/10525
Fixes https://github.com/hazelcast/hazelcast/issues/10732
Fixes https://github.com/hazelcast/hazelcast/issues/10880