### PR TITLE
disable PhoneHome via enviroment variable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -43,6 +43,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static java.lang.System.getenv;
 
 /**
  * Pings phone home server with cluster info daily.
@@ -61,6 +62,7 @@ public final class PhoneHome {
     private static final int J_INTERVAL = 600;
 
     private static final String BASE_PHONE_HOME_URL = "http://phonehome.hazelcast.com/ping";
+    private static final String FALSE = "false";
 
     public PhoneHome() {
     }
@@ -73,6 +75,9 @@ public final class PhoneHome {
             return;
         }
         if (!hazelcastNode.getProperties().getBoolean(GroupProperty.PHONE_HOME_ENABLED)) {
+            return;
+        }
+        if (FALSE.equals(getenv("HZ_PHONE_HOME_ENABLED"))) {
             return;
         }
         try {


### PR DESCRIPTION
from now on, phoneHome can be disabled via **HZ_PHONE_HOME_ENABLED** env variable. just add `export HZ_PHONE_HOME_ENABLED=false` to your `bash` file or enviroment.