### PR TITLE
Minor ringbuffer and reliable topic test enhancements

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
@@ -50,7 +50,8 @@ import static org.junit.Assert.assertEquals;
 @Category(NightlyTest.class)
 public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
 
-    public static final int MAX_BATCH = 100;
+    private final ILogger logger = Logger.getLogger(RingbufferAddAllReadManyStressTest.class);
+    private static final int MAX_BATCH = 100;
     private final AtomicBoolean stop = new AtomicBoolean();
     private Ringbuffer<Long> ringbuffer;
 
@@ -114,13 +115,13 @@ public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
         producer.start();
 
         sleepAndStop(stop, 60);
-        System.out.println("Waiting fo completion");
+        logger.info("Waiting for completion");
 
         producer.assertSucceedsEventually();
         consumer1.assertSucceedsEventually();
         consumer2.assertSucceedsEventually();
 
-        System.out.println("producer.produced:" + producer.produced);
+        logger.info(producer.getName() + " produced:" + producer.produced);
 
         assertEquals(producer.produced, consumer1.seq);
         assertEquals(producer.produced, consumer2.seq);
@@ -217,7 +218,7 @@ public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
                         if (e.getCause() instanceof StaleSequenceException) {
                             // this consumer is used in a stress test and can fall behind the producer if it gets delayed
                             // by any reason. This is ok, just jump to the the middle of the ringbuffer.
-                            System.out.println(getName() + " has fallen behind, catching up...");
+                            logger.info(getName() + " has fallen behind, catching up...");
                             final long tail = ringbuffer.tailSequence();
                             final long head = ringbuffer.headSequence();
                             seq = tail >= head ? ((tail + head) / 2) : head;

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferMigrationTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -36,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 public class RingbufferMigrationTest extends HazelcastTestSupport {
 
     public static final int CAPACITY = 100;
+    public static final String BOUNCING_TEST_PARTITION_COUNT = "10";
     private TestHazelcastInstanceFactory instanceFactory;
 
     @Before
@@ -48,6 +50,7 @@ public class RingbufferMigrationTest extends HazelcastTestSupport {
         final String ringbufferName = "ringbuffer";
         final Config config = new Config()
                 .addRingBufferConfig(new RingbufferConfig(ringbufferName).setTimeToLiveSeconds(0));
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), BOUNCING_TEST_PARTITION_COUNT);
         HazelcastInstance hz1 = instanceFactory.newHazelcastInstance(config);
 
         for (int k = 0; k < 10 * CAPACITY; k++) {
@@ -61,8 +64,10 @@ public class RingbufferMigrationTest extends HazelcastTestSupport {
         HazelcastInstance hz3 = instanceFactory.newHazelcastInstance(config);
 
         assertClusterSizeEventually(3, hz2);
+        waitAllForSafeState(hz1, hz2, hz3);
         hz1.shutdown();
         assertClusterSizeEventually(2, hz2);
+        waitAllForSafeState(hz2, hz3);
 
         assertEquals(oldTailSeq, hz2.getRingbuffer(ringbufferName).tailSequence());
         assertEquals(oldHeadSeq, hz2.getRingbuffer(ringbufferName).headSequence());

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicStressTest.java
@@ -22,12 +22,14 @@ import com.hazelcast.config.TopicConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestThread;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.topic.ReliableMessageListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertEquals;
 @Category(NightlyTest.class)
 public class ReliableTopicStressTest extends HazelcastTestSupport {
 
+    private final ILogger logger = Logger.getLogger(ReliableTopicStressTest.class);
     private final AtomicBoolean stop = new AtomicBoolean();
     private ITopic<Long> topic;
 
@@ -61,7 +64,7 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
         topic = hz.getReliableTopic(topicConfig.getName());
     }
 
-    @Test(timeout = 600000)
+    @Test(timeout = 1000 * 60 * 10)
     public void test() throws InterruptedException {
         final StressMessageListener listener1 = new StressMessageListener(1);
         topic.addMessageListener(listener1);
@@ -71,21 +74,21 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
         final ProduceThread produceThread = new ProduceThread();
         produceThread.start();
 
-        System.out.println("Starting test");
+        logger.info("Starting test");
         sleepAndStop(stop, MINUTES.toSeconds(5));
-        System.out.println("Completed");
+        logger.info("Waiting for completion");
 
         produceThread.assertSucceedsEventually();
 
-        System.out.println("Number of items produced: " + produceThread.send);
+        logger.info("Number of items produced: " + produceThread.send);
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(produceThread.send, listener1.received);
-                assertEquals(produceThread.send, listener2.received);
-                assertEquals(0, listener1.failures);
-                assertEquals(0, listener2.failures);
+                assertEquals(produceThread.send, listener1.received + listener1.lost);
+                assertEquals(produceThread.send, listener2.received + listener2.lost);
+                assertEquals(0, listener1.failed);
+                assertEquals(0, listener2.failed);
             }
         });
     }
@@ -107,10 +110,13 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
         }
     }
 
-    public class StressMessageListener implements MessageListener<Long> {
+    public class StressMessageListener implements ReliableMessageListener<Long> {
         private final int id;
-        private long received = 0;
-        private long failures = 0;
+        private long nextExpectedMessageId = 0; // what's the next expected message ID
+        private long lost = 0; // how many were lost because of slow listener (listener was slow)
+        private long received = 0; // how many were successfully received (listener was fast enough)
+        private long failed = 0; // how many times did the listener fail (listener was fast but got wrong message ID)
+        private boolean listenerWasSlow; // was the listener slow?
 
         public StressMessageListener(int id) {
             this.id = id;
@@ -118,15 +124,24 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
 
         @Override
         public void onMessage(Message<Long> message) {
-            if (!message.getMessageObject().equals(received)) {
-                failures++;
+            final long receivedMessageId = message.getMessageObject();
+            if (receivedMessageId != nextExpectedMessageId) {
+                if (listenerWasSlow) {
+                    logger.info(toString() + " was slow, jumping from " + received + " to " + receivedMessageId);
+                    lost += receivedMessageId - nextExpectedMessageId;
+                    nextExpectedMessageId = receivedMessageId;
+                    listenerWasSlow = false;
+                } else {
+                    failed++;
+                }
             }
 
             if (received % 100000 == 0) {
-                System.out.println(toString() + " is at: " + received);
+                logger.info(toString() + " is at: " + received);
             }
 
             received++;
+            nextExpectedMessageId++;
         }
 
         @Override
@@ -134,6 +149,28 @@ public class ReliableTopicStressTest extends HazelcastTestSupport {
             return "StressMessageListener{" +
                     "id=" + id +
                     '}';
+        }
+
+        @Override
+        public long retrieveInitialSequence() {
+            // -1 indicates start from next message.
+            return -1;
+        }
+
+        @Override
+        public void storeSequence(long sequence) {
+            //np-op
+        }
+
+        @Override
+        public boolean isLossTolerant() {
+            listenerWasSlow = true;
+            return true;
+        }
+
+        @Override
+        public boolean isTerminal(Throwable failure) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
- change System.out.println to logger calls
- decrease partition count for bouncing test as partition count is
irrelevant and makes the test faster and less prone to failing in a
slow environment
- allow the reliable topic stress test listeners to fall behind in a
slow environment and still consider it as a passed test

Fixes : https://github.com/hazelcast/hazelcast/issues/7080