### PR TITLE
Make dynamic config available on lite members

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.dynamicconfig.AddDynamicConfigOperation;
-import com.hazelcast.internal.dynamicconfig.DynamicConfigReplicationOperation;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigPreJoinOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -45,7 +45,7 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int NEAR_CACHE_CONFIG = 3;
     public static final int NEAR_CACHE_PRELOADER_CONFIG = 4;
     public static final int ADD_DYNAMIC_CONFIG_OP = 5;
-    public static final int REPLICATE_CONFIGURATIONS_OP = 6;
+    public static final int DYNAMIC_CONFIG_PRE_JOIN_OP = 6;
     public static final int MULTIMAP_CONFIG = 7;
     public static final int LISTENER_CONFIG = 8;
     public static final int ENTRY_LISTENER_CONFIG = 9;
@@ -129,10 +129,10 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                 return new AddDynamicConfigOperation();
             }
         };
-        constructors[REPLICATE_CONFIGURATIONS_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+        constructors[DYNAMIC_CONFIG_PRE_JOIN_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new DynamicConfigReplicationOperation();
+                return new DynamicConfigPreJoinOperation();
             }
         };
         constructors[MULTIMAP_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -135,4 +135,11 @@ public interface ClusterService extends CoreService, Cluster {
      * @return unique UUID for cluster
      */
     String getClusterId();
+
+    /**
+     * Returns the current version of member list.
+     *
+     * @return current version of member list
+     */
+    int getMemberListVersion();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -1086,7 +1086,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return clusterHeartbeatManager;
     }
 
-    // used for 3.8 compatibility
+    // RU_COMPAT_WITH_3_8
     public MembershipManagerCompat getMembershipManagerCompat() {
         assert getClusterVersion().isLessThan(Versions.V3_9) : "Cluster version should be less than 3.9";
         return membershipManagerCompat;
@@ -1128,6 +1128,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         } finally {
             lock.unlock();
         }
+    }
+
+    @Override
+    public int getMemberListVersion() {
+        return membershipManager.getMemberListVersion();
     }
 
     private MemberImpl getMasterMember() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -442,12 +442,15 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             ClusterClockImpl clusterClock = getClusterClock();
             clusterClock.setClusterStartTime(clusterStartTime);
             clusterClock.setMasterTime(masterTime);
-            membershipManager.updateMembers(membersView);
-            clusterHeartbeatManager.heartbeat();
 
+            // run pre-join op before member list update, so operations other than join ops will be refused by operation service
             if (preJoinOp != null) {
                 nodeEngine.getOperationService().run(preJoinOp);
             }
