### PR TITLE
Removed duplicate clear event on destroy 

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/CacheMetaDataGeneratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/CacheMetaDataGeneratorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl.nearcache.invalidation;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheEventHandler;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static java.lang.Integer.MAX_VALUE;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheMetaDataGeneratorTest extends HazelcastTestSupport {
+
+    private static final String CACHE_NAME = "test";
+    private static final String PREFIXED_CACHE_NAME = "/hz/" + CACHE_NAME;
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final ClientConfig clientConfig = new ClientConfig();
+    private final CacheConfig cacheConfig = new CacheConfig();
+
+    private Cache clientCache;
+    private Cache serverCache;
+    private HazelcastInstance server;
+
+    @Before
+    public void setUp() throws Exception {
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true);
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        cacheConfig.getEvictionConfig()
+                .setMaximumSizePolicy(ENTRY_COUNT)
+                .setSize(MAX_VALUE);
+        cacheConfig.setName(CACHE_NAME);
+
+        Config config = getConfig();
+        server = factory.newHazelcastInstance(config);
+
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(server);
+        CacheManager serverCacheManager = provider.getCacheManager();
+
+        serverCache = serverCacheManager.createCache(CACHE_NAME, cacheConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void destroying_cache_removes_related_metadata_when_near_cache_exists() throws Exception {
+        clientCache = createCacheFromNewClient();
+
+        serverCache.put(1, 1);
+
+        assertNotNull(getMetaDataGenerator(server).getSequenceGenerators().get(PREFIXED_CACHE_NAME));
+
+        ((ICache) clientCache).destroy();
+
+        assertNull(getMetaDataGenerator(server).getSequenceGenerators().get(PREFIXED_CACHE_NAME));
+    }
+
+    @Test
+    public void destroying_cache_removes_related_metadata_when_near_cache_not_exists() throws Exception {
+        serverCache.put(1, 1);
+
+        assertNull(getMetaDataGenerator(server).getSequenceGenerators().get(PREFIXED_CACHE_NAME));
+
+        ((ICache) serverCache).destroy();
+
+        assertNull(getMetaDataGenerator(server).getSequenceGenerators().get(PREFIXED_CACHE_NAME));
+    }
+
+    protected NearCacheConfig newNearCacheConfig() {
+        return new NearCacheConfig(CACHE_NAME);
+    }
+
+    private Cache createCacheFromNewClient() {
+        HazelcastClientProxy client = (HazelcastClientProxy) factory.newHazelcastClient(clientConfig);
+        CachingProvider clientCachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+
+        CacheManager cacheManager = clientCachingProvider.getCacheManager();
+        Cache cache = cacheManager.createCache(CACHE_NAME, cacheConfig);
+
+        assert cache instanceof NearCachedClientCacheProxy;
+
+        return cache;
+    }
+
+    private static MetaDataGenerator getMetaDataGenerator(HazelcastInstance member) {
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(member);
+        CacheService service = nodeEngineImpl.getService(CacheService.SERVICE_NAME);
+        CacheEventHandler cacheEventHandler = service.getCacheEventHandler();
+        return cacheEventHandler.getMetaDataGenerator();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -312,7 +312,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         CacheConfig config = deleteCacheConfig(name);
         if (destroy) {
             destroySegments(name);
-            sendInvalidationEvent(name, null, SOURCE_NOT_AVAILABLE);
+            cacheEventHandler.destroy(name, SOURCE_NOT_AVAILABLE);
         } else {
             closeSegments(name);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -127,6 +127,10 @@ public class CacheEventHandler {
         }
     }
 
+    void destroy(String name, String sourceUuid) {
+        invalidator.destroy(name, sourceUuid);
+    }
+
     void shutdown() {
         invalidator.shutdown();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
@@ -207,11 +207,7 @@ public class BatchInvalidator extends Invalidator {
 
     @Override
     public void destroy(String dataStructureName, String sourceUuid) {
-        InvalidationQueue invalidationQueue = invalidationQueues.remove(dataStructureName);
-        if (invalidationQueue != null) {
-            invalidateInternal(newClearInvalidation(dataStructureName, sourceUuid), dataStructureName.hashCode());
-        }
-
+        invalidationQueues.remove(dataStructureName);
         super.destroy(dataStructureName, sourceUuid);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
@@ -143,6 +143,7 @@ public abstract class Invalidator {
      * @see com.hazelcast.map.impl.MapRemoteService#destroyDistributedObject(String)
      */
     public void destroy(String dataStructureName, String sourceUuid) {
+        invalidateAllKeys(dataStructureName, sourceUuid);
         metaDataGenerator.destroyMetaDataFor(dataStructureName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
@@ -37,7 +37,6 @@ import static com.hazelcast.util.UuidUtil.newUnsecureUUID;
  */
 public class MetaDataGenerator {
 
-    final ConcurrentMap<String, AtomicLongArray> sequenceGenerators = new ConcurrentHashMap<String, AtomicLongArray>();
 
     private final int partitionCount;
     private final ConstructorFunction<String, AtomicLongArray> sequenceGeneratorConstructor
@@ -48,6 +47,7 @@ public class MetaDataGenerator {
         }
     };
     private final ConcurrentMap<Integer, UUID> uuids = new ConcurrentHashMap<Integer, UUID>();
+    private final ConcurrentMap<String, AtomicLongArray> sequenceGenerators = new ConcurrentHashMap<String, AtomicLongArray>();
     private final ConstructorFunction<Integer, UUID> uuidConstructor
             = new ConstructorFunction<Integer, UUID>() {
         @Override
@@ -110,5 +110,10 @@ public class MetaDataGenerator {
 
     public void regenerateUuid(int partitionId) {
         uuids.put(partitionId, uuidConstructor.createNew(partitionId));
+    }
+
+    // used for testing
+    public ConcurrentMap<String, AtomicLongArray> getSequenceGenerators() {
+        return sequenceGenerators;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -133,10 +133,7 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
      */
     @Override
     public boolean destroyNearCache(String mapName) {
-        String uuid = nodeEngine.getLocalMember().getUuid();
-        invalidator.invalidateAllKeys(mapName, uuid);
-        invalidator.destroy(mapName, uuid);
-
+        invalidator.destroy(mapName, nodeEngine.getLocalMember().getUuid());
         return super.destroyNearCache(mapName);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapMetaDataGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapMetaDataGeneratorTest.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.nearcache.impl.invalidation;
+package com.hazelcast.map.impl.nearcache.invalidation;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.impl.invalidation.Invalidator;
+import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
@@ -38,7 +40,7 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MetaDataGeneratorTest extends HazelcastTestSupport {
+public class MapMetaDataGeneratorTest extends HazelcastTestSupport {
 
     @Test
     public void destroying_map_removes_related_metadata_when_near_cache_exists() throws Exception {
@@ -56,13 +58,13 @@ public class MetaDataGeneratorTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertNotNull(metaDataGenerator.sequenceGenerators.get(mapName));
+                assertNotNull(metaDataGenerator.getSequenceGenerators().get(mapName));
             }
         });
 
         map.destroy();
 
-        assertNull(metaDataGenerator.sequenceGenerators.get(mapName));
+        assertNull(metaDataGenerator.getSequenceGenerators().get(mapName));
     }
 
     @Test
@@ -77,14 +79,14 @@ public class MetaDataGeneratorTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertNull(metaDataGenerator.sequenceGenerators.get(mapName));
+                assertNull(metaDataGenerator.getSequenceGenerators().get(mapName));
             }
         });
 
 
         map.destroy();
 
-        assertNull(metaDataGenerator.sequenceGenerators.get(mapName));
+        assertNull(metaDataGenerator.getSequenceGenerators().get(mapName));
     }
 
     protected static MetaDataGenerator getMetaDataGenerator(HazelcastInstance member) {


### PR DESCRIPTION
This pr includes 2 fixes: see commit comments for the fixes
