### PR TITLE
Use real network in multicast discovery test.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -19,11 +19,10 @@ package com.hazelcast.spi.discovery.multicast;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.config.properties.ValidationException;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestEnvironment;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -38,27 +37,25 @@ import java.io.InputStream;
 public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
 
     private Config config;
-    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
     @Before
     public void setUp() {
         String xmlFileName = "hazelcast-multicast-plugin.xml";
         InputStream xmlResource = MulticastDiscoveryStrategy.class.getClassLoader().getResourceAsStream(xmlFileName);
         config = new XmlConfigBuilder(xmlResource).build();
-
-        System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "true");
         System.setProperty("java.net.preferIPv4Stack", "true");
     }
 
     @After
     public void tearDown() {
-        factory.shutdownAll();
+        Hazelcast.shutdownAll();
     }
 
     @Test
     public void formClusterWithTwoMembersTest() throws InterruptedException {
-        HazelcastInstance[] instances = factory.newInstances(config);
-        assertClusterSizeEventually(2, instances[0]);
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Hazelcast.newHazelcastInstance(config);
+        assertClusterSizeEventually(2, instance);
     }
 
     @Test(expected = ValidationException.class)
@@ -66,11 +63,7 @@ public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
         String xmlFileName = "hazelcast-multicast-plugin-invalid-port.xml";
         InputStream xmlResource = MulticastDiscoveryStrategy.class.getClassLoader().getResourceAsStream(xmlFileName);
         config = new XmlConfigBuilder(xmlResource).build();
-        factory.newInstances(config);
+        Hazelcast.newHazelcastInstance(config);
     }
 
-    @After
-    public void shutdown() {
-        factory.shutdownAll();
-    }
 }


### PR DESCRIPTION
Using hazelcastTestFactory is giving wrong impression here.
HazelcastTestFactory has its own discovery mechanism. Nodes were
finding each other via that in the test.

related to https://github.com/hazelcast/hazelcast/issues/10089