### PR TITLE
Introduce failure detector abstraction and PhiAccuralFailureDetector

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,3 +17,6 @@ from the Koloboke project (https://github.com/OpenHFT/Koloboke).
 
 The class classloading.ThreadLocalLeakTestUtils contains code originating
 from the Tomcat project (https://github.com/apache/tomcat).
+
+com.hazelcast.internal.cluster.fd.PhiAccrualFailureDetector contains code originating
+from the Akka project (https://github.com/akka/akka/).

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -32,6 +32,7 @@
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]util[\\/]QuickMath"/>
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]util[\\/]collection[\\/]"/>
     <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]util[\\/]concurrent[\\/]"/>
+    <suppress checks="Header" files="com[\\/]hazelcast[\\/]internal[\\/]cluster[\\/]fd[\\/]PhiAccrualFailureDetector"/>
 
     <!-- Exclude implementation packages from JavaDoc checks -->
     <suppress checks="JavadocPackage" files="[\\/]impl[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetector.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+import com.hazelcast.core.Member;
+
+/**
+ * Cluster failure detector tracks heartbeats of the members and decides liveness/availability of them.
+ */
+public interface ClusterFailureDetector {
+
+    /**
+     * Notifies this failure detector about received heartbeat message from a member.
+     *
+     * @param member member which heartbeat message is received from
+     * @param timestamp timestamp of heartbeat message in milliseconds
+     */
+    void heartbeat(Member member, long timestamp);
+
+    /**
+     * Returns true if given member is considered as alive/available.
+     * @param member member whose liveness is questioned
+     * @param timestamp timestamp in milliseconds
+     * @return true if member is alive
+     */
+    boolean isAlive(Member member, long timestamp);
+
+    /**
+     * Returns the last heartbeat timestamp for a member.
+     * @param member member whose heartbeat timestamp is requested
+     * @return heartbeat timestamp in milliseconds
+     */
+    long lastHeartbeat(Member member);
+
+    /**
+     * Returns suspicion level about a given member. Returned value is mostly implementation dependent.
+     * <code>0</code> indicates no suspicion at all.
+     * @param member member
+     * @param timestamp timestamp in milliseconds
+     * @return suspicion level
+     */
+    double suspicionLevel(Member member, long timestamp);
+
+    /**
+     * Deregister member from tracking and cleanup resources related to this member.
+     * @param member member to be removed
+     */
+    void remove(Member member);
+
+    /**
+     * Clear all state kept by this failure detector
+     */
+    void reset();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/DeadlineClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/DeadlineClusterFailureDetector.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+import com.hazelcast.core.Member;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Deadline based failure detector. This failure detector uses an absolute timeout
+ * for missing/lost heartbeats. After timeout member is considered as dead/unavailable.
+ */
+public class DeadlineClusterFailureDetector implements ClusterFailureDetector {
+
+    private final long maxNoHeartbeatMillis;
+    private final ConcurrentMap<Member, Long> heartbeatTimes = new ConcurrentHashMap<Member, Long>();
+
+    public DeadlineClusterFailureDetector(long maxNoHeartbeatMillis) {
+        this.maxNoHeartbeatMillis = maxNoHeartbeatMillis;
+    }
+
+    @Override
+    public void heartbeat(Member member, long timestamp) {
+        heartbeatTimes.put(member, timestamp);
+    }
+
+    @Override
+    public boolean isAlive(Member member, long timestamp) {
+        long hb = lastHeartbeat(member);
+        return hb + maxNoHeartbeatMillis > timestamp;
+    }
+
+    @Override
+    public long lastHeartbeat(Member member) {
+        Long hb = heartbeatTimes.get(member);
+        return hb != null ? hb : 0L;
+    }
+
+    @Override
+    public double suspicionLevel(Member member, long timestamp) {
+        return isAlive(member, timestamp) ? 0 : 1;
+    }
+
+    @Override
+    public void remove(Member member) {
+        heartbeatTimes.remove(member);
+    }
+
+    @Override
+    public void reset() {
+        heartbeatTimes.clear();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/FailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/FailureDetector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+/**
+ * Failure detector tracks heartbeats of a member and decides liveness/availability of the member.
+ */
+public interface FailureDetector {
+
+    /**
+     * Notifies this failure detector about received heartbeat message from the tracked member.
+     *
+     * @param timestamp timestamp of heartbeat message in milliseconds
+     */
+    void heartbeat(long timestamp);
+
+    /**
+     * Returns true if the tracked member is considered as alive/available.
+     * @param timestamp timestamp in milliseconds
+     * @return true if the member is alive
+     */
+    boolean isAlive(long timestamp);
+
+    /**
+     * Returns the last heartbeat timestamp for the tracked member.
+     * @return heartbeat timestamp in milliseconds
+     */
+    long lastHeartbeat();
+
+    /**
+     * Returns suspicion level about the tracked member. Returned value is mostly implementation dependent.
+     * <code>0</code> indicates no suspicion at all.
+     * @param timestamp timestamp in milliseconds
+     * @return suspicion level
+     */
+    double suspicionLevel(long timestamp);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualClusterFailureDetector.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+import com.hazelcast.util.ConstructorFunction;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Cluster failure detector based on 'The Phi Accrual Failure Detector' by Hayashibara et al.
+ * For more info see {@link PhiAccrualFailureDetector}
+ */
+public class PhiAccrualClusterFailureDetector implements ClusterFailureDetector {
+
+    /**
+     * Threshold for suspicion level. After calculated phi exceeds this threshold, a member is considered as dead.
+     * <p>
+     * <ul>
+     * <li>
+     * A low threshold allows to detect member crashes/failures faster but can generate more mistakes
+     * and cause wrong member suspicions.
+     * </li>
+     * <li>
+     * A high threshold generates fewer mistakes but is slower detect actual crashes/failures.
+     * </li>
+     * </ul>
+     */
+    private static final HazelcastProperty HEARTBEAT_PHI_FAILURE_DETECTOR_THRESHOLD
+            = new HazelcastProperty("hazelcast.heartbeat.phiaccrual.failuredetector.threshold", 10);
+
+    /**
+     * Number of samples to use for calculations.
+     */
+    private static final HazelcastProperty HEARTBEAT_PHI_FAILURE_DETECTOR_SAMPLE_SIZE
+            = new HazelcastProperty("hazelcast.heartbeat.phiaccrual.failuredetector.sample.size", 200);
+
+    /**
+     * Minimum standard deviation to use for the normal distribution used when calculating phi.
+     * Too low standard deviation might result in too much sensitivity.
+     */
+    private static final HazelcastProperty HEARTBEAT_PHI_FAILURE_DETECTOR_MIN_STD_DEV_MILLIS
+            = new HazelcastProperty("hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis", 100, MILLISECONDS);
+
+
+    private final int phiThreshold;
+    private final int maxSampleSize;
+    private final long minStdDeviationMillis;
+    private final long acceptableHeartbeatPauseMillis;
+    private final long firstHeartbeatEstimateMillis;
+
+    private final ConcurrentMap<Member, FailureDetector> failureDetectors
+            = new ConcurrentHashMap<Member, FailureDetector>();
+
+    private final ConstructorFunction<Member, FailureDetector> failureDetectorConstructor
+            = new ConstructorFunction<Member, FailureDetector>() {
+
+        @Override
+        public FailureDetector createNew(Member arg) {
+            return new PhiAccrualFailureDetector(phiThreshold, maxSampleSize, minStdDeviationMillis,
+                    acceptableHeartbeatPauseMillis, firstHeartbeatEstimateMillis);
+        }
+    };
+
+    public PhiAccrualClusterFailureDetector(long maxNoHeartbeatMillis, long heartbeatIntervalMillis, HazelcastProperties props) {
+        acceptableHeartbeatPauseMillis = maxNoHeartbeatMillis;
+        firstHeartbeatEstimateMillis = heartbeatIntervalMillis;
+        phiThreshold = props.getInteger(HEARTBEAT_PHI_FAILURE_DETECTOR_THRESHOLD);
+        maxSampleSize = props.getInteger(HEARTBEAT_PHI_FAILURE_DETECTOR_SAMPLE_SIZE);
+        minStdDeviationMillis = props.getMillis(HEARTBEAT_PHI_FAILURE_DETECTOR_MIN_STD_DEV_MILLIS);
+    }
+
+    @Override
+    public void heartbeat(Member member, long timestamp) {
+        FailureDetector fd = getOrPutIfAbsent(failureDetectors, member, failureDetectorConstructor);
+        fd.heartbeat(timestamp);
+    }
+
+    @Override
+    public boolean isAlive(Member member, long timestamp) {
+        FailureDetector fd = failureDetectors.get(member);
+        return fd != null && fd.isAlive(timestamp);
+    }
+
+    @Override
+    public long lastHeartbeat(Member member) {
+        FailureDetector fd = failureDetectors.get(member);
+        return fd != null ? fd.lastHeartbeat() : 0L;
+    }
+
+    @Override
+    public double suspicionLevel(Member member, long timestamp) {
+        FailureDetector fd = failureDetectors.get(member);
+        return fd != null ? fd.suspicionLevel(timestamp) : phiThreshold;
+    }
+
+    @Override
+    public void remove(Member member) {
+        failureDetectors.remove(member);
+    }
+
+    @Override
+    public void reset() {
+        failureDetectors.clear();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualClusterFailureDetector.java
@@ -46,7 +46,7 @@ public class PhiAccrualClusterFailureDetector implements ClusterFailureDetector 
      * </li>
      * </ul>
      */
-    private static final HazelcastProperty HEARTBEAT_PHI_FAILURE_DETECTOR_THRESHOLD
+    static final HazelcastProperty HEARTBEAT_PHI_FAILURE_DETECTOR_THRESHOLD
             = new HazelcastProperty("hazelcast.heartbeat.phiaccrual.failuredetector.threshold", 10);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+import java.util.LinkedList;
+
+import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static com.hazelcast.util.Preconditions.checkPositive;
+
+/**
+ * Port of Akka's PhiAccrualFailureDetector.scala
+ * <p>
+ * Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al. as defined in their paper.
+ * <p>
+ * The suspicion level of failure is given by a value called φ (phi).
+ * The basic idea of the φ failure detector is to express the value of φ on a scale that
+ * is dynamically adjusted to reflect current network conditions. A configurable
+ * threshold is used to decide if <code>φ</code> is considered to be a failure.
+ * <p>
+ * The value of <code>φ</code> is calculated as:
+ * <p>
+ * <code>
+ * <pre>
+ * φ = -log10(1 - F(timeSinceLastHeartbeat)
+ * </pre>
+ * </code>
+ * where F is the cumulative distribution function of a normal distribution with mean
+ * and standard deviation estimated from historical heartbeat inter-arrival times.
+ */
+public class PhiAccrualFailureDetector implements FailureDetector {
+
+    private static final long NO_HEARTBEAT_TIMESTAMP = -1;
+
+    private final double threshold;
+    private final double minStdDeviationMillis;
+    private final long acceptableHeartbeatPauseMillis;
+
+    private final HeartbeatHistory heartbeatHistory;
+    private volatile long lastHeartbeatMillis = NO_HEARTBEAT_TIMESTAMP;
+
+    /**
+     * @param threshold                      A low threshold is prone to generate many wrong suspicions but ensures
+     *                                       a quick detection in the event of a real crash. Conversely, a high threshold
+     *                                       generates fewer mistakes but needs more time to detect actual crashes
+     * @param maxSampleSize                  Number of samples to use for calculation of mean and standard deviation of
+     *                                       inter-arrival times.
+     * @param minStdDeviationMillis          Minimum standard deviation to use for the normal distribution used when
+     *                                       calculating phi. Too low standard deviation might result in too much sensitivity
+     *                                       for sudden, but normal, deviations in heartbeat inter arrival times.
+     * @param acceptableHeartbeatPauseMillis Duration corresponding to number of potentially lost/delayed
+     *                                       heartbeats that will be accepted before considering it to be an anomaly.
+     *                                       This margin is important to be able to survive sudden, occasional, pauses
+     *                                       in heartbeat arrivals, due to for example garbage collect or network drop.
+     * @param firstHeartbeatEstimateMillis   Bootstrap the stats with heartbeats that corresponds to this duration,
+     *                                       with a with rather high standard deviation (since environment is unknown
+     *                                       in the beginning)
+     */
+    public PhiAccrualFailureDetector(double threshold, int maxSampleSize, double minStdDeviationMillis,
+            long acceptableHeartbeatPauseMillis, long firstHeartbeatEstimateMillis) {
+
+        this.threshold = checkPositive(threshold, "Threshold must be positive: " + threshold);
+        this.minStdDeviationMillis = checkPositive(minStdDeviationMillis, "Minimum standard deviation must be positive: "
+                + minStdDeviationMillis);
+
+        this.acceptableHeartbeatPauseMillis = checkNotNegative(acceptableHeartbeatPauseMillis,
+                "Acceptable heartbeat pause millis must be >= 0: " + acceptableHeartbeatPauseMillis);
+
+        checkPositive(firstHeartbeatEstimateMillis, "First heartbeat value must be > 0: " + firstHeartbeatEstimateMillis);
+
+        heartbeatHistory = new HeartbeatHistory(maxSampleSize);
+        firstHeartbeat(firstHeartbeatEstimateMillis);
+    }
+
+    // guess statistics for first heartbeat,
+    // important so that connections with only one heartbeat becomes unavailable
+    // bootstrap with 2 entries with rather high standard deviation
+    @SuppressWarnings("checkstyle:magicnumber")
+    private void firstHeartbeat(long firstHeartbeatEstimateMillis) {
+        long stdDeviationMillis = firstHeartbeatEstimateMillis / 4;
+        heartbeatHistory.add(firstHeartbeatEstimateMillis - stdDeviationMillis);
+        heartbeatHistory.add(firstHeartbeatEstimateMillis + stdDeviationMillis);
+    }
+
+    private double ensureValidStdDeviation(double stdDeviationMillis) {
+        return Math.max(stdDeviationMillis, minStdDeviationMillis);
+    }
+
+    /**
+     * The suspicion level of the accrual failure detector.
+     *
+     * If a connection does not have any records in failure detector then it is
+     * considered healthy.
+     */
+    private double phi(long timestampMillis) {
+        long timeDiffMillis;
+        double meanMillis;
+        double stdDeviationMillis;
+
+        synchronized (heartbeatHistory) {
+            long lastTimestampMillis = lastHeartbeatMillis;
+            if (lastTimestampMillis == NO_HEARTBEAT_TIMESTAMP) {
+                return 0.0;
+            }
+
+            timeDiffMillis = timestampMillis - lastTimestampMillis;
+            meanMillis = heartbeatHistory.mean();
+            stdDeviationMillis = ensureValidStdDeviation(heartbeatHistory.stdDeviation());
+        }
+
+        return phi(timeDiffMillis, meanMillis + acceptableHeartbeatPauseMillis, stdDeviationMillis);
+    }
+
+    /**
+     * Calculation of phi, derived from the Cumulative distribution function for
+     * N(mean, stdDeviation) normal distribution, given by
+     * 1.0 / (1.0 + math.exp(-y * (1.5976 + 0.070566 * y * y)))
+     * where y = (x - mean) / standard_deviation
+     * This is an approximation defined in β Mathematics Handbook (Logistic approximation).
+     * Error is 0.00014 at +- 3.16
+     * The calculated value is equivalent to -log10(1 - CDF(y))
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    private static double phi(long timeDiffMillis, double meanMillis, double stdDeviationMillis) {
+        double y = (timeDiffMillis - meanMillis) / stdDeviationMillis;
+        double e = Math.exp(-y * (1.5976 + 0.070566 * y * y));
+        if (timeDiffMillis > meanMillis) {
+            return -Math.log10(e / (1.0 + e));
+        } else {
+            return -Math.log10(1.0 - 1.0 / (1.0 + e));
+        }
+    }
+
+    @Override
+    public boolean isAlive(long timestampMillis) {
+        double phi = phi(timestampMillis);
+        return phi < threshold;
+    }
+
+    @Override
+    public void heartbeat(long timestampMillis) {
+        synchronized (heartbeatHistory) {
+            long lastTimestampMillis = getAndSetLastHeartbeat(timestampMillis);
+            if (lastTimestampMillis == NO_HEARTBEAT_TIMESTAMP) {
+                return;
+            }
+
+            if (isAlive(timestampMillis)) {
+                heartbeatHistory.add(timestampMillis - lastTimestampMillis);
+            }
+        }
+    }
+
+    private long getAndSetLastHeartbeat(long timestampMillis) {
+        long lastTimestampMillis = lastHeartbeatMillis;
+        lastHeartbeatMillis = timestampMillis;
+        return lastTimestampMillis;
+    }
+
+    @Override
+    public long lastHeartbeat() {
+        return lastHeartbeatMillis;
+    }
+
+    @Override
+    public double suspicionLevel(long timestamp) {
+        return phi(timestamp);
+    }
+
+    /**
+     * Holds the heartbeat statistics for a specific member.
+     * It is capped by the number of samples specified in `maxSampleSize`.
+     *
+     * The stats (mean, variance, stdDeviation) are not defined for
+     * for empty HeartbeatHistory, i.e. throws ArithmeticException.
+     */
+    private static class HeartbeatHistory {
+        private final int maxSampleSize;
+        private final LinkedList<Long> intervals = new LinkedList<Long>();
+        private long intervalSum;
+        private long squaredIntervalSum;
+
+        HeartbeatHistory(int maxSampleSize) {
+            if (maxSampleSize < 1) {
+                throw new IllegalArgumentException("Sample size must be >= 1 : " + maxSampleSize);
+            }
+            this.maxSampleSize = maxSampleSize;
+        }
+
+        double mean() {
+            return (double) intervalSum / intervals.size();
+        }
+
+        double variance() {
+            double mean = mean();
+            return ((double) squaredIntervalSum / intervals.size()) - (mean * mean);
+        }
+
+        double stdDeviation() {
+            return Math.sqrt(variance());
+        }
+
+        void add(long interval) {
+            if (intervals.size() >= maxSampleSize) {
+                dropOldest();
+            }
+            intervals.add(interval);
+            intervalSum += interval;
+            squaredIntervalSum += pow2(interval);
+        }
+
+        private void dropOldest() {
+            long dropped = intervals.pollFirst();
+            intervalSum -= dropped;
+            squaredIntervalSum -= pow2(dropped);
+        }
+
+        private static long pow2(long x) {
+            return x * x;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
@@ -44,7 +44,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  */
 public class PhiAccrualFailureDetector implements FailureDetector {
 
-    private static final long NO_HEARTBEAT_TIMESTAMP = -1;
+    static final long NO_HEARTBEAT_TIMESTAMP = -1;
 
     private final double threshold;
     private final double minStdDeviationMillis;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains failure detector mechanism and its implementations.
+ */
+package com.hazelcast.internal.cluster.fd;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -20,6 +20,9 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
+import com.hazelcast.internal.cluster.fd.ClusterFailureDetector;
+import com.hazelcast.internal.cluster.fd.DeadlineClusterFailureDetector;
+import com.hazelcast.internal.cluster.fd.PhiAccrualClusterFailureDetector;
 import com.hazelcast.internal.cluster.impl.operations.ExplicitSuspicionOp;
 import com.hazelcast.internal.cluster.impl.operations.HeartbeatComplaintOp;
 import com.hazelcast.internal.cluster.impl.operations.HeartbeatOp;
@@ -40,8 +43,6 @@ import com.hazelcast.util.EmptyStatement;
 import java.net.ConnectException;
 import java.net.NetworkInterface;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
@@ -79,8 +80,8 @@ public class ClusterHeartbeatManager {
     private final ClusterServiceImpl clusterService;
     private final ClusterClockImpl clusterClock;
 
-    private final ConcurrentMap<MemberImpl, Long> heartbeatTimes = new ConcurrentHashMap<MemberImpl, Long>();
-    private final ConcurrentMap<MemberImpl, Long> masterConfirmationTimes = new ConcurrentHashMap<MemberImpl, Long>();
+    private final ClusterFailureDetector heartbeatFailureDetector;
+    private final ClusterFailureDetector masterConfirmationFailureDetector;
 
     private final long maxNoHeartbeatMillis;
     private final long maxNoMasterConfirmationMillis;
@@ -112,15 +113,34 @@ public class ClusterHeartbeatManager {
         icmpEnabled = hazelcastProperties.getBoolean(GroupProperty.ICMP_ENABLED);
         icmpTtl = hazelcastProperties.getInteger(GroupProperty.ICMP_TTL);
         icmpTimeoutMillis = (int) hazelcastProperties.getMillis(GroupProperty.ICMP_TIMEOUT);
+
+        heartbeatFailureDetector = createHeartbeatFailureDetector(hazelcastProperties);
+        masterConfirmationFailureDetector = new DeadlineClusterFailureDetector(maxNoMasterConfirmationMillis);
+    }
+
+    private ClusterFailureDetector createHeartbeatFailureDetector(HazelcastProperties properties) {
+        String type = properties.getString(GroupProperty.HEARTBEAT_FAILURE_DETECTOR_TYPE);
+        if ("deadline".equals(type)) {
+            return new DeadlineClusterFailureDetector(maxNoHeartbeatMillis);
+        }
+        if ("phi-accrual".equals(type)) {
+            int defaultValue = Integer.parseInt(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getDefaultValue());
+            if (maxNoHeartbeatMillis == TimeUnit.SECONDS.toMillis(defaultValue)) {
+                logger.warning("When using Phi-Accrual Failure Detector, please consider using a lower '"
+                        + GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName() + "' value. Current is: "
+                        + defaultValue + " seconds.");
+            }
+            return new PhiAccrualClusterFailureDetector(maxNoHeartbeatMillis, heartbeatIntervalMillis, properties);
+        }
+        throw new IllegalArgumentException("Unknown failure detector type: " + type);
     }
 
     public long getHeartbeatIntervalMillis() {
         return heartbeatIntervalMillis;
     }
 
-    // only used for reading by Diagnostics
-    public ConcurrentMap<MemberImpl, Long> getHeartbeatTimes() {
-        return heartbeatTimes;
+    public long getLastHeartbeatTime(Member member) {
+        return heartbeatFailureDetector.lastHeartbeat(member);
     }
 
     private static long getHeartbeatInterval(HazelcastProperties hazelcastProperties) {
@@ -326,7 +346,7 @@ public class ClusterHeartbeatManager {
             if (isMaster(member)) {
                 clusterClock.setMasterTime(timestamp);
             }
-            heartbeatTimes.put(member, clusterClock.getClusterTime());
+            heartbeatFailureDetector.heartbeat(member, clusterClock.getClusterTime());
 
             MembershipManager membershipManager = clusterService.getMembershipManager();
             membershipManager.clearMemberSuspicion(member.getAddress(), "Valid heartbeat");
@@ -354,7 +374,7 @@ public class ClusterHeartbeatManager {
                                 member, timeToString(clusterTime), timeToString(timestamp)));
                 return;
             }
-            masterConfirmationTimes.put(member, clusterTime);
+            masterConfirmationFailureDetector.heartbeat(member, clusterTime);
         }
     }
 
@@ -481,17 +501,20 @@ public class ClusterHeartbeatManager {
             return true;
         }
 
-        long heartbeatTime = getHeartbeatTime(member);
-        if ((now - heartbeatTime) > maxNoHeartbeatMillis) {
-            String reason = format("Suspecting %s because it has not sent any heartbeats for %d ms."
-                            + " Now: %s, last heartbeat time was %s", member, maxNoHeartbeatMillis,
-                    timeToString(now), timeToString(heartbeatTime));
+        long lastHeartbeat = heartbeatFailureDetector.lastHeartbeat(member);
+        if (!heartbeatFailureDetector.isAlive(member, now)) {
+            double suspicionLevel = heartbeatFailureDetector.suspicionLevel(member, now);
+            String reason = format("Suspecting %s because it has not sent any heartbeats since %s."
+                            + " Now: %s, heartbeat timeout: %d ms, suspicion level: %.2f",
+                    member, timeToString(lastHeartbeat), timeToString(now), maxNoHeartbeatMillis, suspicionLevel);
             logger.warning(reason);
             clusterService.suspectMember(member, reason, true);
             return true;
         }
-        if (logger.isFineEnabled() && (now - heartbeatTime) > heartbeatIntervalMillis * HEART_BEAT_INTERVAL_FACTOR) {
-            logger.fine(format("Not receiving any heartbeats from %s since %s", member, timeToString(heartbeatTime)));
+        if (logger.isFineEnabled() && (now - lastHeartbeat) > heartbeatIntervalMillis * HEART_BEAT_INTERVAL_FACTOR) {
+            double suspicionLevel = heartbeatFailureDetector.suspicionLevel(member, now);
+            logger.fine(format("Not receiving any heartbeats from %s since %s, suspicion level: %.2f",
+                    member, timeToString(lastHeartbeat), suspicionLevel));
         }
         return false;
     }
@@ -509,11 +532,8 @@ public class ClusterHeartbeatManager {
             return false;
         }
 
-        Long lastConfirmation = masterConfirmationTimes.get(member);
-        if (lastConfirmation == null) {
-            lastConfirmation = 0L;
-        }
-        if (now - lastConfirmation > maxNoMasterConfirmationMillis) {
+        if (!masterConfirmationFailureDetector.isAlive(member, now)) {
+            long lastConfirmation = masterConfirmationFailureDetector.lastHeartbeat(member);
             String reason = format("Removing %s because it has not sent any master confirmation for %d ms. "
                             + " Clock time: %s."
                             + " Cluster time: %s."
@@ -574,7 +594,8 @@ public class ClusterHeartbeatManager {
         if (!icmpEnabled) {
             return;
         }
-        if ((now - getHeartbeatTime(member)) >= pingIntervalMillis) {
+        long lastHeartbeat = heartbeatFailureDetector.lastHeartbeat(member);
+        if ((now - lastHeartbeat) >= pingIntervalMillis) {
             ping(member);
         }
     }
@@ -638,19 +659,13 @@ public class ClusterHeartbeatManager {
      * intervals and there is no live connection to the member
      */
     private void logIfConnectionToEndpointIsMissing(long now, MemberImpl member) {
-        long heartbeatTime = getHeartbeatTime(member);
-        if ((now - heartbeatTime) >= pingIntervalMillis) {
+        long heartbeatTime = heartbeatFailureDetector.lastHeartbeat(member);
+        if ((now - heartbeatTime) >= heartbeatIntervalMillis * HEART_BEAT_INTERVAL_FACTOR) {
             Connection conn = node.connectionManager.getOrConnect(member.getAddress());
             if (conn == null || !conn.isAlive()) {
                 logger.warning("This node does not have a connection to " + member);
             }
         }
-    }
-
-    /** Return the last heartbeat time for the {@code member} */
-    private long getHeartbeatTime(MemberImpl member) {
-        Long heartbeatTime = heartbeatTimes.get(member);
-        return (heartbeatTime != null ? heartbeatTime : 0L);
     }
 
     /**
@@ -697,7 +712,7 @@ public class ClusterHeartbeatManager {
     void resetMemberMasterConfirmations() {
         long now = clusterClock.getClusterTime();
         for (MemberImpl member : clusterService.getMemberImpls()) {
-            masterConfirmationTimes.put(member, now);
+            masterConfirmationFailureDetector.heartbeat(member, now);
         }
     }
 
@@ -705,18 +720,18 @@ public class ClusterHeartbeatManager {
     private void resetHeartbeats() {
         long now = clusterClock.getClusterTime();
         for (MemberImpl member : clusterService.getMemberImpls()) {
-            heartbeatTimes.put(member, now);
+            heartbeatFailureDetector.heartbeat(member, now);
         }
     }
 
     /** Remove the {@code member}'s master confirmation and heartbeat timestamps */
     void removeMember(MemberImpl member) {
-        masterConfirmationTimes.remove(member);
-        heartbeatTimes.remove(member);
+        masterConfirmationFailureDetector.remove(member);
+        heartbeatFailureDetector.remove(member);
     }
 
     void reset() {
-        masterConfirmationTimes.clear();
-        heartbeatTimes.clear();
+        masterConfirmationFailureDetector.reset();
+        heartbeatFailureDetector.reset();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
@@ -24,8 +24,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
-import java.util.Map;
-
 import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -98,12 +96,11 @@ public class MemberHeartbeatPlugin extends DiagnosticsPlugin {
     private void render(DiagnosticsLogWriter writer, ClusterServiceImpl clusterService) {
         ClusterHeartbeatManager clusterHeartbeatManager = clusterService.getClusterHeartbeatManager();
         long expectedIntervalMillis = clusterHeartbeatManager.getHeartbeatIntervalMillis();
-        Map<MemberImpl, Long> heartbeatTimes = clusterHeartbeatManager.getHeartbeatTimes();
 
         long nowMillis = System.currentTimeMillis();
         for (MemberImpl member : clusterService.getMemberImpls()) {
-            Long lastHeartbeatMillis = heartbeatTimes.get(member);
-            if (lastHeartbeatMillis == null) {
+            long lastHeartbeatMillis = clusterHeartbeatManager.getLastHeartbeatTime(member);
+            if (lastHeartbeatMillis == 0L) {
                 // member without a heartbeat; lets skip it.
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -332,6 +332,10 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.max.join.seconds", 300, SECONDS);
     public static final HazelcastProperty MAX_JOIN_MERGE_TARGET_SECONDS
             = new HazelcastProperty("hazelcast.max.join.merge.target.seconds", 20, SECONDS);
+
+    /**
+     * The interval at which member heartbeat messages are sent
+     */
     public static final HazelcastProperty HEARTBEAT_INTERVAL_SECONDS
             = new HazelcastProperty("hazelcast.heartbeat.interval.seconds", 5, SECONDS);
 
@@ -357,6 +361,24 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty MAX_NO_MASTER_CONFIRMATION_SECONDS
             = new HazelcastProperty("hazelcast.max.no.master.confirmation.seconds", 350, SECONDS);
+
+    /**
+     * Heartbeat failure detector type. Available options are:
+     * <ul>
+     *    <li><code>deadline</code>:  A deadline based failure detector uses an absolute timeout
+     *    for missing/lost heartbeats. After timeout member is considered as dead/unavailable.
+     *    </li>
+     *    <li><code>phi-accrual</code>: Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al.
+     *    as defined in their paper. Phi Accrual Failure Detector is adaptive to network/environment conditions,
+     *    that's why a lower {@link #MAX_NO_HEARTBEAT_SECONDS} (for example 10 or 15 seconds) can be used to provide
+     *    faster detection of unavailable members.
+     *    </li>
+     * </ul>
+     *
+     * Default failure detector is <code>deadline</code>.
+     */
+    public static final HazelcastProperty HEARTBEAT_FAILURE_DETECTOR_TYPE
+            = new HazelcastProperty("hazelcast.heartbeat.failuredetector.type", "deadline");
 
     /**
      * The interval at which the master sends the member lists are sent to other non-master members

--- a/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
@@ -152,6 +152,21 @@ public final class Preconditions {
     }
 
     /**
+     * Tests if a value is positive; so larger than 0.
+     *
+     * @param value        the value tested to see if it is positive.
+     * @param errorMessage the message
+     * @return the value
+     * @throws java.lang.IllegalArgumentException if the value is not positive.
+     */
+    public static double checkPositive(double value, String errorMessage) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        return value;
+    }
+
+    /**
      * Tests if a value is positive; larger than 0.
      *
      * @param value        the value tested to see if it is positive.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetectorTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
+import com.hazelcast.version.MemberVersion;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClusterFailureDetectorTest {
+
+    private static long HEARTBEAT_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+
+    @Parameterized.Parameters(name = "fd:{0}")
+    public static Collection<Object> parameters() {
+        return Arrays.asList(new Object[]{"deadline", "phi-accrual"});
+    }
+
+    @Parameterized.Parameter
+    public String failureDetectorType;
+
+    private ClusterFailureDetector failureDetector;
+
+    @Before
+    public void setup() {
+        if ("deadline".equals(failureDetectorType))  {
+            failureDetector = new DeadlineClusterFailureDetector(HEARTBEAT_TIMEOUT);
+        } else if ("phi-accrual".equals(failureDetectorType)) {
+            failureDetector = new PhiAccrualClusterFailureDetector(HEARTBEAT_TIMEOUT, 1, new HazelcastProperties(new Properties()));
+        } else {
+            throw new IllegalArgumentException(failureDetectorType);
+        }
+    }
+
+    @Test
+    public void member_isNotAlive_whenNoHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
+    }
+
+    @Test
+    public void member_isAlive_whenHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+        assertTrue(failureDetector.isAlive(member, timestamp));
+    }
+
+    @Test
+    public void member_isAlive_beforeHeartbeatTimeout() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+        assertTrue(failureDetector.isAlive(member, timestamp + HEARTBEAT_TIMEOUT / 2));
+    }
+
+    @Test
+    public void member_isNotAlive_afterHeartbeatTimeout() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        long ts = timestamp + HEARTBEAT_TIMEOUT * 2;
+        assertFalse("Suspicion level: " + failureDetector.suspicionLevel(member, ts), failureDetector.isAlive(member, ts));
+    }
+
+    @Test
+    public void lastHeartbeat_whenNoHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        long lastHeartbeat = failureDetector.lastHeartbeat(member);
+        assertEquals(0L, lastHeartbeat);
+    }
+
+    @Test
+    public void lastHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        long lastHeartbeat = failureDetector.lastHeartbeat(member);
+        assertEquals(timestamp, lastHeartbeat);
+    }
+
+    @Test
+    public void suspicionLevel_whenNoHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        double suspicionLevel = failureDetector.suspicionLevel(member, Clock.currentTimeMillis());
+
+        double failureLevel = getFailureSuspicionLevel(failureDetector);
+        assertEquals(failureLevel, suspicionLevel, 0d);
+    }
+
+    @Test
+    public void suspicionLevel_whenHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        double suspicionLevel = failureDetector.suspicionLevel(member, timestamp);
+        assertEquals(0, suspicionLevel, 0d);
+    }
+
+    @Test
+    public void suspicionLevel_beforeHeartbeatTimeout() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        double suspicionLevel = failureDetector.suspicionLevel(member, timestamp + HEARTBEAT_TIMEOUT / 2);
+
+        double failureLevel = getFailureSuspicionLevel(failureDetector);
+        assertThat(suspicionLevel, lessThan(failureLevel));
+    }
+
+    @Test
+    public void suspicionLevel_afterHeartbeatTimeout() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        double suspicionLevel = failureDetector.suspicionLevel(member, timestamp + HEARTBEAT_TIMEOUT * 2);
+
+        double failureLevel = getFailureSuspicionLevel(failureDetector);
+        assertThat(suspicionLevel, greaterThanOrEqualTo(failureLevel));
+    }
+
+    private static double getFailureSuspicionLevel(ClusterFailureDetector failureDetector) {
+        if (failureDetector instanceof DeadlineClusterFailureDetector) {
+            return 1;
+        }
+        if (failureDetector instanceof PhiAccrualClusterFailureDetector) {
+            return Integer.parseInt(PhiAccrualClusterFailureDetector.HEARTBEAT_PHI_FAILURE_DETECTOR_THRESHOLD.getDefaultValue());
+        }
+        throw new IllegalArgumentException();
+    }
+
+    @Test
+    public void remove_whenNoHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        failureDetector.remove(member);
+        assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
+    }
+
+    @Test
+    public void remove_afterHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        failureDetector.remove(member);
+        assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
+    }
+
+    @Test
+    public void reset_whenNoHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        failureDetector.reset();
+        assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
+    }
+
+    @Test
+    public void reset_afterHeartbeat() throws Exception {
+        Member member = newMember(5000);
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(member, timestamp);
+
+        failureDetector.reset();
+        assertFalse(failureDetector.isAlive(member, Clock.currentTimeMillis()));
+    }
+
+    private static Member newMember(int port) {
+        MemberVersion memberVersion = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
+        return new MemberImpl(newAddress(port), memberVersion, false, newUnsecureUuidString());
+    }
+
+    private static Address newAddress(int port) {
+        try {
+            return new Address(InetAddress.getLocalHost(), port);
+        } catch (UnknownHostException e) {
+            fail("Could not create new Address: " + e.getMessage());
+        }
+        return null;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetectorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.fd;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PhiAccrualFailureDetectorTest {
+
+    private final double phiThreshold = 1;
+    private final long minStdDev = 100;
+    private final long acceptableHeartbeatPause = 1000;
+
+    private FailureDetector failureDetector = new PhiAccrualFailureDetector(phiThreshold, 100, minStdDev,
+            acceptableHeartbeatPause, minStdDev);
+
+    @Test
+    public void member_isAssumedAlive_beforeFirstHeartbeat() throws Exception {
+        assertTrue(failureDetector.isAlive(Clock.currentTimeMillis()));
+    }
+
+    @Test
+    public void member_isAlive_whenHeartbeat() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+        assertTrue(failureDetector.isAlive(timestamp));
+    }
+
+    @Test
+    public void member_isAlive_beforeHeartbeatTimeout() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+        assertTrue(failureDetector.isAlive(timestamp + acceptableHeartbeatPause / 2));
+    }
+
+    @Test
+    public void member_isNotAlive_afterHeartbeatTimeout() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+
+        long ts = timestamp + acceptableHeartbeatPause * 2;
+        assertFalse("Suspicion level: " + failureDetector.suspicionLevel(ts), failureDetector.isAlive(ts));
+    }
+
+    @Test
+    public void lastHeartbeat_whenNoHeartbeat() throws Exception {
+        long lastHeartbeat = failureDetector.lastHeartbeat();
+        assertEquals(PhiAccrualFailureDetector.NO_HEARTBEAT_TIMESTAMP, lastHeartbeat);
+    }
+
+    @Test
+    public void lastHeartbeat() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+
+        long lastHeartbeat = failureDetector.lastHeartbeat();
+        assertEquals(timestamp, lastHeartbeat);
+    }
+
+    @Test
+    public void nonSuspected_beforeFirstHeartbeat() throws Exception {
+        double suspicionLevel = failureDetector.suspicionLevel(Clock.currentTimeMillis());
+
+        assertEquals(0, suspicionLevel, 0d);
+    }
+
+    @Test
+    public void suspicionLevel_whenHeartbeat() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+
+        double suspicionLevel = failureDetector.suspicionLevel(timestamp);
+        assertEquals(0, suspicionLevel, 0d);
+    }
+
+    @Test
+    public void suspicionLevel_beforeHeartbeatTimeout() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+
+        double suspicionLevel = failureDetector.suspicionLevel(timestamp + acceptableHeartbeatPause / 2);
+
+        assertThat(suspicionLevel, lessThan(phiThreshold));
+    }
+
+    @Test
+    public void suspicionLevel_afterHeartbeatTimeout() throws Exception {
+        long timestamp = Clock.currentTimeMillis();
+        failureDetector.heartbeat(timestamp);
+
+        double suspicionLevel = failureDetector.suspicionLevel(timestamp + acceptableHeartbeatPause * 2);
+
+        assertThat(suspicionLevel, greaterThanOrEqualTo(phiThreshold));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withNegativeThreshold() {
+        new PhiAccrualFailureDetector(-1, 1, 1, 1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withZeroThreshold() {
+        new PhiAccrualFailureDetector(0, 1, 1, 1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withNegativeMinStdDev() {
+        new PhiAccrualFailureDetector(1, -1, 1, 1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withZeroMinStdDev() {
+        new PhiAccrualFailureDetector(1, 0, 1, 1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withNegativeFirstHeartbeatEstimation() {
+        new PhiAccrualFailureDetector(1, 1, 1, 1, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withZeroFirstHeartbeatEstimation() {
+        new PhiAccrualFailureDetector(1, 1, 1, 1, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void construct_withNegativeAcceptableHeartbeatPause() {
+        new PhiAccrualFailureDetector(1, 1, 1, -1, 1);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest_withTCP.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest_withTCP.java
@@ -49,6 +49,7 @@ public class MembershipFailureTest_withTCP extends MembershipFailureTest {
 
     @Override
     HazelcastInstance newHazelcastInstance(Config config) {
+        config.setProperty(GroupProperty.HEARTBEAT_FAILURE_DETECTOR_TYPE.getName(), failureDetectorType);
         initConfig(config);
         return HazelcastInstanceFactory.newHazelcastInstance(config, createInstanceName(config), new FirewallingNodeContext());
     }


### PR DESCRIPTION
Currently Hazelcast has a single failure detector mechanism which is based on a fixed deadline. When a member doesn't any send heartbeat messages until a deadline, it's suspected and marked as failed. Even though this is a simple mechanism, it's not adaptable to environment and it's difficult to define a deadline. If deadline is too big then it takes too much to declare a failing member. If it's too small then it can lead to spurious member removals and cluster splits.

The ϕ Accrual Failure Detector is a more advanced failure detector algorithm which is already used by Cassandra and Akka. It's adaptive to network conditions and doesn't require a predefined deadline. We'll abstract the failure detector mechanism in Hazelcast and provide an implementation of ϕ Accrual Failure Detector.

See https://hazelcast.atlassian.net/wiki/spaces/EN/pages/132323170/Phi+Accrual+Failure+Detector+Design

See https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala