### PR TITLE
Do not log Hazelcast version with Jet version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggingServiceImpl.java
@@ -55,8 +55,8 @@ public class LoggingServiceImpl implements LoggingService {
     public LoggingServiceImpl(String groupName, String loggingType, BuildInfo buildInfo) {
         this.loggerFactory = Logger.newLoggerFactory(loggingType);
         JetBuildInfo jetBuildInfo = buildInfo.getJetBuildInfo();
-        versionMessage = "[" + groupName + "]" + (jetBuildInfo != null ? " [" + jetBuildInfo.getVersion() + "]" : "")
-                + " [" + buildInfo.getVersion() + "] ";
+        versionMessage = "[" + groupName + "] ["
+                + (jetBuildInfo != null ?  jetBuildInfo.getVersion() : buildInfo.getVersion()) + "] ";
     }
 
     public void setThisMember(MemberImpl thisMember) {


### PR DESCRIPTION
Since Hazelcast is shaded inside Jet now, it is redundant to log both version numbers. Each version of Jet corresponds to a single Hazelcast version.