### PR TITLE
Added evict methods to near cache tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -31,6 +31,7 @@ import java.util.Set;
 /**
  * Abstracts the Hazelcast data structures with Near Cache support for the Near Cache usage.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public interface DataStructureAdapter<K, V> {
 
     int size();
@@ -56,6 +57,8 @@ public interface DataStructureAdapter<K, V> {
     boolean remove(K key, V oldValue);
 
     ICompletableFuture<V> removeAsync(K key);
+
+    boolean evict(K key);
 
     <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException;
 
@@ -83,6 +86,8 @@ public interface DataStructureAdapter<K, V> {
 
     void removeAll(Set<K> keys);
 
+    void evictAll();
+
     <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
                                                   Object... arguments);
 
@@ -108,6 +113,7 @@ public interface DataStructureAdapter<K, V> {
         REMOVE("remove", Object.class),
         REMOVE_WITH_OLD_VALUE("remove", Object.class, Object.class),
         REMOVE_ASYNC("removeAsync", Object.class),
+        EVICT("evict", Object.class),
         INVOKE("invoke", Object.class, EntryProcessor.class, Object[].class),
         EXECUTE_ON_KEY("executeOnKey", Object.class, com.hazelcast.map.EntryProcessor.class),
         EXECUTE_ON_KEYS("executeOnKeys", Set.class, com.hazelcast.map.EntryProcessor.class),
@@ -121,6 +127,7 @@ public interface DataStructureAdapter<K, V> {
         PUT_ALL("putAll", Map.class),
         REMOVE_ALL("removeAll"),
         REMOVE_ALL_WITH_KEYS("removeAll", Set.class),
+        EVICT_ALL("evictAll"),
         INVOKE_ALL("invokeAll", Set.class, EntryProcessor.class, Object[].class),
         CLEAR("clear"),
         DESTROY("destroy"),

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -28,6 +28,7 @@ import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
 
     private final ICache<K, V> cache;
@@ -94,6 +95,12 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     public ICompletableFuture<V> removeAsync(K key) {
         return cache.getAndRemoveAsync(key);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public boolean evict(K key) {
+        throw new MethodNotAvailableException();
     }
 
     @Override
@@ -165,6 +172,12 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     public void removeAll(Set<K> keys) {
         cache.removeAll(keys);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public void evictAll() {
+        throw new MethodNotAvailableException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -30,6 +30,7 @@ import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
 
     private final IMap<K, V> map;
@@ -100,6 +101,11 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     }
 
     @Override
+    public boolean evict(K key) {
+        return map.evict(key);
+    }
+
+    @Override
     @MethodNotAvailable
     public <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException {
         throw new MethodNotAvailableException();
@@ -166,6 +172,11 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     @MethodNotAvailable
     public void removeAll(final Set<K> keys) {
         throw new MethodNotAvailableException();
+    }
+
+    @Override
+    public void evictAll() {
+        map.evictAll();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
 
     private final ReplicatedMap<K, V> map;
@@ -101,6 +102,12 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     @MethodNotAvailable
     public ICompletableFuture<V> removeAsync(K key) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public boolean evict(K key) {
         throw new MethodNotAvailableException();
     }
 
@@ -180,6 +187,12 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     @MethodNotAvailable
     public void removeAll(Set<K> keys) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public void evictAll() {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -134,6 +134,12 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
 
     @Override
     @MethodNotAvailable
+    public boolean evict(K key) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
     public <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException {
         throw new MethodNotAvailableException();
     }
@@ -183,6 +189,12 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     @Override
     @MethodNotAvailable
     public void removeAll(Set<K> keys) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public void evictAll() {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
@@ -195,6 +195,11 @@ public class ICacheDataStructureAdapterTest extends HazelcastTestSupport {
         assertFalse(cache.containsKey(23));
     }
 
+    @Test(expected = MethodNotAvailableException.class)
+    public void testEvict() {
+        adapter.evict(23);
+    }
+
     @Test
     public void testInvoke() {
         cache.put(23, "value-23");
@@ -304,6 +309,11 @@ public class ICacheDataStructureAdapterTest extends HazelcastTestSupport {
         assertEquals(1, cache.size());
         assertTrue(cache.containsKey(23));
         assertFalse(cache.containsKey(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testEvictAll() {
+        adapter.evictAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
@@ -189,6 +189,20 @@ public class IMapDataStructureAdapterTest extends HazelcastTestSupport {
         assertFalse(map.containsKey(23));
     }
 
+    @Test
+    public void testEvict() {
+        mapWithLoader.put(23, "value-23");
+        mapWithLoader.put(42, "value-42");
+        mapWithLoader.put(65, "value-65");
+
+        adapterWithLoader.evict(42);
+
+        assertEquals(2, mapWithLoader.size());
+        assertTrue(mapWithLoader.containsKey(23));
+        assertFalse(mapWithLoader.containsKey(42));
+        assertTrue(mapWithLoader.containsKey(65));
+    }
+
     @Test(expected = MethodNotAvailableException.class)
     public void testInvoke() {
         adapter.invoke(23, new ICacheReplaceEntryProcessor(), "value", "newValue");
@@ -327,6 +341,20 @@ public class IMapDataStructureAdapterTest extends HazelcastTestSupport {
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAllWithKeys() {
         adapter.removeAll(singleton(42));
+    }
+
+    @Test
+    public void testEvictAll() {
+        mapWithLoader.put(23, "value-23");
+        mapWithLoader.put(42, "value-42");
+        mapWithLoader.put(65, "value-65");
+
+        adapterWithLoader.evictAll();
+
+        assertEquals(0, mapWithLoader.size());
+        assertFalse(mapWithLoader.containsKey(23));
+        assertFalse(mapWithLoader.containsKey(42));
+        assertFalse(mapWithLoader.containsKey(65));
     }
 
     @Test(expected = MethodNotAvailableException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -133,6 +133,11 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
     }
 
     @Test(expected = MethodNotAvailableException.class)
+    public void testEvict() {
+        adapter.evict(23);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
     public void testInvoke() {
         adapter.invoke(23, new ICacheReplaceEntryProcessor(), "value", "newValue");
     }
@@ -216,6 +221,11 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAllWithKeys() {
         adapter.removeAll(singleton(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testEvictAll() {
+        adapter.evictAll();
     }
 
     @Test(expected = MethodNotAvailableException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -158,6 +158,11 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
     }
 
     @Test(expected = MethodNotAvailableException.class)
+    public void testEvict() {
+        adapter.evict(23);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
     public void testInvoke() {
         adapter.invoke(23, new ICacheReplaceEntryProcessor(), "value", "newValue");
     }
@@ -228,6 +233,11 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAllWithKeys() {
         adapter.removeAll(singleton(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testEvictAll() {
+        adapter.evictAll();
     }
 
     @Test(expected = MethodNotAvailableException.class)


### PR DESCRIPTION
The `evict(key)` and `evictAll()` methods from `IMap` have not been tested for the Near Cache.