### PR TITLE
Initialize hash based collections appropriately

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -32,8 +32,6 @@ import javax.cache.expiry.ExpiryPolicy;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +41,8 @@ import java.util.concurrent.Future;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -169,13 +169,14 @@ abstract class AbstractCacheProxy<K, V>
         if (keys.isEmpty()) {
             return emptyMap();
         }
-        Set<Data> ks = new HashSet<Data>(keys.size());
+        final int keyCount = keys.size();
+        final Set<Data> ks = createHashSet(keyCount);
         for (K key : keys) {
             validateNotNull(key);
             Data dataKey = serializationService.toData(key);
             ks.add(dataKey);
         }
-        Map<K, V> result = new HashMap<K, V>();
+        Map<K, V> result = createHashMap(keyCount);
         Collection<Integer> partitions = getPartitionsForKeys(ks);
         try {
             OperationFactory factory = operationProvider.createGetAllOperationFactory(ks, expiryPolicy);
@@ -358,7 +359,7 @@ abstract class AbstractCacheProxy<K, V>
         IPartitionService partitionService = getNodeEngine().getPartitionService();
         int partitions = partitionService.getPartitionCount();
         int capacity = Math.min(partitions, keys.size());
-        Set<Integer> partitionIds = new HashSet<Integer>(capacity);
+        Set<Integer> partitionIds = createHashSet(capacity);
 
         Iterator<Data> iterator = keys.iterator();
         while (iterator.hasNext() && partitionIds.size() < partitions) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -71,6 +71,9 @@ import static com.hazelcast.cache.impl.CacheEventContextUtil.createCacheUpdatedE
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
 import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
+import static java.util.Collections.emptySet;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extends SampleableCacheRecordMap<Data, R>>
@@ -283,7 +286,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             statistics.increaseCacheEvictions(1);
         }
         return evicted;
