### PR TITLE
Fixes and additional tests for dynamic cache config

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -153,8 +153,11 @@ public class ClientDynamicClusterConfig extends Config {
                 cacheConfig.getCacheWriterFactory(), cacheConfig.getCacheLoader(), cacheConfig.getCacheWriter(),
                 cacheConfig.getBackupCount(), cacheConfig.getAsyncBackupCount(), cacheConfig.getInMemoryFormat().name(),
                 cacheConfig.getQuorumName(), cacheConfig.getMergePolicy(), cacheConfig.isDisablePerEntryInvalidationEvents(),
-                partitionLostListenerConfigs, cacheConfig.getExpiryPolicyFactoryConfig().getClassName(),
-                cacheConfig.getExpiryPolicyFactoryConfig().getTimedExpiryPolicyFactoryConfig(),
+                partitionLostListenerConfigs,
+                cacheConfig.getExpiryPolicyFactoryConfig() == null ? null
+                        : cacheConfig.getExpiryPolicyFactoryConfig().getClassName(),
+                cacheConfig.getExpiryPolicyFactoryConfig() == null ? null
+                        : cacheConfig.getExpiryPolicyFactoryConfig().getTimedExpiryPolicyFactoryConfig(),
                 cacheConfig.getCacheEntryListeners(),
                 EvictionConfigHolder.of(cacheConfig.getEvictionConfig(), serializationService),
                 cacheConfig.getWanReplicationRef(), cacheConfig.getHotRestartConfig());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
@@ -26,6 +26,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class AddCacheConfigMessageTask
@@ -74,6 +75,8 @@ public class AddCacheConfigMessageTask
             List<CachePartitionLostListenerConfig> listenerConfigs = (List<CachePartitionLostListenerConfig>)
                     adaptListenerConfigs(parameters.partitionLostListenerConfigs);
             config.setPartitionLostListenerConfigs(listenerConfigs);
+        } else {
+            config.setPartitionLostListenerConfigs(new ArrayList<CachePartitionLostListenerConfig>());
         }
         config.setQuorumName(parameters.quorumName);
         config.setReadThrough(parameters.readThrough);

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -702,6 +702,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
         out.writeBoolean(managementEnabled);
         out.writeBoolean(readThrough);
         out.writeBoolean(writeThrough);
+        out.writeBoolean(disablePerEntryInvalidationEvents);
         out.writeUTF(cacheLoaderFactory);
         out.writeUTF(cacheWriterFactory);
         out.writeUTF(cacheLoader);
@@ -728,6 +729,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
         managementEnabled = in.readBoolean();
         readThrough = in.readBoolean();
         writeThrough = in.readBoolean();
+        disablePerEntryInvalidationEvents = in.readBoolean();
         cacheLoaderFactory = in.readUTF();
         cacheWriterFactory = in.readUTF();
         cacheLoader = in.readUTF();
@@ -863,6 +865,34 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "CacheSimpleConfig{"
+                + "name='" + name + '\''
+                + ", asyncBackupCount=" + asyncBackupCount
+                + ", backupCount=" + backupCount
+                + ", inMemoryFormat=" + inMemoryFormat
+                + ", keyType=" + keyType
+                + ", valueType=" + valueType
+                + ", statisticsEnabled=" + statisticsEnabled
+                + ", managementEnabled=" + managementEnabled
+                + ", readThrough=" + readThrough
+                + ", writeThrough=" + writeThrough
+                + ", cacheLoaderFactory='" + cacheLoaderFactory + '\''
+                + ", cacheWriterFactory='" + cacheWriterFactory + '\''
+                + ", cacheLoader='" + cacheLoader + '\''
+                + ", cacheWriter='" + cacheWriter + '\''
+                + ", expiryPolicyFactoryConfig=" + expiryPolicyFactoryConfig
+                + ", cacheEntryListeners=" + cacheEntryListeners
+                + ", evictionConfig=" + evictionConfig
+                + ", wanReplicationRef=" + wanReplicationRef
+                + ", quorumName=" + quorumName
+                + ", partitionLostListenerConfigs=" + partitionLostListenerConfigs
+                + ", mergePolicy=" + mergePolicy
+                + ", hotRestartConfig=" + hotRestartConfig
+                + '}';
+    }
+
     /**
      * Represents configuration for "ExpiryPolicyFactory".
      */
