### PR TITLE
ClientStateListenerTest.testClientConnectedWithTimeout test sometimes fails

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
@@ -236,7 +236,7 @@ public class ClientStateListenerTest extends ClientTestSupport{
         hazelcastFactory.newHazelcastInstance();
 
         hazelcastFactory.newHazelcastClient(clientConfig);
-        assertTrue(listener.awaitConnected(1, MILLISECONDS));
+        assertTrue(listener.awaitConnected(30, SECONDS));
 
         assertFalse(listener.awaitDisconnected(1, MILLISECONDS));
 


### PR DESCRIPTION
Increased wait time for connected event since it is being delivered by an executor, event may be delivered later based on thread scheduling.

fixes #10885