### PR TITLE
[BACKPORT] Fixed missing fields in copy constructor of NearCachePreloaderConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -31,6 +31,8 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 /**
  * Configuration for eviction.
  * You can set a limit for number of entries or total memory cost of entries.
+ *
+ * @since 3.8
  */
 @Beta
 public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Serializable {
@@ -64,6 +66,8 @@ public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Ser
          */
 
         this(nearCachePreloaderConfig.enabled, nearCachePreloaderConfig.directory);
+        this.storeInitialDelaySeconds = nearCachePreloaderConfig.storeInitialDelaySeconds;
+        this.storeIntervalSeconds = nearCachePreloaderConfig.storeIntervalSeconds;
     }
 
     public NearCachePreloaderConfig(String directory) {
@@ -177,6 +181,7 @@ public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Ser
     @PrivateApi
     private static class NearCachePreloaderConfigReadOnly extends NearCachePreloaderConfig {
 
+        @SuppressWarnings("unused")
         public NearCachePreloaderConfigReadOnly() {
         }
 


### PR DESCRIPTION
This is quite bad, since we also cache the read-only configuration,
which always has the default values in it.

(cherry picked from commit 31dd22b)

Partial backport of https://github.com/hazelcast/hazelcast/pull/10942