@@ -938,6 +968,14 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
             int result = className != null ? className.hashCode() : 0;
             result = 31 * result + (timedExpiryPolicyFactoryConfig != null ? timedExpiryPolicyFactoryConfig.hashCode() : 0);
             return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ExpiryPolicyFactoryConfig{"
+                    + "className='" + className + '\''
+                    + ", timedExpiryPolicyFactoryConfig=" + timedExpiryPolicyFactoryConfig
+                    + '}';
         }
 
         /**
@@ -1036,6 +1074,14 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
                 result = 31 * result + (durationConfig != null ? durationConfig.hashCode() : 0);
                 return result;
             }
+
+            @Override
+            public String toString() {
+                return "TimedExpiryPolicyFactoryConfig{"
+                        + "expiryPolicyType=" + expiryPolicyType
+                        + ", durationConfig=" + durationConfig
+                        + '}';
+            }
         }
 
         /**
@@ -1108,6 +1154,14 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
                 int result = (int) (durationAmount ^ (durationAmount >>> 32));
                 result = 31 * result + (timeUnit != null ? timeUnit.hashCode() : 0);
                 return result;
+            }
+
+            @Override
+            public String toString() {
+                return "DurationConfig{"
+                        + "durationAmount=" + durationAmount
+                        + ", timeUnit" + timeUnit
+                        + '}';
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -16,10 +16,16 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
 /**
  * Simple configuration to hold parsed listener config.
  */
-public class CacheSimpleEntryListenerConfig {
+public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializable {
 
     private String cacheEntryListenerFactory;
     private String cacheEntryEventFilterFactory;
@@ -142,5 +148,43 @@ public class CacheSimpleEntryListenerConfig {
         result = 31 * result + (oldValueRequired ? 1 : 0);
         result = 31 * result + (synchronous ? 1 : 0);
         return result;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.SIMPLE_CACHE_ENTRY_LISTENER_CONFIG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out)
+            throws IOException {
+        out.writeUTF(cacheEntryEventFilterFactory);
+        out.writeUTF(cacheEntryListenerFactory);
+        out.writeBoolean(oldValueRequired);
+        out.writeBoolean(synchronous);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in)
+            throws IOException {
+        cacheEntryEventFilterFactory = in.readUTF();
+        cacheEntryListenerFactory = in.readUTF();
+        oldValueRequired = in.readBoolean();
+        synchronous = in.readBoolean();
+    }
+
+    @Override
+    public String toString() {
+        return "CacheSimpleEntryListenerConfig{"
+                + "cacheEntryListenerFactory='" + cacheEntryListenerFactory + '\''
+                + ", cacheEntryEventFilterFactory='" + cacheEntryEventFilterFactory + '\''
+                + ", oldValueRequired=" + oldValueRequired
+                + ", synchronous=" + synchronous
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -86,8 +86,9 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int EVENT_JOURNAL_CONFIG = 44;
     public static final int QUORUM_LISTENER_CONFIG = 45;
     public static final int CACHE_PARTITION_LOST_LISTENER_CONFIG = 46;
+    public static final int SIMPLE_CACHE_ENTRY_LISTENER_CONFIG = 47;
 
-    private static final int LEN = CACHE_PARTITION_LOST_LISTENER_CONFIG + 1;
+    private static final int LEN = SIMPLE_CACHE_ENTRY_LISTENER_CONFIG + 1;
 
     @Override
     public int getFactoryId() {
@@ -381,6 +382,13 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new CachePartitionLostListenerConfig();
+                    }
+                };
+        constructors[SIMPLE_CACHE_ENTRY_LISTENER_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new CacheSimpleEntryListenerConfig();
                     }
                 };
 


### PR DESCRIPTION
* `CacheSimpleEntryListenerConfig` turned serializable
* Fixes for data transfer omisions
* Added some missing `toString` methods in `CacheSimpleConfig` and related classes
* Tests now cover `CacheSimpleConfig` variants with listeners, loader/writer(factory) etc

Fixes #10814 