### PR TITLE
Cleanup of ReplicatedMap tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAbstractTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("WeakerAccess")
 public abstract class ReplicatedMapAbstractTest extends HazelcastTestSupport {
 
     protected static Field REPLICATED_MAP_SERVICE;
@@ -101,10 +102,10 @@ public abstract class ReplicatedMapAbstractTest extends HazelcastTestSupport {
         return service.getReplicatedRecordStore(map.getName(), false, key);
     }
 
-    public List<ReplicatedMap> createMapOnEachInstance(HazelcastInstance[] instances, String replicatedMapName) {
-        ArrayList<ReplicatedMap> maps = new ArrayList<ReplicatedMap>();
+    public List<ReplicatedMap<String, Object>> createMapOnEachInstance(HazelcastInstance[] instances, String replicatedMapName) {
+        ArrayList<ReplicatedMap<String, Object>> maps = new ArrayList<ReplicatedMap<String, Object>>();
         for (HazelcastInstance instance : instances) {
-            ReplicatedMap<Object, Object> replicatedMap = instance.getReplicatedMap(replicatedMapName);
+            ReplicatedMap<String, Object> replicatedMap = instance.getReplicatedMap(replicatedMapName);
             maps.add(replicatedMap);
         }
         return maps;
@@ -142,5 +143,4 @@ public abstract class ReplicatedMapAbstractTest extends HazelcastTestSupport {
         }
         return testValues;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -52,16 +52,20 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testMapConvergesToSameValueWhenMissingReplicationUpdate() throws Exception {
-        Config config = new Config();
-        SerializationConfig serializationConfig = new SerializationConfig();
-        SerializerConfig serializerConfig = new SerializerConfig();
-        serializerConfig.setTypeClassName(PutOperation.class.getName());
-        serializerConfig.setImplementation(new PutOperationWithNoReplicationSerializer());
-        serializationConfig.addSerializerConfig(serializerConfig);
-        config.setSerializationConfig(serializationConfig);
-        System.setProperty("hazelcast.serialization.custom.override", "true");
+    public void testMapConvergesToSameValueWhenMissingReplicationUpdate() {
         String mapName = randomMapName();
+        System.setProperty("hazelcast.serialization.custom.override", "true");
+
+        SerializerConfig serializerConfig = new SerializerConfig()
+                .setTypeClassName(PutOperation.class.getName())
+                .setImplementation(new PutOperationWithNoReplicationSerializer());
+
+        SerializationConfig serializationConfig = new SerializationConfig()
+                .addSerializerConfig(serializerConfig);
+
+        Config config = new Config()
+                .setSerializationConfig(serializationConfig);
+
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance instance1 = factory.newHazelcastInstance(config);
         HazelcastInstance instance2 = factory.newHazelcastInstance(config);
@@ -84,6 +88,7 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
     }
 
     public class PutOperationWithNoReplicationSerializer implements StreamSerializer<PutOperation> {
+
         @Override
         public void write(ObjectDataOutput out, PutOperation object) throws IOException {
             object.writeData(out);
@@ -103,7 +108,6 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
 
         @Override
         public void destroy() {
-
         }
     }
 
@@ -112,11 +116,9 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
         public PutOperationWithNoReplication() {
         }
 
-
         @Override
         protected Collection<Address> getMemberAddresses() {
             return Collections.emptyList();
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
@@ -74,8 +74,7 @@ public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapAbstrac
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (Map.Entry<String, String> entry : map1.entrySet()) {
                     assertRecord(getReplicatedRecord(map1, entry.getKey()), startTime);
                 }
@@ -84,8 +83,7 @@ public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapAbstrac
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (Map.Entry<String, String> entry : map2.entrySet()) {
                     assertRecord(getReplicatedRecord(map2, entry.getKey()), startTime);
                 }
@@ -226,7 +224,6 @@ public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapAbstrac
         testHitsAreIncrementedOnPutsWithSingleNode(buildConfig(InMemoryFormat.BINARY));
     }
 
-
     private void testHitsAreIncrementedOnPutsWithSingleNode(final Config config) throws Exception {
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         final HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -251,16 +248,16 @@ public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapAbstrac
     }
 
     @Test
-    public void test_hitsAreIncrementedOnPuts_with2Nodes_object() throws Exception {
+    public void test_hitsAreIncrementedOnPuts_with2Nodes_object() {
         testHitsAreIncrementedOnPutsFor1Of2Nodes(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void test_hitsAreIncrementedOnPuts_with2Nodes_Binary() throws Exception {
+    public void test_hitsAreIncrementedOnPuts_with2Nodes_Binary() {
         testHitsAreIncrementedOnPutsFor1Of2Nodes(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testHitsAreIncrementedOnPutsFor1Of2Nodes(final Config config) throws Exception {
+    private void testHitsAreIncrementedOnPutsFor1Of2Nodes(final Config config) {
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
         final HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
         final HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
@@ -283,8 +280,7 @@ public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapAbstrac
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (String key : keys) {
                     final ReplicatedRecord<String, String> record1 = getReplicatedRecord(map1, key);
                     assertNotNull(record1);

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertEquals;
 public class ReplicatedMapListenerTest extends HazelcastTestSupport {
 
     @Test
-    public void testRegisterListenerViaConfiguration() throws Exception {
+    public void testRegisterListenerViaConfiguration() {
         String mapName = randomMapName();
         Config config = new Config();
         ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig(mapName);
@@ -69,7 +69,7 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testEntryAdded() throws Exception {
+    public void testEntryAdded() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener);
@@ -83,7 +83,7 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testEntryUpdated() throws Exception {
+    public void testEntryUpdated() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener);
@@ -98,7 +98,7 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testEntryEvicted() throws Exception {
+    public void testEntryEvicted() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener);
@@ -113,7 +113,7 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testEntryRemoved() throws Exception {
+    public void testEntryRemoved() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener);
@@ -128,7 +128,7 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testMapClear() throws Exception {
+    public void testMapClear() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener);
@@ -142,9 +142,8 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
         });
     }
 
-
     @Test
-    public void testListenToKeyForEntryAdded() throws Exception {
+    public void testListenToKeyForEntryAdded() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener, 1);
@@ -161,7 +160,8 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testListenWithPredicate() throws Exception {
+    @SuppressWarnings("unchecked")
+    public void testListenWithPredicate() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener, FalsePredicate.INSTANCE);
@@ -175,7 +175,8 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testListenToKeyWithPredicate() throws Exception {
+    @SuppressWarnings("unchecked")
+    public void testListenToKeyWithPredicate() {
         ReplicatedMap<Object, Object> replicatedMap = createClusterAndGetRandomReplicatedMap();
         final EventCountingListener listener = new EventCountingListener();
         replicatedMap.addEntryListener(listener, new InstanceOfPredicate(Integer.class), 2);
@@ -193,22 +194,21 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
 
     private ReplicatedMap<Object, Object> createClusterAndGetRandomReplicatedMap() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        HazelcastInstance h1 = factory.newHazelcastInstance();
-        HazelcastInstance h2 = factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
         String mapName = randomMapName();
-        return h1.getReplicatedMap(mapName);
+        return hz.getReplicatedMap(mapName);
     }
-
 
     public class EventCountingListener implements EntryListener<Object, Object> {
 
-        public final ConcurrentLinkedQueue<Object> keys = new ConcurrentLinkedQueue<Object>();
-        public final AtomicLong addCount = new AtomicLong();
-        public final AtomicLong removeCount = new AtomicLong();
-        public final AtomicLong updateCount = new AtomicLong();
-        public final AtomicLong evictCount = new AtomicLong();
-        public final AtomicLong mapClearCount = new AtomicLong();
-        public final AtomicLong mapEvictCount = new AtomicLong();
+        private final ConcurrentLinkedQueue<Object> keys = new ConcurrentLinkedQueue<Object>();
+        private final AtomicLong addCount = new AtomicLong();
+        private final AtomicLong removeCount = new AtomicLong();
+        private final AtomicLong updateCount = new AtomicLong();
+        private final AtomicLong evictCount = new AtomicLong();
+        private final AtomicLong mapClearCount = new AtomicLong();
+        private final AtomicLong mapEvictCount = new AtomicLong();
 
         public EventCountingListener() {
         }
@@ -259,5 +259,4 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
                     '}';
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLiteMemberTest.java
@@ -39,72 +39,68 @@ import static org.junit.Assert.assertTrue;
 public class ReplicatedMapLiteMemberTest extends HazelcastTestSupport {
 
     @Test
-    public void testLiteMembersWithReplicatedMap() throws Exception {
-        final Config config = buildConfig(false);
-        final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+    public void testLiteMembersWithReplicatedMap() {
+        Config config = buildConfig(false);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
 
         final HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
         final HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
         final HazelcastInstance lite = nodeFactory.newHazelcastInstance(buildConfig(true));
 
-        final ReplicatedMap<String, String> map1 = instance1.getReplicatedMap("default");
+        ReplicatedMap<String, String> map1 = instance1.getReplicatedMap("default");
 
         map1.put("key", "value");
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 assertTrue(instance2.getReplicatedMap("default").containsKey("key"));
             }
         });
 
         assertTrueAllTheTime(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
-                final ReplicatedMapService service = getReplicatedMapService(lite);
+            public void run() throws Exception {
+                ReplicatedMapService service = getReplicatedMapService(lite);
                 assertEquals(0, service.getAllReplicatedRecordStores("default").size());
             }
         }, 5);
     }
 
-
     @Test(expected = ReplicatedMapCantBeCreatedOnLiteMemberException.class)
     public void testCreateReplicatedMapOnLiteMember() {
-        final HazelcastInstance lite = createSingleLiteMember();
+        HazelcastInstance lite = createSingleLiteMember();
         lite.getReplicatedMap("default");
     }
 
     @Test(expected = ReplicatedMapCantBeCreatedOnLiteMemberException.class)
     public void testCreateReplicatedStoreOnLiteMember() {
-        final HazelcastInstance lite = createSingleLiteMember();
-        final ReplicatedMapService service = getReplicatedMapService(lite);
+        HazelcastInstance lite = createSingleLiteMember();
+        ReplicatedMapService service = getReplicatedMapService(lite);
         service.getReplicatedRecordStore("default", true, 1);
     }
 
     @Test(expected = ReplicatedMapCantBeCreatedOnLiteMemberException.class)
     public void testGetReplicatedStoreOnLiteMember() {
-        final HazelcastInstance lite = createSingleLiteMember();
-        final ReplicatedMapService service = getReplicatedMapService(lite);
+        HazelcastInstance lite = createSingleLiteMember();
+        ReplicatedMapService service = getReplicatedMapService(lite);
         service.getReplicatedRecordStore("default", false, 1);
     }
 
 
     private HazelcastInstance createSingleLiteMember() {
-        final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         return nodeFactory.newHazelcastInstance(buildConfig(true));
     }
 
     private ReplicatedMapService getReplicatedMapService(HazelcastInstance lite) {
-        final NodeEngineImpl nodeEngine = getNodeEngineImpl(lite);
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(lite);
         return nodeEngine.getService(ReplicatedMapService.SERVICE_NAME);
     }
 
-    private Config buildConfig(final boolean liteMember) {
-        final Config config = new Config();
+    private Config buildConfig(boolean liteMember) {
+        Config config = new Config();
         config.setLiteMember(liteMember);
         return config;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 public class ReplicatedMapLoadingTest extends ReplicatedMapAbstractTest {
 
     @Test
-    public void testAsyncFillUp() throws Exception {
+    public void testAsyncFillUp() {
         Config config = new Config();
         String mapName = randomMapName();
         ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig(mapName);
@@ -48,7 +48,7 @@ public class ReplicatedMapLoadingTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testSyncFillUp() throws Exception {
+    public void testSyncFillUp() {
         Config config = new Config();
         String mapName = randomMapName();
         ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig(mapName);

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
@@ -37,6 +37,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -50,12 +53,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category(NightlyTest.class)
 public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
 
-
-    @Parameterized.Parameters(name = "{0}")
+    @Parameters(name = "{0}")
     public static Collection<Object> parameters() {
         return Arrays.asList(new Object[]{
                 new LatestUpdateMergePolicyTestCase(),
@@ -66,7 +68,7 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
         });
     }
 
-    @Parameterized.Parameter
+    @Parameter
     public ReplicatedMapMergePolicyTestCase testCase;
 
     private TestHazelcastInstanceFactory factory;
@@ -106,8 +108,7 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 ReplicatedMap<Object, Object> mapTest = h1.getReplicatedMap(mapName);
                 for (Map.Entry<Object, Object> entry : expectedValues.entrySet()) {
                     assertEquals(entry.getValue(), mapTest.get(entry.getKey()));
@@ -154,15 +155,16 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
     }
 
     private static class LatestUpdateMergePolicyTestCase implements ReplicatedMapMergePolicyTestCase {
+
         @Override
         public Map<Object, Object> populateMaps(ReplicatedMap<Object, Object> map1, ReplicatedMap<Object, Object> map2,
                                                 HazelcastInstance instance) {
             map1.put("key1", "value");
-            //prevent updating at the same time
+            // prevent updating at the same time
             sleepAtLeastSeconds(1);
             map2.put("key1", "LatestUpdatedValue");
             map2.put("key2", "value2");
-            //prevent updating at the same time
+            // prevent updating at the same time
             sleepAtLeastSeconds(1);
             map1.put("key2", "LatestUpdatedValue2");
 
@@ -184,18 +186,19 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
     }
 
     private static class HighestHitsMergePolicyTestCase implements ReplicatedMapMergePolicyTestCase {
+
         @Override
         public Map<Object, Object> populateMaps(ReplicatedMap<Object, Object> map1, ReplicatedMap<Object, Object> map2,
                                                 HazelcastInstance instance) {
             map1.put("key1", "higherHitsValue");
             map1.put("key2", "value2");
-            //increase hits number
+            // increase hits number
             map1.get("key1");
             map1.get("key1");
 
             map2.put("key1", "value1");
             map2.put("key2", "higherHitsValue2");
-            //increase hits number
+            // increase hits number
             map2.get("key2");
             map2.get("key2");
 
@@ -217,6 +220,7 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
     }
 
     private static class PutIfAbsentMapMergePolicyTestCase implements ReplicatedMapMergePolicyTestCase {
+
         @Override
         public Map<Object, Object> populateMaps(ReplicatedMap<Object, Object> map1, ReplicatedMap<Object, Object> map2,
                                                 HazelcastInstance instance) {
@@ -247,7 +251,6 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
         @Override
         public Map<Object, Object> populateMaps(ReplicatedMap<Object, Object> map1, ReplicatedMap<Object, Object> map2,
                                                 HazelcastInstance instance) {
-
             assertNotNull(instance);
             String key = generateKeyOwnedBy(instance);
             map1.put(key, "value");
@@ -274,10 +277,9 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
         @Override
         public Map<Object, Object> populateMaps(ReplicatedMap<Object, Object> map1, ReplicatedMap<Object, Object> map2,
                                                 HazelcastInstance instance) {
-
             assertNotNull(instance);
             String key = generateKeyOwnedBy(instance);
-            Integer value = Integer.valueOf(1);
+            Integer value = 1;
             map1.put(key, "value");
 
             map2.put(key, value);

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
@@ -44,7 +44,7 @@ public class ReplicatedMapPutSerializationTest extends HazelcastTestSupport {
     static AtomicInteger deSerializationCount = new AtomicInteger(0);
 
     @Test
-    public void testPutShouldNotDeserializeData() throws Exception {
+    public void testPutShouldNotDeserializeData() {
         String mapName = randomName();
         Config config = new Config();
         config.getReplicatedMapConfig(mapName).setInMemoryFormat(InMemoryFormat.BINARY);
@@ -57,12 +57,12 @@ public class ReplicatedMapPutSerializationTest extends HazelcastTestSupport {
         map.put(key, value);
         map.put(key, value);
 
-        // only deserialized once in the proxy.
+        // only deserialized once in the proxy
         assertEquals(1, deSerializationCount.get());
     }
 
-
     static class SerializationCountingData implements DataSerializable {
+
         public SerializationCountingData() {
         }
 
@@ -75,5 +75,4 @@ public class ReplicatedMapPutSerializationTest extends HazelcastTestSupport {
             deSerializationCount.incrementAndGet();
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
@@ -32,19 +32,17 @@ import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(value = {QuickTest.class, ParallelTest.class})
 public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
 
     @Test
-    public void testReadYourWritesBySize() throws Exception {
+    public void testReadYourWritesBySize() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory();
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance();
         final ReplicatedMap<Integer, Integer> map1 = instance1.getReplicatedMap("default");
         final ReplicatedMap<Integer, Integer> map2 = instance2.getReplicatedMap("default");
-
 
         HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
         final int count = 100;
@@ -63,7 +61,7 @@ public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testReadYourWritesByGet() throws Exception {
+    public void testReadYourWritesByGet() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory();
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance();
@@ -76,7 +74,7 @@ public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testReadYourWritesByContainsKey() throws Exception {
+    public void testReadYourWritesByContainsKey() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory();
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance();
@@ -89,7 +87,7 @@ public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testReadYourWritesByContainsValue() throws Exception {
+    public void testReadYourWritesByContainsValue() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory();
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance();
@@ -122,6 +120,4 @@ public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
         map.put(key, value);
         return key;
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
@@ -60,7 +60,7 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
     private Field field;
 
     @After
-    public void tearDown() throws IllegalAccessException {
+    public void tearDown() throws Exception {
         // if updateFactory() has been executed, field & replicatedMapDataSerializableFactory are populated
         if (replicatedMapDataSerializableFactory != null && field != null) {
             // restore original value of ReplicatedMapDataSerializerHook.FACTORY
@@ -69,8 +69,7 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
     }
 
     @Test
-    public void testNonConvergingReplicatedMaps()
-            throws Exception {
+    public void testNonConvergingReplicatedMaps() throws Exception {
         final int nodeCount = 4;
         final int keyCount = 10000;
         final int threadCount = 2;
@@ -119,8 +118,7 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 long version = stores[0].getVersion();
 
                 for (ReplicatedRecordStore store : stores) {
@@ -151,7 +149,7 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
         return nodeEngine.toObject(result.getResponse());
     }
 
-    private void updateFactory() throws NoSuchFieldException, IllegalAccessException {
+    private void updateFactory() throws Exception {
         field = ReplicatedMapDataSerializerHook.class.getDeclaredField("FACTORY");
 
         // remove final modifier from field
@@ -163,14 +161,13 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
         final DataSerializableFactory factory = (DataSerializableFactory) field.get(null);
         replicatedMapDataSerializableFactory = factory;
         field.set(null, new TestReplicatedMapDataSerializerFactory(factory));
-
     }
 
     private static class TestReplicatedMapDataSerializerFactory implements DataSerializableFactory {
 
         private final DataSerializableFactory factory;
 
-        public TestReplicatedMapDataSerializerFactory(DataSerializableFactory factory) {
+        TestReplicatedMapDataSerializerFactory(DataSerializableFactory factory) {
             this.factory = factory;
         }
 
@@ -179,25 +176,20 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
             if (typeId == ReplicatedMapDataSerializerHook.REPLICATE_UPDATE) {
                 return new RetriedReplicateUpdateOperation();
             }
-
             return factory.create(typeId);
         }
-
     }
 
     private static class RetriedReplicateUpdateOperation extends ReplicateUpdateOperation {
 
-        private static final Random random = new Random();
+        private final Random random = new Random();
 
         @Override
         public void run() throws Exception {
             if (random.nextInt(10) < 2) {
                 throw new RetryableHazelcastException();
             }
-
             super.run();
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 public class ReplicatedMapStatsTest extends HazelcastTestSupport {
 
     @Test
-    public void testGetOperationCount() throws Exception {
+    public void testGetOperationCount() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         replicatedMap.put(1, 1);
         int count = 100;
@@ -52,7 +52,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutOperationCount() throws Exception {
+    public void testPutOperationCount() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         int count = 100;
         for (int i = 0; i < count; i++) {
@@ -63,7 +63,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testRemoveOperationCount() throws Exception {
+    public void testRemoveOperationCount() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         int count = 100;
         for (int i = 0; i < count; i++) {
@@ -76,7 +76,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
 
 
     @Test
-    public void testHitsGenerated() throws Exception {
+    public void testHitsGenerated() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         for (int i = 0; i < 100; i++) {
             replicatedMap.put(i, i);
@@ -87,7 +87,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutAndHitsGenerated() throws Exception {
+    public void testPutAndHitsGenerated() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         for (int i = 0; i < 100; i++) {
             replicatedMap.put(i, i);
@@ -98,7 +98,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testGetAndHitsGenerated() throws Exception {
+    public void testGetAndHitsGenerated() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         for (int i = 0; i < 100; i++) {
             replicatedMap.put(i, i);
@@ -109,7 +109,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testHitsGenerated_updatedConcurrently() throws Exception {
+    public void testHitsGenerated_updatedConcurrently() {
         final ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         final int actionCount = 100;
         for (int i = 0; i < actionCount; i++) {
@@ -132,15 +132,14 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         assertEquals(actionCount, initialHits);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 assertEquals(actionCount * 2, stats.getHits());
             }
         });
     }
 
     @Test
-    public void testLastAccessTime() throws InterruptedException {
+    public void testLastAccessTime() {
         final long startTime = Clock.currentTimeMillis();
         ReplicatedMap<String, String> replicatedMap = getReplicatedMap();
         String key = "key";
@@ -152,7 +151,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testLastAccessTime_updatedConcurrently() throws InterruptedException {
+    public void testLastAccessTime_updatedConcurrently() {
         final long startTime = Clock.currentTimeMillis();
         final ReplicatedMap<String, String> map = getReplicatedMap();
         final String key = "key";
@@ -173,15 +172,14 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         assertTrue(lastAccessTime >= startTime);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 assertTrue(stats.getLastAccessTime() >= lastAccessTime);
             }
         });
     }
 
     @Test
-    public void testLastUpdateTime() throws InterruptedException {
+    public void testLastUpdateTime() {
         final long startTime = Clock.currentTimeMillis();
 
         ReplicatedMap<String, String> replicatedMap = getReplicatedMap();
@@ -198,7 +196,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testLastUpdateTime_updatedConcurrently() throws InterruptedException {
+    public void testLastUpdateTime_updatedConcurrently() {
         final long startTime = Clock.currentTimeMillis();
         final ReplicatedMap<String, String> map = getReplicatedMap();
 
@@ -220,8 +218,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         assertTrue(lastUpdateTime >= startTime);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 assertTrue(stats.getLastUpdateTime() >= lastUpdateTime);
             }
         });

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
@@ -45,7 +45,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -59,7 +58,7 @@ import static org.junit.Assert.fail;
 public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
     @Test
-    public void testEmptyMapIsEmpty() throws Exception {
+    public void testEmptyMapIsEmpty() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = instance.getReplicatedMap(randomName());
@@ -67,7 +66,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testNonEmptyMapIsNotEmpty() throws Exception {
+    public void testNonEmptyMapIsNotEmpty() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = instance.getReplicatedMap(randomName());
@@ -76,7 +75,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNegativeTtlThrowsException() throws Exception {
+    public void testNegativeTtlThrowsException() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = instance.getReplicatedMap(randomName());
@@ -84,44 +83,44 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testAddObject() throws Exception {
+    public void testAddObject() {
         testAdd(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testAddObjectSyncFillup() throws Exception {
+    public void testAddObjectSyncFillUp() {
         Config config = buildConfig(InMemoryFormat.OBJECT);
         config.getReplicatedMapConfig("default").setAsyncFillup(false);
         testFillUp(config);
     }
 
     @Test
-    public void testAddObjectAsyncFillup() throws Exception {
+    public void testAddObjectAsyncFillUp() {
         Config config = buildConfig(InMemoryFormat.OBJECT);
         config.getReplicatedMapConfig("default").setAsyncFillup(true);
         testFillUp(config);
     }
 
     @Test
-    public void testAddBinary() throws Exception {
+    public void testAddBinary() {
         testAdd(buildConfig(InMemoryFormat.BINARY));
     }
 
     @Test
-    public void testAddBinarySyncFillup() throws Exception {
+    public void testAddBinarySyncFillUp() {
         Config config = buildConfig(InMemoryFormat.BINARY);
         config.getReplicatedMapConfig("default").setAsyncFillup(false);
         testFillUp(config);
     }
 
     @Test
-    public void testAddBinaryAsyncFillup() throws Exception {
+    public void testAddBinaryAsyncFillUp() {
         Config config = buildConfig(InMemoryFormat.BINARY);
         config.getReplicatedMapConfig("default").setAsyncFillup(true);
         testFillUp(config);
     }
 
-    private void testAdd(Config config) throws Exception {
+    private void testAdd(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -139,8 +138,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar", map1.get(key));
                     assertEquals("bar", map2.get(key));
@@ -166,8 +164,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar", map2.get(key));
                 }
@@ -176,16 +173,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testPutAllObject() throws Exception {
+    public void testPutAllObject() {
         testPutAll(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testPutAllBinary() throws Exception {
+    public void testPutAllBinary() {
         testPutAll(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testPutAll(Config config) throws TimeoutException {
+    private void testPutAll(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
@@ -204,8 +201,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar", map1.get(key));
                     assertEquals("bar", map2.get(key));
@@ -215,16 +211,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testClearObject() throws Exception {
+    public void testClearObject() {
         testClear(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testClearBinary() throws Exception {
+    public void testClearBinary() {
         testClear(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testClear(Config config) throws Exception {
+    private void testClear(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -242,8 +238,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar", map1.get(key));
                     assertEquals("bar", map2.get(key));
@@ -255,8 +250,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 assertEquals(0, map1.size());
                 assertEquals(0, map2.size());
             }
@@ -264,16 +258,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testAddTtlObject() throws Exception {
+    public void testAddTtlObject() {
         testAddTtl(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testAddTtlBinary() throws Exception {
+    public void testAddTtlBinary() {
         testAddTtl(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testAddTtl(Config config) throws Exception {
+    private void testAddTtl(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -291,8 +285,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (String key : keys) {
                     assertEquals("bar", map1.get(key));
                     ReplicatedRecord<String, String> record = getReplicatedRecord(map1, key);
@@ -304,8 +297,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (String key : keys) {
                     assertEquals("bar", map2.get(key));
                     ReplicatedRecord<String, String> record = getReplicatedRecord(map2, key);
@@ -317,16 +309,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testUpdateObject() throws Exception {
+    public void testUpdateObject() {
         testUpdate(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testUpdateBinary() throws Exception {
+    public void testUpdateBinary() {
         testUpdate(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testUpdate(Config config) throws Exception {
+    private void testUpdate(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -344,8 +336,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar", map1.get(key));
                     assertEquals("bar", map2.get(key));
@@ -359,8 +350,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar2", map1.get(key));
                     assertEquals("bar2", map2.get(key));
@@ -370,16 +360,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testUpdateTtlObject() throws Exception {
+    public void testUpdateTtlObject() {
         testUpdateTtl(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testUpdateTtlBinary() throws Exception {
+    public void testUpdateTtlBinary() {
         testUpdateTtl(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testUpdateTtl(Config config) throws Exception {
+    private void testUpdateTtl(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -397,8 +387,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("bar", map1.get(key));
                     assertEquals("bar", map2.get(key));
@@ -412,8 +401,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (String key : keys) {
                     assertEquals("bar2", map1.get(key));
                     ReplicatedRecord<String, String> record = getReplicatedRecord(map1, key);
@@ -425,8 +413,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 for (String key : keys) {
                     assertEquals("bar2", map2.get(key));
                     ReplicatedRecord<String, String> record = getReplicatedRecord(map2, key);
@@ -438,16 +425,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testRemoveObject() throws Exception {
+    public void testRemoveObject() {
         testRemove(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testRemoveBinary() throws Exception {
+    public void testRemoveBinary() {
         testRemove(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testRemove(Config config) throws Exception {
+    private void testRemove(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -465,7 +452,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertEquals("map1 should return value for key " + key, "bar", map1.get(key));
                     assertEquals("map2 should return value for key " + key, "bar", map2.get(key));
@@ -479,7 +466,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertFalse("map1 should not contain key " + key, map1.containsKey(key));
                     assertFalse("map2 should not contain key " + key, map2.containsKey(key));
@@ -489,7 +476,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testContainsKey_returnsFalse_onRemovedKeys() throws Exception {
+    public void testContainsKey_returnsFalse_onRemovedKeys() {
         HazelcastInstance node = createHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
@@ -499,7 +486,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testContainsKey_returnsFalse_onNonexistentKeys() throws Exception {
+    public void testContainsKey_returnsFalse_onNonexistentKeys() {
         HazelcastInstance node = createHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
 
@@ -507,7 +494,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testContainsKey_returnsTrue_onExistingKeys() throws Exception {
+    public void testContainsKey_returnsTrue_onExistingKeys() {
         HazelcastInstance node = createHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
@@ -516,7 +503,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testKeySet_notIncludes_removedKeys() throws Exception {
+    public void testKeySet_notIncludes_removedKeys() {
         HazelcastInstance node = createHazelcastInstance();
         final ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
@@ -526,8 +513,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 Set<Integer> keys = new HashSet<Integer>(map.keySet());
                 assertFalse(keys.contains(1));
             }
@@ -535,7 +521,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testEntrySet_notIncludes_removedKeys() throws Exception {
+    public void testEntrySet_notIncludes_removedKeys() {
         HazelcastInstance node = createHazelcastInstance();
         final ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
@@ -545,8 +531,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 Set<Entry<Integer, Integer>> entries = map.entrySet();
                 for (Entry<Integer, Integer> entry : entries) {
                     if (entry.getKey().equals(1)) {
@@ -558,17 +543,17 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testSizeObject() throws Exception {
+    public void testSizeObject() {
         testSize(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testSizeBinary() throws Exception {
+    public void testSizeBinary() {
         testSize(buildConfig(InMemoryFormat.BINARY));
     }
 
 
-    private void testSize(Config config) throws Exception {
+    private void testSize(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -590,8 +575,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 assertEquals(keys.size(), map1.size());
                 assertEquals(keys.size(), map2.size());
             }
@@ -599,16 +583,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testContainsKeyObject() throws Exception {
+    public void testContainsKeyObject() {
         testContainsKey(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testContainsKeyBinary() throws Exception {
+    public void testContainsKeyBinary() {
         testContainsKey(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testContainsKey(Config config) throws Exception {
+    private void testContainsKey(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -626,8 +610,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertTrue(map1.containsKey(key));
                     assertTrue(map2.containsKey(key));
@@ -637,23 +620,23 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testContainsValue_returnsFalse_onNonexistentValue() throws Exception {
+    public void testContainsValue_returnsFalse_onNonexistentValue() {
         HazelcastInstance node = createHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         assertFalse(map.containsValue(1));
     }
 
     @Test
-    public void testContainsValueObject() throws Exception {
+    public void testContainsValueObject() {
         testContainsValue(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testContainsValueBinary() throws Exception {
+    public void testContainsValueBinary() {
         testContainsValue(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testContainsValue(Config config) throws Exception {
+    private void testContainsValue(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -673,8 +656,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 for (String key : keys) {
                     assertTrue(map1.containsValue(key));
                     assertTrue(map2.containsValue(key));
@@ -684,7 +666,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testValuesWithComparator() throws Exception {
+    public void testValuesWithComparator() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = instance.getReplicatedMap(randomName());
@@ -699,16 +681,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testValuesObject() throws Exception {
+    public void testValuesObject() {
         testValues(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testValuesBinary() throws Exception {
+    public void testValuesBinary() {
         testValues(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testValues(Config config) throws Exception {
+    private void testValues(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -728,8 +710,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 assertEquals(keys, new HashSet<String>(map1.values()));
                 assertEquals(keys, new HashSet<String>(map2.values()));
             }
@@ -737,16 +718,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testKeySetObject() throws Exception {
+    public void testKeySetObject() {
         testKeySet(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testKeySetBinary() throws Exception {
+    public void testKeySetBinary() {
         testKeySet(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testKeySet(Config config) throws Exception {
+    private void testKeySet(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -766,8 +747,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 assertEquals(keys, new HashSet<String>(map1.keySet()));
                 assertEquals(keys, new HashSet<String>(map2.keySet()));
             }
@@ -775,16 +755,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testEntrySetObject() throws Exception {
+    public void testEntrySetObject() {
         testEntrySet(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testEntrySetBinary() throws Exception {
+    public void testEntrySetBinary() {
         testEntrySet(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testEntrySet(Config config) throws Exception {
+    private void testEntrySet(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -804,8 +784,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 List<Entry<String, String>> entrySet1 = new ArrayList<Entry<String, String>>(map1.entrySet());
                 List<Entry<String, String>> entrySet2 = new ArrayList<Entry<String, String>>(map2.entrySet());
                 assertEquals(keys.size(), entrySet1.size());
@@ -823,16 +802,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testAddListenerObject() throws Exception {
+    public void testAddListenerObject() {
         testAddEntryListener(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testAddListenerBinary() throws Exception {
+    public void testAddListenerBinary() {
         testAddEntryListener(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testAddEntryListener(Config config) throws TimeoutException {
+    private void testAddEntryListener(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -855,16 +834,16 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testEvictionObject() throws Exception {
+    public void testEvictionObject() {
         testEviction(buildConfig(InMemoryFormat.OBJECT));
     }
 
     @Test
-    public void testEvictionBinary() throws Exception {
+    public void testEvictionBinary() {
         testEviction(buildConfig(InMemoryFormat.BINARY));
     }
 
-    private void testEviction(Config config) throws TimeoutException {
+    private void testEviction(Config config) {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
@@ -911,7 +890,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void putNullKey() throws Exception {
+    public void putNullKey() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Object, Object> map1 = instance1.getReplicatedMap("default");
@@ -919,7 +898,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void removeNullKey() throws Exception {
+    public void removeNullKey() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Object, Object> map1 = instance1.getReplicatedMap("default");
@@ -927,7 +906,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void removeEmptyListener() throws Exception {
+    public void removeEmptyListener() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Object, Object> map1 = instance1.getReplicatedMap("default");
@@ -935,7 +914,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void removeNullListener() throws Exception {
+    public void removeNullListener() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
         ReplicatedMap<Object, Object> map1 = instance1.getReplicatedMap("default");
@@ -943,7 +922,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testSizeAfterRemove() throws Exception {
+    public void testSizeAfterRemove() {
         HazelcastInstance node = createHazelcastInstance();
         ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
@@ -952,7 +931,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testDestroy() throws Exception {
+    public void testDestroy() {
         HazelcastInstance instance = createHazelcastInstance();
         ReplicatedMap<Object, Object> replicatedMap = instance.getReplicatedMap(randomName());
         replicatedMap.put(1, 1);
@@ -965,7 +944,7 @@ public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
         @Override
         public int compare(Integer o1, Integer o2) {
-            return o1 == o2 ? 0 : o1 > o2 ? -1 : 1;
+            return o1.equals(o2) ? 0 : o1 > o2 ? -1 : 1;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
 
     @Test
-    public void testPutWithTTL_withMigration() throws Exception {
+    public void testPutWithTTL_withMigration() {
         int nodeCount = 1;
         int keyCount = 10000;
         int operationCount = 10000;
@@ -45,7 +45,7 @@ public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
     }
 
     @Test
-    public void testPutWithTTL_withoutMigration() throws Exception {
+    public void testPutWithTTL_withoutMigration() {
         int nodeCount = 5;
         int keyCount = 10000;
         int operationCount = 10000;
@@ -55,12 +55,12 @@ public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
     }
 
     private void testPutWithTTL(int nodeCount, int keyCount, int operationCount, int threadCount, int ttl,
-                                boolean causeMigration) throws InterruptedException {
+                                boolean causeMigration) {
         TimeUnit timeUnit = TimeUnit.MILLISECONDS;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance[] instances = factory.newInstances(null, nodeCount);
         String mapName = randomMapName();
-        List<ReplicatedMap> maps = createMapOnEachInstance(instances, mapName);
+        List<ReplicatedMap<String, Object>> maps = createMapOnEachInstance(instances, mapName);
         ArrayList<Integer> keys = generateRandomIntegerList(keyCount);
         Thread[] threads = createThreads(threadCount, maps, keys, ttl, timeUnit, operationCount);
         for (Thread thread : threads) {
@@ -70,11 +70,9 @@ public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
         if (causeMigration) {
             instance = factory.newHazelcastInstance();
         }
-        for (Thread thread : threads) {
-            thread.join();
-        }
+        assertJoinable(threads);
         if (causeMigration) {
-            ReplicatedMap<Object, Object> map = instance.getReplicatedMap(mapName);
+            ReplicatedMap<String, Object> map = instance.getReplicatedMap(mapName);
             maps.add(map);
         }
         for (ReplicatedMap map : maps) {
@@ -82,7 +80,7 @@ public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
         }
     }
 
-    private Thread[] createThreads(int count, List<ReplicatedMap> maps, ArrayList<Integer> keys,
+    private Thread[] createThreads(int count, List<ReplicatedMap<String, Object>> maps, ArrayList<Integer> keys,
                                    long ttl, TimeUnit timeunit, int operations) {
         Thread[] threads = new Thread[count];
         int size = maps.size();
@@ -107,5 +105,4 @@ public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
             }
         });
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
+@SuppressWarnings("WeakerAccess")
 public class AbstractBaseReplicatedRecordStoreTest extends HazelcastTestSupport {
 
     TestReplicatedRecordStore recordStore;
@@ -58,7 +59,7 @@ public class AbstractBaseReplicatedRecordStoreTest extends HazelcastTestSupport 
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown()  {
         shutdownNodeFactory();
     }
 
@@ -95,7 +96,7 @@ public class AbstractBaseReplicatedRecordStoreTest extends HazelcastTestSupport 
 
     private class TestReplicatedRecordStore extends AbstractReplicatedRecordStore<String, String> {
 
-        public TestReplicatedRecordStore(String name, ReplicatedMapService replicatedMapService, int partitionId) {
+        TestReplicatedRecordStore(String name, ReplicatedMapService replicatedMapService, int partitionId) {
             super(name, replicatedMapService, partitionId);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/EntryViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/EntryViewTest.java
@@ -35,13 +35,13 @@ import static org.junit.Assert.assertEquals;
 public class EntryViewTest extends HazelcastTestSupport {
 
     @Test
-    public void testEntryView() throws Exception {
+    public void testEntryView() {
         ReplicatedMapEntryView entryView = createEntryView();
         verifyFields(entryView);
     }
 
     @Test
-    public void testEntryViewSerialization() throws Exception {
+    public void testEntryViewSerialization() {
         ReplicatedMapEntryView entryView = createEntryView();
         SerializationServiceBuilder serializationServiceBuilder = new DefaultSerializationServiceBuilder();
         SerializationService serializationService = serializationServiceBuilder.build();
@@ -49,11 +49,10 @@ public class EntryViewTest extends HazelcastTestSupport {
         Data data = serializationService.toData(entryView);
         ReplicatedMapEntryView deserialized = serializationService.toObject(data);
         verifyFields(deserialized);
-
     }
 
     private ReplicatedMapEntryView createEntryView() {
-        ReplicatedMapEntryView entryView = new ReplicatedMapEntryView("foo", "bar");
+        ReplicatedMapEntryView entryView = new ReplicatedMapEntryView<String, String>("foo", "bar");
         entryView.setCreationTime(1);
         entryView.setLastAccessTime(2);
         entryView.setLastUpdateTime(3);
@@ -75,6 +74,4 @@ public class EntryViewTest extends HazelcastTestSupport {
         assertEquals(-1, entryView.getCost());
         assertEquals(-1, entryView.getVersion());
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyCollectionTest.java
@@ -30,55 +30,56 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
+@SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
 public class LazyCollectionTest {
 
-    LazyCollection collection;
+    private LazyCollection<Object, Object> collection;
 
     @Before
-    public void setUp() throws Exception {
-        ValuesIteratorFactory iteratorFactory = mock(ValuesIteratorFactory.class);
-        InternalReplicatedMapStorage storage = mock(InternalReplicatedMapStorage.class);
-        collection = new LazyCollection(iteratorFactory, storage);
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        ValuesIteratorFactory<Object, Object> iteratorFactory = mock(ValuesIteratorFactory.class);
+        InternalReplicatedMapStorage<Object, Object> storage = mock(InternalReplicatedMapStorage.class);
+        collection = new LazyCollection<Object, Object>(iteratorFactory, storage);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_add_throws_exception() throws Exception {
+    public void test_add_throws_exception() {
         collection.add(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_add_all_throws_exception() throws Exception {
+    public void test_add_all_throws_exception() {
         collection.addAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_remove_throws_exception() throws Exception {
+    public void test_remove_throws_exception() {
         collection.remove(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_removeAll_throws_exception() throws Exception {
+    public void test_removeAll_throws_exception() {
         collection.removeAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_throws_exception() throws Exception {
+    public void test_contains_throws_exception() {
         collection.contains(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_all_throws_exception() throws Exception {
+    public void test_contains_all_throws_exception() {
         collection.containsAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_retain_all_throws_exception() throws Exception {
+    public void test_retain_all_throws_exception() {
         collection.retainAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_clear_throws_exception() throws Exception {
+    public void test_clear_throws_exception() {
         collection.clear();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -41,8 +41,8 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class LazyIteratorTest
-        extends HazelcastTestSupport {
+@SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+public class LazyIteratorTest extends HazelcastTestSupport {
 
     private static final InternalReplicatedMapStorage<String, Integer> TEST_DATA_SIMPLE;
     private static final InternalReplicatedMapStorage<String, Integer> TEST_DATA_TOMBS;
@@ -67,37 +67,35 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_set_size() throws Exception {
+    public void test_lazy_set_size() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> set = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         assertEquals(100, set.size());
     }
 
     @Test
-    public void test_lazy_set_empty() throws Exception {
+    public void test_lazy_set_empty() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> set = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         assertFalse(set.isEmpty());
     }
 
     @Test
-    public void test_lazy_collection_size() throws Exception {
+    public void test_lazy_collection_size() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         assertEquals(100, collection.size());
     }
 
     @Test
-    public void test_lazy_collection_empty() throws Exception {
+    public void test_lazy_collection_empty() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         assertFalse(collection.isEmpty());
     }
 
     @Test
-    public void test_lazy_values_no_tombs_with_has_next()
-            throws Exception {
-
+    public void test_lazy_values_no_tombs_with_has_next() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         Iterator<Integer> iterator = collection.iterator();
@@ -113,9 +111,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_values_no_tombs_with_has_next_every_second_time()
-            throws Exception {
-
+    public void test_lazy_values_no_tombs_with_has_next_every_second_time() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         Iterator<Integer> iterator = collection.iterator();
@@ -125,16 +121,13 @@ public class LazyIteratorTest
             if (i % 2 == 0) {
                 iterator.hasNext();
             }
-
             values.add(iterator.next());
         }
         assertEquals(100, values.size());
     }
 
     @Test
-    public void test_lazy_values_no_tombs_more_elements_possible()
-            throws Exception {
-
+    public void test_lazy_values_no_tombs_more_elements_possible() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         Iterator<Integer> iterator = collection.iterator();
@@ -149,15 +142,13 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_values_with_tombs_with_has_next()
-            throws Exception {
-
+    public void test_lazy_values_with_tombs_with_has_next() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
         Iterator<Integer> iterator = collection.iterator();
@@ -173,9 +164,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_values_with_tombs_with_next()
-            throws Exception {
-
+    public void test_lazy_values_with_tombs_with_next() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
         Iterator<Integer> iterator = collection.iterator();
@@ -190,15 +179,13 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_values_with_tombs_copy()
-            throws Exception {
-
+    public void test_lazy_values_with_tombs_copy() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
@@ -215,15 +202,13 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_values_with_tombs_to_array_new_array()
-            throws Exception {
-
+    public void test_lazy_values_with_tombs_to_array_new_array() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
@@ -232,9 +217,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_values_with_tombs_to_array_passed_array_too_small()
-            throws Exception {
-
+    public void test_lazy_values_with_tombs_to_array_passed_array_too_small() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
@@ -243,9 +226,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_values_with_tombs_to_array_passed_array_matching_size()
-            throws Exception {
-
+    public void test_lazy_values_with_tombs_to_array_passed_array_matching_size() {
         ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
@@ -254,9 +235,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_keyset_no_tombs_with_has_next()
-            throws Exception {
-
+    public void test_lazy_keyset_no_tombs_with_has_next() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         Iterator<String> iterator = collection.iterator();
@@ -272,9 +251,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_keyset_no_tombs_with_has_next_every_second_time()
-            throws Exception {
-
+    public void test_lazy_keyset_no_tombs_with_has_next_every_second_time() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         Iterator<String> iterator = collection.iterator();
@@ -291,9 +268,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_keyset_no_tombs_more_elements_possible()
-            throws Exception {
-
+    public void test_lazy_keyset_no_tombs_more_elements_possible() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         Iterator<String> iterator = collection.iterator();
@@ -308,15 +283,13 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_with_has_next()
-            throws Exception {
-
+    public void test_lazy_keyset_with_tombs_with_has_next() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
         Iterator<String> iterator = collection.iterator();
@@ -332,9 +305,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_with_next()
-            throws Exception {
-
+    public void test_lazy_keyset_with_tombs_with_next() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
         Iterator<String> iterator = collection.iterator();
@@ -349,15 +320,13 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_copy()
-            throws Exception {
-
+    public void test_lazy_keyset_with_tombs_copy() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
@@ -374,15 +343,13 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_to_array_new_array()
-            throws Exception {
-
+    public void test_lazy_keyset_with_tombs_to_array_new_array() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
@@ -391,9 +358,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_to_array_passed_array_too_small()
-            throws Exception {
-
+    public void test_lazy_keyset_with_tombs_to_array_passed_array_too_small() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
@@ -402,9 +367,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_to_array_passed_array_matching_size()
-            throws Exception {
-
+    public void test_lazy_keyset_with_tombs_to_array_passed_array_matching_size() {
         KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
@@ -413,9 +376,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_entryset_no_tombs_with_has_next()
-            throws Exception {
-
+    public void test_lazy_entryset_no_tombs_with_has_next() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
                 new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
@@ -432,9 +393,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_entryset_no_tombs_with_has_next_every_second_time()
-            throws Exception {
-
+    public void test_lazy_entryset_no_tombs_with_has_next_every_second_time() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
                 new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
@@ -452,9 +411,7 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_entryset_no_tombs_more_elements_possible()
-            throws Exception {
-
+    public void test_lazy_entryset_no_tombs_more_elements_possible() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
                 new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
@@ -470,18 +427,16 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_with_has_next()
-            throws Exception {
-
+    public void test_lazy_entryset_with_tombs_with_has_next() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
 
         int count = 0;
@@ -495,12 +450,10 @@ public class LazyIteratorTest
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_with_next()
-            throws Exception {
-
+    public void test_lazy_entryset_with_tombs_with_next() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
 
         Set<Integer> values = new HashSet<Integer>();
@@ -513,18 +466,16 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_copy()
-            throws Exception {
-
+    public void test_lazy_entryset_with_tombs_copy() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
         Set<Map.Entry<String, Integer>> copy = new HashSet<Map.Entry<String, Integer>>(collection);
         Iterator<Map.Entry<String, Integer>> iterator = copy.iterator();
@@ -539,44 +490,38 @@ public class LazyIteratorTest
             iterator.next();
             fail("Shouldn't have further elements!");
         } catch (NoSuchElementException e) {
-            // We need to catch it here since we won't have a successful test
+            // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_to_array_new_array()
-            throws Exception {
-
+    public void test_lazy_entryset_with_tombs_to_array_new_array() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
         Object[] array = collection.toArray();
         assertEquals(50, array.length);
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_to_array_passed_array_too_small()
-            throws Exception {
-
+    public void test_lazyEntrySet_with_tombs_to_array_passed_array_too_small() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
-        Map.Entry<String, Integer>[] array = collection.toArray(new Map.Entry[0]);
+        Map.Entry[] array = collection.toArray(new Map.Entry[0]);
         assertEquals(50, array.length);
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_to_array_passed_array_matching_size()
-            throws Exception {
-
+    public void test_lazy_entryset_with_tombs_to_array_passed_array_matching_size() {
         EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
-        Map.Entry<String, Integer>[] array = collection.toArray(new Map.Entry[50]);
+        Map.Entry[] array = collection.toArray(new Map.Entry[50]);
         assertEquals(50, array.length);
     }
 
@@ -599,7 +544,6 @@ public class LazyIteratorTest
 
         @Override
         public void evict(Object key) {
-
         }
 
         @Override
@@ -668,12 +612,10 @@ public class LazyIteratorTest
 
         @Override
         public void clearWithVersion(long version) {
-
         }
 
         @Override
         public void reset() {
-
         }
 
         @Override
@@ -712,7 +654,6 @@ public class LazyIteratorTest
 
         @Override
         public void putRecords(Collection<RecordMigrationInfo> records, long version) {
-
         }
 
         @Override
@@ -737,14 +678,11 @@ public class LazyIteratorTest
 
         @Override
         public void setLoaded(boolean loaded) {
-
         }
 
         @Override
         public boolean merge(Object key, ReplicatedMapEntryView entryView, ReplicatedMapMergePolicy policy) {
             return false;
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazySetTest.java
@@ -30,55 +30,56 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
+@SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
 public class LazySetTest {
 
-    LazySet set;
+    private LazySet<Object, Object, Object> set;
 
     @Before
-    public void setUp() throws Exception {
-        KeySetIteratorFactory keySetIteratorFactory = mock(KeySetIteratorFactory.class);
-        InternalReplicatedMapStorage storage = mock(InternalReplicatedMapStorage.class);
-        set = new LazySet(keySetIteratorFactory, storage);
+    @SuppressWarnings("unchecked")
+    public void setUp()  {
+        KeySetIteratorFactory<Object, Object> keySetIteratorFactory = mock(KeySetIteratorFactory.class);
+        InternalReplicatedMapStorage<Object, Object> storage = mock(InternalReplicatedMapStorage.class);
+        set = new LazySet<Object, Object, Object>(keySetIteratorFactory, storage);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_add_throws_exception() throws Exception {
+    public void test_add_throws_exception()  {
         set.add(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_add_all_throws_exception() throws Exception {
+    public void test_add_all_throws_exception()  {
         set.addAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_remove_throws_exception() throws Exception {
+    public void test_remove_throws_exception()  {
         set.remove(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_removeAll_throws_exception() throws Exception {
+    public void test_removeAll_throws_exception()  {
         set.removeAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_throws_exception() throws Exception {
+    public void test_contains_throws_exception()  {
         set.contains(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_all_throws_exception() throws Exception {
+    public void test_contains_all_throws_exception()  {
         set.containsAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_retain_all_throws_exception() throws Exception {
+    public void test_retain_all_throws_exception()  {
         set.retainAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_clear_throws_exception() throws Exception {
+    public void test_clear_throws_exception()  {
         set.clear();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ResultSetTest.java
@@ -37,23 +37,24 @@ import static junit.framework.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
+@SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
 public class ResultSetTest {
 
     @Test
-    public void testSize_whenEmpty() throws Exception {
+    public void testSize_whenEmpty() {
         List<Map.Entry<Object, Object>> emptyList = Collections.emptyList();
         ResultSet<Object, Object> resultSet = new ResultSet<Object, Object>(emptyList, IterationType.KEY);
         assertEquals(0, resultSet.size());
     }
 
     @Test
-    public void testSize_whenNull() throws Exception {
+    public void testSize_whenNull() {
         ResultSet<Object, Object> resultSet = new ResultSet<Object, Object>(null, IterationType.KEY);
         assertEquals(0, resultSet.size());
     }
 
     @Test
-    public void testSize_whenNotEmpty() throws Exception {
+    public void testSize_whenNotEmpty() {
         List<Map.Entry<Object, Object>> entries = new ArrayList<Map.Entry<Object, Object>>();
         entries.add(new MapEntrySimple<Object, Object>(null, null));
         ResultSet<Object, Object> resultSet = new ResultSet<Object, Object>(entries, IterationType.KEY);
@@ -61,7 +62,7 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testIterator_whenEmpty() throws Exception {
+    public void testIterator_whenEmpty() {
         List<Map.Entry<Object, Object>> emptyList = Collections.emptyList();
         ResultSet<Object, Object> resultSet = new ResultSet<Object, Object>(emptyList, IterationType.KEY);
         Iterator iterator = resultSet.iterator();
@@ -69,14 +70,14 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testIterator_whenNull() throws Exception {
+    public void testIterator_whenNull() {
         ResultSet<Object, Object> resultSet = new ResultSet<Object, Object>(null, IterationType.KEY);
         Iterator iterator = resultSet.iterator();
         assertFalse(iterator.hasNext());
     }
 
     @Test
-    public void testIterator_whenNotEmpty_IterationType_Key() throws Exception {
+    public void testIterator_whenNotEmpty_IterationType_Key() {
         List<Map.Entry<Object, Object>> entries = new ArrayList<Map.Entry<Object, Object>>();
         MapEntrySimple<Object, Object> entry = new MapEntrySimple<Object, Object>("key", "value");
         entries.add(entry);
@@ -87,7 +88,7 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testIterator_whenNotEmpty_IterationType_Value() throws Exception {
+    public void testIterator_whenNotEmpty_IterationType_Value() {
         List<Map.Entry<Object, Object>> entries = new ArrayList<Map.Entry<Object, Object>>();
         MapEntrySimple<Object, Object> entry = new MapEntrySimple<Object, Object>("key", "value");
         entries.add(entry);
@@ -98,7 +99,7 @@ public class ResultSetTest {
     }
 
     @Test
-    public void testIterator_whenNotEmpty_IterationType_Entry() throws Exception {
+    public void testIterator_whenNotEmpty_IterationType_Entry() {
         List<Map.Entry<Object, Object>> entries = new ArrayList<Map.Entry<Object, Object>>();
         MapEntrySimple<Object, Object> entry = new MapEntrySimple<Object, Object>("key", "value");
         entries.add(entry);
@@ -108,8 +109,5 @@ public class ResultSetTest {
         Map.Entry<Object, Object> entryFromIterator = iterator.next();
         assertEquals("key", entryFromIterator.getKey());
         assertEquals("value", entryFromIterator.getValue());
-
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/AbstractReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/AbstractReplicatedMapMergePolicyTest.java
@@ -67,7 +67,5 @@ public abstract class AbstractReplicatedMapMergePolicyTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
@@ -31,5 +31,4 @@ public class HigherHitsReplicatedMapMergePolicyTest extends AbstractReplicatedMa
     public void given() {
         policy = HigherHitsMapMergePolicy.INSTANCE;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
@@ -31,5 +31,4 @@ public class LatestUpdateReplicatedMapMergePolicyTest extends AbstractReplicated
     public void given() {
         policy = LatestUpdateMapMergePolicy.INSTANCE;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/MergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/MergePolicyProviderTest.java
@@ -85,5 +85,4 @@ public class MergePolicyProviderTest extends HazelcastTestSupport {
         assertNotNull(mergePolicy);
         assertEquals(mergePolicyName, mergePolicy.getClass().getName());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
@@ -54,9 +54,8 @@ public class PassThroughMapMergePolicyTest {
     @Test
     public void merge_mergingNull() {
         ReplicatedMapEntryView existing = entryWithGivenValue(EXISTING);
-        ReplicatedMapEntryView merging = null;
 
-        assertEquals(EXISTING, policy.merge("map", merging, existing));
+        assertEquals(EXISTING, policy.merge("map", null, existing));
     }
 
     private ReplicatedMapEntryView entryWithGivenValue(String value) {
@@ -69,5 +68,4 @@ public class PassThroughMapMergePolicyTest {
         }
 
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
@@ -76,7 +76,5 @@ public class PutIfAbsentMapMergePolicyTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
@@ -75,11 +75,8 @@ public class SimpleReplicatedMapTest {
 
     /**
      * Expects the Management Center to be running.
-     *
-     * @param input
-     * @throws InterruptedException
      */
-    public static void main(String[] input) throws InterruptedException {
+    public static void main(String[] input) throws Exception {
         int threadCount = 40;
         int entryCount = 300;
         int valueSize = 100;
@@ -114,7 +111,7 @@ public class SimpleReplicatedMapTest {
         test.start();
     }
 
-    private void start() throws InterruptedException {
+    private void start() throws Exception {
         printVariables();
         ExecutorService es = Executors.newFixedThreadPool(threadCount);
         startPrintStats();
@@ -126,6 +123,7 @@ public class SimpleReplicatedMapTest {
         final ReplicatedMap<String, Object> map = instance.getReplicatedMap(NAMESPACE);
         for (int i = 0; i < threadCount; i++) {
             es.execute(new Runnable() {
+                @Override
                 public void run() {
                     try {
                         while (true) {
@@ -156,7 +154,7 @@ public class SimpleReplicatedMapTest {
         return new byte[valueSize];
     }
 
-    private void load(ExecutorService es) throws InterruptedException {
+    private void load(ExecutorService es) throws Exception {
         if (!load) {
             return;
         }
@@ -205,7 +203,7 @@ public class SimpleReplicatedMapTest {
     }
 
     /**
-     * A basic statistics class
+     * A basic statistics class.
      */
     private class Stats {
 
@@ -213,7 +211,7 @@ public class SimpleReplicatedMapTest {
         private AtomicLong puts = new AtomicLong();
         private AtomicLong removes = new AtomicLong();
 
-        public void printAndReset() {
+        void printAndReset() {
             long getsNow = gets.getAndSet(0);
             long putsNow = puts.getAndSet(0);
             long removesNow = removes.getAndSet(0);


### PR DESCRIPTION
The usual stuff, no logic changes.
* removed a lot of superfluous newlines
* removed a ton of superfluous `throws Exception`
* fixed a lot of warnings