### PR TITLE
Add listener registration check for members

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.listeners;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -30,6 +31,11 @@ import org.junit.runner.RunWith;
 public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private IMap<String, String> iMap;
+
+    @Override
+    String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.listeners;
 
+import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemListener;
@@ -30,6 +31,11 @@ import org.junit.runner.RunWith;
 public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private IList<String> iList;
+
+    @Override
+    String getServiceName() {
+        return ListService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.listeners;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.MultiMap;
+import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -30,6 +31,11 @@ import org.junit.runner.RunWith;
 public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private MultiMap<String, String> multiMap;
+
+    @Override
+    String getServiceName() {
+        return MultiMapService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.listeners;
 
+import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemListener;
@@ -30,6 +31,11 @@ import org.junit.runner.RunWith;
 public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private IQueue<String> iQueue;
+
+    @Override
+    String getServiceName() {
+        return QueueService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -16,20 +16,34 @@
 
 package com.hazelcast.client.listeners;
 
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertTrue;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
 
     private ReplicatedMap<String, String> replicatedMap;
+
+    @Override
+    String getServiceName() {
+        return ReplicatedMapService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {
@@ -51,5 +65,24 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
     @Override
     public boolean removeListener(String registrationId) {
         return replicatedMap.removeEntryListener(registrationId);
+    }
+
+    @Override
+    protected void validateRegistrationsOnMembers(final TestHazelcastFactory factory) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                boolean found = false;
+                for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
+                    NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
+                    EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
+                    EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
+                    if (serviceSegment != null && serviceSegment.getRegistrationIdMap().size() == 1) {
+                        found = true;
+                    }
+                }
+                assertTrue(found);
+            }
+        });
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.listeners;
 
+import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.core.ISet;
 import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemListener;
@@ -30,6 +31,11 @@ import org.junit.runner.RunWith;
 public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
 
     private ISet<String> iSet;
+
+    @Override
+    String getServiceName() {
+        return SetService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.impl.TopicService;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -30,6 +31,11 @@ import org.junit.runner.RunWith;
 public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
 
     private ITopic<String> topic;
+
+    @Override
+    String getServiceName() {
+        return TopicService.SERVICE_NAME;
+    }
 
     @Override
     protected String addListener() {


### PR DESCRIPTION
When a new member is added after listener is registered. Registrations
are carried to new member in PostJoinOperations.

We had cluster size check before to make sure registartions are done
before firing events. This was not sufficient by itself. A post join
operation can finish later.

With this pr, we are checking if each member will eventually have
registration. Then we will fire events.

fixes #10698