### PR TITLE
[BACKPORT] HTTP HEAD Support in Rest Interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
@@ -77,6 +77,7 @@ public final class TextCommandConstants {
         HTTP_POST((byte) 31),
         HTTP_PUT((byte) 32),
         HTTP_DELETE((byte) 33),
+        HTTP_HEAD((byte) 34),
         NO_OP((byte) 98),
         STOP((byte) 99);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -34,6 +34,7 @@ import com.hazelcast.internal.ascii.memcache.TouchCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.VersionCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpDeleteCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpGetCommandProcessor;
+import com.hazelcast.internal.ascii.rest.HttpHeadCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpPostCommandProcessor;
 import com.hazelcast.internal.ascii.rest.RestValue;
 import com.hazelcast.logging.ILogger;
@@ -62,6 +63,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.GET_END;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_DELETE;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_GET;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_HEAD;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_POST;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_PUT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.INCREMENT;
@@ -128,6 +130,7 @@ public class TextCommandServiceImpl implements TextCommandService {
         textCommandProcessors[HTTP_POST.getValue()] = new HttpPostCommandProcessor(this);
         textCommandProcessors[HTTP_PUT.getValue()] = new HttpPostCommandProcessor(this);
         textCommandProcessors[HTTP_DELETE.getValue()] = new HttpDeleteCommandProcessor(this);
+        textCommandProcessors[HTTP_HEAD.getValue()] = new HttpHeadCommandProcessor(this);
         textCommandProcessors[NO_OP.getValue()] = new NoOpCommandProcessor(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 import static com.hazelcast.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.util.StringUtil.stringToBytes;
@@ -32,6 +33,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
     public static final String HEADER_CONTENT_LENGTH = "content-length: ";
     public static final String HEADER_CHUNKED = "transfer-encoding: chunked";
     public static final String HEADER_EXPECT_100 = "expect: 100";
+    public static final String HEADER_CUSTOM_PREFIX = "Hazelcast-";
     public static final byte[] RES_200 = stringToBytes("HTTP/1.1 200 OK\r\n");
     public static final byte[] RES_400 = stringToBytes("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
     public static final byte[] RES_403 = stringToBytes("HTTP/1.1 403 Forbidden\r\n\r\n");
@@ -78,6 +80,44 @@ public abstract class HttpCommand extends AbstractTextCommand {
 
     public void send200() {
         setResponse(null, null);
+    }
+
+    /**
+     * HTTP/1.0 200 OK
+     * Content-Length: 0
+     * Custom-Header1: val1
+     * Custom-Header2: val2
+     *
+     * @param headers
+     */
+    public void setResponse(Map<String, Object> headers) {
+        int size = RES_200.length;
+        byte[] len = stringToBytes(String.valueOf(0));
+        size += CONTENT_LENGTH.length;
+        size += len.length;
+        size += TextCommandConstants.RETURN.length;
+        if (headers != null) {
+            for (Map.Entry<String, Object> entry : headers.entrySet()) {
+                size += stringToBytes(HEADER_CUSTOM_PREFIX + entry.getKey() + ": ").length;
+                size += stringToBytes(entry.getValue().toString()).length;
+                size += TextCommandConstants.RETURN.length;
+            }
+        }
+        size += TextCommandConstants.RETURN.length;
+        this.response = ByteBuffer.allocate(size);
+        response.put(RES_200);
+        response.put(CONTENT_LENGTH);
+        response.put(len);
+        response.put(TextCommandConstants.RETURN);
+        if (headers != null) {
+            for (Map.Entry<String, Object> entry : headers.entrySet()) {
+                response.put(stringToBytes(HEADER_CUSTOM_PREFIX + entry.getKey() + ": "));
+                response.put(stringToBytes(entry.getValue().toString()));
+                response.put(TextCommandConstants.RETURN);
+            }
+        }
+        response.put(TextCommandConstants.RETURN);
+        response.flip();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
+
+import java.nio.ByteBuffer;
+
+public class HttpHeadCommand extends HttpCommand {
+    private boolean nextLine;
+
+    public HttpHeadCommand(String uri) {
+        super(TextCommandType.HTTP_HEAD, uri);
+    }
+
+    @Override
+    public boolean readFrom(ByteBuffer src) {
+        while (src.hasRemaining()) {
+            char c = (char) src.get();
+            if (c == '\n') {
+                if (nextLine) {
+                    return true;
+                }
+                nextLine = true;
+            } else if (c != '\r') {
+                nextLine = false;
+            }
+        }
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import com.hazelcast.internal.ascii.CommandParser;
+import com.hazelcast.internal.ascii.TextCommand;
+import com.hazelcast.internal.ascii.memcache.ErrorCommand;
+import com.hazelcast.nio.ascii.TextReadHandler;
+
+import java.util.StringTokenizer;
+
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
+
+public class HttpHeadCommandParser implements CommandParser {
+
+    @Override
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
+        StringTokenizer st = new StringTokenizer(cmd);
+        st.nextToken();
+        String uri;
+        if (st.hasMoreTokens()) {
+            uri = st.nextToken();
+        } else {
+            return new ErrorCommand(ERROR_CLIENT);
+        }
+        return new HttpHeadCommand(uri);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.rest;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
+import com.hazelcast.internal.ascii.TextCommandService;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.partition.InternalPartitionService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class HttpHeadCommandProcessor extends HttpCommandProcessor<HttpHeadCommand> {
+
+    public HttpHeadCommandProcessor(TextCommandService textCommandService) {
+        super(textCommandService);
+    }
+
+    @Override
+    public void handle(HttpHeadCommand command) {
+        String uri = command.getURI();
+        if (uri.startsWith(URI_MAPS)) {
+            command.send200();
+        } else if (uri.startsWith(URI_QUEUES)) {
+            command.send200();
+        } else if (uri.startsWith(URI_CLUSTER)) {
+            command.send200();
+        } else if (uri.equals(URI_HEALTH_URL)) {
+            handleHealthcheck(command);
+        } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
+            command.send200();
+        } else {
+            command.send400();
+        }
+        textCommandService.sendResponse(command);
+    }
+
+    private void handleHealthcheck(HttpHeadCommand command) {
+        Node node = textCommandService.getNode();
+        NodeState nodeState = node.getState();
+
+        ClusterServiceImpl clusterService = node.getClusterService();
+        ClusterState clusterState = clusterService.getClusterState();
+        int clusterSize = clusterService.getMembers().size();
+
+        InternalPartitionService partitionService = node.getPartitionService();
+        long migrationQueueSize = partitionService.getMigrationQueueSize();
+
+        Map<String, Object> headervals = new LinkedHashMap<String, Object>();
+        headervals.put("NodeState", nodeState);
+        headervals.put("ClusterState", clusterState);
+        headervals.put("MigrationQueueSize", migrationQueueSize);
+        headervals.put("ClusterSize", clusterSize);
+
+        command.setResponse(headervals);
+    }
+
+    @Override
+    public void handleRejection(HttpHeadCommand command) {
+        handle(command);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.ascii.rest.HttpCommand;
 import com.hazelcast.internal.ascii.rest.HttpCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpDeleteCommandParser;
 import com.hazelcast.internal.ascii.rest.HttpGetCommandParser;
+import com.hazelcast.internal.ascii.rest.HttpHeadCommandParser;
 import com.hazelcast.internal.ascii.rest.HttpPostCommandParser;
 import com.hazelcast.internal.networking.ReadHandler;
 import com.hazelcast.logging.ILogger;
@@ -88,6 +89,7 @@ public class TextReadHandler implements ReadHandler {
         MAP_COMMAND_PARSERS.put("POST", new HttpPostCommandParser());
         MAP_COMMAND_PARSERS.put("PUT", new HttpPostCommandParser());
         MAP_COMMAND_PARSERS.put("DELETE", new HttpDeleteCommandParser());
+        MAP_COMMAND_PARSERS.put("HEAD", new HttpHeadCommandParser());
     }
 
     private ByteBuffer commandLineBuffer = ByteBuffer.allocate(INITIAL_CAPACITY);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -255,4 +255,42 @@ public class RestClusterTest extends HazelcastTestSupport {
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         communicator.getClusterHealth();
     }
+
+    @Test
+    public void testHeadRequest_ClusterVersion() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.headRequestToClusterVersionURI().responseCode);
+    }
+
+    @Test
+    public void testHeadRequest_ClusterInfo() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.headRequestToClusterInfoURI().responseCode);
+    }
+
+    @Test
+    public void testHeadRequest_ClusterHealth() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        HTTPCommunicator.ConnectionResponse response = communicator.headRequestToClusterHealthURI();
+        assertEquals(HttpURLConnection.HTTP_OK, response.responseCode);
+        assertEquals(response.responseHeaders.get("Hazelcast-NodeState").size(), 1);
+        assertContains(response.responseHeaders.get("Hazelcast-NodeState"), "ACTIVE");
+        assertEquals(response.responseHeaders.get("Hazelcast-ClusterState").size(), 1);
+        assertContains(response.responseHeaders.get("Hazelcast-ClusterState"), "ACTIVE");
+        assertEquals(response.responseHeaders.get("Hazelcast-ClusterSize").size(), 1);
+        assertContains(response.responseHeaders.get("Hazelcast-ClusterSize"), "2");
+        assertEquals(response.responseHeaders.get("Hazelcast-MigrationQueueSize").size(), 1);
+        assertContains(response.responseHeaders.get("Hazelcast-MigrationQueueSize"), "0");
+    }
+
+    @Test
+    public void testHeadRequest_GarbageClusterHealth() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.headRequestToGarbageClusterHealthURI().responseCode);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -241,5 +242,23 @@ public class RestTest extends HazelcastTestSupport {
         int response = communicator.mapPut(mapName, key.toString(), value);
         assertEquals(HTTP_OK, response);
         assertEquals(value, communicator.mapGet(mapName, key.toString()));
+    }
+
+    @Test
+    public void testMap_HeadRequest() throws IOException {
+        int response = communicator.headRequestToMapURI().responseCode;
+        assertEquals(HTTP_OK, response);
+    }
+
+    @Test
+    public void testQueue_HeadRequest() throws IOException {
+        int response = communicator.headRequestToQueueURI().responseCode;
+        assertEquals(HTTP_OK, response);
+    }
+
+    @Test
+    public void testUndefined_HeadRequest() throws IOException {
+        int response = communicator.headRequestToUndefinedURI().responseCode;
+        assertEquals(HTTP_BAD_REQUEST, response);
     }
 }


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/10999

- Return HTTP 200 for defined endpoints.
- Add cluster heath data as custom headers for health check URI (except ClusterSafe state)
- Add tests