### PR TITLE
Shutdown client cluster thread when shutdown called explicitly

### DIFF
--- a/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
@@ -17,6 +17,7 @@
 package classloading;
 
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -36,5 +37,15 @@ public class ThreadLeakClientTest extends AbstractThreadLeakTest {
 
         client.shutdown();
         member.shutdown();
+    }
+
+    @Test
+    public void testThreadLeak_withoutCluster() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
+        clientConfig.getNetworkConfig()
+                .setConnectionAttemptLimit(Integer.MAX_VALUE);
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        client.shutdown();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -155,4 +155,14 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         System.gc();
         test.get("key");
     }
+
+    @Test(timeout = 10000)
+    public void testShutdownClient_whenThereIsNoCluster() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
+        clientConfig.getNetworkConfig()
+                .setConnectionAttemptLimit(Integer.MAX_VALUE);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        client.shutdown();
+    }
 }


### PR DESCRIPTION
Shutdown client cluster thread when shutdown called explicitly

When client cluster thread trying to connect to a cluster, it
was not checking if client is running correctly. It was quitting
only after `connection-attemp-limit` runs out.

fixes #10237