### PR TITLE
Revert owner check to by address

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -423,15 +423,16 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     }
 
     private void fireConnectionRemovedEvent(ClientConnection connection) {
-        if (connection.isAuthenticatedAsOwner() && client.getLifecycleService().isRunning()) {
+        Address endpoint = connection.getEndPoint();
+        boolean ownerDisconnected = endpoint != null && endpoint.equals(ownerConnectionAddress);
+        if (ownerDisconnected && client.getLifecycleService().isRunning()) {
             fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED);
         }
 
         for (ConnectionListener listener : connectionListeners) {
             listener.connectionRemoved(connection);
         }
-        Address endpoint = connection.getEndPoint();
-        if (endpoint != null && endpoint.equals(ownerConnectionAddress)) {
+        if (ownerDisconnected) {
             setOwnerConnectionAddress(null);
             connectionStrategy.onDisconnectFromCluster();
         }


### PR DESCRIPTION
We changed the check from
`connection.getEndPoint().equals(ownerConnectionAddress)`
to
`connection.isAuthenticatedAsOwner()`
in
https://github.com/hazelcast/hazelcast/pull/10729

This leads to race condition when connection closes right after
authenticated. Since it is closed immediately, the steps before
CLIENT_CONNECTED event is not able completed and the event is
not fired.

When this connection is getting closed the check above is done
and if holds true, CLIENT_DISCONNECTED event is fired. Without the
fix, CLIENT_DISCONNECTED is fired even though CLIENT_CONNECTED is
not fired. Fix makes sures that CLIENT_DISCONNECTED event is also
will not fired.

related to changes made in https://github.com/hazelcast/hazelcast/pull/10729
issue is detected in the logs of https://github.com/hazelcast/hazelcast/issues/10870

fixes https://github.com/hazelcast/hazelcast/issues/10870