### PR TITLE
When starting a caching provider, get-or-create with default

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
@@ -37,18 +37,19 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.junit.Assert.assertNotNull;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ClientCachingProviderTest extends CachingProviderTest {
 
+    private static final String CONFIG_CLASSPATH_LOCATION = "test-hazelcast-jcache.xml";
     private final List<HazelcastInstance> instances = new ArrayList<HazelcastInstance>();
 
     @Before
     public void setup() {
         // start a member
         Config config = new Config();
-        config.getGroupConfig().setName("test-group1");
-        config.getGroupConfig().setPassword("test-pass1");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         instances.add(instance);
         // start two client instances
@@ -73,8 +74,6 @@ public class ClientCachingProviderTest extends CachingProviderTest {
         // we are using real instances.
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setInstanceName(instanceName);
-        clientConfig.getGroupConfig().setName("test-group1");
-        clientConfig.getGroupConfig().setPassword("test-pass1");
         HazelcastInstance instance = HazelcastClient.newHazelcastClient(clientConfig);
         instances.add(instance);
         return instance;
@@ -83,6 +82,13 @@ public class ClientCachingProviderTest extends CachingProviderTest {
     @Override
     protected CachingProvider createCachingProvider(HazelcastInstance defaultInstance) {
         return HazelcastClientCachingProvider.createCachingProvider(defaultInstance);
+    }
+
+    @Override
+    protected void assertInstanceStarted(String instanceName) {
+        HazelcastInstance otherInstance = HazelcastClient.getHazelcastClientByName(instanceName);
+        assertNotNull(otherInstance);
+        otherInstance.getLifecycleService().terminate();
     }
 
     @After

--- a/hazelcast-client/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast-client/src/test/resources/test-hazelcast-jcache.xml
@@ -36,9 +36,5 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <instance-name>test-hazelcast-jcache</instance-name>
-    <group>
-        <name>test-group1</name>
-        <password>test-pass1</password>
-    </group>
 
 </hazelcast-client>

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -27,9 +27,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.HashSet;
 import java.util.Properties;
-import java.util.Set;
 
 import static com.hazelcast.cache.HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION;
 import static com.hazelcast.cache.HazelcastCachingProvider.HAZELCAST_INSTANCE_ITSELF;
@@ -47,17 +45,6 @@ import static com.hazelcast.util.StringUtil.isNullOrEmptyAfterTrim;
  */
 public final class HazelcastServerCachingProvider
         extends AbstractHazelcastCachingProvider {
-
-    private static final Set<String> SUPPORTED_SCHEMES;
-
-    static {
-        Set<String> supportedSchemes = new HashSet<String>();
-        supportedSchemes.add("classpath");
-        supportedSchemes.add("file");
-        supportedSchemes.add("http");
-        supportedSchemes.add("https");
-        SUPPORTED_SCHEMES = supportedSchemes;
-    }
 
     /**
      * Helper method for creating caching provider for testing, etc.
@@ -198,27 +185,6 @@ public final class HazelcastServerCachingProvider
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }
-    }
-
-    // returns true when location itself or its resolved value as system property placeholder has one of supported schemes
-    // from which Config objects can be initialized
-    boolean isConfigLocation(URI location) {
-        String scheme = location.getScheme();
-        if (scheme == null) {
-            // interpret as place holder
-            try {
-                String resolvedPlaceholder = System.getProperty(location.getRawSchemeSpecificPart());
-                if (resolvedPlaceholder == null) {
-                    return false;
-                }
-                location = new URI(resolvedPlaceholder);
-                scheme = location.getScheme();
-            } catch (URISyntaxException e) {
-                return false;
-            }
-        }
-
-        return (scheme != null && SUPPORTED_SCHEMES.contains(scheme.toLowerCase()));
     }
 
     private Config getConfig(URL configURL, ClassLoader theClassLoader, String instanceName)

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -27,7 +27,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import static com.hazelcast.cache.HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION;
 import static com.hazelcast.cache.HazelcastCachingProvider.HAZELCAST_INSTANCE_ITSELF;
@@ -45,6 +47,17 @@ import static com.hazelcast.util.StringUtil.isNullOrEmptyAfterTrim;
  */
 public final class HazelcastServerCachingProvider
         extends AbstractHazelcastCachingProvider {
+
+    private static final Set<String> SUPPORTED_SCHEMES;
+
+    static {
+        Set<String> supportedSchemes = new HashSet<String>();
+        supportedSchemes.add("classpath");
+        supportedSchemes.add("file");
+        supportedSchemes.add("http");
+        supportedSchemes.add("https");
+        SUPPORTED_SCHEMES = supportedSchemes;
+    }
 
     /**
      * Helper method for creating caching provider for testing, etc.
@@ -85,30 +98,35 @@ public final class HazelcastServerCachingProvider
             return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);
         }
 
-        // If instance name is specified via properties, get instance through it.
+        // If instance name is specified via properties, get instance through it or create a new instance with default config
+        // and given instance name
         if (instanceName != null) {
-            return Hazelcast.getHazelcastInstanceByName(instanceName);
+            HazelcastInstance instance = getOrCreateByInstanceName(instanceName);
+            return instance;
         }
 
         // resolving HazelcastInstance via properties failed, try with URI as XML configuration file location
         final boolean isDefaultURI = (uri == null || uri.equals(getDefaultURI()));
         if (!isDefaultURI) {
-            try {
-                // try locating a Hazelcast config at CacheManager URI
-                Config config = getConfigFromLocation(uri, classLoader, null);
-                return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);
-            } catch (Exception e) {
-                if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("Could not get or create hazelcast instance from URI " + uri.toString(), e);
+            // attempt to resolve URI as config location or as instance name
+            if (isConfigLocation(uri)) {
+                try {
+                    // try locating a Hazelcast config at CacheManager URI
+                    Config config = getConfigFromLocation(uri, classLoader, null);
+                    return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);
+                } catch (Exception e) {
+                    if (LOGGER.isFinestEnabled()) {
+                        LOGGER.finest("Could not get or create hazelcast instance from URI " + uri.toString(), e);
+                    }
                 }
-            }
-
-            try {
-                // try again, this time interpreting CacheManager URI as hazelcast instance name
-                return Hazelcast.getHazelcastInstanceByName(uri.toString());
-            } catch (Exception e) {
-                if (LOGGER.isFinestEnabled()) {
-                    LOGGER.finest("Could not get a hazelcast instance from instance name " + uri.toString(), e);
+            } else {
+                try {
+                    // try again, this time interpreting CacheManager URI as hazelcast instance name
+                    return getOrCreateByInstanceName(uri.toString());
+                } catch (Exception e) {
+                    if (LOGGER.isFinestEnabled()) {
+                        LOGGER.finest("Could not get hazelcast instance from instance name" + uri.toString(), e);
+                    }
                 }
             }
             // could not locate hazelcast instance, return null and an exception will be thrown from invoker
@@ -121,7 +139,7 @@ public final class HazelcastServerCachingProvider
     protected HazelcastInstance getDefaultInstance() {
         if (hazelcastInstance == null) {
             // Since there is no default instance in use, get-or-create by instance name in default config or create new
-            Config config = new XmlConfigBuilder().build();
+            Config config = getDefaultConfig();
             if (isNullOrEmptyAfterTrim(config.getInstanceName())) {
                 hazelcastInstance = Hazelcast.newHazelcastInstance();
             } else {
@@ -129,6 +147,27 @@ public final class HazelcastServerCachingProvider
             }
         }
         return hazelcastInstance;
+    }
+
+    /**
+     * Get an existing {@link HazelcastInstance} by {@code instanceName} or, if not found, create a new {@link HazelcastInstance}
+     * with default configuration and given {@code instanceName}.
+     *
+     * @param instanceName name by which to lookup existing {@link HazelcastInstance} or create new one.
+     * @return             a {@link HazelcastInstance} with the given {@code instanceName}
+     */
+    private HazelcastInstance getOrCreateByInstanceName(String instanceName) {
+        HazelcastInstance instance = Hazelcast.getHazelcastInstanceByName(instanceName);
+        if (instance == null) {
+            Config config = getDefaultConfig();
+            config.setInstanceName(instanceName);
+            instance = Hazelcast.getOrCreateHazelcastInstance(config);
+        }
+        return instance;
+    }
+
+    private Config getDefaultConfig() {
+        return new XmlConfigBuilder().build();
     }
 
     private Config getConfigFromLocation(String location, ClassLoader classLoader, String instanceName)
@@ -143,6 +182,7 @@ public final class HazelcastServerCachingProvider
         if (scheme == null) {
             // It may be a place holder
             location = new URI(System.getProperty(location.getRawSchemeSpecificPart()));
+            scheme = location.getScheme();
         }
         ClassLoader theClassLoader = classLoader == null ? getDefaultClassLoader() : classLoader;
         final URL configURL;
@@ -158,6 +198,27 @@ public final class HazelcastServerCachingProvider
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }
+    }
+
+    // returns true when location itself or its resolved value as system property placeholder has one of supported schemes
+    // from which Config objects can be initialized
+    boolean isConfigLocation(URI location) {
+        String scheme = location.getScheme();
+        if (scheme == null) {
+            // interpret as place holder
+            try {
+                String resolvedPlaceholder = System.getProperty(location.getRawSchemeSpecificPart());
+                if (resolvedPlaceholder == null) {
+                    return false;
+                }
+                location = new URI(resolvedPlaceholder);
+                scheme = location.getScheme();
+            } catch (URISyntaxException e) {
+                return false;
+            }
+        }
+
+        return (scheme != null && SUPPORTED_SCHEMES.contains(scheme.toLowerCase()));
     }
 
     private Config getConfig(URL configURL, ClassLoader theClassLoader, String instanceName)

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -35,7 +36,11 @@ import javax.cache.spi.CachingProvider;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceName;
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByLocation;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -77,29 +82,28 @@ public class CachingProviderTest extends HazelcastTestSupport {
 
     @Test
     public void whenDefaultURI_instanceNameAsProperty_thenThatInstanceIsUsed() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(null, null,
-                HazelcastCachingProvider.propertiesByInstanceName(INSTANCE_2_NAME));
+        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
+                null, null, propertiesByInstanceName(INSTANCE_2_NAME));
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
     @Test
     public void whenOtherURI_instanceNameAsProperty_thenThatInstanceIsUsed() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(new URI("other-uri"), null,
-                HazelcastCachingProvider.propertiesByInstanceName(INSTANCE_2_NAME));
+        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
+                new URI("other-uri"), null, propertiesByInstanceName(INSTANCE_2_NAME));
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
-    @Test(expected = CacheException.class)
-    public void whenDefaultURI_invalidInstanceNameAsProperty_thenFails() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(null, null,
-                HazelcastCachingProvider.propertiesByInstanceName("instance-does-not-exist"));
+    @Test
+    public void whenDefaultURI_inexistentInstanceNameAsProperty_thenStartsOtherInstance() throws URISyntaxException {
+        cachingProvider.getCacheManager(null, null, propertiesByInstanceName("instance-does-not-exist"));
+        assertInstanceStarted("instance-does-not-exist");
     }
 
-    @Test(expected = CacheException.class)
-    public void whenOtherURI_invalidInstanceNameAsProperty_thenFails() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("other-uri"), null,
-                HazelcastCachingProvider.propertiesByInstanceName("instance-does-not-exist"));
+    @Test
+    public void whenOtherURI_inexistentInstanceNameAsProperty_thenStartsNewInstance() throws URISyntaxException {
+        cachingProvider.getCacheManager(new URI("other-uri"), null, propertiesByInstanceName("instance-does-not-exist"));
+        assertInstanceStarted("instance-does-not-exist");
     }
 
     @Test
@@ -108,21 +112,17 @@ public class CachingProviderTest extends HazelcastTestSupport {
         assertCacheManagerInstance(cacheManager, instance1);
     }
 
-    @Test(expected = CacheException.class)
-    public void whenOtherURI_noInstanceName_thenFails() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("other-uri"),null);
-    }
-
     @Test
     public void whenInstanceNameAsUri_thenThatInstanceIsUsed() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(new URI(INSTANCE_2_NAME), null);
