### PR TITLE
Local statistics latency resolution is not enough for low latencies

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
@@ -28,7 +28,7 @@ import java.security.Permission;
 
 public abstract class AbstractMapPutMessageTask<P> extends AbstractMapPartitionMessageTask<P> {
 
-    protected transient long startTime;
+    protected transient long startTimeNanos;
 
     protected AbstractMapPutMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -36,17 +36,17 @@ public abstract class AbstractMapPutMessageTask<P> extends AbstractMapPartitionM
 
     @Override
     protected void beforeProcess() {
-        startTime = System.currentTimeMillis();
+        startTimeNanos = System.nanoTime();
     }
 
     @Override
     protected void beforeResponse() {
-        final long latency = System.currentTimeMillis() - startTime;
+        final long latency = System.nanoTime() - startTimeNanos;
         final MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(getDistributedObjectName());
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(getDistributedObjectName())
-                    .incrementPuts(latency);
+                    .incrementPutLatencyNanos(latency);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
@@ -41,12 +41,12 @@ public abstract class AbstractMapPutMessageTask<P> extends AbstractMapPartitionM
 
     @Override
     protected void beforeResponse() {
-        final long latency = System.nanoTime() - startTimeNanos;
+        final long latencyNanos = System.nanoTime() - startTimeNanos;
         final MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(getDistributedObjectName());
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(getDistributedObjectName())
-                    .incrementPutLatencyNanos(latency);
+                    .incrementPutLatencyNanos(latencyNanos);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
@@ -69,7 +69,7 @@ public class MapGetMessageTask
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementGets(latency);
+                    .incrementGetLatencyNanos(latency);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 public class MapGetMessageTask
         extends AbstractMapPartitionMessageTask<MapGetCodec.RequestParameters> {
 
-    private transient long startTime;
+    private transient long startTimeNanos;
 
     public MapGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -59,17 +59,17 @@ public class MapGetMessageTask
 
     @Override
     protected void beforeProcess() {
-        startTime = System.currentTimeMillis();
+        startTimeNanos = System.nanoTime();
     }
 
     @Override
     protected void beforeResponse() {
-        final long latency = System.currentTimeMillis() - startTime;
+        final long latencyNanos = System.nanoTime() - startTimeNanos;
         final MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementGetLatencyNanos(latency);
+                    .incrementGetLatencyNanos(latencyNanos);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
@@ -46,12 +46,12 @@ public class MapRemoveMessageTask
 
     @Override
     protected void beforeResponse() {
-        final long latency = System.nanoTime() - startTimeNanos;
+        final long latencyNanos = System.nanoTime() - startTimeNanos;
         final MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementRemoveLatencyNanos(latency);
+                    .incrementRemoveLatencyNanos(latencyNanos);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
@@ -33,7 +33,7 @@ import java.security.Permission;
 public class MapRemoveMessageTask
         extends AbstractMapPartitionMessageTask<MapRemoveCodec.RequestParameters> {
 
-    protected transient long startTime;
+    protected transient long startTimeNanos;
 
     public MapRemoveMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -41,17 +41,17 @@ public class MapRemoveMessageTask
 
     @Override
     protected void beforeProcess() {
-        startTime = System.currentTimeMillis();
+        startTimeNanos = System.nanoTime();
     }
 
     @Override
     protected void beforeResponse() {
-        final long latency = System.currentTimeMillis() - startTime;
+        final long latency = System.nanoTime() - startTimeNanos;
         final MapService mapService = getService(MapService.SERVICE_NAME);
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(parameters.name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(parameters.name)
-                    .incrementRemoves(latency);
+                    .incrementRemoveLatencyNanos(latency);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -679,13 +679,13 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public void incrementOperationStats(long startTime, LocalMapStatsImpl localMapStats, String mapName, Operation operation) {
-        final long duration = System.currentTimeMillis() - startTime;
+        final long durationNanos = System.nanoTime() - startTime;
         if (operation instanceof BasePutOperation) {
-            localMapStats.incrementPuts(duration);
+            localMapStats.incrementPutLatencyNanos(durationNanos);
         } else if (operation instanceof BaseRemoveOperation) {
-            localMapStats.incrementRemoves(duration);
+            localMapStats.incrementRemoveLatencyNanos(durationNanos);
         } else if (operation instanceof GetOperation) {
-            localMapStats.incrementGets(duration);
+            localMapStats.incrementGetLatencyNanos(durationNanos);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -70,7 +70,7 @@ public final class EntryOperator {
     private final boolean wanReplicationEnabled;
     private final boolean hasEventRegistration;
     private final int partitionId;
-    private final long now = Clock.currentTimeMillis();
+    private final long startTimeNanos = System.nanoTime();
     private final String mapName;
     private final RecordStore recordStore;
     private final InternalSerializationService ss;
@@ -301,7 +301,7 @@ public final class EntryOperator {
                 newValue = record == null ? null : record.getValue();
             }
             mapServiceContext.interceptAfterPut(mapName, newValue);
-            stats.incrementPuts(getLatencyFrom(now));
+            stats.incrementPutLatencyNanos(getLatencyFrom(startTimeNanos));
         }
     }
 
@@ -311,12 +311,12 @@ public final class EntryOperator {
         } else {
             recordStore.delete(dataKey);
             mapServiceContext.interceptAfterRemove(mapName, oldValue);
-            stats.incrementRemoves(getLatencyFrom(now));
+            stats.incrementRemoveLatencyNanos(getLatencyFrom(startTimeNanos));
         }
     }
 
-    private static long getLatencyFrom(long begin) {
-        return Clock.currentTimeMillis() - begin;
+    private static long getLatencyFrom(long beginTimeNanos) {
+        return System.nanoTime() - beginTimeNanos;
     }
 
     private void process(Map.Entry entry) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -301,7 +301,7 @@ public final class EntryOperator {
                 newValue = record == null ? null : record.getValue();
             }
             mapServiceContext.interceptAfterPut(mapName, newValue);
-            stats.incrementPutLatencyNanos(getLatencyFrom(startTimeNanos));
+            stats.incrementPutLatencyNanos(getLatencyNanos(startTimeNanos));
         }
     }
 
@@ -311,11 +311,11 @@ public final class EntryOperator {
         } else {
             recordStore.delete(dataKey);
             mapServiceContext.interceptAfterRemove(mapName, oldValue);
-            stats.incrementRemoveLatencyNanos(getLatencyFrom(startTimeNanos));
+            stats.incrementRemoveLatencyNanos(getLatencyNanos(startTimeNanos));
         }
     }
 
-    private static long getLatencyFrom(long beginTimeNanos) {
+    private static long getLatencyNanos(long beginTimeNanos) {
         return System.nanoTime() - beginTimeNanos;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -53,11 +53,11 @@ public class LocalMapStatsImpl implements LocalMapStats {
 
     // The resolution is in nano seconds for the following latencies
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_GET_LATENCIES =
-            newUpdater(LocalMapStatsImpl.class, "totalGetLatencies");
+            newUpdater(LocalMapStatsImpl.class, "totalGetLatenciesNanos");
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_PUT_LATENCIES =
-            newUpdater(LocalMapStatsImpl.class, "totalPutLatencies");
+            newUpdater(LocalMapStatsImpl.class, "totalPutLatenciesNanos");
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_REMOVE_LATENCIES =
-            newUpdater(LocalMapStatsImpl.class, "totalRemoveLatencies");
+            newUpdater(LocalMapStatsImpl.class, "totalRemoveLatenciesNanos");
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_GET_LATENCY =
             newUpdater(LocalMapStatsImpl.class, "maxGetLatency");
     private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_PUT_LATENCY =
@@ -74,9 +74,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long getCount;
     private volatile long putCount;
     private volatile long removeCount;
-    private volatile long totalGetLatencies;
-    private volatile long totalPutLatencies;
-    private volatile long totalRemoveLatencies;
+    private volatile long totalGetLatenciesNanos;
+    private volatile long totalPutLatenciesNanos;
+    private volatile long totalRemoveLatenciesNanos;
     private volatile long maxGetLatency;
     private volatile long maxPutLatency;
     private volatile long maxRemoveLatency;
@@ -243,17 +243,17 @@ public class LocalMapStatsImpl implements LocalMapStats {
 
     @Override
     public long getTotalPutLatency() {
-        return NANOSECONDS.toMillis(totalPutLatencies);
+        return NANOSECONDS.toMillis(totalPutLatenciesNanos);
     }
 
     @Override
     public long getTotalGetLatency() {
-        return NANOSECONDS.toMillis(totalGetLatencies);
+        return NANOSECONDS.toMillis(totalGetLatenciesNanos);
     }
 
     @Override
     public long getTotalRemoveLatency() {
-        return NANOSECONDS.toMillis(totalRemoveLatencies);
+        return NANOSECONDS.toMillis(totalRemoveLatenciesNanos);
     }
 
     @Override
@@ -328,9 +328,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
         root.add("dirtyEntryCount", dirtyEntryCount);
 
         // keep the contract as milliseconds for latencies sent using Json
-        root.add("totalGetLatencies", NANOSECONDS.toMillis(totalGetLatencies));
-        root.add("totalPutLatencies", NANOSECONDS.toMillis(totalPutLatencies));
-        root.add("totalRemoveLatencies", NANOSECONDS.toMillis(totalRemoveLatencies));
+        root.add("totalGetLatencies", NANOSECONDS.toMillis(totalGetLatenciesNanos));
+        root.add("totalPutLatencies", NANOSECONDS.toMillis(totalPutLatenciesNanos));
+        root.add("totalRemoveLatencies", NANOSECONDS.toMillis(totalRemoveLatenciesNanos));
         root.add("maxGetLatency", NANOSECONDS.toMillis(maxGetLatency));
         root.add("maxPutLatency", NANOSECONDS.toMillis(maxPutLatency));
         root.add("maxRemoveLatency", NANOSECONDS.toMillis(maxRemoveLatency));
@@ -353,9 +353,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
         lastUpdateTime = getLong(json, "lastUpdateTime", -1L);
 
         // Json uses milliseconds but we keep latencies in nanoseconds internally
-        totalGetLatencies = MILLISECONDS.toNanos(getLong(json, "totalGetLatencies", -1L));
-        totalPutLatencies = MILLISECONDS.toNanos(getLong(json, "totalPutLatencies", -1L));
-        totalRemoveLatencies = MILLISECONDS.toNanos(getLong(json, "totalRemoveLatencies", -1L));
+        totalGetLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalGetLatencies", -1L));
+        totalPutLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalPutLatencies", -1L));
+        totalRemoveLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalRemoveLatencies", -1L));
         maxGetLatency = MILLISECONDS.toNanos(getLong(json, "maxGetLatency", -1L));
         maxPutLatency = MILLISECONDS.toNanos(getLong(json, "maxPutLatency", -1L));
         maxRemoveLatency = MILLISECONDS.toNanos(getLong(json, "maxRemoveLatency", -1L));
@@ -388,9 +388,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", getCount=" + getCount
                 + ", putCount=" + putCount
                 + ", removeCount=" + removeCount
-                + ", totalGetLatencies=" + NANOSECONDS.toMillis(totalGetLatencies)
-                + ", totalPutLatencies=" + NANOSECONDS.toMillis(totalPutLatencies)
-                + ", totalRemoveLatencies=" + NANOSECONDS.toMillis(totalRemoveLatencies)
+                + ", totalGetLatencies=" + NANOSECONDS.toMillis(totalGetLatenciesNanos)
+                + ", totalPutLatencies=" + NANOSECONDS.toMillis(totalPutLatenciesNanos)
+                + ", totalRemoveLatencies=" + NANOSECONDS.toMillis(totalRemoveLatenciesNanos)
                 + ", maxGetLatency=" + NANOSECONDS.toMillis(maxGetLatency)
                 + ", maxPutLatency=" + NANOSECONDS.toMillis(maxPutLatency)
                 + ", maxRemoveLatency=" + NANOSECONDS.toMillis(maxRemoveLatency)

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -246,17 +246,17 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
             Future f;
             Object o;
             if (config.isStatisticsEnabled()) {
-                long time = System.currentTimeMillis();
+                long startTimeNanos = System.nanoTime();
                 f = nodeEngine.getOperationService()
                         .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
                 o = f.get();
                 if (operation instanceof PutOperation) {
                     //TODO @ali should we remove statics from operations ?
-                    getService().getLocalMultiMapStatsImpl(name).incrementPuts(System.currentTimeMillis() - time);
+                    getService().getLocalMultiMapStatsImpl(name).incrementPutLatencyNanos(System.nanoTime() - startTimeNanos);
                 } else if (operation instanceof RemoveOperation || operation instanceof RemoveAllOperation) {
-                    getService().getLocalMultiMapStatsImpl(name).incrementRemoves(System.currentTimeMillis() - time);
+                    getService().getLocalMultiMapStatsImpl(name).incrementRemoveLatencyNanos(System.nanoTime() - startTimeNanos);
                 } else if (operation instanceof GetAllOperation) {
-                    getService().getLocalMultiMapStatsImpl(name).incrementGets(System.currentTimeMillis() - time);
+                    getService().getLocalMultiMapStatsImpl(name).incrementGetLatencyNanos(System.nanoTime() - startTimeNanos);
                 }
             } else {
                 f = nodeEngine.getOperationService()

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
@@ -28,7 +28,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -37,7 +36,7 @@ public class TxnPutOperation extends MultiMapKeyBasedOperation implements Backup
 
     long recordId;
     Data value;
-    long begin = -1;
+    long startTimeNanos = -1;
 
     public TxnPutOperation() {
     }
@@ -50,7 +49,7 @@ public class TxnPutOperation extends MultiMapKeyBasedOperation implements Backup
 
     @Override
     public void run() throws Exception {
-        begin = Clock.currentTimeMillis();
+        startTimeNanos = System.nanoTime();
         MultiMapContainer container = getOrCreateContainer();
         MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
         response = true;
@@ -65,9 +64,9 @@ public class TxnPutOperation extends MultiMapKeyBasedOperation implements Backup
 
     @Override
     public void afterRun() throws Exception {
-        long elapsed = Math.max(0, Clock.currentTimeMillis() - begin);
+        long elapsed = Math.max(0, System.nanoTime() - startTimeNanos);
         final MultiMapService service = getService();
-        service.getLocalMultiMapStatsImpl(name).incrementPuts(elapsed);
+        service.getLocalMultiMapStatsImpl(name).incrementPutLatencyNanos(elapsed);
         if (Boolean.TRUE.equals(response)) {
             publishEvent(EntryEventType.ADDED, dataKey, value, null);
         }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -50,12 +51,12 @@ public class LocalMapStatsImplTest {
         localMapStats.setLockedEntryCount(1231);
         localMapStats.setDirtyEntryCount(4252);
 
-        localMapStats.incrementPuts(5631);
-        localMapStats.incrementPuts(1);
-        localMapStats.incrementGets(1233);
-        localMapStats.incrementGets(5);
-        localMapStats.incrementGets(9);
-        localMapStats.incrementRemoves(1238);
+        localMapStats.incrementPutLatencyNanos(MILLISECONDS.toNanos(5631));
+        localMapStats.incrementPutLatencyNanos(MILLISECONDS.toNanos(1));
+        localMapStats.incrementGetLatencyNanos(MILLISECONDS.toNanos(1233));
+        localMapStats.incrementGetLatencyNanos(MILLISECONDS.toNanos(5));
+        localMapStats.incrementGetLatencyNanos(MILLISECONDS.toNanos(9));
+        localMapStats.incrementRemoveLatencyNanos(MILLISECONDS.toNanos(1238));
         localMapStats.incrementOtherOperations();
         localMapStats.incrementOtherOperations();
         localMapStats.incrementOtherOperations();

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImplTest.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -50,12 +52,13 @@ public class LocalMultiMapStatsImplTest {
         localMapStats.setLockedEntryCount(1231);
         localMapStats.setDirtyEntryCount(4252);
 
-        localMapStats.incrementPuts(5631);
-        localMapStats.incrementPuts(1);
-        localMapStats.incrementGets(1233);
-        localMapStats.incrementGets(5);
-        localMapStats.incrementGets(9);
-        localMapStats.incrementRemoves(1238);
+        localMapStats.incrementPutLatencyNanos(MILLISECONDS.toNanos(5631));
+        localMapStats.incrementPutLatencyNanos(MILLISECONDS.toNanos(1));
+        localMapStats.incrementGetLatencyNanos(MILLISECONDS.toNanos(1233));
+        localMapStats.incrementGetLatencyNanos(MILLISECONDS.toNanos(5));
+        localMapStats.incrementGetLatencyNanos(MILLISECONDS.toNanos(9));
+        localMapStats.incrementRemoveLatencyNanos(MILLISECONDS.toNanos(1238));
+
         localMapStats.incrementOtherOperations();
         localMapStats.incrementOtherOperations();
         localMapStats.incrementOtherOperations();
@@ -86,12 +89,14 @@ public class LocalMultiMapStatsImplTest {
         assertEquals(2, localMapStats.getPutOperationCount());
         assertEquals(3, localMapStats.getGetOperationCount());
         assertEquals(1, localMapStats.getRemoveOperationCount());
+
         assertEquals(5632, localMapStats.getTotalPutLatency());
         assertEquals(1247, localMapStats.getTotalGetLatency());
         assertEquals(1238, localMapStats.getTotalRemoveLatency());
         assertEquals(5631, localMapStats.getMaxPutLatency());
         assertEquals(1233, localMapStats.getMaxGetLatency());
         assertEquals(1238, localMapStats.getMaxRemoveLatency());
+
         assertEquals(5, localMapStats.getOtherOperationCount());
         assertEquals(2, localMapStats.getEventOperationCount());
 
@@ -122,12 +127,14 @@ public class LocalMultiMapStatsImplTest {
         assertEquals(2, deserialized.getPutOperationCount());
         assertEquals(3, deserialized.getGetOperationCount());
         assertEquals(1, deserialized.getRemoveOperationCount());
+
         assertEquals(5632, deserialized.getTotalPutLatency());
         assertEquals(1247, deserialized.getTotalGetLatency());
         assertEquals(1238, deserialized.getTotalRemoveLatency());
         assertEquals(5631, deserialized.getMaxPutLatency());
         assertEquals(1233, deserialized.getMaxGetLatency());
         assertEquals(1238, deserialized.getMaxRemoveLatency());
+
         assertEquals(5, deserialized.getOtherOperationCount());
         assertEquals(2, deserialized.getEventOperationCount());
 


### PR DESCRIPTION
Local statistics uses milliseconds for get/put/remove latencies. It is very usual for latencies to be around microseconds, hence the values may become 0 very easily. Especially the accumulative statistics such as totalGetLatencies and such, it does not make sense to stay at 0 even though there are millions of gets each below millisecond latency.

Changed the stats impl. so that the latencies are now kept at microseconds resolution. The json contract still uses milliseconds resolution.

related to #10025

fixes #10938