### PR TITLE
Operation-heartbeat diagnostics plugin

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -102,7 +102,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.diagnostics.ConfigPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
-import com.hazelcast.internal.diagnostics.NetworkingPlugin;
+import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
 import com.hazelcast.internal.diagnostics.SystemPropertiesPlugin;
 import com.hazelcast.internal.metrics.ProbeLevel;
@@ -427,8 +427,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         diagnostics.register(
                 new SystemLogPlugin(properties, connectionManager, this, loggingService.getLogger(SystemLogPlugin.class)));
         diagnostics.register(
-                new NetworkingPlugin(properties, connectionManager.getEventLoopGroup(),
-                        loggingService.getLogger(NetworkingPlugin.class)));
+                new NetworkingImbalancePlugin(properties, connectionManager.getEventLoopGroup(),
+                        loggingService.getLogger(NetworkingImbalancePlugin.class)));
 
         metricsRegistry.collectMetrics(listenerService);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
@@ -30,31 +30,32 @@ import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * The {@link NetworkingPlugin} is an experimental plugin meant for detecting imbalance in the io system. This plugin will
- * probably mostly be used for internal purposes to get a better understanding of imbalances. Normally imbalances are taken
- * care of by the IOBalancer; but we need to make sure it makes the right choice.
+ * The {@link NetworkingImbalancePlugin} is an experimental plugin meant for detecting imbalance in the io system. This
+ * plugin will probably mostly be used for internal purposes to get a better understanding of imbalances. Normally imbalances
+ * are taken care of by the IOBalancer; but we need to make sure it makes the right choice.
  *
  * This plugin can be used on server and client side.
  */