+        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
+                new URI(INSTANCE_2_NAME), null);
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
-    @Test(expected = CacheException.class)
-    public void whenInvalidInstanceNameAsUri_thenFails() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(new URI("does-not-exist"), null);
+    @Test
+    public void whenInexistentInstanceNameAsUri_thenOtherInstanceIsStarted() throws URISyntaxException {
+        cachingProvider.getCacheManager(new URI("does-not-exist"), null);
+        assertInstanceStarted("does-not-exist");
     }
 
     @Test
@@ -132,10 +132,17 @@ public class CachingProviderTest extends HazelcastTestSupport {
         assertCacheManagerInstance(cacheManager, instance3);
     }
 
+    @Test
+    public void whenConfigLocationAsUriViaProperty_thenThatInstanceIsUsed() throws URISyntaxException {
+        System.setProperty("PROPERTY_PLACEHOLDER", "classpath:" + CONFIG_CLASSPATH_LOCATION);
+        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
+                new URI("PROPERTY_PLACEHOLDER"), null);
+        assertCacheManagerInstance(cacheManager, instance3);
+    }
+
     @Test(expected = CacheException.class)
     public void whenInvalidConfigLocationAsUri_thenFails() throws URISyntaxException {
-        HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("classpath:this-config-does-not-exist"), null);
+        cachingProvider.getCacheManager(new URI("classpath:this-config-does-not-exist"), null);
     }
 
     // test that config location property has priority over attempting URI interpretation:
