### PR TITLE
Fixed race in ClientNearCacheTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -70,15 +69,11 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
-    @Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10988")
-    // FIXME before 3.9 release
     public void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache() {
         putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(inMemoryFormat);
     }
 
     @Test
-    @Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10988")
-    // FIXME before 3.9 release
     public void putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCache() {
         putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCache(inMemoryFormat);
     }
@@ -89,8 +84,6 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
-    @Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10988")
-    // FIXME before 3.9 release
     public void putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCache() {
         putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCache(inMemoryFormat);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTestSupport.java
@@ -207,7 +207,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         final NearCacheTestContext nearCacheTestContext2 = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         // put cache record from client-1
-        populateCache(nearCacheTestContext1);
+        populateCache(nearCacheTestContext1, nearCacheTestContext2);
 
         // get records from client-2
         populateNearCacheAndAssertNearCacheValues(nearCacheTestContext2);
@@ -310,7 +310,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         final NearCacheTestContext nearCacheTestContext2 = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         // put cache record from client-1
-        populateCache(nearCacheTestContext1);
+        populateCache(nearCacheTestContext1, nearCacheTestContext2);
 
         // get records from client-2
         populateNearCacheAndAssertNearCacheValues(nearCacheTestContext2);
@@ -387,7 +387,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         final NearCacheTestContext nearCacheTestContext2 = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         // put cache record from client-1
-        populateCache(nearCacheTestContext1);
+        populateCache(nearCacheTestContext1, nearCacheTestContext2);
 
         // get records from client-2
         populateNearCacheAndAssertNearCacheValues(nearCacheTestContext2);
@@ -555,11 +555,12 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         NearCacheTestUtils.assertNearCacheInvalidations(nearCacheTestContext.invalidationListener, DEFAULT_RECORD_COUNT, stats);
     }
 
-    protected static void populateCache(NearCacheTestContext nearCacheTestContext1) {
+    private static void populateCache(NearCacheTestContext nearCacheTestContext1, NearCacheTestContext nearCacheTestContext2) {
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             nearCacheTestContext1.cache.put(i, generateValueFromKey(i));
         }
         assertNearCacheInvalidations(nearCacheTestContext1);
+        assertNearCacheInvalidations(nearCacheTestContext2);
     }
 
     protected static void populateNearCacheAndAssertNearCacheValues(final NearCacheTestContext nearCacheTestContext) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+
 public class ClientCacheInvalidationListener
         extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
         implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
@@ -46,12 +48,14 @@ public class ClientCacheInvalidationListener
 
     @Override
     public void handle(String name, Data key, String sourceUuid, UUID partitionUuid, long sequence) {
+        sleepMillis(100);
         invalidationCount.incrementAndGet();
     }
 
     @Override
     public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids,
                        Collection<UUID> partitionUuids, Collection<Long> sequences) {
+        sleepMillis(100);
         invalidationCount.addAndGet(keys.size());
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+
 class ClientMapInvalidationListener
         extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler
         implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
@@ -52,6 +54,7 @@ class ClientMapInvalidationListener
     @Override
     public void handle(Collection<Data> keys, Collection<String> sourceUuids,
                        Collection<UUID> partitionUuids, Collection<Long> sequences) {
+        sleepMillis(100);
         invalidationCount.addAndGet(keys.size());
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapInvalidationListener.java
@@ -27,6 +27,8 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+
 class ClientReplicatedMapInvalidationListener
         extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler
         implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
@@ -52,6 +54,10 @@ class ClientReplicatedMapInvalidationListener
     public void handle(Data dataKey, Data value, Data oldValue, Data mergingValue, int eventType, String uuid,
                        int numberOfAffectedEntries) {
         EntryEventType entryEventType = EntryEventType.getByType(eventType);
+        if (entryEventType == null) {
+            return;
+        }
+        sleepMillis(100);
         switch (entryEventType) {
             case ADDED:
             case REMOVED:

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapInvalidationListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapInvalidationListener.java
@@ -25,6 +25,8 @@ import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+
 public class MapInvalidationListener implements NearCacheInvalidationListener, InvalidationListener {
 
     private final AtomicLong invalidationCount = new AtomicLong();
@@ -41,6 +43,7 @@ public class MapInvalidationListener implements NearCacheInvalidationListener, I
 
     @Override
     public void onInvalidate(Invalidation invalidation) {
+        sleepMillis(100);
         if (invalidation instanceof BatchNearCacheInvalidation) {
             BatchNearCacheInvalidation batch = ((BatchNearCacheInvalidation) invalidation);
             int batchInvalidationCount = batch.getInvalidations().size();


### PR DESCRIPTION
I could not find an issue in the production code itself, just a race in the test-only invalidation listener. The `NearCacheInvalidationListener` implementations are used in tests only, to wait for the first wave of incoming invalidations from the population of a backing data structure.

The issue is, that the invalidations are counted as soon as they are incoming, not when they are finished. There could also be a race with the real invalidation listener (so our test listener could be notified first). A proper fix would be to react on finished invalidations, not on incoming ones.

We also forgot to wait for invalidations on the second client, which is properly fixed now (assuming that the `NearCacheInvalidationListener` works deterministic eventually).

* `assertNearCacheInvalidations(nearCacheTestContext2);` was missing after `JCache` population
* added a workaround to wait for 100 ms before counting an incoming invalidation

Fixes https://github.com/hazelcast/hazelcast/issues/10988

A proper fix would be https://github.com/hazelcast/hazelcast/pull/10998