### PR TITLE
ClientLockTest.testLockTtl test timing fix and redesign of the test

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -69,25 +69,6 @@ public class ClientLockTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testTryLockShouldFailIfLockTTLisNotFinished() throws Exception {
-        factory.newHazelcastInstance();
-        HazelcastInstance hz = factory.newHazelcastClient();
-        final ILock lock = hz.getLock(randomName());
-        final int longLockTimeout = 60;
-
-        lock.lock(longLockTimeout, TimeUnit.SECONDS);
-        final CountDownLatch latch = new CountDownLatch(1);
-        new Thread() {
-            public void run() {
-                if (!lock.tryLock()) {
-                    latch.countDown();
-                }
-            }
-        }.start();
-        assertOpenEventually(latch);
-    }
-
-    @Test
     public void testTryLockShouldSucceedWhenLockTTLisFinished() throws Exception {
         factory.newHazelcastInstance();
         HazelcastInstance hz = factory.newHazelcastClient();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -69,20 +69,39 @@ public class ClientLockTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testLockTtl() throws Exception {
+    public void testTryLockShouldFailIfLockTTLisNotFinished() throws Exception {
         factory.newHazelcastInstance();
         HazelcastInstance hz = factory.newHazelcastClient();
         final ILock lock = hz.getLock(randomName());
+        final int longLockTimeout = 60;
 
-        lock.lock(3, TimeUnit.SECONDS);
-        final CountDownLatch latch = new CountDownLatch(2);
+        lock.lock(longLockTimeout, TimeUnit.SECONDS);
+        final CountDownLatch latch = new CountDownLatch(1);
         new Thread() {
             public void run() {
                 if (!lock.tryLock()) {
                     latch.countDown();
                 }
+            }
+        }.start();
+        assertOpenEventually(latch);
+    }
+
+    @Test
+    public void testTryLockShouldSucceedWhenLockTTLisFinished() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+        final int lockTimeout = 3;
+
+        lock.lock(lockTimeout, TimeUnit.SECONDS);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        new Thread() {
+            public void run() {
                 try {
-                    if (lock.tryLock(5, TimeUnit.SECONDS)) {
+                    // Allow half the ASSERT_TRUE_EVENTUALLY_TIMEOUT for any possible gc and other pauses
+                    if (lock.tryLock(lockTimeout + ASSERT_TRUE_EVENTUALLY_TIMEOUT / 2, TimeUnit.SECONDS)) {
                         latch.countDown();
                     }
                 } catch (InterruptedException e) {
@@ -90,8 +109,8 @@ public class ClientLockTest extends HazelcastTestSupport {
                 }
             }
         }.start();
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-        lock.forceUnlock();
+
+        assertOpenEventually(latch);
     }
 
     @Test


### PR DESCRIPTION
ClientLockTest.testLockTtl tests two different concerns in the same test. This PR separates the two concerns into two different tests. It also makes the timings more robust against and gc and such pauses.

fixes #10896 