-}
+    }
 
     protected Data toData(Object obj) {
         if (obj instanceof Data) {
@@ -846,7 +849,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @SuppressFBWarnings("WMI_WRONG_MAP_ITERATOR")
     protected void deleteAllCacheEntry(Set<Data> keys) {
         if (isWriteThrough() && cacheWriter != null && keys != null && !keys.isEmpty()) {
-            Map<Object, Data> keysToDelete = new HashMap<Object, Data>();
+            Map<Object, Data> keysToDelete = createHashMap(keys.size());
             for (Data key : keys) {
                 Object localKeyObj = dataToValue(key);
                 keysToDelete.put(localKeyObj, key);
@@ -871,7 +874,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected Map<Data, Object> loadAllCacheEntry(Set<Data> keys) {
         if (cacheLoader != null) {
-            Map<Object, Data> keysToLoad = new HashMap<Object, Data>();
+            Map<Object, Data> keysToLoad = createHashMap(keys.size());
             for (Data key : keys) {
                 Object localKeyObj = dataToValue(key);
                 keysToLoad.put(localKeyObj, key);
@@ -886,7 +889,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     throw (CacheLoaderException) e;
                 }
             }
-            Map<Data, Object> result = new HashMap<Data, Object>();
+            Map<Data, Object> result = createHashMap(keysToLoad.size());
             for (Map.Entry<Object, Data> entry : keysToLoad.entrySet()) {
                 Object keyObj = entry.getKey();
                 Object valueObject = loaded.get(keyObj);
@@ -1406,11 +1409,11 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     @Override
     public Set<Data> loadAll(Set<Data> keys, boolean replaceExistingValues) {
-        Set<Data> keysLoaded = new HashSet<Data>();
         Map<Data, Object> loaded = loadAllCacheEntry(keys);
         if (loaded == null || loaded.isEmpty()) {
-            return keysLoaded;
+            return emptySet();
         }
+        Set<Data> keysLoaded = createHashSet(loaded.size());
         if (replaceExistingValues) {
             for (Map.Entry<Data, Object> entry : loaded.entrySet()) {
                 Data key = entry.getKey();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -37,7 +37,6 @@ import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -47,6 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateCacheConfig;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createLinkedHashSet;
 
 /**
  * <p>
@@ -266,7 +266,7 @@ public abstract class AbstractHazelcastCacheManager
         if (isClosed()) {
             names = Collections.emptySet();
         } else {
-            names = new LinkedHashSet<String>();
+            names = createLinkedHashSet(caches.size());
             for (Map.Entry<String, ICacheInternal<?, ?>> entry : caches.entrySet()) {
                 String nameWithPrefix = entry.getKey();
                 int index = nameWithPrefix.indexOf(cacheNamePrefix) + cacheNamePrefix.length();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -42,7 +42,6 @@ import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.expiry.ExpiryPolicy;
 import java.util.Collection;
 import java.util.EventListener;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +56,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Abstract {@link com.hazelcast.cache.ICache} implementation which provides shared internal implementations
@@ -278,7 +278,7 @@ abstract class AbstractInternalCacheProxy<K, V>
     void removeAllInternal(Set<? extends K> keys) {
         Set<Data> keysData = null;
         if (keys != null) {
-            keysData = new HashSet<Data>();
+            keysData = createHashSet(keys.size());
             for (K key : keys) {
                 validateNotNull(key);
                 keysData.add(serializationService.toData(key));

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventSet.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 /**
  * <p>Internal Set wrapper of {@link CacheEventData} items used during publishing and dispatching events.</p>
  *
@@ -111,7 +113,7 @@ public class CacheEventSet
         eventType = CacheEventType.getByType(in.readInt());
         completionId = in.readInt();
         final int size = in.readInt();
-        events = new HashSet<CacheEventData>(size);
+        events = createHashSet(size);
         for (int i = 0; i < size; i++) {
             CacheEventData ced = in.readObject();
             events.add(ced);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -21,8 +21,8 @@ import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.cache.impl.event.InternalCachePartitionLostListenerAdapter;
 import com.hazelcast.cache.impl.journal.CacheEventJournalReadOperation;
 import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
-import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.cache.impl.operation.CacheListenerRegistrationOperation;
+import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
@@ -49,15 +49,15 @@ import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * <h1>ICache implementation</h1>
@@ -116,7 +116,7 @@ public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> implements EventJ
         for (K key : keys) {
             CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
         }
-        HashSet<Data> keysData = new HashSet<Data>(keys.size());
+        Set<Data> keysData = createHashSet(keys.size());
         for (K key : keys) {
             validateNotNull(key);
             keysData.add(serializationService.toData(key));
@@ -258,7 +258,7 @@ public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> implements EventJ
         ensureOpen();
         validateNotNull(keys);
         checkNotNull(entryProcessor, "Entry Processor is null");
-        Map<K, EntryProcessorResult<T>> allResult = new HashMap<K, EntryProcessorResult<T>>();
+        Map<K, EntryProcessorResult<T>> allResult = createHashMap(keys.size());
         for (K key : keys) {
             validateNotNull(key);
             CacheEntryProcessorResult<T> ceResult;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -32,13 +32,13 @@ import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Handles split-brain functionality for cache.
@@ -59,7 +59,7 @@ class CacheSplitBrainHandlerService implements SplitBrainHandlerService {
 
     @Override
     public Runnable prepareMergeRunnable() {
-        final Map<String, Map<Data, CacheRecord>> recordMap = new HashMap<String, Map<Data, CacheRecord>>(configs.size());
+        final Map<String, Map<Data, CacheRecord>> recordMap = createHashMap(configs.size());
         final IPartitionService partitionService = nodeEngine.getPartitionService();
         final int partitionCount = partitionService.getPartitionCount();
         final Address thisAddress = nodeEngine.getClusterService().getThisAddress();
@@ -77,7 +77,7 @@ class CacheSplitBrainHandlerService implements SplitBrainHandlerService {
                     String cacheName = cacheRecordStore.getName();
                     Map<Data, CacheRecord> records = recordMap.get(cacheName);
                     if (records == null) {
-                        records = new HashMap<Data, CacheRecord>(cacheRecordStore.size());
+                        records = createHashMap(cacheRecordStore.size());
                         recordMap.put(cacheName, records);
                     }
                     for (Map.Entry<Data, CacheRecord> cacheRecordEntry : cacheRecordStore.getReadOnlyRecords().entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 /**
  * Gets all keys from the cache.
  * <p>{@link com.hazelcast.cache.impl.operation.CacheGetAllOperationFactory} creates this operation.</p>
@@ -39,7 +41,7 @@ public class CacheGetAllOperation
         extends PartitionWideCacheOperation
         implements ReadonlyOperation {
 
-    private Set<Data> keys = new HashSet<Data>();
+    private Set<Data> keys;
     private ExpiryPolicy expiryPolicy;
 
     public CacheGetAllOperation(String name, Set<Data> keys, ExpiryPolicy expiryPolicy) {
@@ -49,6 +51,7 @@ public class CacheGetAllOperation
     }
 
     public CacheGetAllOperation() {
+        keys = new HashSet<Data>();
     }
 
     public void run() {
@@ -102,6 +105,7 @@ public class CacheGetAllOperation
         expiryPolicy = in.readObject();
         int size = in.readInt();
         if (size > -1) {
+            keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
                 Data key = in.readData();
                 keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 /**
  * Factory implementation for {@link com.hazelcast.cache.impl.operation.CacheGetAllOperation}.
  * @see com.hazelcast.spi.OperationFactory
@@ -37,10 +39,11 @@ public class CacheGetAllOperationFactory
         implements OperationFactory, IdentifiedDataSerializable {
 
     private String name;
-    private Set<Data> keys = new HashSet<Data>();
+    private Set<Data> keys;
     private ExpiryPolicy expiryPolicy;
 
     public CacheGetAllOperationFactory() {
+        keys = new HashSet<Data>();
     }
 
     public CacheGetAllOperationFactory(String name, Set<Data> keys, ExpiryPolicy expiryPolicy) {
@@ -81,6 +84,7 @@ public class CacheGetAllOperationFactory
         name = in.readUTF();
         expiryPolicy = in.readObject();
         int size = in.readInt();
+        keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
             Data data = in.readData();
             keys.add(data);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
@@ -36,10 +36,12 @@ import com.hazelcast.spi.partition.IPartitionService;
 
 import javax.cache.CacheException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Loads all entries of the keys to partition record store {@link com.hazelcast.cache.impl.ICacheRecordStore}.
@@ -96,7 +98,7 @@ public class CacheLoadAllOperation
             Set<Data> keysLoaded = cache.loadAll(filteredKeys, replaceExistingValues);
             int loadedKeyCount = keysLoaded.size();
             if (loadedKeyCount > 0) {
-                backupRecords = new HashMap<Data, CacheRecord>(loadedKeyCount);
+                backupRecords = createHashMap(loadedKeyCount);
                 for (Data key : keysLoaded) {
                     CacheRecord record = cache.getRecord(key);
                     // Loaded keys may have been evicted, then record will be null.
@@ -176,7 +178,7 @@ public class CacheLoadAllOperation
         replaceExistingValues = in.readBoolean();
         if (in.readBoolean()) {
             int size = in.readInt();
-            keys = new HashSet<Data>(size);
+            keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
                 keys.add(in.readData());
             }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
@@ -25,8 +25,9 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Factory implementation for {@link com.hazelcast.cache.impl.operation.CacheLoadAllOperation}.
@@ -85,7 +86,7 @@ public class CacheLoadAllOperationFactory
         boolean isKeysNotNull = in.readBoolean();
         if (isKeysNotNull) {
             int size = in.readInt();
-            keys = new HashSet<Data>(size);
+            keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
                 Data key = in.readData();
                 keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -35,8 +35,9 @@ import com.hazelcast.spi.impl.AbstractNamedOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Cache PutAllBackup Operation is the backup operation used by load all operation. Provides backup of
@@ -131,7 +132,7 @@ public class CachePutAllBackupOperation
         final boolean recordNotNull = in.readBoolean();
         if (recordNotNull) {
             int size = in.readInt();
-            cacheRecords = new HashMap<Data, CacheRecord>(size);
+            cacheRecords = createHashMap(size);
             for (int i = 0; i < size; i++) {
                 final Data key = in.readData();
                 final CacheRecord record = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
@@ -38,9 +38,10 @@ import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class CachePutAllOperation
         extends AbstractNamedOperation
@@ -82,7 +83,7 @@ public class CachePutAllOperation
         String callerUuid = getCallerUuid();
         ICacheService service = getService();
         cache = service.getOrCreateRecordStore(name, partitionId);
-        backupRecords = new HashMap<Data, CacheRecord>(entries.size());
+        backupRecords = createHashMap(entries.size());
         for (Map.Entry<Data, Data> entry : entries) {
             Data key = entry.getKey();
             Data value = entry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -31,8 +31,9 @@ import com.hazelcast.spi.impl.AbstractNamedOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Backup operation of {@link com.hazelcast.cache.impl.operation.CacheRemoveAllOperation}.
@@ -123,7 +124,7 @@ public class CacheRemoveAllBackupOperation
         boolean isKeysNotNull = in.readBoolean();
         if (isKeysNotNull) {
             int size = in.readInt();
-            keys = new HashSet<Data>(size);
+            keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
                 Data key = in.readData();
                 keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.cache.impl.CacheEventContextUtil.createCacheCompleteEvent;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * TODO add a proper JavaDoc
@@ -147,7 +148,7 @@ public class CacheRemoveAllOperation
         boolean isKeysNotNull = in.readBoolean();
         if (isKeysNotNull) {
             int size = in.readInt();
-            keys = new HashSet<Data>(size);
+            keys = createHashSet(size);
             for (int i = 0; i < size; i++) {
                 Data key = in.readData();
                 keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
@@ -25,8 +25,9 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * {@link com.hazelcast.spi.OperationFactory} implementation for RemoveAll Operations.
@@ -80,7 +81,7 @@ public class CacheRemoveAllOperationFactory implements OperationFactory, Identif
         if (size == -1) {
             return;
         }
-        keys = new HashSet<Data>(size);
+        keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
             keys.add(in.readData());
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -40,6 +40,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 /**
  * Replication operation is the data migration operation of {@link com.hazelcast.cache.impl.CacheRecordStore}.
  * <p>
@@ -175,7 +177,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
         for (int i = 0; i < count; i++) {
             int subCount = in.readInt();
             String name = in.readUTF();
-            Map<Data, CacheRecord> m = new HashMap<Data, CacheRecord>(subCount);
+            Map<Data, CacheRecord> m = createHashMap(subCount);
             data.put(name, m);
             // subCount + 1 because of the DefaultData written as the last entry
             // which adds another Data entry at the end of the stream!

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
@@ -25,8 +25,9 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ReplicationOperation extends Operation
         implements IdentifiedDataSerializable {
@@ -76,7 +77,7 @@ public class ReplicationOperation extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, CardinalityEstimatorContainer>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             CardinalityEstimatorContainer newCont = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -28,7 +28,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import javax.security.auth.login.LoginException;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -36,6 +35,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Manages and stores {@link com.hazelcast.client.impl.ClientEndpointImpl}s.
@@ -62,7 +62,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
     public Set<ClientEndpoint> getEndpoints(String clientUuid) {
         checkNotNull(clientUuid, "clientUuid can't be null");
 
-        Set<ClientEndpoint> endpointSet = new HashSet<ClientEndpoint>();
+        Set<ClientEndpoint> endpointSet = createHashSet(endpoints.size());
         for (ClientEndpoint endpoint : endpoints.values()) {
             if (clientUuid.equals(endpoint.getUuid())) {
                 endpointSet.add(endpoint);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -77,10 +77,11 @@ import com.hazelcast.util.executor.ExecutorType;
 
 import javax.security.auth.login.LoginException;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -90,10 +91,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Class that requests, listeners from client handled in node side.
  */
+@SuppressWarnings("checkstyle:classdataabstractioncoupling")
 public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwareService,
         ManagedService, MembershipAwareService, EventPublishingService<ClientEvent, ClientListener> {
 
@@ -345,8 +348,9 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     public Collection<Client> getClients() {
-        final HashSet<Client> clients = new HashSet<Client>();
-        for (ClientEndpoint endpoint : endpointManager.getEndpoints()) {
+        final Collection<ClientEndpoint> endpoints = endpointManager.getEndpoints();
+        final Set<Client> clients = createHashSet(endpoints.size());
+        for (ClientEndpoint endpoint : endpoints) {
             clients.add(endpoint);
         }
         return clients;
@@ -544,7 +548,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         int numberOfOtherClients = 0;
 
         OperationService operationService = node.nodeEngine.getOperationService();
-        Map<ClientType, Integer> resultMap = new HashMap<ClientType, Integer>();
         Map<String, ClientType> clientsMap = new HashMap<String, ClientType>();
 
         for (Member member : node.getClusterService().getMembers()) {
@@ -588,6 +591,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                     numberOfOtherClients++;
             }
         }
+
+        final Map<ClientType, Integer> resultMap = new EnumMap<ClientType, Integer>(ClientType.class);
 
         resultMap.put(ClientType.CPP, numberOfCppClients);
         resultMap.put(ClientType.CSHARP, numberOfDotNetClients);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/GetConnectedClientsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/GetConnectedClientsOperation.java
@@ -23,8 +23,10 @@ import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.spi.ReadonlyOperation;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 
 public class GetConnectedClientsOperation extends AbstractClientOperation implements ReadonlyOperation {
@@ -37,8 +39,9 @@ public class GetConnectedClientsOperation extends AbstractClientOperation implem
     @Override
     public void run() throws Exception {
         ClientEngineImpl service = getService();
-        this.clients = new HashMap<String, ClientType>();
-        for (Client clientEndpoint : service.getClients()) {
+        final Collection<Client> serviceClients = service.getClients();
+        this.clients = createHashMap(serviceClients.size());
+        for (Client clientEndpoint : serviceClients) {
             ClientEndpointImpl clientEndpointImpl = (ClientEndpointImpl) clientEndpoint;
             this.clients.put(clientEndpointImpl.getUuid(), clientEndpointImpl.getClientType());
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
@@ -23,10 +23,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class PostJoinClientOperation extends AbstractClientOperation {
 
@@ -89,7 +90,7 @@ public class PostJoinClientOperation extends AbstractClientOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int len = in.readInt();
-        mappings = new HashMap<String, String>(len);
+        mappings = createHashMap(len);
         for (int i = 0; i < len; i++) {
             String clientUuid = in.readUTF();
             String ownerUuid = in.readUTF();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
@@ -27,10 +27,10 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.function.Supplier;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.util.Collections.EMPTY_MAP;
 
 public abstract class AbstractMultiTargetMessageTask<P> extends AbstractMessageTask<P> {
@@ -77,7 +77,7 @@ public abstract class AbstractMultiTargetMessageTask<P> extends AbstractMessageT
 
         private MultiTargetCallback(Collection<Member> targets) {
             this.targets = new HashSet<Member>(targets);
-            this.results = new HashMap<Member, Object>(targets.size());
+            this.results = createHashMap(targets.size());
         }
 
         public synchronized void notify(Member target, Object result) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsMessageTask.java
@@ -23,13 +23,13 @@ import com.hazelcast.collection.impl.collection.operations.CollectionContainsOpe
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.ListPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
-import java.util.HashSet;
+
+import static java.util.Collections.singleton;
 
 /**
  * Client Protocol Task for handling messages with type ID:
@@ -44,9 +44,7 @@ public class ListContainsMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        HashSet<Data> values = new HashSet<Data>(1);
-        values.add(parameters.value);
-        return new CollectionContainsOperation(parameters.name, values);
+        return new CollectionContainsOperation(parameters.name, singleton(parameters.value));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 public class MapExecuteOnKeysMessageTask
         extends AbstractMultiPartitionMessageTask<MapExecuteOnKeysCodec.RequestParameters> {
 
@@ -73,7 +75,7 @@ public class MapExecuteOnKeysMessageTask
         IPartitionService partitionService = nodeEngine.getPartitionService();
         int partitions = partitionService.getPartitionCount();
         int capacity = Math.min(partitions, parameters.keys.size());
-        Set<Integer> partitionIds = new HashSet<Integer>(capacity);
+        Set<Integer> partitionIds = createHashSet(capacity);
         Iterator<Data> iterator = parameters.keys.iterator();
         while (iterator.hasNext() && partitionIds.size() < partitions) {
             Data key = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
@@ -39,12 +39,12 @@ import com.hazelcast.util.ExceptionUtil;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Client Protocol Task for handling messages with type ID:
@@ -88,7 +88,7 @@ public class MapPublisherCreateMessageTask
     }
 
     private Set<Data> getQueryResults(List<Future> futures) {
-        Set<Data> results = new HashSet<Data>(futures.size());
+        Set<Data> results = createHashSet(futures.size());
         for (Future future : futures) {
             Object result = null;
             try {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
@@ -39,13 +39,13 @@ import com.hazelcast.util.ExceptionUtil;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Client Protocol Task for handling messages with type ID:
@@ -89,7 +89,7 @@ public class MapPublisherCreateWithValueMessageTask
     }
 
     private Set<Map.Entry<Data, Data>> getQueryResults(List<Future> futures) {
-        HashMap<Data, Data> results = new HashMap<Data, Data>(futures.size());
+        Map<Data, Data> results = createHashMap(futures.size());
         for (Future future : futures) {
             Object result = null;
             try {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -29,8 +29,9 @@ import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class MapPutAllMessageTask
         extends AbstractMapPartitionMessageTask<MapPutAllCodec.RequestParameters> {
@@ -78,7 +79,7 @@ public class MapPutAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        HashMap<Data, Data> map = new HashMap<Data, Data>();
+        Map<Data, Data> map = createHashMap(parameters.entries.size());
         for (Map.Entry<Data, Data> entry : parameters.entries) {
             map.put(entry.getKey(), entry.getValue());
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsMessageTask.java
@@ -23,14 +23,13 @@ import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.queue.operations.ContainsOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.QueuePermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
-import java.util.Collection;
-import java.util.HashSet;
+
+import static java.util.Collections.singleton;
 
 /**
  * Client Protocol Task for handling messages with type ID:
@@ -45,9 +44,7 @@ public class QueueContainsMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Collection<Data> datList = new HashSet<Data>();
-        datList.add(parameters.value);
-        return new ContainsOperation(parameters.name, datList);
+        return new ContainsOperation(parameters.name, singleton(parameters.value));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapPutAllMessageTask.java
@@ -30,8 +30,9 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.security.Permission;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ReplicatedMapPutAllMessageTask
         extends AbstractAllPartitionsMessageTask<ReplicatedMapPutAllCodec.RequestParameters> {
@@ -88,7 +89,7 @@ public class ReplicatedMapPutAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        final HashMap map = new HashMap();
+        final Map map = createHashMap(parameters.entries.size());
         for (Map.Entry entry : parameters.entries) {
             map.put(entry.getKey(), entry.getValue());
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsMessageTask.java
@@ -23,13 +23,13 @@ import com.hazelcast.collection.impl.collection.operations.CollectionContainsOpe
 import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.SetPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
-import java.util.HashSet;
+
+import static java.util.Collections.singleton;
 
 /**
  * SetContainsMessageTask
@@ -43,9 +43,7 @@ public class SetContainsMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        HashSet<Data> values = new HashSet<Data>(1);
-        values.add(parameters.value);
-        return new CollectionContainsOperation(parameters.name, values);
+        return new CollectionContainsOperation(parameters.name, singleton(parameters.value));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
@@ -46,13 +46,14 @@ import com.hazelcast.util.ExceptionUtil;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
+import static java.util.Collections.singleton;
 
 public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> extends AbstractDistributedObject<S>
         implements InitializingObject {
@@ -128,9 +129,8 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
     public boolean contains(Object o) {
         checkObjectNotNull(o);
 
-        Set<Data> valueSet = new HashSet<Data>(1);
-        valueSet.add(getNodeEngine().toData(o));
-        final CollectionContainsOperation operation = new CollectionContainsOperation(name, valueSet);
+        final CollectionContainsOperation operation = new CollectionContainsOperation(name,
+                singleton(getNodeEngine().toData(o)));
         final Boolean result = invoke(operation);
         return result;
     }
@@ -138,7 +138,7 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
     public boolean containsAll(Collection<?> c) {
         checkObjectNotNull(c);
 
-        Set<Data> valueSet = new HashSet<Data>(c.size());
+        Set<Data> valueSet = createHashSet(c.size());
         final NodeEngine nodeEngine = getNodeEngine();
         for (Object o : c) {
             checkObjectNotNull(o);
@@ -174,7 +174,7 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
     private boolean compareAndRemove(boolean retain, Collection<?> c) {
         checkObjectNotNull(c);
 
-        Set<Data> valueSet = new HashSet<Data>(c.size());
+        Set<Data> valueSet = createHashSet(c.size());
         final NodeEngine nodeEngine = getNodeEngine();
         for (Object o : c) {
             checkObjectNotNull(o);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 @SuppressWarnings("checkstyle:methodcount")
 public abstract class CollectionContainer implements IdentifiedDataSerializable {
 
@@ -99,7 +101,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
 
     public Map<Long, Data> clear() {
         final Collection<CollectionItem> coll = getCollection();
-        Map<Long, Data> itemIdMap = new HashMap<Long, Data>(coll.size());
+        Map<Long, Data> itemIdMap = createHashMap(coll.size());
         for (CollectionItem item : coll) {
             itemIdMap.put(item.getItemId(), (Data) item.getValue());
         }
@@ -127,7 +129,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
 
     public Map<Long, Data> addAll(List<Data> valueList) {
         final int size = valueList.size();
-        final Map<Long, Data> map = new HashMap<Long, Data>(size);
+        final Map<Long, Data> map = createHashMap(size);
         List<CollectionItem> list = new ArrayList<CollectionItem>(size);
         for (Data value : valueList) {
             final long itemId = nextId();
@@ -140,7 +142,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
     }
 
     public void addAllBackup(Map<Long, Data> valueMap) {
-        Map<Long, CollectionItem> map = new HashMap<Long, CollectionItem>(valueMap.size());
+        Map<Long, CollectionItem> map = createHashMap(valueMap.size());
         for (Map.Entry<Long, Data> entry : valueMap.entrySet()) {
             final long itemId = entry.getKey();
             map.put(itemId, new CollectionItem(itemId, entry.getValue()));

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
@@ -24,8 +24,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class CollectionAddAllBackupOperation extends CollectionOperation implements BackupOperation {
 
@@ -64,7 +65,7 @@ public class CollectionAddAllBackupOperation extends CollectionOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         final int size = in.readInt();
-        valueMap = new HashMap<Long, Data>(size);
+        valueMap = createHashMap(size);
         for (int i = 0; i < size; i++) {
             final long itemId = in.readLong();
             final Data value = in.readData();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearBackupOperation.java
@@ -23,8 +23,9 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class CollectionClearBackupOperation extends CollectionOperation implements BackupOperation {
 
@@ -62,7 +63,7 @@ public class CollectionClearBackupOperation extends CollectionOperation implemen
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         final int size = in.readInt();
-        itemIdSet = new HashSet<Long>(size);
+        itemIdSet = createHashSet(size);
         for (int i = 0; i < size; i++) {
             itemIdSet.add(in.readLong());
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionCompareAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionCompareAndRemoveOperation.java
@@ -25,9 +25,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class CollectionCompareAndRemoveOperation extends CollectionBackupAwareOperation {
 
@@ -88,7 +89,7 @@ public class CollectionCompareAndRemoveOperation extends CollectionBackupAwareOp
         super.readInternal(in);
         retain = in.readBoolean();
         final int size = in.readInt();
-        valueSet = new HashSet<Data>(size);
+        valueSet = createHashSet(size);
         for (int i = 0; i < size; i++) {
             Data value = in.readData();
             valueSet.add(value);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionContainsOperation.java
@@ -23,8 +23,9 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class CollectionContainsOperation extends CollectionOperation {
 
@@ -62,7 +63,7 @@ public class CollectionContainsOperation extends CollectionOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         final int size = in.readInt();
-        valueSet = new HashSet<Data>(size);
+        valueSet = createHashSet(size);
         for (int i = 0; i < size; i++) {
             Data value = in.readData();
             valueSet.add(value);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 public class ListContainer extends CollectionContainer {
 
     private static final int INITIAL_CAPACITY = 1000;
@@ -130,7 +132,7 @@ public class ListContainer extends CollectionContainer {
 
     public Map<Long, Data> addAll(int index, List<Data> valueList) {
         final int size = valueList.size();
-        final Map<Long, Data> map = new HashMap<Long, Data>(size);
+        final Map<Long, Data> map = createHashMap(size);
         List<CollectionItem> list = new ArrayList<CollectionItem>(size);
         for (Data value : valueList) {
             final long itemId = nextId();
@@ -178,7 +180,7 @@ public class ListContainer extends CollectionContainer {
     protected Map<Long, CollectionItem> getMap() {
         if (itemMap == null) {
             if (itemList != null && !itemList.isEmpty()) {
-                itemMap = new HashMap<Long, CollectionItem>(itemList.size());
+                itemMap = createHashMap(itemList.size());
                 for (CollectionItem item : itemList) {
                     itemMap.put(item.getItemId(), item);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
@@ -23,8 +23,9 @@ import com.hazelcast.collection.impl.list.ListContainer;
 import com.hazelcast.nio.ObjectDataInput;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ListReplicationOperation extends CollectionReplicationOperation {
 
@@ -43,7 +44,7 @@ public class ListReplicationOperation extends CollectionReplicationOperation {
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, CollectionContainer>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             ListContainer container = new ListContainer();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -46,6 +45,10 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.MapUtil.createLinkedHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * The {@code QueueContainer} contains the actual queue and provides functionalities such as :
@@ -468,7 +471,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
      * @return map of item ID and items added
      */
     public Map<Long, Data> addAll(Collection<Data> dataList) {
-        final Map<Long, Data> map = new HashMap<Long, Data>(dataList.size());
+        final Map<Long, Data> map = createHashMap(dataList.size());
         final List<QueueItem> list = new ArrayList<QueueItem>(dataList.size());
         for (Data data : dataList) {
             final QueueItem item = new QueueItem(this, nextId(), null);
@@ -583,7 +586,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
         if (maxSizeParam < 0 || maxSizeParam > getItemQueue().size()) {
             maxSizeParam = getItemQueue().size();
         }
-        final LinkedHashMap<Long, Data> map = new LinkedHashMap<Long, Data>(maxSizeParam);
+        final Map<Long, Data> map = createLinkedHashMap(maxSizeParam);
         mapDrainIterator(maxSizeParam, map);
         if (store.isEnabled() && maxSizeParam != 0) {
             try {
@@ -649,7 +652,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
 
     public Map<Long, Data> clear() {
         long current = Clock.currentTimeMillis();
-        LinkedHashMap<Long, Data> map = new LinkedHashMap<Long, Data>(getItemQueue().size());
+        final Map<Long, Data> map = createLinkedHashMap(getItemQueue().size());
         for (QueueItem item : getItemQueue()) {
             map.put(item.getItemId(), item.getData());
             // For stats
@@ -838,7 +841,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
         } else if (bulkLoad > 1) {
             long maxIdToLoad = -1;
             final Iterator<QueueItem> iter = getItemQueue().iterator();
-            final HashSet<Long> keySet = new HashSet<Long>(bulkLoad);
+            final Set<Long> keySet = createHashSet(bulkLoad);
 
             keySet.add(item.getItemId());
             while (keySet.size() < bulkLoad && iter.hasNext()) {
@@ -912,13 +915,15 @@ public class QueueContainer implements IdentifiedDataSerializable {
      */
     private Map<Long, QueueItem> getBackupMap() {
         if (backupMap == null) {
-            backupMap = new HashMap<Long, QueueItem>();
             if (itemQueue != null) {
+                backupMap = createHashMap(itemQueue.size());
                 for (QueueItem item : itemQueue) {
                     backupMap.put(item.getItemId(), item);
                 }
                 itemQueue.clear();
                 itemQueue = null;
+            } else {
+                backupMap = new HashMap<Long, QueueItem>();
             }
         }
         return backupMap;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -53,7 +53,6 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
 import com.hazelcast.util.scheduler.EntryTaskSchedulerFactory;
 import com.hazelcast.util.scheduler.ScheduleType;
@@ -66,6 +65,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Provides important services via methods for the the Queue
@@ -338,7 +339,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     @Override
     public Map<String, LocalQueueStats> getStats() {
-        Map<String, LocalQueueStats> queueStats = MapUtil.createHashMap(containerMap.size());
+        Map<String, LocalQueueStats> queueStats = createHashMap(containerMap.size());
         for (Entry<String, QueueContainer> entry : containerMap.entrySet()) {
             String name = entry.getKey();
             LocalQueueStats queueStat = createLocalQueueStats(name);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
@@ -32,10 +32,10 @@ import com.hazelcast.util.EmptyStatement;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -174,7 +174,7 @@ public final class QueueStoreWrapper implements QueueStore<Data> {
             return;
         }
 
-        final Map<Long, Object> objectMap = new HashMap<Long, Object>(map.size());
+        final Map<Long, Object> objectMap = createHashMap(map.size());
         if (binary) {
             // WARNING: we can't pass original Data to the user
             // TODO: @mm - is there really an advantage of using binary storeAll?
@@ -230,7 +230,7 @@ public final class QueueStoreWrapper implements QueueStore<Data> {
         if (map == null) {
             return Collections.emptyMap();
         }
-        final Map<Long, Data> dataMap = new HashMap<Long, Data>(map.size());
+        final Map<Long, Data> dataMap = createHashMap(map.size());
         if (binary) {
             for (Map.Entry<Long, ?> entry : map.entrySet()) {
                 byte[] dataBuffer = (byte[]) entry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
@@ -25,8 +25,9 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Provides backup functionality for {@link AddAllOperation}
@@ -70,7 +71,7 @@ public class AddAllBackupOperation extends QueueOperation implements BackupOpera
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int size = in.readInt();
-        dataMap = new HashMap<Long, Data>(size);
+        dataMap = createHashMap(size);
         for (int i = 0; i < size; i++) {
             long itemId = in.readLong();
             Data value = in.readData();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearBackupOperation.java
@@ -24,8 +24,9 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Store items' ID as set when ClearOperation run.
@@ -67,7 +68,7 @@ public class ClearBackupOperation extends QueueOperation implements BackupOperat
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int size = in.readInt();
-        itemIdSet = new HashSet<Long>(size);
+        itemIdSet = createHashSet(size);
         for (int i = 0; i < size; i++) {
             itemIdSet.add(in.readLong());
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveBackupOperation.java
@@ -24,8 +24,9 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * This class triggers backup method for items' ID.
@@ -67,7 +68,7 @@ public class CompareAndRemoveBackupOperation extends QueueOperation implements B
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int size = in.readInt();
-        keySet = new HashSet<Long>(size);
+        keySet = createHashSet(size);
         for (int i = 0; i < size; i++) {
             keySet.add(in.readLong());
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainBackupOperation.java
@@ -24,8 +24,9 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * This class stores items' ID when DrainOperation run.
@@ -73,7 +74,7 @@ public class DrainBackupOperation extends QueueOperation implements BackupOperat
         super.readInternal(in);
         if (in.readBoolean()) {
             int size = in.readInt();
-            itemIdSet = new HashSet<Long>(size);
+            itemIdSet = createHashSet(size);
             for (int i = 0; i < size; i++) {
                 itemIdSet.add(in.readLong());
             }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
@@ -28,8 +28,9 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Replication operation for the Queue.
@@ -89,7 +90,7 @@ public class QueueReplicationOperation extends Operation implements IdentifiedDa
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, QueueContainer>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             QueueContainer container = new QueueContainer(name);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 public class SetContainer extends CollectionContainer {
 
     private static final int INITIAL_CAPACITY = 1000;
@@ -54,7 +56,7 @@ public class SetContainer extends CollectionContainer {
     @Override
     public Map<Long, Data> addAll(List<Data> valueList) {
         final int size = valueList.size();
-        final Map<Long, Data> map = new HashMap<Long, Data>(size);
+        final Map<Long, Data> map = createHashMap(size);
         List<CollectionItem> list = new ArrayList<CollectionItem>(size);
         for (Data value : valueList) {
             final long itemId = nextId();
@@ -87,7 +89,7 @@ public class SetContainer extends CollectionContainer {
     protected Map<Long, CollectionItem> getMap() {
         if (itemMap == null) {
             if (itemSet != null && !itemSet.isEmpty()) {
-                itemMap = new HashMap<Long, CollectionItem>(itemSet.size());
+                itemMap = createHashMap(itemSet.size());
                 for (CollectionItem item : itemSet) {
                     itemMap.put(item.getItemId(), item);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
@@ -23,8 +23,9 @@ import com.hazelcast.collection.impl.set.SetContainer;
 import com.hazelcast.nio.ObjectDataInput;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class SetReplicationOperation extends CollectionReplicationOperation {
 
@@ -38,7 +39,7 @@ public class SetReplicationOperation extends CollectionReplicationOperation {
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, CollectionContainer>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             SetContainer container = new SetContainer();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
@@ -25,10 +25,10 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.REPLICATION;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class AtomicLongReplicationOperation extends Operation
         implements IdentifiedDataSerializable {
@@ -80,7 +80,7 @@ public class AtomicLongReplicationOperation extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, Long>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             Long longContainer = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
@@ -26,8 +26,9 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class AtomicReferenceReplicationOperation extends Operation
         implements IdentifiedDataSerializable {
@@ -79,7 +80,7 @@ public class AtomicReferenceReplicationOperation extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<String, Data>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             Data data = in.readData();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -26,7 +26,6 @@ import com.hazelcast.util.Clock;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -36,6 +35,8 @@ import java.util.Set;
 
 import static com.hazelcast.concurrent.lock.LockDataSerializerHook.F_ID;
 import static com.hazelcast.concurrent.lock.LockDataSerializerHook.LOCK_RESOURCE;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 final class LockResourceImpl implements IdentifiedDataSerializable, LockResource {
 
@@ -172,7 +173,7 @@ final class LockResourceImpl implements IdentifiedDataSerializable, LockResource
 
     void addAwait(String conditionId, String caller, long threadId) {
         if (waiters == null) {
-            waiters = new HashMap<String, WaitersInfo>(2);
+            waiters = createHashMap(2);
         }
 
         WaitersInfo condition = waiters.get(conditionId);
@@ -455,7 +456,7 @@ final class LockResourceImpl implements IdentifiedDataSerializable, LockResource
 
         int len = in.readInt();
         if (len > 0) {
-            waiters = new HashMap<String, WaitersInfo>(len);
+            waiters = createHashMap(len);
             for (int i = 0; i < len; i++) {
                 WaitersInfo condition = new WaitersInfo();
                 condition.readData(in);
@@ -465,7 +466,7 @@ final class LockResourceImpl implements IdentifiedDataSerializable, LockResource
 
         len = in.readInt();
         if (len > 0) {
-            conditionKeys = new HashSet<ConditionKey>(len);
+            conditionKeys = createHashSet(len);
             for (int i = 0; i < len; i++) {
                 conditionKeys.add(new ConditionKey(in.readUTF(), key, in.readUTF(), in.readUTF(), in.readLong()));
             }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -31,7 +31,6 @@ import com.hazelcast.util.scheduler.EntryTaskScheduler;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -42,6 +41,7 @@ import static com.hazelcast.concurrent.lock.LockDataSerializerHook.F_ID;
 import static com.hazelcast.concurrent.lock.LockDataSerializerHook.LOCK_STORE;
 import static com.hazelcast.concurrent.lock.ObjectNamespaceSerializationHelper.readNamespaceCompatibly;
 import static com.hazelcast.concurrent.lock.ObjectNamespaceSerializationHelper.writeNamespaceCompatibly;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public final class LockStoreImpl implements IdentifiedDataSerializable, LockStore, Versioned {
 
@@ -231,7 +231,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
 
     @Override
     public Set<Data> getLockedKeys() {
-        Set<Data> keySet = new HashSet<Data>(locks.size());
+        Set<Data> keySet = createHashSet(locks.size());
         for (Map.Entry<Data, LockResourceImpl> entry : locks.entrySet()) {
             Data key = entry.getKey();
             LockResource lock = entry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/WaitersInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/WaitersInfo.java
@@ -19,9 +19,9 @@ package com.hazelcast.concurrent.lock;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.SetUtil;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.concurrent.lock.LockDataSerializerHook.F_ID;
@@ -29,8 +29,10 @@ import static com.hazelcast.concurrent.lock.LockDataSerializerHook.WAITERS_INFO;
 
 final class WaitersInfo implements IdentifiedDataSerializable {
 
+    private static final int INITIAL_WAITER_SIZE = 2;
+
     private String conditionId;
-    private Set<ConditionWaiter> waiters = new HashSet<ConditionWaiter>(2);
+    private Set<ConditionWaiter> waiters = SetUtil.createHashSet(INITIAL_WAITER_SIZE);
 
     public WaitersInfo() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook.CONTAINER;
 import static com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook.F_ID;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class SemaphoreContainer implements IdentifiedDataSerializable {
 
@@ -185,7 +186,7 @@ public class SemaphoreContainer implements IdentifiedDataSerializable {
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         int size = in.readInt();
-        attachMap = new HashMap<String, Integer>(size);
+        attachMap = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String owner = in.readUTF();
             Integer val = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreReplicationOperation.java
@@ -25,8 +25,9 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class SemaphoreReplicationOperation extends Operation implements IdentifiedDataSerializable {
 
@@ -77,7 +78,7 @@ public class SemaphoreReplicationOperation extends Operation implements Identifi
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        migrationData = new HashMap<String, SemaphoreContainer>(size);
+        migrationData = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String name = in.readUTF();
             SemaphoreContainer semaphoreContainer = new SemaphoreContainer();

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -67,6 +67,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
 import static com.hazelcast.memory.MemoryUnit.BYTES;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -725,7 +726,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         if (args.length > 3) {
             start = Integer.parseInt(args[3]);
         }
-        Map<String, byte[]> theMap = new HashMap<String, byte[]>(count);
+        Map<String, byte[]> theMap = createHashMap(count);
         for (int i = 0; i < count; i++) {
             theMap.put("key" + (start + i), value);
         }

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStoreAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStoreAdapter.java
@@ -17,8 +17,9 @@
 package com.hazelcast.core;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Adapter for MapStore.
@@ -70,7 +71,7 @@ public class MapStoreAdapter<K, V> implements MapStore<K, V> {
      * {@inheritDoc}
      */
     public Map<K, V> loadAll(final Collection<K> keys) {
-        Map<K, V> result = new HashMap<K, V>();
+        Map<K, V> result = createHashMap(keys.size());
         for (K key : keys) {
             V value = load(key);
             if (value != null) {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
@@ -22,13 +22,13 @@ import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.logging.ILogger;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
@@ -49,7 +49,7 @@ class ExecutionCallbackAdapterFactory {
     ExecutionCallbackAdapterFactory(ILogger logger, Collection<Member> members,
                                     MultiExecutionCallback multiExecutionCallback) {
         this.multiExecutionCallback = multiExecutionCallback;
-        this.responses = new ConcurrentHashMap<Member, ValueWrapper>(members.size());
+        this.responses = createConcurrentHashMap(members.size());
         this.members = new HashSet<Member>(members);
         this.logger = logger;
     }
@@ -67,7 +67,7 @@ class ExecutionCallbackAdapterFactory {
             return;
         }
 
-        Map<Member, Object> realResponses = new HashMap<Member, Object>(members.size());
+        Map<Member, Object> realResponses = createHashMap(members.size());
         for (Map.Entry<Member, ValueWrapper> entry : responses.entrySet()) {
             Member key = entry.getKey();
             Object value = entry.getValue().value;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -38,12 +38,12 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.Clock;
+import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.executor.CompletedFuture;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -58,9 +58,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.logging.Level;
 
-import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 
@@ -312,7 +312,7 @@ public class ExecutorServiceProxy
 
     @Override
     public <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, Collection<Member> members) {
-        Map<Member, Future<T>> futures = new HashMap<Member, Future<T>>(members.size());
+        Map<Member, Future<T>> futures = createHashMap(members.size());
         for (Member member : members) {
             futures.put(member, submitToMember(task, member));
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -42,13 +42,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.AddressUtil.fixScopeIdAndGetInetAddress;
+import static com.hazelcast.util.MapUtil.createLinkedHashMap;
 
 class DefaultAddressPicker implements AddressPicker {
 
@@ -218,9 +218,9 @@ class DefaultAddressPicker implements AddressPicker {
         Map<String, String> addressDomainMap;
         TcpIpConfig tcpIpConfig = networkConfig.getJoin().getTcpIpConfig();
         if (tcpIpConfig.isEnabled()) {
-            // LinkedHashMap is to guarantee order
-            addressDomainMap = new LinkedHashMap<String, String>();
             Collection<String> possibleAddresses = TcpIpJoiner.getConfigurationMembers(config);
+            // LinkedHashMap is to guarantee order
+            addressDomainMap = createLinkedHashMap(possibleAddresses.size());
             for (String possibleAddress : possibleAddresses) {
                 String addressHolder = AddressUtil.getAddressHolder(possibleAddress).getAddress();
                 if (AddressUtil.isIpAddress(addressHolder)) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -29,7 +29,6 @@ import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -61,7 +61,7 @@ public final class HazelcastInstanceFactory {
     }
 
     public static Set<HazelcastInstance> getAllHazelcastInstances() {
-        Set<HazelcastInstance> result = new HashSet<HazelcastInstance>();
+        Set<HazelcastInstance> result = createHashSet(INSTANCE_MAP.size());
         for (InstanceFuture f : INSTANCE_MAP.values()) {
             result.add(f.get());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -26,10 +26,11 @@ import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
@@ -222,7 +223,7 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
 
     @Override
     public Map<K, V> getAll(Set<K> keys) {
-        Map<K, V> result = new HashMap<K, V>(keys.size());
+        Map<K, V> result = createHashMap(keys.size());
         for (K key : keys) {
             result.put(key, map.get(key));
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
 import static com.hazelcast.internal.cluster.Versions.V3_10;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class MemberInfo implements IdentifiedDataSerializable {
 
@@ -106,7 +107,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
         liteMember = in.readBoolean();
         int size = in.readInt();
         if (size > 0) {
-            attributes = new HashMap<String, Object>();
+            attributes = createHashMap(size);
         }
         for (int i = 0; i < size; i++) {
             String key = in.readUTF();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static com.hazelcast.spi.properties.GroupProperty.APPLICATION_VALIDATION_TOKEN;
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Contains enough information about Hazelcast Config, to do a validation check so that clusters with different configurations
@@ -232,7 +233,7 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
             }
         }
         int propSize = in.readInt();
-        properties = new HashMap<String, String>(propSize);
+        properties = createHashMap(propSize);
         for (int k = 0; k < propSize; k++) {
             String key = in.readUTF();
             String value = in.readUTF();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -25,11 +25,12 @@ import com.hazelcast.version.MemberVersion;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.util.Collections.unmodifiableSet;
 
 public class JoinRequest extends JoinMessage {
@@ -86,14 +87,14 @@ public class JoinRequest extends JoinMessage {
         }
         tryCount = in.readInt();
         int size = in.readInt();
-        attributes = new HashMap<String, Object>();
+        attributes = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String key = in.readUTF();
             Object value = in.readObject();
             attributes.put(key, value);
         }
         size = in.readInt();
-        Set<String> excludedMemberUuids = new HashSet<String>();
+        Set<String> excludedMemberUuids = createHashSet(size);
         for (int i = 0; i < size; i++) {
             excludedMemberUuids.add(in.readUTF());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createLinkedHashMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableCollection;
 
@@ -92,8 +93,8 @@ final class MemberMap {
      * @return a new {@code MemberMap}
      */
     static MemberMap createNew(int version, MemberImpl... members) {
-        Map<Address, MemberImpl> addressMap = new LinkedHashMap<Address, MemberImpl>();
-        Map<String, MemberImpl> uuidMap = new LinkedHashMap<String, MemberImpl>();
+        Map<Address, MemberImpl> addressMap = createLinkedHashMap(members.length);
+        Map<String, MemberImpl> uuidMap = createLinkedHashMap(members.length);
 
         for (MemberImpl member : members) {
             putMember(addressMap, uuidMap, member);

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ClientEngineMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ClientEngineMBean.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.jmx;
 import com.hazelcast.client.ClientEngine;
 import com.hazelcast.core.HazelcastInstance;
 
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.client.ClientEngine}
@@ -29,10 +30,13 @@ import static com.hazelcast.internal.jmx.ManagementService.quote;
 @ManagedDescription("HazelcastInstance.ClientEngine")
 public class ClientEngineMBean extends HazelcastMBean<ClientEngine> {
 
+    private static final int PROPERTY_COUNT = 3;
+
     public ClientEngineMBean(HazelcastInstance hazelcastInstance, ClientEngine clientEngine, ManagementService service) {
         super(clientEngine, service);
 
-        Hashtable<String, String> properties = new Hashtable<String, String>(3);
+        //no need to create HashTable here, as the setObjectName method creates a copy of the given properties
+        final Map<String, String> properties = createHashMap(PROPERTY_COUNT);
         properties.put("type", quote("HazelcastInstance.ClientEngine"));
         properties.put("name", quote(hazelcastInstance.getName()));
         properties.put("instance", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ConnectionManagerMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ConnectionManagerMBean.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.jmx;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.ConnectionManager;
 
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.nio.ConnectionManager}
@@ -29,11 +30,14 @@ import static com.hazelcast.internal.jmx.ManagementService.quote;
 @ManagedDescription("HazelcastInstance.ConnectionManager")
 public class ConnectionManagerMBean extends HazelcastMBean<ConnectionManager> {
 
+    private static final int PROPERTY_COUNT = 3;
+
     public ConnectionManagerMBean(HazelcastInstance hazelcastInstance, ConnectionManager connectionManager,
                                   ManagementService service) {
         super(connectionManager, service);
 
-        Hashtable<String, String> properties = new Hashtable<String, String>(3);
+        //no need to create HashTable here, as the setObjectName method creates a copy of the given properties
+        final Map<String, String> properties = createHashMap(PROPERTY_COUNT);
         properties.put("type", quote("HazelcastInstance.ConnectionManager"));
         properties.put("instance", quote(hazelcastInstance.getName()));
         properties.put("name", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/EventServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/EventServiceMBean.java
@@ -29,7 +29,7 @@ import static com.hazelcast.internal.jmx.ManagementService.quote;
 @ManagedDescription("HazelcastInstance.EventService")
 public class EventServiceMBean extends HazelcastMBean<EventService> {
 
-    private static final int INITIAL_CAPACITY = 3;
+    private static final int INITIAL_CAPACITY = 5;
 
     public EventServiceMBean(HazelcastInstance hazelcastInstance, EventService eventService, ManagementService service) {
         super(eventService, service);

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -28,11 +28,12 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.core.HazelcastInstance}
@@ -114,7 +115,7 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
     }
 
     private void createProperties(HazelcastInstanceImpl hazelcastInstance) {
-        Hashtable<String, String> properties = new Hashtable<String, String>(INITIAL_CAPACITY);
+        final Map<String, String> properties = createHashMap(INITIAL_CAPACITY);
         properties.put("type", quote("HazelcastInstance"));
         properties.put("instance", quote(hazelcastInstance.getName()));
         properties.put("name", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MBeans.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MBeans.java
@@ -46,8 +46,9 @@ import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicProxy;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 
 /**
  * A helper class which contains various types of {@link HazelcastMBean} factory methods and metadata.
@@ -55,7 +56,7 @@ import java.util.concurrent.ConcurrentMap;
 final class MBeans {
 
     private static final ConcurrentMap<String, MBeanFactory> MBEAN_FACTORY_TYPES_REGISTRY
-            = new ConcurrentHashMap<String, MBeanFactory>(MBeanFactory.values().length);
+            = createConcurrentHashMap(MBeanFactory.values().length);
 
     static {
         MBeanFactory[] mBeanFactories = MBeanFactory.values();

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedExecutorServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedExecutorServiceMBean.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.jmx;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.util.executor.ManagedExecutorService}
@@ -34,7 +35,7 @@ public class ManagedExecutorServiceMBean extends HazelcastMBean<ManagedExecutorS
                                        ManagementService service) {
         super(executorService, service);
 
-        Hashtable<String, String> properties = new Hashtable<String, String>(INITIAL_CAPACITY);
+        final Map<String, String> properties = createHashMap(INITIAL_CAPACITY);
         properties.put("type", quote("HazelcastInstance.ManagedExecutorService"));
         properties.put("name", quote(executorService.getName()));
         properties.put("instance", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+
 import java.lang.management.ManagementFactory;
 import java.util.Hashtable;
 import java.util.List;
@@ -44,7 +45,7 @@ import static com.hazelcast.internal.jmx.MBeans.getObjectTypeOrNull;
 public class ManagementService implements DistributedObjectListener {
 
     static final String DOMAIN = "com.hazelcast";
-    private static final int INITIAL_CAPACITY = 3;
+    private static final int INITIAL_CAPACITY = 5;
 
     final HazelcastInstanceImpl instance;
     private final boolean enabled;

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/NodeMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/NodeMBean.java
@@ -20,9 +20,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.instance.Node}
@@ -35,7 +36,7 @@ public class NodeMBean extends HazelcastMBean<Node> {
     public NodeMBean(HazelcastInstance hazelcastInstance, Node node, ManagementService service) {
         super(node, service);
 
-        Hashtable<String, String> properties = new Hashtable<String, String>(INITIAL_CAPACITY);
+        final Map<String, String> properties = createHashMap(INITIAL_CAPACITY);
         properties.put("type", quote("HazelcastInstance.Node"));
         properties.put("name", quote("node" + node.address));
         properties.put("instance", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.jmx;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.spi.OperationService}
@@ -35,7 +36,7 @@ public class OperationServiceMBean extends HazelcastMBean<InternalOperationServi
                                  ManagementService service) {
         super(operationService, service);
 
-        Hashtable<String, String> properties = new Hashtable<String, String>(INITIAL_CAPACITY);
+        final Map<String, String> properties = createHashMap(INITIAL_CAPACITY);
         properties.put("type", quote("HazelcastInstance.OperationService"));
         properties.put("name", quote("operationService" + hazelcastInstance.getName()));
         properties.put("instance", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
@@ -21,9 +21,10 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
 
 import java.net.InetSocketAddress;
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.core.PartitionService}
@@ -39,7 +40,7 @@ public class PartitionServiceMBean extends HazelcastMBean<InternalPartitionServi
         super(partitionService, service);
 
         this.hazelcastInstance = hazelcastInstance;
-        Hashtable<String, String> properties = new Hashtable<String, String>(INITIAL_CAPACITY);
+        final Map<String, String> properties = createHashMap(INITIAL_CAPACITY);
         properties.put("type", quote("HazelcastInstance.PartitionServiceMBean"));
         properties.put("name", quote(hazelcastInstance.getName()));
         properties.put("instance", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ProxyServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ProxyServiceMBean.java
@@ -19,9 +19,10 @@ package com.hazelcast.internal.jmx;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.ProxyService;
 
-import java.util.Hashtable;
+import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Management bean for {@link com.hazelcast.spi.ProxyService}
@@ -34,7 +35,7 @@ public class ProxyServiceMBean extends HazelcastMBean<ProxyService> {
     public ProxyServiceMBean(HazelcastInstance hazelcastInstance, ProxyService proxyService, ManagementService service) {
         super(proxyService, service);
 
-        Hashtable<String, String> properties = new Hashtable<String, String>(INITIAL_CAPACITY);
+        final Map<String, String> properties = createHashMap(INITIAL_CAPACITY);
         properties.put("type", quote("HazelcastInstance.ProxyService"));
         properties.put("name", quote("proxyService" + hazelcastInstance.getName()));
         properties.put("instance", quote(hazelcastInstance.getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -69,11 +69,12 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * A Factory for creating {@link com.hazelcast.monitor.TimedMemberState} instances.
@@ -152,8 +153,9 @@ public class TimedMemberStateFactory {
                                    Collection<StatisticsAwareService> services) {
         Node node = instance.node;
 
-        HashSet<ClientEndPointDTO> serializableClientEndPoints = new HashSet<ClientEndPointDTO>();
-        for (Client client : instance.node.clientEngine.getClients()) {
+        final Collection<Client> clients = instance.node.clientEngine.getClients();
+        final Set<ClientEndPointDTO> serializableClientEndPoints = createHashSet(clients.size());
+        for (Client client : clients) {
             serializableClientEndPoints.add(new ClientEndPointDTO(client));
         }
         memberState.setClients(serializableClientEndPoints);
@@ -222,7 +224,7 @@ public class TimedMemberStateFactory {
                                 Collection<StatisticsAwareService> services) {
         int count = 0;
         Config config = instance.getConfig();
-        Set<String> longInstanceNames = new HashSet<String>(maxVisibleInstanceCount);
+        Set<String> longInstanceNames = createHashSet(maxVisibleInstanceCount);
         for (StatisticsAwareService service : services) {
             if (count < maxVisibleInstanceCount) {
                 if (service instanceof MapService) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -41,8 +41,9 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Helper class to be gather JMX related stats for {@link TimedMemberStateFactory}
@@ -107,7 +108,8 @@ final class TimedMemberStateFactoryHelper {
         MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
         MemoryUsage heapMemory = memoryMxBean.getHeapMemoryUsage();
         MemoryUsage nonHeapMemory = memoryMxBean.getNonHeapMemoryUsage();
-        Map<String, Long> map = new HashMap<String, Long>();
+        final int propertyCount = 29;
+        Map<String, Long> map = createHashMap(propertyCount);
         map.put("runtime.availableProcessors", Integer.valueOf(runtime.availableProcessors()).longValue());
         map.put("date.startTime", runtimeMxBean.getStartTime());
         map.put("seconds.upTime", runtimeMxBean.getUptime());

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTO.java
@@ -23,10 +23,10 @@ import com.hazelcast.config.HotRestartClusterDataRecoveryPolicy;
 import com.hazelcast.internal.management.JsonSerializable;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.hazelcast.config.HotRestartClusterDataRecoveryPolicy.FULL_RECOVERY_ONLY;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
@@ -122,7 +122,7 @@ public class ClusterHotRestartStatusDTO implements JsonSerializable {
         remainingDataLoadTimeMillis = root.getLong("remainingDataLoadTimeMillis", -1);
 
         JsonArray memberStatuses = (JsonArray) root.get("memberHotRestartStatuses");
-        memberHotRestartStatusMap = new HashMap<String, MemberHotRestartStatus>(memberStatuses.size());
+        memberHotRestartStatusMap = createHashMap(memberStatuses.size());
         for (JsonValue value : memberStatuses) {
             JsonObject memberStatus = (JsonObject) value;
             String member = memberStatus.getString("member", "<unknown>");

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -25,12 +25,13 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 /**
- *  Operation to execute script on the node.
+ * Operation to execute script on the node.
  */
 public class ScriptExecutorOperation extends AbstractManagementOperation {
 
@@ -97,7 +98,7 @@ public class ScriptExecutorOperation extends AbstractManagementOperation {
         script = in.readUTF();
         int size = in.readInt();
         if (size > 0) {
-            bindings = new HashMap<String, Object>(size);
+            bindings = createHashMap(size);
             for (int i = 0; i < size; i++) {
                 String key = in.readUTF();
                 Object value = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static com.hazelcast.util.JsonUtil.getArray;
 import static com.hazelcast.util.JsonUtil.getBoolean;
 import static com.hazelcast.util.JsonUtil.getString;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Request for executing scripts on the nodes from Management Center.
@@ -120,8 +121,9 @@ public class ExecuteScriptRequest implements ConsoleRequest {
     public void fromJson(JsonObject json) {
         script = getString(json, "script", "");
         engine = getString(json, "engine", "");
-        targets = new HashSet<String>();
-        for (JsonValue target : getArray(json, "targets", new JsonArray())) {
+        final JsonArray array = getArray(json, "targets", new JsonArray());
+        targets = createHashSet(array.size());
+        for (JsonValue target : array) {
             targets.add(target.asString());
         }
         targetAllMembers = getBoolean(json, "targetAllMembers", false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -20,12 +20,14 @@ import com.hazelcast.internal.util.counters.Counter;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Utility functions for probes.
@@ -43,32 +45,36 @@ final class ProbeUtils {
     static final int TYPE_COUNTER = 7;
     static final int TYPE_SEMAPHORE = 8;
 
-    private static final Map<Class<?>, Integer> TYPES = new HashMap<Class<?>, Integer>();
+    private static final Map<Class<?>, Integer> TYPES;
 
     static {
-        TYPES.put(byte.class, TYPE_PRIMITIVE_LONG);
-        TYPES.put(short.class, TYPE_PRIMITIVE_LONG);
-        TYPES.put(int.class, TYPE_PRIMITIVE_LONG);
-        TYPES.put(long.class, TYPE_PRIMITIVE_LONG);
+        final Map<Class<?>, Integer> types = createHashMap(18);
 
-        TYPES.put(Byte.class, TYPE_LONG_NUMBER);
-        TYPES.put(Short.class, TYPE_LONG_NUMBER);
-        TYPES.put(Integer.class, TYPE_LONG_NUMBER);
-        TYPES.put(Long.class, TYPE_LONG_NUMBER);
-        TYPES.put(AtomicInteger.class, TYPE_LONG_NUMBER);
-        TYPES.put(AtomicLong.class, TYPE_LONG_NUMBER);
+        types.put(byte.class, TYPE_PRIMITIVE_LONG);
+        types.put(short.class, TYPE_PRIMITIVE_LONG);
+        types.put(int.class, TYPE_PRIMITIVE_LONG);
+        types.put(long.class, TYPE_PRIMITIVE_LONG);
 
-        TYPES.put(double.class, TYPE_DOUBLE_PRIMITIVE);
-        TYPES.put(float.class, TYPE_DOUBLE_PRIMITIVE);
+        types.put(Byte.class, TYPE_LONG_NUMBER);
+        types.put(Short.class, TYPE_LONG_NUMBER);
+        types.put(Integer.class, TYPE_LONG_NUMBER);
+        types.put(Long.class, TYPE_LONG_NUMBER);
+        types.put(AtomicInteger.class, TYPE_LONG_NUMBER);
+        types.put(AtomicLong.class, TYPE_LONG_NUMBER);
 
-        TYPES.put(Double.class, TYPE_DOUBLE_NUMBER);
-        TYPES.put(Float.class, TYPE_DOUBLE_NUMBER);
+        types.put(double.class, TYPE_DOUBLE_PRIMITIVE);
+        types.put(float.class, TYPE_DOUBLE_PRIMITIVE);
 
-        TYPES.put(Collection.class, TYPE_COLLECTION);
-        TYPES.put(Map.class, TYPE_MAP);
-        TYPES.put(Counter.class, TYPE_COUNTER);
+        types.put(Double.class, TYPE_DOUBLE_NUMBER);
+        types.put(Float.class, TYPE_DOUBLE_NUMBER);
 
-        TYPES.put(Semaphore.class, TYPE_SEMAPHORE);
+        types.put(Collection.class, TYPE_COLLECTION);
+        types.put(Map.class, TYPE_MAP);
+        types.put(Counter.class, TYPE_COUNTER);
+
+        types.put(Semaphore.class, TYPE_SEMAPHORE);
+
+        TYPES = unmodifiableMap(types);
     }
 
     private ProbeUtils() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -23,11 +23,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -35,18 +36,22 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public final class GarbageCollectionMetricSet {
 
-    private static final Set<String> YOUNG_GC = new HashSet<String>(3);
-    private static final Set<String> OLD_GC = new HashSet<String>(3);
+    private static final Set<String> YOUNG_GC;
+    private static final Set<String> OLD_GC;
     private static final int PUBLISH_FREQUENCY_SECONDS = 1;
 
     static {
-        YOUNG_GC.add("PS Scavenge");
-        YOUNG_GC.add("ParNew");
-        YOUNG_GC.add("G1 Young Generation");
+        final Set<String> youngGC = createHashSet(3);
+        youngGC.add("PS Scavenge");
+        youngGC.add("ParNew");
+        youngGC.add("G1 Young Generation");
+        YOUNG_GC = Collections.unmodifiableSet(youngGC);
 
-        OLD_GC.add("PS MarkSweep");
-        OLD_GC.add("ConcurrentMarkSweep");
-        OLD_GC.add("G1 Old Generation");
+        final Set<String> oldGC = createHashSet(3);
+        oldGC.add("PS MarkSweep");
+        oldGC.add("ConcurrentMarkSweep");
+        oldGC.add("G1 Old Generation");
+        OLD_GC = Collections.unmodifiableSet(oldGC);
     }
 
     private GarbageCollectionMetricSet() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.ItemCounter;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -29,6 +28,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 
 /**
@@ -66,7 +66,7 @@ class LoadTracker {
         this.ioThreads = new NioThread[ioThreads.length];
         System.arraycopy(ioThreads, 0, this.ioThreads, 0, ioThreads.length);
 
-        this.selectorToHandlers = new HashMap<NioThread, Set<MigratableHandler>>();
+        this.selectorToHandlers = createHashMap(ioThreads.length);
         for (NioThread selector : ioThreads) {
             selectorToHandlers.put(selector, new HashSet<MigratableHandler>());
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -35,13 +35,14 @@ import com.hazelcast.util.FutureUtil;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class PartitionServiceProxy implements PartitionService {
 
@@ -64,7 +65,7 @@ public class PartitionServiceProxy implements PartitionService {
         this.partitionService = partitionService;
 
         int partitionCount = partitionService.getPartitionCount();
-        Map<Integer, Partition> map = new HashMap<Integer, Partition>(partitionCount);
+        Map<Integer, Partition> map = createHashMap(partitionCount);
         Set<Partition> set = new TreeSet<Partition>();
         for (int i = 0; i < partitionCount; i++) {
             Partition partition = new PartitionProxy(i);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -72,7 +72,6 @@ import com.hazelcast.version.Version;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,6 +91,7 @@ import java.util.logging.Level;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -954,7 +954,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         int dataMembersSize = dataMembers.size();
         int partitionsPerMember = (dataMembersSize > 0 ? (int) ceil((float) partitionCount / dataMembersSize) : 0);
 
-        Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(dataMembersSize);
+        Map<Address, List<Integer>> memberPartitions = createHashMap(dataMembersSize);
         for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
             Address owner = getPartitionOwnerOrWait(partitionId);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableWriter.java
@@ -26,11 +26,11 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class DefaultPortableWriter implements PortableWriter {
 
@@ -47,7 +47,7 @@ public class DefaultPortableWriter implements PortableWriter {
         this.serializer = serializer;
         this.out = out;
         this.cd = cd;
-        this.writtenFields = new HashSet<String>(cd.getFieldCount());
+        this.writtenFields = createHashSet(cd.getFieldCount());
         this.begin = out.position();
 
         // room for final offset

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -47,7 +47,6 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +76,7 @@ import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.D
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.EnumSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JavaSerializer;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createSerializerAdapter;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class SerializationServiceV1 extends AbstractSerializationService {
 
@@ -189,7 +189,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     }
 
     public void registerClassDefinitions(Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {
-        final Map<Integer, ClassDefinition> classDefMap = new HashMap<Integer, ClassDefinition>(classDefinitions.size());
+        final Map<Integer, ClassDefinition> classDefMap = createHashMap(classDefinitions.size());
         for (ClassDefinition cd : classDefinitions) {
             if (classDefMap.containsKey(cd.getClassId())) {
                 throw new HazelcastSerializationException("Duplicate registration found for class-id[" + cd.getClassId() + "]!");

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParser.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 public final class ClassNameFilterParser {
 
     private static final String[] BUILTIN_BLACKLIST_PREFIXES = {
@@ -55,13 +57,14 @@ public final class ClassNameFilterParser {
     }
 
     private static Set<String> parsePrefixes(String prefixes) {
-        Set<String> blacklistSet = new HashSet<String>();
         if (prefixes == null) {
-            return blacklistSet;
+            return new HashSet<String>();
         }
 
         prefixes = prefixes.trim();
         String[] prefixArray = prefixes.split(",");
+
+        Set<String> blacklistSet = createHashSet(prefixArray.length + BUILTIN_BLACKLIST_PREFIXES.length);
         for (String prefix : prefixArray) {
             blacklistSet.add(prefix.trim());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.UnmodifiableIterator;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +31,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public final class MapKeyLoaderUtil {
@@ -114,7 +114,7 @@ public final class MapKeyLoaderUtil {
      * @return the grouped entries by entry key
      */
     private static Map<Integer, List<Data>> nextBatch(Iterator<Entry<Integer, Data>> entries, int maxBatch) {
-        Map<Integer, List<Data>> batch = new HashMap<Integer, List<Data>>();
+        Map<Integer, List<Data>> batch = createHashMap(maxBatch);
         while (entries.hasNext()) {
             Entry<Integer, Data> e = entries.next();
             List<Data> partitionKeys = CollectionUtil.addToValueList(batch, e.getKey(), e.getValue());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeySet.java
@@ -22,8 +22,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class MapKeySet implements IdentifiedDataSerializable {
 
@@ -52,7 +53,7 @@ public class MapKeySet implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        keySet = new HashSet<Data>(size);
+        keySet = createHashSet(size);
         for (int i = 0; i < size; i++) {
             Data data = in.readData();
             keySet.add(data);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -34,7 +34,6 @@ import com.hazelcast.util.Clock;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -43,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 class MapSplitBrainHandlerService implements SplitBrainHandlerService {
 
@@ -57,8 +57,9 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
     @Override
     public Runnable prepareMergeRunnable() {
         long now = Clock.currentTimeMillis();
+
         Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
-        Map<MapContainer, Collection<Record>> recordMap = new HashMap<MapContainer, Collection<Record>>(mapContainers.size());
+        Map<MapContainer, Collection<Record>> recordMap = createHashMap(mapContainers.size());
         ILogger logger = nodeEngine.getLogger(getClass());
         IPartitionService partitionService = nodeEngine.getPartitionService();
         int partitionCount = partitionService.getPartitionCount();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheNaturalFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheNaturalFilteringStrategy.java
@@ -31,7 +31,6 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.collection.Int2ObjectHashMap;
 
 import java.util.Collection;
-import java.util.Map;
 
 import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.EVICTED;
@@ -39,6 +38,7 @@ import static com.hazelcast.core.EntryEventType.EXPIRED;
 import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.core.EntryEventType.REMOVED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
+import static com.hazelcast.util.MapUtil.createInt2ObjectHashMap;
 
 /**
  * A filtering strategy that preserves the default behavior in most cases, but processes entry events for listeners with
@@ -192,8 +192,8 @@ public class QueryCacheNaturalFilteringStrategy extends AbstractFilteringStrateg
      * including values and one for excluding values.
      */
     private class EntryEventDataPerEventTypeCache implements EntryEventDataCache {
-        Map<Integer, EntryEventData> eventDataIncludingValues;
-        Map<Integer, EntryEventData> eventDataExcludingValues;
+        Int2ObjectHashMap<EntryEventData> eventDataIncludingValues;
+        Int2ObjectHashMap<EntryEventData> eventDataExcludingValues;
         boolean empty = true;
 
         @Override
@@ -201,13 +201,13 @@ public class QueryCacheNaturalFilteringStrategy extends AbstractFilteringStrateg
                                                    Object mergingValue, int eventType, boolean includingValues) {
             if (includingValues) {
                 if (eventDataIncludingValues == null) {
-                    eventDataIncludingValues = new Int2ObjectHashMap<EntryEventData>(EVENT_DATA_MAP_CAPACITY);
+                    eventDataIncludingValues = createInt2ObjectHashMap(EVENT_DATA_MAP_CAPACITY);
                 }
                 return getOrCreateEventData(eventDataIncludingValues, mapName, caller, dataKey, newValue, oldValue, mergingValue,
                         eventType);
             } else {
                 if (eventDataExcludingValues == null) {
-                    eventDataExcludingValues = new Int2ObjectHashMap<EntryEventData>(EVENT_DATA_MAP_CAPACITY);
+                    eventDataExcludingValues = createInt2ObjectHashMap(EVENT_DATA_MAP_CAPACITY);
                 }
                 return getOrCreateEventData(eventDataExcludingValues, mapName, caller, dataKey, null, null, null,
                         eventType);
@@ -247,7 +247,7 @@ public class QueryCacheNaturalFilteringStrategy extends AbstractFilteringStrateg
          * @return {@code EntryEventData} already cached in {@code Map eventDataPerEventType} for the given {@code eventType} or
          * if not already cached, a new {@code EntryEventData} object.
          */
-        private EntryEventData getOrCreateEventData(Map<Integer, EntryEventData> eventDataPerEventType, String mapName,
+        private EntryEventData getOrCreateEventData(Int2ObjectHashMap<EntryEventData> eventDataPerEventType, String mapName,
                                                     Address caller, Data dataKey, Object newValue, Object oldValue,
                                                     Object mergingValue, int eventType) {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.util.CollectionUtil.isEmpty;
+import static com.hazelcast.util.MapUtil.createLinkedHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -46,7 +47,7 @@ class CoalescedWriteBehindQueue implements WriteBehindQueue<DelayedEntry> {
             return;
         }
         int expectedCapacity = map.size() + collection.size();
-        Map<Data, DelayedEntry> newMap = createMapWithExpectedCapacity(expectedCapacity);
+        Map<Data, DelayedEntry> newMap = createLinkedHashMap(expectedCapacity);
         for (DelayedEntry next : collection) {
             newMap.put((Data) next.getKey(), next);
         }
@@ -158,11 +159,4 @@ class CoalescedWriteBehindQueue implements WriteBehindQueue<DelayedEntry> {
             delayedEntry.setStoreTime(currentStoreTime);
         }
     }
-
-    private static <K, V> Map<K, V> createMapWithExpectedCapacity(int expectedCapacity) {
-        final double defaultLoadFactor = 0.75;
-        int initialCapacity = (int) (expectedCapacity / defaultLoadFactor) + 1;
-        return new LinkedHashMap<K, V>(initialCapacity);
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.util.CollectionUtil.isNotEmpty;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -176,8 +177,8 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
     }
 
     private Map prepareBatchMap(DelayedEntry[] delayedEntries) {
-        final Map<Object, DelayedEntry> batchMap = new HashMap<Object, DelayedEntry>();
         final int length = delayedEntries.length;
+        final Map<Object, DelayedEntry> batchMap = createHashMap(length);
         // process in reverse order since we do want to process
         // last store operation on a specific key
         for (int i = length - 1; i >= 0; i--) {
@@ -221,7 +222,7 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
     }
 
     private Map convertToObject(Map<Object, DelayedEntry> batchMap) {
-        final Map map = new HashMap();
+        final Map map = createHashMap(batchMap.size());
         for (DelayedEntry entry : batchMap.values()) {
             final Object key = toObject(entry.getKey());
             final Object value = toObject(entry.getValue());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -35,7 +35,6 @@ import com.hazelcast.spi.OperationService;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
@@ -48,6 +47,7 @@ import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Write behind map data store implementation.
@@ -224,7 +224,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
         if (keys == null || keys.isEmpty()) {
             return Collections.emptyMap();
         }
-        Map<Object, Object> map = new HashMap<Object, Object>();
+        Map<Object, Object> map = createHashMap(keys.size());
         Iterator iterator = keys.iterator();
         while (iterator.hasNext()) {
             Object key = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -27,11 +27,18 @@ import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 public class GetAllOperation extends MapOperation implements ReadonlyOperation, PartitionAwareOperation {
+
+    /**
+     * Speculative factor to be used when initialising collections
+     * of an approximate final size.
+     */
+    private static final double SIZING_FUDGE_FACTOR = 1.3;
 
     private List<Data> keys = new ArrayList<Data>();
     private MapEntries entries;
@@ -48,7 +55,8 @@ public class GetAllOperation extends MapOperation implements ReadonlyOperation, 
     public void run() {
         IPartitionService partitionService = getNodeEngine().getPartitionService();
         int partitionId = getPartitionId();
-        Set<Data> partitionKeySet = new HashSet<Data>();
+        final int roughSize = (int) (keys.size() * SIZING_FUDGE_FACTOR / partitionService.getPartitionCount());
+        Set<Data> partitionKeySet = createHashSet(roughSize);
         for (Data key : keys) {
             if (partitionId == partitionService.getPartitionId(key)) {
                 partitionKeySet.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -42,7 +42,6 @@ import com.hazelcast.util.ThreadUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -50,6 +49,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Holder for raw IMap key-value pairs and their metadata.
@@ -85,8 +86,8 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     }
 
     void prepare(PartitionContainer container, Collection<ServiceNamespace> namespaces, int replicaIndex) {
-        data = new HashMap<String, Set<RecordReplicationInfo>>(namespaces.size());
-        loaded = new HashMap<String, Boolean>(namespaces.size());
+        data = createHashMap(namespaces.size());
+        loaded = createHashMap(namespaces.size());
         mapIndexInfos = new ArrayList<MapIndexInfo>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
             ObjectNamespace mapNamespace = (ObjectNamespace) namespace;
@@ -106,7 +107,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
 
             loaded.put(mapName, recordStore.isLoaded());
             // now prepare data to migrate records
-            Set<RecordReplicationInfo> recordSet = new HashSet<RecordReplicationInfo>(recordStore.size());
+            Set<RecordReplicationInfo> recordSet = createHashSet(recordStore.size());
             final Iterator<Record> iterator = recordStore.iterator();
             while (iterator.hasNext()) {
                 Record record = iterator.next();
@@ -240,11 +241,11 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        data = new HashMap<String, Set<RecordReplicationInfo>>(size);
+        data = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String name = in.readUTF();
             int mapSize = in.readInt();
-            Set<RecordReplicationInfo> recordReplicationInfos = new HashSet<RecordReplicationInfo>(mapSize);
+            Set<RecordReplicationInfo> recordReplicationInfos = createHashSet(mapSize);
             for (int j = 0; j < mapSize; j++) {
                 RecordReplicationInfo recordReplicationInfo = in.readObject();
                 recordReplicationInfos.add(recordReplicationInfo);
@@ -253,7 +254,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         }
 
         int loadedSize = in.readInt();
-        loaded = new HashMap<String, Boolean>(loadedSize);
+        loaded = createHashMap(loadedSize);
         for (int i = 0; i < loadedSize; i++) {
             loaded.put(in.readUTF(), in.readBoolean());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -24,10 +24,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
+import static com.hazelcast.util.SetUtil.createLinkedHashSet;
 
 public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOperation implements BackupOperation {
 
@@ -54,7 +54,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
         super.readInternal(in);
         backupProcessor = in.readObject();
         int size = in.readInt();
-        keys = new LinkedHashSet<Data>(size);
+        keys = createLinkedHashSet(size);
         for (int i = 0; i < size; i++) {
             Data key = in.readData();
             keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -32,10 +32,10 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 
 public class MultipleEntryOperation extends MapOperation
@@ -119,7 +119,7 @@ public class MultipleEntryOperation extends MapOperation
         super.readInternal(in);
         entryProcessor = in.readObject();
         int size = in.readInt();
-        keys = new HashSet<Data>(size);
+        keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
             Data key = in.readData();
             keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
@@ -24,8 +24,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class MultipleEntryOperationFactory extends AbstractMapOperationFactory {
 
@@ -61,7 +62,7 @@ public class MultipleEntryOperationFactory extends AbstractMapOperationFactory {
     public void readData(ObjectDataInput in) throws IOException {
         this.name = in.readUTF();
         int size = in.readInt();
-        this.keys = new HashSet<Data>(size);
+        this.keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
             Data key = in.readData();
             keys.add(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.CollectionUtil.isEmpty;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
+import static com.hazelcast.util.MapUtil.createInt2ObjectHashMap;
 import static com.hazelcast.util.MapUtil.isNullOrEmpty;
 import static com.hazelcast.util.collection.InflatableSet.newBuilder;
 import static java.util.Collections.emptySet;
@@ -154,7 +155,10 @@ public class PartitionWideEntryWithPredicateOperationFactory extends PartitionAw
             return Collections.emptyMap();
         }
 
-        Map<Integer, List<Data>> partitionToKeys = new Int2ObjectHashMap<List<Data>>();
+        final int roughSize = Math.min(partitionService.getPartitionCount(), keys.size());
+
+        //using the type of Int2ObjectHashMap allows the get and put operations to avoid auto-boxing
+        final Int2ObjectHashMap<List<Data>> partitionToKeys = createInt2ObjectHashMap(roughSize);
         for (Data key : keys) {
             int partitionId = partitionService.getPartitionId(key);
             List<Data> keyList = partitionToKeys.get(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -45,12 +45,13 @@ import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class PostJoinMapOperation extends Operation implements IdentifiedDataSerializable {
 
@@ -98,7 +99,7 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
         InterceptorRegistry interceptorRegistry = mapContainer.getInterceptorRegistry();
         List<MapInterceptor> interceptorList = interceptorRegistry.getInterceptors();
         Map<String, MapInterceptor> interceptorMap = interceptorRegistry.getId2InterceptorMap();
-        Map<MapInterceptor, String> revMap = new HashMap<MapInterceptor, String>();
+        Map<MapInterceptor, String> revMap = createHashMap(interceptorMap.size());
         for (Map.Entry<String, MapInterceptor> entry : interceptorMap.entrySet()) {
             revMap.put(entry.getValue(), entry.getKey());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
@@ -38,10 +38,11 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Holder for write-behind-specific state.
@@ -70,8 +71,8 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
     void prepare(PartitionContainer container, Collection<ServiceNamespace> namespaces, int replicaIndex) {
         int size = namespaces.size();
 
-        flushSequences = new HashMap<String, Queue<WriteBehindStore.Sequence>>(size);
-        delayedEntries = new HashMap<String, List<DelayedEntry>>(size);
+        flushSequences = createHashMap(size);
+        delayedEntries = createHashMap(size);
 
         for (ServiceNamespace namespace : namespaces) {
             ObjectNamespace mapNamespace = (ObjectNamespace) namespace;
@@ -156,7 +157,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
 
-        delayedEntries = new HashMap<String, List<DelayedEntry>>(size);
+        delayedEntries = createHashMap(size);
 
         for (int i = 0; i < size; i++) {
             String mapName = in.readUTF();
@@ -178,7 +179,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
         }
 
         int expectedSize = in.readInt();
-        flushSequences = new HashMap<String, Queue<WriteBehindStore.Sequence>>(expectedSize);
+        flushSequences = createHashMap(expectedSize);
         for (int i = 0; i < expectedSize; i++) {
             String mapName = in.readUTF();
             int setSize = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -80,7 +80,6 @@ import com.hazelcast.util.executor.DelegatingFuture;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -100,6 +99,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
 import static com.hazelcast.util.Preconditions.checkTrue;
 import static com.hazelcast.util.Preconditions.isNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -718,7 +718,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         if (keys.isEmpty()) {
             return emptyMap();
         }
-        Set<Data> dataKeys = new HashSet<Data>(keys.size());
+        Set<Data> dataKeys = createHashSet(keys.size());
         return executeOnKeysInternal(keys, dataKeys, entryProcessor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -108,6 +108,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static com.hazelcast.util.ThreadUtil.getThreadId;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log10;
@@ -758,7 +759,7 @@ abstract class MapProxySupport<K, V>
         int partitions = partitionService.getPartitionCount();
         // TODO: is there better way to estimate the size?
         int capacity = min(partitions, keys.size());
-        Set<Integer> partitionIds = new HashSet<Integer>(capacity);
+        Set<Integer> partitionIds = createHashSet(capacity);
 
         Iterator<Data> iterator = keys.iterator();
         while (iterator.hasNext() && partitionIds.size() < partitions) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorHandler.java
@@ -24,15 +24,17 @@ import com.hazelcast.map.impl.querycache.event.BatchEventData;
 import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.properties.GroupProperty;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Handler for processing of event data in an {@link Accumulator Accumulator}.
@@ -87,7 +89,10 @@ public class PublisherAccumulatorHandler implements AccumulatorHandler<Sequenced
             return Collections.emptyMap();
         }
 
-        Map<Integer, List<QueryCacheEventData>> map = new HashMap<Integer, List<QueryCacheEventData>>();
+        final int defaultPartitionCount = Integer.parseInt(GroupProperty.PARTITION_COUNT.getDefaultValue());
+        final int roughSize = Math.min(events.size(), defaultPartitionCount);
+
+        final Map<Integer, List<QueryCacheEventData>> map = createHashMap(roughSize);
 
         do {
             QueryCacheEventData eventData = events.poll();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -54,6 +54,7 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -318,15 +319,17 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public Set<K> keySet(Predicate predicate) {
         checkNotNull(predicate, "Predicate cannot be null!");
 
-        Set<K> resultingSet = new HashSet<K>();
+        final Set<K> resultingSet;
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
+            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 K key = (K) entry.getKey();
                 resultingSet.add(key);
             }
         } else {
+            resultingSet = new HashSet<K>();
             doFullKeyScan(predicate, resultingSet);
         }
 
@@ -337,17 +340,19 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public Set<Map.Entry<K, V>> entrySet(Predicate predicate) {
         checkNotNull(predicate, "Predicate cannot be null!");
 
-        Set<Map.Entry<K, V>> resultingSet = new HashSet<Map.Entry<K, V>>();
+        Set<Map.Entry<K, V>> resultingSet;
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
             if (query.isEmpty()) {
                 return Collections.emptySet();
             }
+            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 resultingSet.add(entry);
             }
         } else {
+            resultingSet = new HashSet<Map.Entry<K, V>>();
             doFullEntryScan(predicate, resultingSet);
         }
         return resultingSet;
@@ -361,14 +366,16 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
             return Collections.emptySet();
         }
 
-        Set<V> resultingSet = new HashSet<V>();
+        final Set<V> resultingSet;
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
+            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 resultingSet.add((V) entry.getValue());
             }
         } else {
+            resultingSet = new HashSet<V>();
             doFullValueScan(predicate, resultingSet);
         }
         return resultingSet;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SetAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SetAdapter.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 /**
  * A simple adapter class to serialize values of a {@link java.util.Set} using
  * Hazelcast serialization support.
@@ -59,7 +61,7 @@ public class SetAdapter<E>
             throws IOException {
 
         int size = in.readInt();
-        Set<E> set = new HashSet<E>(size);
+        Set<E> set = createHashSet(size);
         for (int i = 0; i < size; i++) {
             set.add((E) in.readObject());
         }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/HashMapAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/HashMapAdapter.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 /**
  * Simple HashMap adapter class to implement DataSerializable serialization semantics
  * to not loose hands on serialization while sending intermediate results.
@@ -78,7 +80,7 @@ public class HashMapAdapter<K, V>
             throws IOException {
 
         int size = in.readInt();
-        Map<K, V> map = new HashMap<K, V>(size);
+        Map<K, V> map = createHashMap(size);
         for (int i = 0; i < size; i++) {
             K key = in.readObject();
             V value = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/IntermediateChunkNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/IntermediateChunkNotification.java
@@ -22,8 +22,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Notification that is fired every time the chunk limit is reached and is send to the reducers
@@ -71,7 +72,7 @@ public class IntermediateChunkNotification<KeyOut, Value>
             throws IOException {
         super.readData(in);
         int size = in.readInt();
-        chunk = new HashMap<KeyOut, Value>();
+        chunk = createHashMap(size);
         for (int i = 0; i < size; i++) {
             KeyOut key = in.readObject();
             Value value = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/LastChunkNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/LastChunkNotification.java
@@ -22,8 +22,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * This notification is used to notify the reducer that this chunk is the last chunk of the
@@ -80,7 +81,7 @@ public class LastChunkNotification<KeyOut, Value>
             throws IOException {
         super.readData(in);
         int size = in.readInt();
-        chunk = new HashMap<KeyOut, Value>();
+        chunk = createHashMap(size);
         for (int i = 0; i < size; i++) {
             KeyOut key = in.readObject();
             Value value = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentOperation.java
@@ -28,7 +28,6 @@ import com.hazelcast.partition.NoDataMemberInClusterException;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,6 +35,8 @@ import static com.hazelcast.mapreduce.TopologyChangedStrategy.CANCEL_RUNNING_OPE
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.CHECK_STATE_FAILED;
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.NO_SUPERVISOR;
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.SUCCESSFUL;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * This operation is used to request assignment for keys on the job owners node. The job owner
@@ -71,10 +72,10 @@ public class KeysAssignmentOperation
             return;
         }
 
-        Map<Object, Address> assignment = new HashMap<Object, Address>();
 
         // Precheck if still all members are available
         if (!supervisor.checkAssignedMembersAvailable()) {
+            Map<Object, Address> assignment = new HashMap<Object, Address>();
             TopologyChangedStrategy tcs = supervisor.getConfiguration().getTopologyChangedStrategy();
             if (tcs == CANCEL_RUNNING_OPERATION) {
                 Exception exception = new TopologyChangedException();
@@ -92,6 +93,8 @@ public class KeysAssignmentOperation
                 return;
             }
         }
+
+        final Map<Object, Address> assignment = createHashMap(keys.size());
 
         try {
             for (Object key : keys) {
@@ -120,7 +123,7 @@ public class KeysAssignmentOperation
             throws IOException {
         super.readInternal(in);
         int size = in.readInt();
-        keys = new HashSet<Object>();
+        keys = createHashSet(size);
         for (int i = 0; i < size; i++) {
             keys.add(in.readObject());
         }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentResult.java
@@ -24,8 +24,9 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * This class is used to store assignment results in {@link com.hazelcast.mapreduce.impl.operation.KeysAssignmentOperation}
@@ -72,7 +73,7 @@ public class KeysAssignmentResult
             throws IOException {
         if (in.readBoolean()) {
             int size = in.readInt();
-            assignment = new HashMap<Object, Address>(size);
+            assignment = createHashMap(size);
             for (int i = 0; i < size; i++) {
                 assignment.put(in.readObject(), (Address) in.readObject());
             }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -22,10 +22,9 @@ import com.hazelcast.mapreduce.Combiner;
 import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.mapreduce.Context;
 import com.hazelcast.mapreduce.impl.CombinerResultList;
-import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.mapreduce.impl.MapReduceUtil;
-import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.nio.serialization.BinaryInterface;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.IConcurrentMap;
 
@@ -35,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG;
+import static com.hazelcast.util.MapUtil.createHashMapAdapter;
 
 /**
  * This is the internal default implementation of a map reduce context mappers emit values to. It controls the emitted
@@ -85,7 +85,7 @@ public class DefaultContext<KeyIn, ValueIn>
 
     public <Chunk> Map<KeyIn, Chunk> requestChunk() {
         int mapSize = MapReduceUtil.mapSize(combiners.size());
-        Map<KeyIn, Chunk> chunkMap = new HashMapAdapter<KeyIn, Chunk>(mapSize);
+        Map<KeyIn, Chunk> chunkMap = createHashMapAdapter(mapSize);
         for (Map.Entry<KeyIn, Combiner<ValueIn, ?>> entry : combiners.entrySet()) {
             Combiner<ValueIn, ?> combiner = entry.getValue();
             Chunk chunk = (Chunk) combiner.finalizeChunk();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -24,7 +24,6 @@ import com.hazelcast.mapreduce.JobProcessInformation;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.impl.AbstractJobTracker;
-import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.mapreduce.impl.MapReduceUtil;
 import com.hazelcast.mapreduce.impl.notification.IntermediateChunkNotification;
@@ -60,6 +59,7 @@ import static com.hazelcast.mapreduce.JobPartitionState.State.REDUCING;
 import static com.hazelcast.mapreduce.impl.MapReduceUtil.createJobProcessInformation;
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.SUCCESSFUL;
 import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
+import static com.hazelcast.util.MapUtil.createHashMapAdapter;
 
 /**
  * The JobSupervisor is the overall control instance of a map reduce job. There is one JobSupervisor per
@@ -237,7 +237,7 @@ public class JobSupervisor {
         Map<Object, Object> result;
         if (configuration.getReducerFactory() != null) {
             int mapSize = MapReduceUtil.mapSize(reducers.size());
-            result = new HashMapAdapter<Object, Object>(mapSize);
+            result = createHashMapAdapter(mapSize);
             for (Map.Entry<Object, Reducer> entry : reducers.entrySet()) {
                 Object reducedResults = entry.getValue().finalizeReduce();
                 if (reducedResults != null) {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MapCombineTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MapCombineTask.java
@@ -42,7 +42,6 @@ import com.hazelcast.util.ExceptionUtil;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -55,6 +54,8 @@ import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.Resu
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.NO_MORE_PARTITIONS;
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.NO_SUPERVISOR;
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.SUCCESSFUL;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * This class acutally executed the mapping-combine phase. It is responsible for opening / closing
@@ -167,7 +168,7 @@ public class MapCombineTask<KeyIn, ValueIn, KeyOut, ValueOut, Chunk> {
 
     public static <K, V> Map<Address, Map<K, V>> mapResultToMember(JobSupervisor supervisor, Map<K, V> result) {
 
-        Set<Object> unassignedKeys = new HashSet<Object>();
+        Set<Object> unassignedKeys = createHashSet(result.size());
         for (Map.Entry<K, V> entry : result.entrySet()) {
             Address address = supervisor.getReducerAddressByKey(entry.getKey());
             if (address == null) {
@@ -180,7 +181,7 @@ public class MapCombineTask<KeyIn, ValueIn, KeyOut, ValueOut, Chunk> {
         }
 
         // Now assign all keys
-        Map<Address, Map<K, V>> mapping = new HashMap<Address, Map<K, V>>();
+        Map<Address, Map<K, V>> mapping = createHashMap(result.size());
         for (Map.Entry<K, V> entry : result.entrySet()) {
             Address address = supervisor.getReducerAddressByKey(entry.getKey());
             if (address != null) {

--- a/hazelcast/src/main/java/com/hazelcast/memory/GCStatsSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/GCStatsSupport.java
@@ -18,25 +18,31 @@ package com.hazelcast.memory;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Used to gather garbage collection statistics.
  */
 public final class GCStatsSupport {
 
-    private static final Set<String> YOUNG_GC = new HashSet<String>(3);
-    private static final Set<String> OLD_GC = new HashSet<String>(3);
+    private static final Set<String> YOUNG_GC;
+    private static final Set<String> OLD_GC;
 
     static {
-        YOUNG_GC.add("PS Scavenge");
-        YOUNG_GC.add("ParNew");
-        YOUNG_GC.add("G1 Young Generation");
+        final Set<String> youngGC = createHashSet(3);
+        youngGC.add("PS Scavenge");
+        youngGC.add("ParNew");
+        youngGC.add("G1 Young Generation");
+        YOUNG_GC = Collections.unmodifiableSet(youngGC);
 
-        OLD_GC.add("PS MarkSweep");
-        OLD_GC.add("ConcurrentMarkSweep");
-        OLD_GC.add("G1 Old Generation");
+        final Set<String> oldGC = createHashSet(3);
+        oldGC.add("PS MarkSweep");
+        oldGC.add("ConcurrentMarkSweep");
+        oldGC.add("G1 Old Generation");
+        OLD_GC = Collections.unmodifiableSet(oldGC);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
@@ -24,7 +24,6 @@ import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.monitor.impl.MemberStateImpl;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,6 +32,7 @@ import static com.hazelcast.util.JsonUtil.getBoolean;
 import static com.hazelcast.util.JsonUtil.getLong;
 import static com.hazelcast.util.JsonUtil.getObject;
 import static com.hazelcast.util.JsonUtil.getString;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 
 public final class TimedMemberState implements Cloneable, JsonSerializable {
@@ -168,13 +168,13 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         time = getLong(json, "time");
         master = getBoolean(json, "master");
         clusterName = getString(json, "clusterName");
-        instanceNames = new HashSet<String>();
         final JsonArray jsonInstanceNames = getArray(json, "instanceNames");
+        instanceNames = createHashSet(jsonInstanceNames.size());
         for (JsonValue instanceName : jsonInstanceNames.values()) {
             instanceNames.add(instanceName.asString());
         }
-        memberList = new ArrayList<String>();
         final JsonArray jsonMemberList = getArray(json, "memberList");
+        memberList = new ArrayList<String>(jsonMemberList.size());
         for (JsonValue member : jsonMemberList.values()) {
             memberList.add(member.asString());
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -24,13 +24,13 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.util.Clock.currentTimeMillis;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * MultiMap container which holds a map of {@link MultiMapValue}.
@@ -116,9 +116,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
 
     public Set<Data> keySet() {
         Set<Data> keySet = multiMapValues.keySet();
-        Set<Data> keys = new HashSet<Data>(keySet.size());
-        keys.addAll(keySet);
-        return keys;
+        return new HashSet<Data>(keySet);
     }
 
     public Collection<MultiMapRecord> values() {
@@ -152,7 +150,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     public Map<Data, Collection<MultiMapRecord>> copyCollections() {
-        Map<Data, Collection<MultiMapRecord>> map = new HashMap<Data, Collection<MultiMapRecord>>(multiMapValues.size());
+        Map<Data, Collection<MultiMapRecord>> map = createHashMap(multiMapValues.size());
         for (Map.Entry<Data, MultiMapValue> entry : multiMapValues.entrySet()) {
             Data key = entry.getKey();
             Collection<MultiMapRecord> col = entry.getValue().getCollection(true);
@@ -171,7 +169,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
 
     public int clear() {
         final Collection<Data> locks = lockStore != null ? lockStore.getLockedKeys() : Collections.<Data>emptySet();
-        Map<Data, MultiMapValue> lockedKeys = new HashMap<Data, MultiMapValue>(locks.size());
+        Map<Data, MultiMapValue> lockedKeys = createHashMap(locks.size());
         for (Data key : locks) {
             MultiMapValue multiMapValue = multiMapValues.get(key);
             if (multiMapValue != null) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -64,6 +64,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 public class MultiMapService implements ManagedService, RemoteService, FragmentedMigrationAwareService,
         EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsAwareService<LocalMultiMapStats> {
 
@@ -255,7 +257,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         }
 
         int replicaIndex = event.getReplicaIndex();
-        Map<String, Map> map = new HashMap<String, Map>(namespaces.size());
+        Map<String, Map> map = createHashMap(namespaces.size());
 
         for (ServiceNamespace namespace : namespaces) {
             assert isKnownServiceNamespace(namespace) : namespace + " is not a MultiMapService namespace!";

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
 import static com.hazelcast.util.Preconditions.isNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class ObjectMultiMapProxy<K, V>
         extends MultiMapProxySupport
@@ -360,7 +361,7 @@ public class ObjectMultiMapProxy<K, V>
 
     private Set<K> toObjectSet(Set<Data> dataSet) {
         final NodeEngine nodeEngine = getNodeEngine();
-        Set<K> keySet = new HashSet<K>(dataSet.size());
+        Set<K> keySet = createHashSet(dataSet.size());
         for (Data dataKey : dataSet) {
             keySet.add((K) nodeEngine.toObject(dataKey));
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/ValueCollectionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/ValueCollectionFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl;
 
 import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.util.SetUtil;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -61,7 +62,7 @@ public final class ValueCollectionFactory {
                                                      int initialCapacity) {
         switch (collectionType) {
             case SET:
-                return initialCapacity <= 0 ? new HashSet<T>() : new HashSet<T>(initialCapacity);
+                return initialCapacity <= 0 ? new HashSet<T>() : SetUtil.<T>createHashSet(initialCapacity);
             case LIST:
                 return new LinkedList<T>();
             default:

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetResponse.java
@@ -28,10 +28,11 @@ import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class EntrySetResponse implements IdentifiedDataSerializable {
 
@@ -41,7 +42,7 @@ public class EntrySetResponse implements IdentifiedDataSerializable {
     }
 
     public EntrySetResponse(Map<Data, Collection<MultiMapRecord>> map, NodeEngine nodeEngine) {
-        this.map = new HashMap<Data, Collection<Data>>(map.size());
+        this.map = createHashMap(map.size());
         for (Map.Entry<Data, Collection<MultiMapRecord>> entry : map.entrySet()) {
             Collection<MultiMapRecord> records = entry.getValue();
             Collection<Data> coll = new ArrayList<Data>(records.size());
@@ -53,7 +54,7 @@ public class EntrySetResponse implements IdentifiedDataSerializable {
     }
 
     public Set<Map.Entry<Data, Data>> getDataEntrySet() {
-        Set<Map.Entry<Data, Data>> entrySet = new HashSet<Map.Entry<Data, Data>>();
+        Set<Map.Entry<Data, Data>> entrySet = createHashSet(map.size() * 2);
         for (Map.Entry<Data, Collection<Data>> entry : map.entrySet()) {
             Data key = entry.getKey();
             Collection<Data> coll = entry.getValue();
@@ -65,7 +66,7 @@ public class EntrySetResponse implements IdentifiedDataSerializable {
     }
 
     public <K, V> Set<Map.Entry<K, V>> getObjectEntrySet(NodeEngine nodeEngine) {
-        Set<Map.Entry<K, V>> entrySet = new HashSet<Map.Entry<K, V>>();
+        Set<Map.Entry<K, V>> entrySet = createHashSet(map.size() * 2);
         for (Map.Entry<Data, Collection<Data>> entry : map.entrySet()) {
             K key = nodeEngine.toObject(entry.getKey());
             Collection<Data> coll = entry.getValue();
@@ -93,7 +94,7 @@ public class EntrySetResponse implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        map = new HashMap<Data, Collection<Data>>(size);
+        map = createHashMap(size);
         for (int i = 0; i < size; i++) {
             Data key = in.readData();
             int collSize = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
@@ -29,11 +29,12 @@ import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class MultiMapReplicationOperation extends Operation implements IdentifiedDataSerializable {
 
@@ -81,19 +82,19 @@ public class MultiMapReplicationOperation extends Operation implements Identifie
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        int mapSize = in.readInt();
-        map = new HashMap<String, Map>(mapSize);
+        final int mapSize = in.readInt();
+        map = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
             int collectionSize = in.readInt();
-            Map<Data, MultiMapValue> collections = new HashMap<Data, MultiMapValue>();
+            Map<Data, MultiMapValue> collections = createHashMap(collectionSize);
             for (int j = 0; j < collectionSize; j++) {
                 Data key = in.readData();
                 int collSize = in.readInt();
                 String collectionType = in.readUTF();
                 Collection<MultiMapRecord> coll;
                 if (collectionType.equals(MultiMapConfig.ValueCollectionType.SET.name())) {
-                    coll = new HashSet<MultiMapRecord>();
+                    coll = createHashSet(collSize);
                 } else {
                     coll = new LinkedList<MultiMapRecord>();
                 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ConfigMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ConfigMemberGroupFactory.java
@@ -24,17 +24,18 @@ import com.hazelcast.util.AddressUtil;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createLinkedHashMap;
 
 public class ConfigMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
 
     private final Map<Integer, MemberGroupConfig> memberGroupConfigMap;
 
     public ConfigMemberGroupFactory(Collection<MemberGroupConfig> memberGroupConfigs) {
-        this.memberGroupConfigMap = new LinkedHashMap<Integer, MemberGroupConfig>();
+        this.memberGroupConfigMap = createLinkedHashMap(memberGroupConfigs.size());
         int key = 0;
         for (MemberGroupConfig groupConfig : memberGroupConfigs) {
             memberGroupConfigMap.put(key++, groupConfig);

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/HostAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/HostAwareMemberGroupFactory.java
@@ -21,16 +21,17 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class HostAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
 
     @Override
     protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
-        Map<String, MemberGroup> groups = new HashMap<String, MemberGroup>();
+        Map<String, MemberGroup> groups = createHashMap(allMembers.size());
         for (Member member : allMembers) {
             Address address = ((MemberImpl) member).getAddress();
             MemberGroup group = groups.get(address.getHost());

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SPIAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SPIAwareMemberGroupFactory.java
@@ -26,10 +26,10 @@ import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * SPIAwareMemberGroupFactory is responsible for providing custom MemberGroups
@@ -49,7 +49,7 @@ public class SPIAwareMemberGroupFactory extends BackupSafeMemberGroupFactory imp
 
     @Override
     protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
-        Set<MemberGroup> memberGroups = new HashSet<MemberGroup>();
+        Set<MemberGroup> memberGroups = createHashSet(allMembers.size());
 
         for (Member member : allMembers) {
             try {

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroupFactory.java
@@ -19,8 +19,9 @@ package com.hazelcast.partition.membergroup;
 import com.hazelcast.core.Member;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Arranges members in single-member groups (every member is its own group).
@@ -29,7 +30,7 @@ public class SingleMemberGroupFactory implements MemberGroupFactory {
 
     @Override
     public Set<MemberGroup> createMemberGroups(Collection<? extends Member> members) {
-        Set<MemberGroup> groups = new HashSet<MemberGroup>(members.size());
+        Set<MemberGroup> groups = createHashSet(members.size());
         for (Member member : members) {
             groups.add(new SingleMemberGroup(member));
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/Parser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Parser.java
@@ -18,10 +18,11 @@ package com.hazelcast.query;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 
 class Parser {
@@ -44,27 +45,29 @@ class Parser {
     private static final int AND_PRECEDENCE = 5;
     private static final int OR_PRECEDENCE = 3;
 
-    private static final Map<String, Integer> PRECEDENCE = new HashMap<String, Integer>();
+    private static final Map<String, Integer> PRECEDENCE;
 
     static {
-        PRECEDENCE.put("(", PARENTHESIS_PRECEDENCE);
-        PRECEDENCE.put(")", PARENTHESIS_PRECEDENCE);
-        PRECEDENCE.put("not", NOT_PRECEDENCE);
-        PRECEDENCE.put("=", EQUAL_PRECEDENCE);
-        PRECEDENCE.put(">", GREATER_PRECEDENCE);
-        PRECEDENCE.put("<", LESS_PRECEDENCE);
-        PRECEDENCE.put(">=", GREATER_EQUAL_PRECEDENCE);
-        PRECEDENCE.put("<=", LESS_EQUAL_PRECEDENCE);
-        PRECEDENCE.put("==", ASSIGN_PRECEDENCE);
-        PRECEDENCE.put("!=", NOT_EQUAL_PRECEDENCE);
-        PRECEDENCE.put("<>", NOT_EQUAL_PRECEDENCE);
-        PRECEDENCE.put("between", BETWEEN_PRECEDENCE);
-        PRECEDENCE.put("in", IN_PRECEDENCE);
-        PRECEDENCE.put("like", LIKE_PRECEDENCE);
-        PRECEDENCE.put("ilike", ILIKE_PRECEDENCE);
-        PRECEDENCE.put("regex", REGEX_PRECEDENCE);
-        PRECEDENCE.put("and", AND_PRECEDENCE);
-        PRECEDENCE.put("or", OR_PRECEDENCE);
+        final Map<String, Integer> precedence = createHashMap(18);
+        precedence.put("(", PARENTHESIS_PRECEDENCE);
+        precedence.put(")", PARENTHESIS_PRECEDENCE);
+        precedence.put("not", NOT_PRECEDENCE);
+        precedence.put("=", EQUAL_PRECEDENCE);
+        precedence.put(">", GREATER_PRECEDENCE);
+        precedence.put("<", LESS_PRECEDENCE);
+        precedence.put(">=", GREATER_EQUAL_PRECEDENCE);
+        precedence.put("<=", LESS_EQUAL_PRECEDENCE);
+        precedence.put("==", ASSIGN_PRECEDENCE);
+        precedence.put("!=", NOT_EQUAL_PRECEDENCE);
+        precedence.put("<>", NOT_EQUAL_PRECEDENCE);
+        precedence.put("between", BETWEEN_PRECEDENCE);
+        precedence.put("in", IN_PRECEDENCE);
+        precedence.put("like", LIKE_PRECEDENCE);
+        precedence.put("ilike", ILIKE_PRECEDENCE);
+        precedence.put("regex", REGEX_PRECEDENCE);
+        precedence.put("and", AND_PRECEDENCE);
+        precedence.put("or", OR_PRECEDENCE);
+        PRECEDENCE = Collections.unmodifiableMap(precedence);
     }
 
     private static final List<String> CHAR_OPERATORS

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -119,7 +119,7 @@ public class SqlPredicate
 
     private Predicate createPredicate(String sql) {
         String paramSql = sql;
-        Map<String, String> mapPhrases = new HashMap<String, String>(1);
+        Map<String, String> mapPhrases = new HashMap<String, String>();
         int apoIndex = getApostropheIndex(paramSql, 0);
         if (apoIndex != -1) {
             int phraseId = 0;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DuplicateDetectingMultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DuplicateDetectingMultiResult.java
@@ -19,10 +19,11 @@ package com.hazelcast.query.impl;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.AbstractSet;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class DuplicateDetectingMultiResult extends AbstractSet<QueryableEntry> implements MultiResultSet {
     private Map<Data, QueryableEntry> records;
@@ -30,7 +31,7 @@ public class DuplicateDetectingMultiResult extends AbstractSet<QueryableEntry> i
     @Override
     public void addResultSet(Map<Data, QueryableEntry> resultSet) {
         if (records == null) {
-            records = new HashMap<Data, QueryableEntry>(resultSet.size());
+            records = createHashMap(resultSet.size());
         }
 
         for (Map.Entry<Data, QueryableEntry> entry : resultSet.entrySet()) {
@@ -53,10 +54,9 @@ public class DuplicateDetectingMultiResult extends AbstractSet<QueryableEntry> i
     @Override
     public Iterator<QueryableEntry> iterator() {
         if (records == null) {
-            return new HashSet<QueryableEntry>().iterator();
-        } else {
-            return records.values().iterator();
+            return Collections.<QueryableEntry>emptyList().iterator();
         }
+        return records.values().iterator();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -28,10 +28,10 @@ import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class IndexImpl implements Index {
 
@@ -99,7 +99,7 @@ public class IndexImpl implements Index {
             return getRecords(values[0]);
         } else {
             if (converter != null) {
-                Set<Comparable> convertedValues = new HashSet<Comparable>(values.length);
+                Set<Comparable> convertedValues = createHashSet(values.length);
                 for (Comparable value : values) {
                     convertedValues.add(convert(value));
                 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrResultSet.java
@@ -23,10 +23,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.util.SetUtil.createHashSet;
+
 /**
  * Or result set for Predicates.
  */
 public class OrResultSet extends AbstractSet<QueryableEntry> {
+
+    private static final int ENTRY_MULTIPLE = 4;
+    private static final int ENTRY_MIN_SIZE = 8;
 
     private final List<Set<QueryableEntry>> indexedResults;
     private Set<QueryableEntry> entries;
@@ -77,7 +82,7 @@ public class OrResultSet extends AbstractSet<QueryableEntry> {
                 if (indexedResults.size() == 1) {
                     entries = new HashSet<QueryableEntry>(indexedResults.get(0));
                 } else {
-                    entries = new HashSet<QueryableEntry>();
+                    entries = createHashSet(Math.max(ENTRY_MIN_SIZE, indexedResults.size() * ENTRY_MULTIPLE));
                     for (Set<QueryableEntry> result : indexedResults) {
                         entries.addAll(result);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
@@ -21,9 +21,10 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.query.extractor.ValueExtractor;
 import com.hazelcast.util.StringUtil;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public final class ExtractorHelper {
 
@@ -32,7 +33,7 @@ public final class ExtractorHelper {
 
     static Map<String, ValueExtractor> instantiateExtractors(List<MapAttributeConfig> mapAttributeConfigs,
                                                              ClassLoader classLoader) {
-        Map<String, ValueExtractor> extractors = new HashMap<String, ValueExtractor>();
+        Map<String, ValueExtractor> extractors = createHashMap(mapAttributeConfigs.size());
         for (MapAttributeConfig config : mapAttributeConfigs) {
             if (extractors.containsKey(config.getName())) {
                 throw new IllegalArgumentException("Could not add " + config

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -24,9 +24,10 @@ import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * In Predicate
@@ -56,7 +57,7 @@ public class InPredicate extends AbstractIndexAwarePredicate {
         }
         Set<Comparable> set = convertedInValues;
         if (set == null) {
-            set = new HashSet<Comparable>(values.length);
+            set = createHashSet(values.length);
             for (Comparable value : values) {
                 set.add(convert(entry, attributeValue, value));
             }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +59,7 @@ import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.isNotNull;
+import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log10;
 
@@ -75,6 +75,8 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
 
     private static final int WAIT_INTERVAL_MILLIS = 1000;
     private static final int RETRY_INTERVAL_COUNT = 3;
+    private static final int KEY_SET_MIN_SIZE = 16;
+    private static final int KEY_SET_STORE_MULTIPLE = 4;
 
     private final String name;
     private final NodeEngine nodeEngine;
@@ -375,7 +377,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
     @Override
     public Set<K> keySet() {
         Collection<ReplicatedRecordStore> stores = service.getAllReplicatedRecordStores(getName());
-        Set<K> keySet = new HashSet<K>();
+        Set<K> keySet = createHashSet(Math.max(KEY_SET_MIN_SIZE, stores.size() * KEY_SET_STORE_MULTIPLE));
         for (ReplicatedRecordStore store : stores) {
             keySet.addAll(store.keySet(true));
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersionOperation.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.INVOCATION_TRY_COUNT;
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 
 /**
  * Checks whether replica version is in sync with the primary.
@@ -45,8 +46,8 @@ public class CheckReplicaVersionOperation extends AbstractSerializableOperation 
     }
 
     public CheckReplicaVersionOperation(PartitionContainer container) {
-        versions = new ConcurrentHashMap<String, Long>();
         ConcurrentMap<String, ReplicatedRecordStore> stores = container.getStores();
+        versions = createConcurrentHashMap(stores.size());
         for (Map.Entry<String, ReplicatedRecordStore> storeEntry : stores.entrySet()) {
             String name = storeEntry.getKey();
             ReplicatedRecordStore store = storeEntry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
@@ -29,11 +29,12 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Carries all the partition data for replicated map from old owner to the new owner.
@@ -76,12 +77,12 @@ public class ReplicationOperation extends AbstractSerializableOperation {
 
     private void fetchReplicatedMapRecords(PartitionContainer container) {
         int storeCount = container.getStores().size();
-        data = new HashMap<String, Set<RecordMigrationInfo>>(storeCount);
-        versions = new HashMap<String, Long>(storeCount);
+        data = createHashMap(storeCount);
+        versions = createHashMap(storeCount);
         for (Map.Entry<String, ReplicatedRecordStore> entry : container.getStores().entrySet()) {
             String name = entry.getKey();
             ReplicatedRecordStore store = entry.getValue();
-            Set<RecordMigrationInfo> recordSet = new HashSet<RecordMigrationInfo>(store.size());
+            Set<RecordMigrationInfo> recordSet = createHashSet(store.size());
             Iterator<ReplicatedRecord> iterator = store.recordIterator();
             while (iterator.hasNext()) {
                 ReplicatedRecord record = iterator.next();
@@ -135,11 +136,11 @@ public class ReplicationOperation extends AbstractSerializableOperation {
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        data = new HashMap<String, Set<RecordMigrationInfo>>(size);
+        data = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String name = in.readUTF();
             int mapSize = in.readInt();
-            Set<RecordMigrationInfo> recordSet = new HashSet<RecordMigrationInfo>(mapSize);
+            Set<RecordMigrationInfo> recordSet = createHashSet(mapSize);
             for (int j = 0; j < mapSize; j++) {
                 RecordMigrationInfo record = new RecordMigrationInfo();
                 record.readData(in);
@@ -148,7 +149,7 @@ public class ReplicationOperation extends AbstractSerializableOperation {
             data.put(name, recordSet);
         }
         int versionsSize = in.readInt();
-        versions = new HashMap<String, Long>(versionsSize);
+        versions = createHashMap(versionsSize);
         for (int i = 0; i < versionsSize; i++) {
             String name = in.readUTF();
             long version = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
@@ -30,12 +30,12 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.INVOCATION_TRY_COUNT;
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Collects and sends the replicated map data from the executing node to the caller via
@@ -82,7 +82,7 @@ public class RequestMapDataOperation extends AbstractSerializableOperation {
     }
 
     private Set<RecordMigrationInfo> getRecordSet(ReplicatedRecordStore store) {
-        Set<RecordMigrationInfo> recordSet = new HashSet<RecordMigrationInfo>(store.size());
+        Set<RecordMigrationInfo> recordSet = createHashSet(store.size());
         Iterator<ReplicatedRecord> iterator = store.recordIterator();
         while (iterator.hasNext()) {
             ReplicatedRecord record = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -26,9 +26,10 @@ import com.hazelcast.replicatedmap.impl.record.RecordMigrationInfo;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
  * Carries set of replicated map records for a partition from one node to another
@@ -98,7 +99,7 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractSerializableOp
         name = in.readUTF();
         version = in.readLong();
         int size = in.readInt();
-        recordSet = new HashSet<RecordMigrationInfo>(size);
+        recordSet = createHashSet(size);
         for (int j = 0; j < size; j++) {
             RecordMigrationInfo record = new RecordMigrationInfo();
             record.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
@@ -34,7 +34,6 @@ import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -42,6 +41,7 @@ import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.F_ID;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.REPLICATION_OPERATION;
 import static com.hazelcast.ringbuffer.impl.RingbufferService.SERVICE_NAME;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ReplicationOperation extends Operation implements IdentifiedDataSerializable, Versioned {
 
@@ -133,7 +133,7 @@ public class ReplicationOperation extends Operation implements IdentifiedDataSer
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
-        migrationData = new HashMap<ObjectNamespace, RingbufferContainer>(mapSize);
+        migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             final ObjectNamespace namespace = isGreaterOrEqualV39(in)
                     ? (ObjectNamespace) in.readObject()

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -45,6 +45,7 @@ import static com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorS
 import static com.hazelcast.scheduledexecutor.impl.TaskDefinition.Type.SINGLE_RUN;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ScheduledExecutorContainer {
 
@@ -272,7 +273,7 @@ public class ScheduledExecutorContainer {
     }
 
     Map<String, ScheduledTaskDescriptor> prepareForReplication(boolean migrationMode) {
-        Map<String, ScheduledTaskDescriptor> replicas = new HashMap<String, ScheduledTaskDescriptor>();
+        Map<String, ScheduledTaskDescriptor> replicas = createHashMap(tasks.size());
 
         for (ScheduledTaskDescriptor descriptor : tasks.values()) {
             try {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
@@ -23,9 +23,10 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.ConstructorFunction;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ScheduledExecutorPartition extends AbstractScheduledExecutorContainerHolder {
 
@@ -55,8 +56,7 @@ public class ScheduledExecutorPartition extends AbstractScheduledExecutorContain
     }
 
     public Operation prepareReplicationOperation(int replicaIndex, boolean migrationMode) {
-        Map<String, Map<String, ScheduledTaskDescriptor>> map =
-                new HashMap<String, Map<String, ScheduledTaskDescriptor>>();
+        Map<String, Map<String, ScheduledTaskDescriptor>> map = createHashMap(containers.size());
 
         if (logger.isFinestEnabled()) {
             logger.finest("[Partition: " + partitionId + "] "

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
@@ -19,7 +19,6 @@ package com.hazelcast.scheduledexecutor.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.nio.Address;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.IScheduledFuture;
@@ -41,7 +40,6 @@ import com.hazelcast.util.function.Supplier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,6 +53,8 @@ import static com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorS
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.MapUtil.createHashMapAdapter;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 @SuppressWarnings({"unchecked", "checkstyle:methodcount"})
@@ -243,7 +243,7 @@ public class ScheduledExecutorServiceProxy
         initializeManagedContext(command);
 
         String name = extractNameOrGenerateOne(command);
-        Map<Member, IScheduledFuture<V>> futures = new HashMap<Member, IScheduledFuture<V>>();
+        Map<Member, IScheduledFuture<V>> futures = createHashMap(members.size());
         for (Member member : members) {
             TaskDefinition<V> definition = new TaskDefinition<V>(
                     TaskDefinition.Type.SINGLE_RUN, name, command, delay, unit);
@@ -266,7 +266,7 @@ public class ScheduledExecutorServiceProxy
 
         String name = extractNameOrGenerateOne(command);
         ScheduledRunnableAdapter<?> adapter = createScheduledRunnableAdapter(command);
-        Map<Member, IScheduledFuture<?>> futures = new HashMapAdapter<Member, IScheduledFuture<?>>();
+        Map<Member, IScheduledFuture<?>> futures = createHashMapAdapter(members.size());
         for (Member member : members) {
             TaskDefinition definition = new TaskDefinition(
                     TaskDefinition.Type.AT_FIXED_RATE, name, adapter, initialDelay, period, unit);

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ReplicationOperation.java
@@ -25,8 +25,9 @@ import com.hazelcast.scheduledexecutor.impl.ScheduledExecutorPartition;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskDescriptor;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class ReplicationOperation
         extends AbstractSchedulerOperation {
@@ -73,12 +74,11 @@ public class ReplicationOperation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int size = in.readInt();
-        map = new HashMap<String, Map<String, ScheduledTaskDescriptor>>(size);
+        map = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String key = in.readUTF();
             int subSize = in.readInt();
-            Map<String, ScheduledTaskDescriptor> subMap =
-                    new HashMap<String, ScheduledTaskDescriptor>(subSize);
+            Map<String, ScheduledTaskDescriptor> subMap = createHashMap(subSize);
             map.put(key, subMap);
             for (int k = 0; k < subSize; k++) {
                 subMap.put(in.readUTF(), (ScheduledTaskDescriptor) in.readObject());

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
@@ -25,10 +25,10 @@ import com.hazelcast.scheduledexecutor.impl.ScheduledTaskStatisticsImpl;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService.MEMBER_BIN;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 public class SyncStateOperation
         extends AbstractBackupAwareSchedulerOperation {
@@ -107,7 +107,7 @@ public class SyncStateOperation
         super.readInternal(in);
         this.taskName = in.readUTF();
         int stateSize = in.readInt();
-        this.state = new HashMap(stateSize);
+        this.state = createHashMap(stateSize);
         for (int i = 0; i < stateSize; i++) {
             this.state.put(in.readObject(), in.readObject());
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 public class DefaultDiscoveryService
         implements DiscoveryService {
 
@@ -198,7 +200,7 @@ public class DefaultDiscoveryService
         }
 
         Map<String, Comparable> properties = config.getProperties();
-        Map<String, Comparable> mappedProperties = new HashMap<String, Comparable>();
+        Map<String, Comparable> mappedProperties = createHashMap(propertyDefinitions.size());
 
         for (PropertyDefinition propertyDefinition : propertyDefinitions) {
             String propertyKey = propertyDefinition.key();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableCollection.java
@@ -26,8 +26,9 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
+
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public final class PortableCollection implements Portable {
 
@@ -78,7 +79,7 @@ public final class PortableCollection implements Portable {
         if (list) {
             collection = new ArrayList<Data>(size);
         } else {
-            collection = new HashSet<Data>(size);
+            collection = createHashSet(size);
         }
         final ObjectDataInput in = reader.getRawDataInput();
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -25,7 +25,6 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOpe
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,7 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareFactoryAccessor.extractPartitionAware;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Executes an operation on a set of partitions.
@@ -56,9 +56,9 @@ final class InvokeOnPartitions {
         this.serviceName = serviceName;
         this.operationFactory = operationFactory;
         this.memberPartitions = memberPartitions;
-        this.futures = new HashMap<Address, Future>(memberPartitions.size());
+        this.futures = createHashMap(memberPartitions.size());
         int partitionCount = operationService.nodeEngine.getPartitionService().getPartitionCount();
-        this.partitionResults = new HashMap<Integer, Object>(partitionCount);
+        this.partitionResults = createHashMap(partitionCount);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -55,7 +55,6 @@ import com.hazelcast.util.executor.ManagedExecutorService;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,6 +69,7 @@ import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.properties.GroupProperty.FAIL_ON_INDETERMINATE_OPERATION_STATE;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.util.CollectionUtil.toIntegerList;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.Collections.newSetFromMap;
@@ -387,7 +387,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
                                                    Collection<Integer> partitions) throws Exception {
 
-        Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(3);
+        Map<Address, List<Integer>> memberPartitions = createHashMap(3);
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
         for (int partition : partitions) {
             Address owner = partitionService.getPartitionOwnerOrWait(partition);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -43,10 +43,12 @@ import com.hazelcast.util.ExceptionUtil;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -249,8 +251,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
             InternalCompletableFuture<SerializableList> future = operationService.invokeOnTarget(SERVICE_NAME, op, address);
             futureList.add(future);
         }
-        HashSet<SerializableXID> xids = new HashSet<SerializableXID>();
-        xids.addAll(xaService.getPreparedXids());
+        Set<SerializableXID> xids = new HashSet<SerializableXID>(xaService.getPreparedXids());
 
         for (Future<SerializableList> future : futureList) {
             try {

--- a/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
@@ -16,15 +16,21 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.mapreduce.impl.HashMapAdapter;
+import com.hazelcast.util.collection.Int2ObjectHashMap;
+
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Utility class for Maps
  */
 public final class MapUtil {
 
-    private static final double HASHMAP_DEFAULT_LOAD_FACTOR = 0.75;
+    private static final float HASHMAP_DEFAULT_LOAD_FACTOR = 0.75f;
 
     private MapUtil() { }
 
@@ -33,8 +39,44 @@ public final class MapUtil {
      * to minimize rehash operations
      */
     public static <K, V> Map<K, V> createHashMap(int expectedMapSize) {
-        int initialCapacity = (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
-        return new HashMap<K, V>(initialCapacity);
+        final int initialCapacity = (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+        return new HashMap<K, V>(initialCapacity, HASHMAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Utility method that creates an {@link HashMapAdapter} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <K, V> Map<K, V> createHashMapAdapter(int expectedMapSize) {
+        final int initialCapacity = (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+        return new HashMapAdapter<K, V>(initialCapacity, HASHMAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Utility method that creates an {@link java.util.LinkedHashMap} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <K, V> Map<K, V> createLinkedHashMap(int expectedMapSize) {
+        final int initialCapacity = (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+        return new LinkedHashMap<K, V>(initialCapacity, HASHMAP_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Utility method that creates an {@link java.util.LinkedHashMap} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <K, V> ConcurrentMap<K, V> createConcurrentHashMap(int expectedMapSize) {
+        //concurrent hash map will size itself to accomodate this many elements
+        return new ConcurrentHashMap<K, V>(expectedMapSize);
+    }
+
+    /**
+     * Utility method that creates an {@link Int2ObjectHashMap} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <V> Int2ObjectHashMap<V> createInt2ObjectHashMap(int expectedMapSize) {
+        final int initialCapacity = (int) (expectedMapSize / Int2ObjectHashMap.DEFAULT_LOAD_FACTOR) + 1;
+        return new Int2ObjectHashMap<V>(initialCapacity, Int2ObjectHashMap.DEFAULT_LOAD_FACTOR);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/util/SetUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SetUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Utility class for Sets
+ */
+public final class SetUtil {
+
+    private static final float HASHSET_DEFAULT_LOAD_FACTOR = 0.75f;
+
+    private SetUtil() { }
+
+    /**
+     * Utility method that creates an {@link java.util.HashSet} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <E> Set<E> createHashSet(int expectedMapSize) {
+        final int initialCapacity = (int) (expectedMapSize / HASHSET_DEFAULT_LOAD_FACTOR) + 1;
+        return new HashSet<E>(initialCapacity, HASHSET_DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * Utility method that creates an {@link java.util.LinkedHashSet} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <E> Set<E> createLinkedHashSet(int expectedMapSize) {
+        final int initialCapacity = (int) (expectedMapSize / HASHSET_DEFAULT_LOAD_FACTOR) + 1;
+        return new LinkedHashSet<E>(initialCapacity, HASHSET_DEFAULT_LOAD_FACTOR);
+    }
+}


### PR DESCRIPTION
The hash collections were initialised with a capacity that caused
rehashing even though the final size was known in advance. Fixed
sizing and introduced some minor refactoring.

Rebased version of : https://github.com/hazelcast/hazelcast/pull/9597
Fixes : https://github.com/hazelcast/hazelcast/issues/9445
Thanks to @bokken for submitting the PR