### PR TITLE
[BACKPORT] Removed near cache clear on listener registrations, reconciliation ta…

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -997,18 +997,21 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     private final class RepairableNearCacheEventHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
             implements EventHandler<ClientMessage> {
 
-        private volatile RepairingHandler repairingHandler;
+        private final RepairingHandler repairingHandler;
 
-        @Override
-        public void beforeListenerRegister() {
-            nearCache.clear();
+        public RepairableNearCacheEventHandler() {
             getRepairingTask().deregisterHandler(nameWithPrefix);
             repairingHandler = getRepairingTask().registerAndGetHandler(nameWithPrefix, nearCache);
         }
 
         @Override
+        public void beforeListenerRegister() {
+            // NOP
+        }
+
+        @Override
         public void onListenerRegister() {
-            nearCache.clear();
+            // NOP
         }
 
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -578,18 +578,22 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     private final class RepairableNearCacheEventHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler
             implements EventHandler<ClientMessage> {
 
-        private volatile RepairingHandler repairingHandler;
+        private final RepairingHandler repairingHandler;
+
+        public RepairableNearCacheEventHandler() {
+            RepairingTask repairingTask = getContext().getRepairingTask(SERVICE_NAME);
+            repairingTask.deregisterHandler(name);
+            repairingHandler = repairingTask.registerAndGetHandler(name, nearCache);
+        }
 
         @Override
         public void beforeListenerRegister() {
-            nearCache.clear();
-            getRepairingTask().deregisterHandler(name);
-            repairingHandler = getRepairingTask().registerAndGetHandler(name, nearCache);
+            // NOP
         }
 
         @Override
         public void onListenerRegister() {
-            nearCache.clear();
+            // NOP
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheNearCacheSmokeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheNearCacheSmokeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl.nearcache.invalidation;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static java.lang.Integer.MAX_VALUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheNearCacheSmokeTest extends HazelcastTestSupport {
+
+    private static final String CACHE_NAME = "test";
+    private static final int CLUSTER_SIZE = 3;
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final ClientConfig clientConfig = new ClientConfig();
+    private final CacheConfig cacheConfig = new CacheConfig();
+
+    private Cache<Integer, Integer> serverCache1;
+    private Cache<Integer, Integer> clientCache;
+
+    HazelcastInstance server1;
+
+    @Before
+    public void setUp() throws Exception {
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true);
+
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        cacheConfig.getEvictionConfig()
+                .setMaximumSizePolicy(ENTRY_COUNT)
+                .setSize(MAX_VALUE);
+
+        Config config = getConfig();
+        config.setProperty(GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), "false");
+
+        server1 = factory.newHazelcastInstance(config);
+        HazelcastInstance server2 = factory.newHazelcastInstance(config);
+        HazelcastInstance server3 = factory.newHazelcastInstance(config);
+        assertClusterSize(CLUSTER_SIZE, server1);
+
+        serverCache1 = createServerCache(server1);
+    }
+
+    protected NearCacheConfig newNearCacheConfig() {
+        return new NearCacheConfig(CACHE_NAME);
+    }
+
+    private Cache createServerCache(HazelcastInstance server1) {
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(server1);
+        CacheManager serverCacheManager = provider.getCacheManager();
+
+        return serverCacheManager.createCache(CACHE_NAME, cacheConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void smoke_near_cache_population() throws Exception {
+        int cacheSize = 1000;
+
+        // 1. populate server side cache
+        for (int i = 0; i < cacheSize; i++) {
+            serverCache1.put(i, i);
+        }
+
+        // 2. add client with near cache
+        clientCache = createCacheFromNewClient();
+
+        // 3. populate client near cache
+        for (int i = 0; i < cacheSize; i++) {
+            assertNotNull(clientCache.get(i));
+        }
+
+        // 4. assert number of entries in client near cache
+        assertEquals(cacheSize, ((ClientCacheProxy) clientCache).getNearCache().size());
+    }
+
+    private Cache createCacheFromNewClient() {
+        HazelcastClientProxy client = (HazelcastClientProxy) factory.newHazelcastClient(clientConfig);
+        CachingProvider clientCachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+
+        CacheManager cacheManager = clientCachingProvider.getCacheManager();
+        return cacheManager.createCache(CACHE_NAME, cacheConfig);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -89,6 +89,44 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
+    public void smoke_near_cache_population() throws Exception {
+        String mapName = "test";
+        int mapSize = 1000;
+
+        // 1. create cluster
+        Config config = getConfig();
+        HazelcastInstance server1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance server2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance server3 = hazelcastFactory.newHazelcastInstance(config);
+        assertClusterSizeEventually(3, server1);
+
+        // 2. populate server side map
+        IMap<Integer, Integer> nodeMap = server1.getMap(mapName);
+        for (int i = 0; i < mapSize; i++) {
+            nodeMap.put(i, i);
+        }
+
+        // 3. add client with near cache
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setName(mapName);
+
+        ClientConfig clientConfig = newClientConfig();
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        // 4. populate client near cache
+        final IMap<Integer, Integer> clientMap = client.getMap(mapName);
+        for (int i = 0; i < mapSize; i++) {
+            assertNotNull(clientMap.get(i));
+        }
+
+        // 5. assert number of entries in client near cache
+        assertEquals(mapSize, ((NearCachedClientMapProxy) clientMap).getNearCache().size());
+    }
+
+    @Test
     public void testGetAllChecksNearCacheFirst() {
         IMap<Integer, Integer> map = getNearCachedMapFromClient(newNoInvalidationNearCacheConfig());
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.query.EntryObject;
@@ -946,5 +947,46 @@ public class NearCacheTest extends NearCacheTestSupport {
 
         NearCacheStats nearCacheStats = map.getLocalMapStats().getNearCacheStats();
         assertEquals(1, nearCacheStats.getMisses());
+    }
+
+    @Test
+    public void smoke_near_cache_population() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        String mapName = "test";
+        int mapSize = 1000;
+
+        // 1. create cluster
+        Config config = getConfig();
+        HazelcastInstance server1 = factory.newHazelcastInstance(config);
+        HazelcastInstance server2 = factory.newHazelcastInstance(config);
+        HazelcastInstance server3 = factory.newHazelcastInstance(config);
+
+        assertClusterSize(3, server1);
+
+        // 2. populate server side map
+        IMap<Integer, Integer> nodeMap = server1.getMap(mapName);
+        for (int i = 0; i < mapSize; i++) {
+            nodeMap.put(i, i);
+        }
+
+        // 3. add client with near cache
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setCacheLocalEntries(true);
+        nearCacheConfig.setName(mapName);
+
+        Config nearCachedConfig = getConfig();
+        nearCachedConfig.getMapConfig(mapName).setNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance client = factory.newHazelcastInstance(nearCachedConfig);
+
+        // 4. populate near cache
+        final IMap<Integer, Integer> nearCachedMap = client.getMap(mapName);
+        for (int i = 0; i < mapSize; i++) {
+            assertNotNull(nearCachedMap.get(i));
+        }
+
+        // 5. assert number of entries in client near cache
+        assertEquals(mapSize, ((NearCachedMapProxyImpl) nearCachedMap).getNearCache().size());
     }
 }


### PR DESCRIPTION
…sk will handle any missing invalidation cases

backport of https://github.com/hazelcast/hazelcast/pull/11003