### PR TITLE
Defined EventService as PostJoinAwareService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -456,8 +456,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     /**
-     * Collects all post-join operations. This will include event registrations which are not
-     * local and operations returned from services implementing {@link PostJoinAwareService}.
+     * Collects all post-join operations from {@link PostJoinAwareService}s.
      * <p>
      * Post join operations should return response, at least a {@code null} response.
      * <p>
@@ -470,13 +469,9 @@ public class NodeEngineImpl implements NodeEngine {
      */
     public Operation[] getPostJoinOperations() {
         final Collection<Operation> postJoinOps = new LinkedList<Operation>();
-        Operation eventPostJoinOp = eventService.getPostJoinOperation();
-        if (eventPostJoinOp != null) {
-            postJoinOps.add(eventPostJoinOp);
-        }
         Collection<PostJoinAwareService> services = getServices(PostJoinAwareService.class);
         for (PostJoinAwareService service : services) {
-            final Operation postJoinOperation = service.getPostJoinOperation();
+            Operation postJoinOperation = service.getPostJoinOperation();
             if (postJoinOperation != null) {
                 if (postJoinOperation.getPartitionId() >= 0) {
                     logger.severe(

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/InternalEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/InternalEventService.java
@@ -18,17 +18,18 @@ package com.hazelcast.spi.impl.eventservice;
 
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.impl.PacketHandler;
 
 /**
  * The InternalEventService is an {@link EventService} interface that adds additional capabilities
  * we don't want to expose to the end user. So they are purely meant to be used internally.
  */
-public interface InternalEventService extends EventService, PacketHandler {
+public interface InternalEventService extends EventService, PacketHandler, PostJoinAwareService {
 
     /**
      * Closes an EventRegistration.
-     *
+     * <p>
      * If the EventRegistration has any closeable resource, e.g. a listener, than this listener is closed.
      *
      * @param eventRegistration the EventRegistration to close.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -88,6 +88,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * event can be retransmitted causing it to be received by the target node at a later time.
  */
 public class EventServiceImpl implements InternalEventService, MetricsProvider {
+
+    public static final String SERVICE_NAME = "hz:core:eventService";
+
     /**
      * Usually remote events are sent asynchronously. This property dictates how often the event is sent
      * synchronously. This means that the event will be sent as a {@link SendEventOperation} and we will
@@ -620,6 +623,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
      *
      * @return the post join operation containing all non-local registrations
      */
+    @Override
     public PostJoinRegistrationOperation getPostJoinOperation() {
         final Collection<Registration> registrations = new LinkedList<Registration>();
         for (EventServiceSegment segment : segments.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -53,6 +53,7 @@ import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.SharedService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.spi.impl.servicemanager.RemoteServiceDescriptor;
 import com.hazelcast.spi.impl.servicemanager.RemoteServiceDescriptorProvider;
@@ -122,6 +123,7 @@ public final class ServiceManagerImpl implements ServiceManager {
         registerService(ClientEngineImpl.SERVICE_NAME, node.clientEngine);
         registerService(QuorumServiceImpl.SERVICE_NAME, nodeEngine.getQuorumService());
         registerService(WanReplicationService.SERVICE_NAME, nodeEngine.getWanReplicationService());
+        registerService(EventServiceImpl.SERVICE_NAME, nodeEngine.getEventService());
     }
 
     private void registerExtensionServices() {


### PR DESCRIPTION
`EventService` is effectively behaving like `PostJoinAwareService` and it has a `getPostJoinOperation` method but it is not implementing `PostJoinAwareService`. This PR tries to fix that confusion. 