@@ -145,7 +152,7 @@ public class CachingProviderTest extends HazelcastTestSupport {
     public void whenConfigLocationAsProperty_thenThatInstanceIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
                 new URI("classpath:this-config-does-not-exist"), null,
-                HazelcastCachingProvider.propertiesByLocation("classpath:" + CONFIG_CLASSPATH_LOCATION));
+                propertiesByLocation("classpath:" + CONFIG_CLASSPATH_LOCATION));
         assertCacheManagerInstance(cacheManager, instance3);
     }
 
@@ -155,40 +162,35 @@ public class CachingProviderTest extends HazelcastTestSupport {
     @Test
     public void whenInstanceNameAsProperty_thenThatInstanceIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("classpath:this-config-does-not-exist"), null,
-                HazelcastCachingProvider.propertiesByInstanceName(INSTANCE_2_NAME));
+                new URI("classpath:this-config-does-not-exist"), null, propertiesByInstanceName(INSTANCE_2_NAME));
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
     @Test
     public void whenInstanceItselfAsProperty_andInvalidConfigURI_thenInstanceItselfIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("classpath:this-config-does-not-exist"), null,
-                HazelcastCachingProvider.propertiesByInstanceItself(instance2));
+                new URI("classpath:this-config-does-not-exist"), null, propertiesByInstanceItself(instance2));
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
     @Test
     public void whenInstanceItselfAsProperty_andValidConfigURI_thenInstanceItselfIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("classpath:" + CONFIG_CLASSPATH_LOCATION), null,
