### PR TITLE
SslEngineFactory has 'forClient' flag in init method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactory.java
@@ -21,6 +21,8 @@ import java.util.Properties;
 
 /**
  * The {@link SSLEngineFactory} is responsible for creating an SSLEngine instance.
+ *
+ * @since 3.9
  */
 public interface SSLEngineFactory {
 
@@ -28,15 +30,19 @@ public interface SSLEngineFactory {
      * Initializes this class with config from {@link com.hazelcast.config.SSLConfig}
      *
      * @param properties properties form config
-     * @throws Exception
+     * @param forClient if the SslEngineFactory is created for a client or for a member. This can be used to
+     *                  validate the configuration.
+     * @throws Exception if something goes wrong while initializing.
      */
-    void init(Properties properties) throws Exception;
-
+    void init(Properties properties, boolean forClient) throws Exception;
 
     /**
      * Creates a SSLEngine.
      *
      * @param clientMode if the SSLEngine should be in client mode, or server-mode. See {@link SSLEngine#getUseClientMode()}.
+     *                   If this SSLEngineFactory is used by a java-client, then clientMode will always be true. But if it is
+     *                   created for a member, then the side of the socket that initiated the connection will be in 'clientMode'
+     *                   while the other one will be in 'serverMode'.
      * @return the created SSLEngine.
      */
     SSLEngine create(boolean clientMode);


### PR DESCRIPTION
The forClient flag is needed to do SslConfig validation correctly.

See https://github.com/hazelcast/hazelcast-enterprise/issues/1601

This change will not break any compatibility since the interface is added in 3.9. 