### PR TITLE
Do not create new DynamicSecurityConfig instance on each get

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -205,7 +205,7 @@ public class Node {
 
             nodeEngine = new NodeEngineImpl(this);
             config.setConfigurationService(nodeEngine.getConfigurationService());
-            config.setSecurityService(getSecurityService());
+            config.onSecurityServiceUpdated(getSecurityService());
             MetricsRegistry metricsRegistry = nodeEngine.getMetricsRegistry();
             metricsRegistry.collectMetrics(nodeExtension);
             healthMonitor = new HealthMonitor(this);


### PR DESCRIPTION
Also asserts new DynamicConfigurationAwareConfig in not wrapping another
DynamicConfigurationAwareConfig.

Requires EE counterpart
Fixes #10834 