-public class NetworkingPlugin extends DiagnosticsPlugin {
+public class NetworkingImbalancePlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds this plugin runs.
      *
      * If set to 0, the plugin is disabled.
      */
-    public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(PREFIX + ".networking.seconds", 0, SECONDS);
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty(PREFIX + ".networking-imbalance.seconds", 0, SECONDS);
 
     private static final double HUNDRED = 100d;
 
     private final NioEventLoopGroup eventLoopGroup;
     private final long periodMillis;
 
-    public NetworkingPlugin(NodeEngineImpl nodeEngine) {
-        this(nodeEngine.getProperties(), getThreadingModel(nodeEngine), nodeEngine.getLogger(NetworkingPlugin.class));
+    public NetworkingImbalancePlugin(NodeEngineImpl nodeEngine) {
+        this(nodeEngine.getProperties(), getThreadingModel(nodeEngine), nodeEngine.getLogger(NetworkingImbalancePlugin.class));
     }
 
-    public NetworkingPlugin(HazelcastProperties properties, EventLoopGroup eventLoopGroup, ILogger logger) {
+    public NetworkingImbalancePlugin(HazelcastProperties properties, EventLoopGroup eventLoopGroup, ILogger logger) {
         super(logger);
 
         if (eventLoopGroup instanceof NioEventLoopGroup) {
@@ -85,7 +86,7 @@ public class NetworkingPlugin extends DiagnosticsPlugin {
 
     @Override
     public void run(DiagnosticsLogWriter writer) {
-        writer.startSection("Networking");
+        writer.startSection("NetworkingImbalance");
 
         writer.startSection("InputThreads");
         render(writer, eventLoopGroup.getInputThreads());

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.impl.InvocationMonitor;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+
+/**
+ * A diagnostics plugin that checks how the network is behaving by checking deviations in Operation-heartbeats to assist with
+ * network related problems like split-brain.
+ *
+ * It does this by checking the deviation in the interval between operation-heartbeat packets. Operation-heartbeat packets
+ * are send at a fixed interval (operation-call-timeout/4) and are not processed by operation-threads; but by their own system.
+ * If there is a big deviation, then it could indicate networking problems. But it could also indicate other problems like JVM
+ * issues.
+ */
+public class OperationHeartbeatPlugin extends DiagnosticsPlugin {
+
+    /**
+     * The period in seconds this plugin runs.
+     *
+     * This plugin is very cheap to run and is enabled by default.
+     *
+     * It will also not print output every time it is executed, only when one or more members have a too high operation-heartbeat
+     * deviation, the plugin will render output.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty(PREFIX + ".operation-heartbeat.seconds", 10, SECONDS);
+
+    /**
+     * The maximum allowed deviation. E.g. with a default 60 call timeout and operation-heartbeat interval being 15 seconds,
+     * the maximum deviation with a deviation-percentage of 33, is 5 seconds. So if a packet is arrived after 19 seconds; no
+     * problem; but if it arrives after 21 seconds, then the plugin will render.
+     */
+    public static final HazelcastProperty MAX_DEVIATION_PERCENTAGE
+            = new HazelcastProperty(PREFIX + ".operation-heartbeat.max-deviation-percentage", 33);
+
+    private static final float HUNDRED = 100f;
+
+    private final InvocationMonitor invocationMonitor;
+    private final long periodMillis;
+    private final long expectedIntervalMillis;
+    private final int maxDeviationPercentage;
+    private final ConcurrentMap<Address, AtomicLong> heartbeatPerMember;
+    private boolean mainSectionStarted;
+
+    public OperationHeartbeatPlugin(NodeEngineImpl nodeEngine) {
+        super(nodeEngine.getLogger(OperationHeartbeatPlugin.class));
+        this.invocationMonitor = ((OperationServiceImpl) nodeEngine.getOperationService()).getInvocationMonitor();
+        HazelcastProperties properties = nodeEngine.getProperties();
+        this.periodMillis = properties.getMillis(PERIOD_SECONDS);
+        this.maxDeviationPercentage = properties.getInteger(MAX_DEVIATION_PERCENTAGE);
+        this.expectedIntervalMillis = invocationMonitor.getHeartbeatBroadcastPeriodMillis();
+        this.heartbeatPerMember = invocationMonitor.getHeartbeatPerMember();
+    }
+
+    @Override
+    public long getPeriodMillis() {
+        return periodMillis;
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("Plugin:active: period-millis:" + periodMillis + " max-deviation:" + maxDeviationPercentage + "%");
+    }
+
+    @Override
+    public void run(DiagnosticsLogWriter writer) {
+        long nowMillis = System.currentTimeMillis();
+        for (Map.Entry<Address, AtomicLong> entry : heartbeatPerMember.entrySet()) {
+            Address member = entry.getKey();
+            long lastHeartbeatMillis = entry.getValue().longValue();
+            long noHeartbeatMillis = nowMillis - lastHeartbeatMillis;
+            float deviation = HUNDRED * ((float) (noHeartbeatMillis - expectedIntervalMillis)) / expectedIntervalMillis;
+            if (deviation >= maxDeviationPercentage) {
+                startLazyMainSection(writer);
+
+                writer.startSection("member" + member);
+                writer.writeKeyValueEntry("deviation(%)", deviation);
+                writer.writeKeyValueEntry("noHeartbeat(ms)", noHeartbeatMillis);
+                writer.writeKeyValueEntry("lastHeartbeat(ms)", lastHeartbeatMillis);
+                writer.writeKeyValueEntryAsDateTime("lastHeartbeat(date-time)", lastHeartbeatMillis);
+                writer.writeKeyValueEntry("now(ms)", nowMillis);
+                writer.writeKeyValueEntryAsDateTime("now(date-time)", nowMillis);
+                writer.endSection();
+            }
+        }
+
+        endLazyMainSection(writer);
+    }
+
+    private void startLazyMainSection(DiagnosticsLogWriter writer) {
+        if (!mainSectionStarted) {
+            mainSectionStarted = true;
+            writer.startSection("OperationHeartbeat");
+        }
+    }
+
+    private void endLazyMainSection(DiagnosticsLogWriter writer) {
+        if (mainSectionStarted) {
+            mainSectionStarted = false;
+            writer.endSection();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SingleLineDiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SingleLineDiagnosticsLogWriter.java
@@ -58,7 +58,7 @@ class SingleLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
 
     private void appendComma() {
         if (firstEntry) {
-            firstEntry = false;
+            this.firstEntry = false;
         } else {
             write(',');
         }
@@ -97,7 +97,7 @@ class SingleLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
 
     @Override
     protected void init(PrintWriter writer) {
-        firstEntry = true;
+        this.firstEntry = true;
         super.init(writer);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -29,7 +29,8 @@ import com.hazelcast.internal.diagnostics.InvocationPlugin;
 import com.hazelcast.internal.diagnostics.MemberHazelcastInstanceInfoPlugin;
 import com.hazelcast.internal.diagnostics.MemberHeartbeatPlugin;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
-import com.hazelcast.internal.diagnostics.NetworkingPlugin;
+import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
+import com.hazelcast.internal.diagnostics.OperationHeartbeatPlugin;
 import com.hazelcast.internal.diagnostics.OverloadedConnectionsPlugin;
 import com.hazelcast.internal.diagnostics.PendingInvocationsPlugin;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
@@ -253,8 +254,9 @@ public class NodeEngineImpl implements NodeEngine {
         diagnostics.register(new MemberHazelcastInstanceInfoPlugin(this));
         diagnostics.register(new SystemLogPlugin(this));
         diagnostics.register(new StoreLatencyPlugin(this));
-        diagnostics.register(new NetworkingPlugin(this));
         diagnostics.register(new MemberHeartbeatPlugin(this));
+        diagnostics.register(new NetworkingImbalancePlugin(this));
+        diagnostics.register(new OperationHeartbeatPlugin(this));
     }
 
     public Diagnostics getDiagnostics() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePluginTest.java
@@ -16,20 +16,20 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class NetworkingPluginTest extends AbstractDiagnosticsPluginTest {
+public class NetworkingImbalancePluginTest extends AbstractDiagnosticsPluginTest {
 
-    private NetworkingPlugin plugin;
+    private NetworkingImbalancePlugin plugin;
     private HazelcastInstance hz;
 
     @Before
     public void setup() {
         Config config = new Config()
-                .setProperty(NetworkingPlugin.PERIOD_SECONDS.getName(), "1");
+                .setProperty(NetworkingImbalancePlugin.PERIOD_SECONDS.getName(), "1");
 
         // we need to start a real Hazelcast instance here, since the mocked network doesn't have a TcpIpConnectionManager
         hz = Hazelcast.newHazelcastInstance(config);
 
-        plugin = new NetworkingPlugin(getNodeEngineImpl(hz));
+        plugin = new NetworkingImbalancePlugin(getNodeEngineImpl(hz));
         plugin.onStart();
     }
 


### PR DESCRIPTION
This plugin currently works based on the deviation between
operation heartbeats to determine the qos of the network.

Operation heartbeats are processed by their own system and
are priority packets; so no reliance on operation-executor.

If there is a big deviation; then we know there are potential
networking problems. This will hopefully assist with split
brains and other complex networking issues.

Example output (with some artificial packet processing delays)

```
20-7-2017 11:12:55 OperationHeartbeats[
                                  member[10.212.1.119]:5701[
                                          deviation(%)=146.6666717529297
                                          noHeartbeat(ms)=37,000
                                          lastHeartbeat(ms)=1,500,538,338,603
                                          lastHeartbeat(date-time)=20-7-2017 11:12:18]]
```