### PR TITLE
Mock network address provider is incorrectly adding more ports

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -96,7 +96,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
                 Collection<InetSocketAddress> inetAddresses = new ArrayList<InetSocketAddress>();
                 for (Address address : getKnownAddresses()) {
                     Collection<InetSocketAddress> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
-                            address.getHost(), 3);
+                            address.getHost(), 1);
                     inetAddresses.addAll(addresses);
                 }
                 return inetAddresses;


### PR DESCRIPTION
Mock network address provider is incorrectly adding more ports than the member ports and hence causing a client to connect to a member of another test. This fix prevents it.

Part of the fix for #10870  

The problem can be observed at the attached log file (search for test initialMemberEvents_whenClusterRestarted). It incorrectly tries to connect to member in another test (
04:25:35,569  INFO |initialMemberEvents_whenClusterRestarted| - [ClientConnectionManager] hz.client_484.cluster- - hz.client_484 [dev] [3.9-SNAPSHOT] Trying to connect to [127.0.0.1]:5812 as owner member
)

[com.hazelcast.client.MembershipListenerTest-output.txt](https://github.com/hazelcast/hazelcast/files/1162155/com.hazelcast.client.MembershipListenerTest-output.txt)
