### PR TITLE
MembershipListenerTest.initialMemberEvents_whenClusterRestarted fails due to connect/disconnect to cluster race

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.ConnectionListenable;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.Future;
 
 /**
  * Responsible for managing {@link com.hazelcast.client.connection.nio.ClientConnection} objects.
@@ -71,5 +72,5 @@ public interface ClientConnectionManager extends ConnectionListenable {
 
     void connectToCluster();
 
-    void connectToClusterAsync();
+    Future<Void> connectToClusterAsync();
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -175,7 +175,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                 ClassLoader configClassLoader = client.getClientConfig().getClassLoader();
                 return ClassLoaderUtil.newInstance(configClassLoader, className);
             } catch (Exception e) {
-                throw ExceptionUtil.rethrow(e);
+                throw rethrow(e);
             }
         } else {
             strategy = new DefaultClientConnectionStrategy();
@@ -363,7 +363,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                 }
             }
         } catch (Throwable e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -458,9 +458,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
                     return null;
                 }
-            }).get();
+            });
         } catch (Exception e) {
-            rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -509,7 +509,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             if (socketChannel != null) {
                 socketChannel.close();
             }
-            throw ExceptionUtil.rethrow(e, IOException.class);
+            throw rethrow(e, IOException.class);
         }
     }
 
@@ -805,7 +805,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                         }
                     }, client.getName() + ".clientShutdown-").start();
 
-                    rethrow(e);
+                    throw rethrow(e);
                 }
                 return null;
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -266,7 +266,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         for (Connection connection : activeConnections.values()) {
             connection.close("Hazelcast client is shutting down", null);
         }
-        ClientExecutionServiceImpl.shutdownExecutor("clusterExecutor", clusterConnectionExecutor, logger);
+        clusterConnectionExecutor.shutdown();
         stopEventLoopGroup();
         connectionListeners.clear();
         heartbeat.shutdown();
@@ -804,6 +804,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                             }
                         }
                     }, client.getName() + ".clientShutdown-").start();
+
+                    rethrow(e);
                 }
                 return null;
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -208,7 +209,7 @@ public class ClientStateListenerTest extends ClientTestSupport{
     @Test
     public void testClientReconnecModeOffDisconnected() throws InterruptedException {
         ClientConfig clientConfig = new ClientConfig();
-        ClientStateListener listener = new ClientStateListener(clientConfig);
+        final ClientStateListener listener = new ClientStateListener(clientConfig);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(OFF);
 
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
@@ -225,7 +226,13 @@ public class ClientStateListenerTest extends ClientTestSupport{
 
         assertFalse(listener.isStarted());
 
-        assertEquals(SHUTDOWN, listener.getCurrentState());
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(SHUTDOWN, listener.getCurrentState());
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
Fix for the race between cluster connect and disconnect. Uses the same cluster connection executor for cluster disconnect as it was used for cluster connect.

fixes #10870 

See the attached file for the logs:
[com.hazelcast.client.MembershipListenerTest-output.txt](https://github.com/hazelcast/hazelcast/files/1165763/com.hazelcast.client.MembershipListenerTest-output.txt)