-                HazelcastCachingProvider.propertiesByInstanceItself(instance2));
+                new URI("classpath:" + CONFIG_CLASSPATH_LOCATION), null, propertiesByInstanceItself(instance2));
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
     @Test
     public void whenInstanceItselfAsProperty_andValidInstanceNameURI_thenInstanceItselfIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                new URI("classpath:" + CONFIG_CLASSPATH_LOCATION), null,
-                HazelcastCachingProvider.propertiesByInstanceItself(instance2));
+                new URI("classpath:" + CONFIG_CLASSPATH_LOCATION), null, propertiesByInstanceItself(instance2));
         assertCacheManagerInstance(cacheManager, instance2);
     }
 
     @Test
     public void whenInstanceItselfAsProperty_andDefaultURI_thenInstanceItselfIsUsed() throws URISyntaxException {
         HazelcastCacheManager cacheManager = (HazelcastCacheManager) cachingProvider.getCacheManager(
-                null, null,
-                HazelcastCachingProvider.propertiesByInstanceItself(instance3));
+                null, null, propertiesByInstanceItself(instance3));
         assertCacheManagerInstance(cacheManager, instance3);
     }
 
@@ -196,4 +198,9 @@ public class CachingProviderTest extends HazelcastTestSupport {
         assertEquals(instance, cacheManager.getHazelcastInstance());
     }
 
+    private void assertInstanceStarted(String instanceName) {
+        HazelcastInstance otherInstance = Hazelcast.getHazelcastInstanceByName(instanceName);
+        assertNotNull(otherInstance);
+        otherInstance.getLifecycleService().terminate();
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -198,7 +198,7 @@ public class CachingProviderTest extends HazelcastTestSupport {
         assertEquals(instance, cacheManager.getHazelcastInstance());
     }
 
-    private void assertInstanceStarted(String instanceName) {
+    protected void assertInstanceStarted(String instanceName) {
         HazelcastInstance otherInstance = Hazelcast.getHazelcastInstanceByName(instanceName);
         assertNotNull(otherInstance);
         otherInstance.getLifecycleService().terminate();


### PR DESCRIPTION
config when instance with given name does not yet exist.

Fixes an issue with locating configuration when passed via property
placeholder. Increases test coverage of server caching provider.

(cherry picked from commit 170dff5)

Backport of #11040 