### PR TITLE
Abstract Serialization Test can not be reused for EE test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -60,9 +60,12 @@ public class AbstractSerializationServiceTest {
 
     @Before
     public void setup() {
+        abstractSerializationService = getAbstractSerializationService();
+    }
+
+    protected AbstractSerializationService getAbstractSerializationService() {
         DefaultSerializationServiceBuilder defaultSerializationServiceBuilder = new DefaultSerializationServiceBuilder();
-        abstractSerializationService = defaultSerializationServiceBuilder
-                .setVersion(InternalSerializationService.VERSION_1).build();
+        return defaultSerializationServiceBuilder.setVersion(InternalSerializationService.VERSION_1).build();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -60,10 +60,10 @@ public class AbstractSerializationServiceTest {
 
     @Before
     public void setup() {
-        abstractSerializationService = getAbstractSerializationService();
+        abstractSerializationService = newAbstractSerializationService();
     }
 
-    protected AbstractSerializationService getAbstractSerializationService() {
+    protected AbstractSerializationService newAbstractSerializationService() {
         DefaultSerializationServiceBuilder defaultSerializationServiceBuilder = new DefaultSerializationServiceBuilder();
         return defaultSerializationServiceBuilder.setVersion(InternalSerializationService.VERSION_1).build();
     }


### PR DESCRIPTION
Refactored the serialization test so that the derived test at the enterprise can use the enterprise serializer by overriding the protected getter method.