### PR TITLE
[Backport] PR 11050 - Extend serialization test to test deserialization of typed serialization to the correct class type

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
@@ -18,7 +18,6 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.TypedDataSerializable;
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
@@ -39,7 +38,7 @@ import java.util.Set;
  * @param <V> the value type.
  */
 @BinaryInterface
-public class LegacyCacheConfig<K, V> implements DataSerializable, TypedDataSerializable {
+public class LegacyCacheConfig<K, V> implements TypedDataSerializable {
 
     private CacheConfig<K, V> config;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
@@ -18,7 +18,6 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.TypedDataSerializable;
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
@@ -30,7 +29,7 @@ import java.io.IOException;
  * Comparator support is not provided for compatibility.
  */
 @BinaryInterface
-public class LegacyCacheEvictionConfig implements DataSerializable, TypedDataSerializable {
+public class LegacyCacheEvictionConfig implements TypedDataSerializable {
 
     final CacheEvictionConfig config;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -245,6 +245,11 @@ public class AbstractSerializationServiceTest {
 
         TypedBaseClass typedBaseObject = new TypedBaseClass(baseObject);
         Data typedData = abstractSerializationService.toData(typedBaseObject);
+
+        deserializedObject = abstractSerializationService.toObject(typedData);
+        assertEquals(BaseClass.class, deserializedObject.getClass());
+        assertEquals(baseObject, deserializedObject);
+
         deserializedObject = abstractSerializationService.toObject(typedData, TypedBaseClass.class);
         assertEquals(typedBaseObject, deserializedObject);
     }
@@ -268,12 +273,14 @@ public class AbstractSerializationServiceTest {
         @Override
         public void writeData(ObjectDataOutput out)
                 throws IOException {
+            innerObj.writeData(out);
             out.writeInt(innerObj.intField);
         }
 
         @Override
         public void readData(ObjectDataInput in)
                 throws IOException {
+            innerObj.readData(in);
             innerObj.intField = in.readInt();
         }
 


### PR DESCRIPTION
Backport PR #11050 