+
+            membershipManager.updateMembers(membersView);
+            clusterHeartbeatManager.heartbeat();
+
             setJoined(true);
 
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterTopologyChangedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterTopologyChangedException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+
+/**
+ * Thrown when a cluster topology change is detected.
+ */
+public class ClusterTopologyChangedException extends RetryableHazelcastException {
+
+    public ClusterTopologyChangedException() {
+    }
+
+    public ClusterTopologyChangedException(String message) {
+        super(message);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
@@ -46,10 +46,13 @@ public class AddDynamicConfigOperation extends AbstractDynamicConfigOperation {
         ClusterWideConfigurationService service = getService();
         service.registerConfigLocally(config, ConfigCheckMode.THROW_EXCEPTION);
         ClusterService clusterService = getNodeEngine().getClusterService();
-        int currentMemberListVersion = clusterService.getMemberListVersion();
-        if (currentMemberListVersion != memberListVersion) {
-            throw new ClusterTopologyChangedException(format("Current member list version %d does not match expected %d",
-                    currentMemberListVersion, memberListVersion));
+        if (clusterService.isMaster()) {
+            int currentMemberListVersion = clusterService.getMemberListVersion();
+            if (currentMemberListVersion != memberListVersion) {
+                throw new ClusterTopologyChangedException(
+                        format("Current member list version %d does not match expected %d", currentMemberListVersion,
+                                memberListVersion));
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.ExceptionAction;
 
 import java.io.IOException;
 
@@ -73,4 +74,9 @@ public class AddDynamicConfigOperation extends AbstractDynamicConfigOperation {
         return ConfigDataSerializerHook.ADD_DYNAMIC_CONFIG_OP;
     }
 
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        return (throwable instanceof ClusterTopologyChangedException) ? ExceptionAction.THROW_EXCEPTION
+                : super.onInvocationException(throwable);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
@@ -17,38 +17,52 @@
 package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.ConfigDataSerializerHook;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
+import static java.lang.String.format;
+
 public class AddDynamicConfigOperation extends AbstractDynamicConfigOperation {
 
     private IdentifiedDataSerializable config;
+    private int memberListVersion;
 
     public AddDynamicConfigOperation() {
 
     }
 
-    public AddDynamicConfigOperation(IdentifiedDataSerializable config) {
+    public AddDynamicConfigOperation(IdentifiedDataSerializable config, int memberListVersion) {
         this.config = config;
+        this.memberListVersion = memberListVersion;
     }
 
     @Override
     public void run() throws Exception {
         ClusterWideConfigurationService service = getService();
         service.registerConfigLocally(config, ConfigCheckMode.THROW_EXCEPTION);
+        ClusterService clusterService = getNodeEngine().getClusterService();
+        int currentMemberListVersion = clusterService.getMemberListVersion();
+        if (currentMemberListVersion != memberListVersion) {
+            throw new ClusterTopologyChangedException(format("Current member list version %d does not match expected %d",
+                    currentMemberListVersion, memberListVersion));
+        }
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeObject(config);
+        out.writeInt(memberListVersion);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         config = in.readObject();
+        memberListVersion = in.readInt();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperationFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -29,19 +30,22 @@ import java.io.IOException;
  */
 public class AddDynamicConfigOperationFactory implements OperationFactory {
 
+    private final ClusterService clusterService;
     private final IdentifiedDataSerializable config;
 
     public AddDynamicConfigOperationFactory() {
+        this.clusterService = null;
         this.config = null;
     }
 
-    public AddDynamicConfigOperationFactory(IdentifiedDataSerializable config) {
+    public AddDynamicConfigOperationFactory(ClusterService clusterService, IdentifiedDataSerializable config) {
+        this.clusterService = clusterService;
         this.config = config;
     }
 
     @Override
     public Operation createOperation() {
-        return new AddDynamicConfigOperation(config);
+        return new AddDynamicConfigOperation(config, clusterService.getMemberListVersion());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -44,12 +44,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.CoreService;
 import com.hazelcast.spi.ManagedService;
-import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.PartitionMigrationEvent;
-import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.PreJoinAwareService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
@@ -72,7 +69,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.lang.Boolean.getBoolean;
 
 @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
-public class ClusterWideConfigurationService implements MigrationAwareService, PreJoinAwareService,
+public class ClusterWideConfigurationService implements PreJoinAwareService,
         CoreService, ClusterVersionListener, ManagedService, ConfigurationService, SplitBrainHandlerService {
     public static final String SERVICE_NAME = "configuration-service";
     public static final int CONFIG_PUBLISH_MAX_ATTEMPT_COUNT = 100;
@@ -147,7 +144,7 @@ public class ClusterWideConfigurationService implements MigrationAwareService, P
     }
 
     @Override
-    public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+    public Operation getPreJoinOperation() {
         if (version.isLessOrEqual(V3_8)) {
             return null;
         }
@@ -156,12 +153,7 @@ public class ClusterWideConfigurationService implements MigrationAwareService, P
             // there is no dynamic configuration -> no need to send an empty operation
             return null;
         }
-        return new DynamicConfigReplicationOperation(allConfigurations, ConfigCheckMode.WARNING);
-    }
-
-    @Override
-    public Operation getPreJoinOperation() {
-        return prepareReplicationOperation(null);
+        return new DynamicConfigPreJoinOperation(allConfigurations, ConfigCheckMode.WARNING);
     }
 
     private boolean noConfigurationExist(IdentifiedDataSerializable[] configurations) {
@@ -175,21 +167,6 @@ public class ClusterWideConfigurationService implements MigrationAwareService, P
             all.addAll(values);
         }
         return all.toArray(new IdentifiedDataSerializable[0]);
-    }
-
-    @Override
-    public void beforeMigration(PartitionMigrationEvent event) {
-        //no-op
-    }
-
-    @Override
-    public void commitMigration(PartitionMigrationEvent event) {
-        //no-op
-    }
-
-    @Override
-    public void rollbackMigration(PartitionMigrationEvent event) {
-        //no-op
     }
 
     @Override
@@ -564,7 +541,7 @@ public class ClusterWideConfigurationService implements MigrationAwareService, P
         if (noConfigurationExist(allConfigurations)) {
             return null;
         }
-        return new Merger(nodeEngine, new DynamicConfigReplicationOperation(allConfigurations, ConfigCheckMode.SILENT));
+        return new Merger(nodeEngine, new DynamicConfigPreJoinOperation(allConfigurations, ConfigCheckMode.SILENT));
     }
 
     public static class Merger implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -318,7 +318,7 @@ public class ClusterWideConfigurationService implements MigrationAwareService,
 
     private void registerEventJournalConfig(EventJournalConfig eventJournalConfig, ConfigCheckMode configCheckMode) {
         String mapName = eventJournalConfig.getMapName();
-        String cacheName = eventJournalConfig.getMapName();
+        String cacheName = eventJournalConfig.getCacheName();
         synchronized (journalMutex) {
             EventJournalConfig currentMapJournalConfig = null;
             if (mapName != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -37,8 +37,8 @@ import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.ClusterVersionListener;
-
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -231,7 +231,8 @@ public class ClusterWideConfigurationService implements MigrationAwareService,
         // and avoid config serialization altogether.
         // we certainly do not want the dynamic config service to reference object a user can mutate
         IdentifiedDataSerializable clonedConfig = cloneConfig(config);
-        return invokeOnStableClusterSerial(nodeEngine, new AddDynamicConfigOperationFactory(clonedConfig),
+        ClusterService clusterService = nodeEngine.getClusterService();
+        return invokeOnStableClusterSerial(nodeEngine, new AddDynamicConfigOperationFactory(clusterService, clonedConfig),
                 CONFIG_PUBLISH_MAX_ATTEMPT_COUNT);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -50,6 +50,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
+import com.hazelcast.spi.PreJoinAwareService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -71,7 +72,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.lang.Boolean.getBoolean;
 
 @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
-public class ClusterWideConfigurationService implements MigrationAwareService,
+public class ClusterWideConfigurationService implements MigrationAwareService, PreJoinAwareService,
         CoreService, ClusterVersionListener, ManagedService, ConfigurationService, SplitBrainHandlerService {
     public static final String SERVICE_NAME = "configuration-service";
     public static final int CONFIG_PUBLISH_MAX_ATTEMPT_COUNT = 100;
@@ -156,6 +157,11 @@ public class ClusterWideConfigurationService implements MigrationAwareService,
             return null;
         }
         return new DynamicConfigReplicationOperation(allConfigurations, ConfigCheckMode.WARNING);
+    }
+
+    @Override
+    public Operation getPreJoinOperation() {
+        return prepareReplicationOperation(null);
     }
 
     private boolean noConfigurationExist(IdentifiedDataSerializable[] configurations) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
@@ -24,22 +24,19 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
-/**
- * Replicates dynamic configs. Note that this operation is used both as pre-join and as replication operation by the
- * {@link ClusterWideConfigurationService}.
- */
-public class DynamicConfigReplicationOperation extends AbstractDynamicConfigOperation {
+public class DynamicConfigPreJoinOperation
+        extends AbstractDynamicConfigOperation {
 
     private IdentifiedDataSerializable[] configs;
     private ConfigCheckMode configCheckMode;
 
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public DynamicConfigReplicationOperation(IdentifiedDataSerializable[] configs, ConfigCheckMode configCheckMode) {
+    public DynamicConfigPreJoinOperation(IdentifiedDataSerializable[] configs, ConfigCheckMode configCheckMode) {
         this.configs = configs;
         this.configCheckMode = configCheckMode;
     }
 
-    public DynamicConfigReplicationOperation() {
+    public DynamicConfigPreJoinOperation() {
 
     }
 
@@ -72,6 +69,6 @@ public class DynamicConfigReplicationOperation extends AbstractDynamicConfigOper
 
     @Override
     public int getId() {
-        return ConfigDataSerializerHook.REPLICATE_CONFIGURATIONS_OP;
+        return ConfigDataSerializerHook.DYNAMIC_CONFIG_PRE_JOIN_OP;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigReplicationOperation.java
@@ -24,6 +24,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
+/**
+ * Replicates dynamic configs. Note that this operation is used both as pre-join and as replication operation by the
+ * {@link ClusterWideConfigurationService}.
+ */
 public class DynamicConfigReplicationOperation extends AbstractDynamicConfigOperation {
 
     private IdentifiedDataSerializable[] configs;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -60,7 +60,7 @@ public final class InvocationUtil {
      *
      * If there is an exception - other than {@link MemberLeftException} or
      * {@link com.hazelcast.spi.exception.TargetNotMemberException} while invoking then the iteration
-     * is interrupted and the exception is propagates to the caller.
+     * is interrupted and the exception is propagated to the caller.
      *
      * @param nodeEngine
      * @param operationFactory

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
@@ -18,8 +18,10 @@
 package com.hazelcast.internal.util.futures;
 
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
@@ -39,7 +41,9 @@ public class ChainingFuture<T> extends AbstractCompletableFuture<T> {
     public static final ExceptionHandler IGNORE_CLUSTER_TOPOLOGY_CHANGES = new ExceptionHandler() {
         @Override
         public <T extends Throwable> void handle(T throwable) throws T {
-            if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
+            if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException
+                    || throwable instanceof HazelcastInstanceNotActiveException
+                    || throwable instanceof ClusterTopologyChangedException) {
                 return;
             }
             throw throwable;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
@@ -18,12 +18,8 @@
 package com.hazelcast.internal.util.futures;
 
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
 
 import java.util.Iterator;
@@ -38,17 +34,6 @@ import java.util.concurrent.Executor;
  * @param <T>
  */
 public class ChainingFuture<T> extends AbstractCompletableFuture<T> {
-    public static final ExceptionHandler IGNORE_CLUSTER_TOPOLOGY_CHANGES = new ExceptionHandler() {
-        @Override
-        public <T extends Throwable> void handle(T throwable) throws T {
-            if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException
-                    || throwable instanceof HazelcastInstanceNotActiveException
-                    || throwable instanceof ClusterTopologyChangedException) {
-                return;
-            }
-            throw throwable;
-        }
-    };
 
     private final ExceptionHandler exceptionHandler;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/DefaultPublisherContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/DefaultPublisherContext.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.IFunction;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipAdapter;
 import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.QueryCacheScheduler;
 import com.hazelcast.map.impl.querycache.accumulator.AccumulatorInfo;
@@ -182,7 +182,7 @@ public class DefaultPublisherContext implements PublisherContext {
     }
 
     private void handleSubscriberAddRemove() {
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
+        ClusterService clusterService = nodeEngine.getClusterService();
         clusterService.addMembershipListener(new MembershipAdapter() {
             @Override
             public void memberRemoved(MembershipEvent membershipEvent) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -22,7 +22,7 @@ import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.monitor.LocalMultiMapStats;
 import com.hazelcast.monitor.impl.LocalMultiMapStatsImpl;
@@ -344,7 +344,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         long backupEntryCount = 0;
         long hits = 0;
         long lockedEntryCount = 0;
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
+        ClusterService clusterService = nodeEngine.getClusterService();
 
         Address thisAddress = clusterService.getThisAddress();
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.serialization.impl.HeapData;
@@ -84,7 +84,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     private final NodeEngine nodeEngine;
     private final PartitionContainer[] partitionContainers;
     private final InternalPartitionServiceImpl partitionService;
-    private final ClusterServiceImpl clusterService;
+    private final ClusterService clusterService;
     private final OperationService operationService;
     private final ReplicatedMapEventPublishingService eventPublishingService;
     private final MergePolicyProvider mergePolicyProvider;
@@ -103,7 +103,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
         this.nodeEngine = nodeEngine;
         this.config = nodeEngine.getConfig();
         this.partitionService = (InternalPartitionServiceImpl) nodeEngine.getPartitionService();
-        this.clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
+        this.clusterService = nodeEngine.getClusterService();
         this.operationService = nodeEngine.getOperationService();
         this.partitionContainers = new PartitionContainer[nodeEngine.getPartitionService().getPartitionCount()];
         this.eventPublishingService = new ReplicatedMapEventPublishingService(this);

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.CacheDeserializedValues;
@@ -22,7 +38,7 @@ import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,7 +51,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({SlowTest.class, ParallelTest.class})
 public class DynamicConfigBouncingTest extends HazelcastTestSupport {
     @Rule
     public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig())

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSlowPreJoinBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSlowPreJoinBouncingTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.dynamicconfig;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PreJoinAwareService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelTest.class})
+public class DynamicConfigSlowPreJoinBouncingTest extends DynamicConfigBouncingTest {
+
+    public Config getConfig() {
+        DelaysPreparingPreJoinOpService service = new DelaysPreparingPreJoinOpService();
+        Config config = new Config();
+        config.getServicesConfig().addServiceConfig(
+                new ServiceConfig().setEnabled(true).setName(DelaysPreparingPreJoinOpService.SERVICE_NAME)
+                                   .setImplementation(service));
+        return config;
+    }
+
+    private static class DelaysPreparingPreJoinOpService implements PreJoinAwareService {
+
+        static final String SERVICE_NAME = "delaying-pre-join-op-prep-service";
+
+        public DelaysPreparingPreJoinOpService() {
+        }
+
+        @Override
+        public Operation getPreJoinOperation() {
+            sleepSeconds(1);
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -96,7 +96,6 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
 
         //start an instance AFTER the config was already submitted
         HazelcastInstance i3 = factory.newHazelcastInstance();
-        waitAllForSafeState(i1, i2, i3);
 
         multiMapConfig = i3.getConfig().getMultiMapConfig(mapName);
         assertEquals(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT, multiMapConfig.getBackupCount());
@@ -179,5 +178,27 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
             topicConfig = instance.getConfig().getTopicConfig(topicName);
             assertEquals(listenerClassName, topicConfig.getMessageListenerConfigs().get(0).getClassName());
         }
+    }
+
+    @Test
+    public void mapConfig_withLiteMemberJoiningLater_isImmediatelyAvailable() {
+        String mapName = randomMapName();
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance i1 = factory.newHazelcastInstance();
+        HazelcastInstance i2 = factory.newHazelcastInstance();
+
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
+        Config config = i1.getConfig();
+        config.addMapConfig(mapConfig);
+
+        //start a lite member after the dynamic config was submitted
+        Config liteConfig = new Config();
+        liteConfig.setLiteMember(true);
+        HazelcastInstance i3 = factory.newHazelcastInstance(liteConfig);
+
+        MapConfig mapConfigOnLiteMember = i3.getConfig().getMapConfig(mapName);
+        assertEquals(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT, mapConfigOnLiteMember.getBackupCount());
     }
 }


### PR DESCRIPTION
* Pre-join operations are now executed on the joining member before any other operations
* `ClusterWideConfigurationService` now implement `PreJoinAwareService` so lite members are also aware of dynamic configs.
* Member list version as observed on operation source member at time of `AddDynamicConfig` creation is verified to be the same when operation finishes on target member to avoid races between applying the dynamic config and updating the member list as members are added or removed to/from the cluster.
* `HazelcastInstanceNotActiveException` is also considered as a topology change indication (may be thrown when `AddDynamicConfig` is sent to a shutting down member) so is also ignored by the `IGNORE_CLUSTER_TOPOLOGY_CHANGES` exception handler.
* Fixes a typo when applying event journal dynamic config
* Cleanup: removes unnecessary casts to `ClusterServiceImpl`

Fixes #10926
Fixes #10946
Supersedes #10981  

See each separate commit for easier review.