### PR TITLE
Do not search highest classloader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -101,12 +101,7 @@ public final class ServiceLoader {
     private static Set<URLDefinition> collectFactoryUrls(String factoryId, ClassLoader classLoader) {
         String resourceName = "META-INF/services/" + factoryId;
         try {
-            Enumeration<URL> configs;
-            if (classLoader != null) {
-                configs = classLoader.getResources(resourceName);
-            } else {
-                configs = ClassLoader.getSystemResources(resourceName);
-            }
+            Enumeration<URL> configs = classLoader.getResources(resourceName);
 
             Set<URLDefinition> urlDefinitions = new HashSet<URLDefinition>();
             while (configs.hasMoreElements()) {
@@ -167,7 +162,7 @@ public final class ServiceLoader {
 
         // check if TCCL is same as given classLoader
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        if (tccl != classLoader) {
+        if (tccl != null && tccl != classLoader) {
             classLoaders.add(tccl);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -58,8 +58,27 @@ import static org.junit.Assert.assertTrue;
 public class ServiceLoaderTest extends HazelcastTestSupport {
 
     @Test
+    public void selectClassLoaders_whenTCCL_isNull_thenDoNotSelectNullClassloader() {
+        Thread.currentThread().setContextClassLoader(null);
+        ClassLoader dummyClassLoader = new URLClassLoader(new URL[0]);
+        List<ClassLoader> classLoaders = ServiceLoader.selectClassLoaders(dummyClassLoader);
+
+        assertNotContains(classLoaders, null);
+    }
+
+    @Test
+    public void selectClassLoaders_whenPassedClassLoaderIsisNull_thenDoNotSelectNullClassloader() {
+        Thread.currentThread().setContextClassLoader(null);
+        List<ClassLoader> classLoaders = ServiceLoader.selectClassLoaders(null);
+
+        assertNotContains(classLoaders, null);
+    }
+
+    @Test
     public void testMultipleClassloaderLoadsTheSameClass() throws Exception {
         ClassLoader parent = this.getClass().getClassLoader();
+
+        //child classloader will steal bytecode from the parent and will define classes on its own
         ClassLoader childLoader = new StealingClassloader(parent);
 
         Class<?> interfaceClass = childLoader.loadClass(PortableHook.class.getName());

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.serialization.PortableHook;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
@@ -33,14 +34,18 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.TestCollectionUtils.setOf;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
@@ -51,6 +56,46 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ServiceLoaderTest extends HazelcastTestSupport {
+
+    @Test
+    public void testMultipleClassloaderLoadsTheSameClass() throws Exception {
+        ClassLoader parent = this.getClass().getClassLoader();
+        ClassLoader childLoader = new StealingClassloader(parent);
+
+        Class<?> interfaceClass = childLoader.loadClass(PortableHook.class.getName());
+        Iterator<? extends Class<?>> iterator = ServiceLoader.classIterator(interfaceClass, "com.hazelcast.PortableHook", childLoader);
+
+        //make sure some hook were found.
+        assertTrue(iterator.hasNext());
+
+        while (iterator.hasNext()) {
+            Class<?> hook = iterator.next();
+            assertEquals(childLoader, hook.getClassLoader());
+        }
+    }
+
+    @Test
+    public void testHookDeduplication() {
+        ClassLoader parentClassloader = PortableHook.class.getClassLoader();
+
+        Class<?> hook = newClassImplementingInterface("com.hazelcast.internal.serialization.SomeHook",
+                PortableHook.class, parentClassloader);
+
+        //child classloader delegating everything to its parent
+        URLClassLoader childClassloader = new URLClassLoader(new URL[]{}, parentClassloader);
+
+        ServiceLoader.ServiceDefinition definition1 = new ServiceLoader.ServiceDefinition(hook.getName(), parentClassloader);
+        //the definition loaded by the child classloader -> it only delegates to the parent -> it's a duplicated
+        ServiceLoader.ServiceDefinition definition2 = new ServiceLoader.ServiceDefinition(hook.getName(), childClassloader);
+
+        Set<ServiceLoader.ServiceDefinition> definitions = setOf(definition1, definition2);
+        ServiceLoader.ClassIterator<PortableHook> iterator = new ServiceLoader.ClassIterator<PortableHook>(definitions, PortableHook.class);
+
+        assertTrue(iterator.hasNext());
+        Class<PortableHook> hookFromIterator = iterator.next();
+        assertEquals(hook, hookFromIterator);
+        assertFalse(iterator.hasNext());
+    }
 
     @Test
     public void testSkipHooksWithImplementingTheExpectedInterfaceButLoadedByDifferentClassloader() {
@@ -367,5 +412,64 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
         public boolean isOverwritable() {
             return false;
         }
+    }
+
+    /**
+     * Delegates everything to a given parent classloader.
+     * When a loaded class is defined by the parent then it "steals"
+     * its bytecode and try to define it on its own.
+     *
+     * It simulates the situation where child and parent defines the same classes.
+     *
+     */
+    private static class StealingClassloader extends ClassLoader {
+        private final ClassLoader parent;
+
+        private StealingClassloader(ClassLoader parent) {
+            super(parent);
+            this.parent = parent;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            Class<?> loadedByParent = parent.loadClass(name);
+            if (loadedByParent != null && parent.equals(loadedByParent.getClassLoader())) {
+                byte[] bytecode = loadBytecodeFromParent(name);
+                Class<?> clazz = defineClass(name, bytecode, 0, bytecode.length);
+                resolveClass(clazz);
+                return clazz;
+            } else {
+                return loadedByParent;
+            }
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            return parent.getResources(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return parent.getResourceAsStream(name);
+        }
+
+        private byte[] loadBytecodeFromParent(String className) {
+            String resource = className.replace('.', '/').concat(".class");
+            InputStream is = null;
+            try {
+                is = parent.getResourceAsStream(resource);
+                if (is != null) {
+                    try {
+                        return toByteArray(is);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            } finally {
+                IOUtil.closeResource(is);
+            }
+            return null;
+        }
+
     }
 }


### PR DESCRIPTION
--Problem--
Short Version:
Our classloading assumes a hiearchical parent-first delegation model.
This assumption is not always right.

Long Version:
Imagine this classloader hiearchy: childCL -> parentCL
Both childCl and parentCL can access the same JAR. The childCL does
not simply delegate to its parent, it loads (&define) classes on its own.

Now Hazelcast is loaded by the childCL. It's loading hooks with service
definitions when it's starting. It finds `META-INF/service/c.h.hook` resource
can be loaded by the childCl. However when the `findHighestReachableClassLoader()`
is used then it will also find the parentCL can load the resource as well (because both classloaders point to the same physical JAR thus they both have a resource with the same URL available) ->
Hazelcast will use the parentCl to load the hook. However the classes loaded
by parentCL are not the same as classes loaded by childCL -> `ClassCastException`.

Solution:
Do not search for the highest available classloader.

Problem with the solution:
We now might have multiple classloaders loading the same resource
-> Duplicate registration

Solution of the problem:
De-duplication in the `ClassIterator`.