### PR TITLE
Clarify name of Version comparison methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -188,9 +188,9 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
         return clusterVersion.isLessOrEqual(version);
     }
 
-    boolean isClusterVersionUnknownLessOrEqual(Version version) {
+    boolean isClusterVersionUnknownOrLessOrEqual(Version version) {
         Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
-        return clusterVersion.isUnknownLessOrEqual(version);
+        return clusterVersion.isUnknownOrLessOrEqual(version);
     }
 
     boolean isClusterVersionGreaterThan(Version version) {
@@ -208,9 +208,9 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
         return clusterVersion.isGreaterOrEqual(version);
     }
 
-    boolean isClusterVersionUnknownGreaterOrEqual(Version version) {
+    boolean isClusterVersionUnknownOrGreaterOrEqual(Version version) {
         Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
-        return clusterVersion.isUnknownGreaterOrEqual(version);
+        return clusterVersion.isUnknownOrGreaterOrEqual(version);
     }
 
     boolean isClusterVersionEqualTo(Version version) {

--- a/hazelcast/src/main/java/com/hazelcast/version/Version.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/Version.java
@@ -193,7 +193,7 @@ public final class Version implements IdentifiedDataSerializable, Comparable<Ver
      * @param version other version to compare to
      * @return {@code true} if this version is unknown or if this version is greater than or equal to {@code version}
      */
-    public boolean isUnknownGreaterOrEqual(Version version) {
+    public boolean isUnknownOrGreaterOrEqual(Version version) {
         return isUnknown() || (!version.isUnknown() && compareTo(version) >= 0);
     }
 
@@ -225,7 +225,7 @@ public final class Version implements IdentifiedDataSerializable, Comparable<Ver
      * @param version other version to compare to
      * @return {@code true} if this version is unknown or if this version is less than or equal to {@code version}
      */
-    public boolean isUnknownLessOrEqual(Version version) {
+    public boolean isUnknownOrLessOrEqual(Version version) {
         return isUnknown() || compareTo(version) <= 0;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/AbstractDistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/AbstractDistributedObjectTest.java
@@ -64,7 +64,7 @@ public class AbstractDistributedObjectTest extends HazelcastTestSupport {
 
     @Test
     public void testClusterVersion_isUnknownGreaterOrEqual_currentVersion() {
-        assertTrue(object.isClusterVersionUnknownGreaterOrEqual(CURRENT_CLUSTER_VERSION));
+        assertTrue(object.isClusterVersionUnknownOrGreaterOrEqual(CURRENT_CLUSTER_VERSION));
     }
 
     @Test
@@ -84,7 +84,7 @@ public class AbstractDistributedObjectTest extends HazelcastTestSupport {
 
     @Test
     public void testClusterVersion_isUnknownLessOrEqual_currentVersion() {
-        assertTrue(object.isClusterVersionUnknownLessOrEqual(CURRENT_CLUSTER_VERSION));
+        assertTrue(object.isClusterVersionUnknownOrLessOrEqual(CURRENT_CLUSTER_VERSION));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/version/VersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/VersionTest.java
@@ -79,11 +79,11 @@ public class VersionTest {
 
     @Test
     public void isUnknownGreaterOrEqual() throws Exception {
-        assertTrue(V3_0.isUnknownGreaterOrEqual(of(2, 0)));
-        assertTrue(V3_0.isUnknownGreaterOrEqual(of(3, 0)));
-        assertTrue(V3_0.isUnknownGreaterOrEqual(of(3, 0)));
-        assertFalse(V3_0.isUnknownGreaterOrEqual(of(4, 0)));
-        assertTrue(UNKNOWN.isUnknownGreaterOrEqual(of(4, 0)));
+        assertTrue(V3_0.isUnknownOrGreaterOrEqual(of(2, 0)));
+        assertTrue(V3_0.isUnknownOrGreaterOrEqual(of(3, 0)));
+        assertTrue(V3_0.isUnknownOrGreaterOrEqual(of(3, 0)));
+        assertFalse(V3_0.isUnknownOrGreaterOrEqual(of(4, 0)));
+        assertTrue(UNKNOWN.isUnknownOrGreaterOrEqual(of(4, 0)));
     }
 
     @Test
@@ -114,10 +114,10 @@ public class VersionTest {
 
     @Test
     public void isUnknownLessOrEqual() throws Exception {
-        assertFalse(V3_0.isUnknownLessOrEqual(of(2, 0)));
-        assertTrue(V3_0.isUnknownLessOrEqual(of(3, 0)));
-        assertTrue(V3_0.isUnknownLessOrEqual(of(4, 0)));
-        assertTrue(UNKNOWN.isUnknownLessOrEqual(of(4, 0)));
+        assertFalse(V3_0.isUnknownOrLessOrEqual(of(2, 0)));
+        assertTrue(V3_0.isUnknownOrLessOrEqual(of(3, 0)));
+        assertTrue(V3_0.isUnknownOrLessOrEqual(of(4, 0)));
+        assertTrue(UNKNOWN.isUnknownOrLessOrEqual(of(4, 0)));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/version/VersionUnknownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/VersionUnknownTest.java
@@ -108,22 +108,22 @@ public class VersionUnknownTest {
 
     @Test
     public void unknown_is_unknownGreaterOrEqual_any() throws Exception {
-        assertTrue(UNKNOWN.isUnknownGreaterOrEqual(ANY_VERSION));
+        assertTrue(UNKNOWN.isUnknownOrGreaterOrEqual(ANY_VERSION));
     }
 
     @Test
     public void unknown_is_unknownGreaterOrEqual_unknown() throws Exception {
-        assertTrue(UNKNOWN.isUnknownGreaterOrEqual(UNKNOWN));
+        assertTrue(UNKNOWN.isUnknownOrGreaterOrEqual(UNKNOWN));
     }
 
     @Test
     public void unknown_is_unknownLessOrEqual_any() throws Exception {
-        assertTrue(UNKNOWN.isUnknownLessOrEqual(ANY_VERSION));
+        assertTrue(UNKNOWN.isUnknownOrLessOrEqual(ANY_VERSION));
     }
 
     @Test
     public void unknown_is_unknownLessOrEqual_unknown() throws Exception {
-        assertTrue(UNKNOWN.isUnknownLessOrEqual(UNKNOWN));
+        assertTrue(UNKNOWN.isUnknownOrLessOrEqual(UNKNOWN));
     }
 
     @Test
@@ -163,12 +163,12 @@ public class VersionUnknownTest {
 
     @Test
     public void any_isNot_unknownGreaterOrEqual_unknown() throws Exception {
-        assertFalse(ANY_VERSION.isUnknownGreaterOrEqual(UNKNOWN));
+        assertFalse(ANY_VERSION.isUnknownOrGreaterOrEqual(UNKNOWN));
     }
 
     @Test
     public void any_isNot_unknownLessOrEqual_unknown() throws Exception {
-        assertFalse(ANY_VERSION.isUnknownLessOrEqual(UNKNOWN));
+        assertFalse(ANY_VERSION.isUnknownOrLessOrEqual(UNKNOWN));
     }
 
 }


### PR DESCRIPTION
`Version.isUnknownGreaterOrEqual` -> `Version.isUnknownOrGreaterOrEqual`
`Version.isUnknownLessOrEqual` -> `Version.isUnknownOrLessOrEqual`

as discussed [here](https://github.com/hazelcast/hazelcast/pull/10908#discussion_r128244856)