### PR TITLE
Make ClusterWideConfigurationService PreJoinAware

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.dynamicconfig.AddDynamicConfigOperation;
-import com.hazelcast.internal.dynamicconfig.DynamicConfigReplicationOperation;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigPreJoinOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -45,7 +45,7 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int NEAR_CACHE_CONFIG = 3;
     public static final int NEAR_CACHE_PRELOADER_CONFIG = 4;
     public static final int ADD_DYNAMIC_CONFIG_OP = 5;
-    public static final int REPLICATE_CONFIGURATIONS_OP = 6;
+    public static final int DYNAMIC_CONFIG_PRE_JOIN_OP = 6;
     public static final int MULTIMAP_CONFIG = 7;
     public static final int LISTENER_CONFIG = 8;
     public static final int ENTRY_LISTENER_CONFIG = 9;
@@ -129,10 +129,10 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                 return new AddDynamicConfigOperation();
             }
         };
-        constructors[REPLICATE_CONFIGURATIONS_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+        constructors[DYNAMIC_CONFIG_PRE_JOIN_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new DynamicConfigReplicationOperation();
+                return new DynamicConfigPreJoinOperation();
             }
         };
         constructors[MULTIMAP_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
@@ -24,18 +24,18 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
-public class DynamicConfigReplicationOperation extends AbstractDynamicConfigOperation {
+public class DynamicConfigPreJoinOperation extends AbstractDynamicConfigOperation {
 
     private IdentifiedDataSerializable[] configs;
     private ConfigCheckMode configCheckMode;
 
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public DynamicConfigReplicationOperation(IdentifiedDataSerializable[] configs, ConfigCheckMode configCheckMode) {
+    public DynamicConfigPreJoinOperation(IdentifiedDataSerializable[] configs, ConfigCheckMode configCheckMode) {
         this.configs = configs;
         this.configCheckMode = configCheckMode;
     }
 
-    public DynamicConfigReplicationOperation() {
+    public DynamicConfigPreJoinOperation() {
 
     }
 
@@ -68,6 +68,6 @@ public class DynamicConfigReplicationOperation extends AbstractDynamicConfigOper
 
     @Override
     public int getId() {
-        return ConfigDataSerializerHook.REPLICATE_CONFIGURATIONS_OP;
+        return ConfigDataSerializerHook.DYNAMIC_CONFIG_PRE_JOIN_OP;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -96,7 +96,6 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
 
         //start an instance AFTER the config was already submitted
         HazelcastInstance i3 = factory.newHazelcastInstance();
-        waitAllForSafeState(i1, i2, i3);
 
         multiMapConfig = i3.getConfig().getMultiMapConfig(mapName);
         assertEquals(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT, multiMapConfig.getBackupCount());
@@ -179,5 +178,27 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
             topicConfig = instance.getConfig().getTopicConfig(topicName);
             assertEquals(listenerClassName, topicConfig.getMessageListenerConfigs().get(0).getClassName());
         }
+    }
+
+    @Test
+    public void mapConfig_withLiteMemberJoiningLater_isImmediatelyAvailable() {
+        String mapName = randomMapName();
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance i1 = factory.newHazelcastInstance();
+        HazelcastInstance i2 = factory.newHazelcastInstance();
+
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
+        Config config = i1.getConfig();
+        config.addMapConfig(mapConfig);
+
+        //start a lite member after the dynamic config was submitted
+        Config liteConfig = new Config();
+        liteConfig.setLiteMember(true);
+        HazelcastInstance i3 = factory.newHazelcastInstance(liteConfig);
+
+        MapConfig mapConfigOnLiteMember = i3.getConfig().getMapConfig(mapName);
+        assertEquals(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT, mapConfigOnLiteMember.getBackupCount());
     }
 }


### PR DESCRIPTION
Instead of replicating dynamic config through partition migrations, each joining member becomes aware of dynamic config before its node is joined via a pre-join operation.

Fixes #10926 