### PR TITLE
Copy properties to proxied HazelcastInstances

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -65,6 +65,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -755,6 +756,25 @@ public abstract class HazelcastTestSupport {
             throw new ComparisonFailure("", expected, actual);
         }
         fail(formatAssertMessage("", expected, null));
+    }
+
+    public static void assertPropertiesEquals(Properties expected, Properties actual) {
+        if (expected == null && actual == null) {
+            return;
+        }
+
+        if (expected == null || actual == null) {
+            fail(formatAssertMessage("", expected, actual));
+        }
+
+        for (String key : expected.stringPropertyNames()) {
+            assertEquals("Unexpected value for key " + key, expected.getProperty(key), actual.getProperty(key));
+        }
+
+        for (String key : actual.stringPropertyNames()) {
+            assertEquals("Unexpected value for key " + key + " from actual object", expected.getProperty(key),
+                    actual.getProperty(key));
+        }
     }
 
     private static String formatAssertMessage(String message, Object expected, Object actual) {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ConfigConstructor.java
@@ -100,7 +100,8 @@ public class ConfigConstructor extends AbstractStarterObjectConstructor {
             if ((setter = getSetter(otherConfigClass, otherReturnType, createSetterName(method))) != null) {
 
                 if (Properties.class.isAssignableFrom(returnType)) {
-                    //ignore
+                    Properties original = (Properties) method.invoke(thisConfigObject, null);
+                    updateConfig(setter, otherConfigObject, copy(original));
                 } else if (Map.class.isAssignableFrom(returnType) || ConcurrentMap.class.isAssignableFrom(returnType)) {
                     Map map = (Map) method.invoke(thisConfigObject, null);
                     Map otherMap = ConcurrentMap.class.isAssignableFrom(returnType) ? new ConcurrentHashMap() : new HashMap();
@@ -183,5 +184,18 @@ public class ConfigConstructor extends AbstractStarterObjectConstructor {
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method method = obj.getClass().getMethod(getter, null);
         return method.invoke(obj, null);
+    }
+
+    private static Properties copy(Properties original) {
+        if (original == null) {
+            return null;
+        }
+
+        Properties copy = new Properties();
+        for (String name : original.stringPropertyNames()) {
+            copy.setProperty(name, original.getProperty(name));
+        }
+
+        return copy;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/ConfigTest.java
@@ -28,6 +28,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Properties;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertPropertiesEquals;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -44,6 +47,8 @@ public class ConfigTest {
 
         thisConfig.addListenerConfig(new ListenerConfig("the.listener.config.class"));
 
+        thisConfig.setProperties(buildPropertiesWithDefaults());
+
         ConfigConstructor configConstructor = new ConfigConstructor(Config.class);
 
         Config otherConfig = (Config) configConstructor.createNew(thisConfig);
@@ -51,5 +56,14 @@ public class ConfigTest {
         assertEquals(otherConfig.getMapConfigs().size(), thisConfig.getMapConfigs().size());
         assertEquals(otherConfig.getListConfigs().size(), thisConfig.getListConfigs().size());
         assertEquals(otherConfig.getListenerConfigs().size(), thisConfig.getListenerConfigs().size());
+        assertPropertiesEquals(thisConfig.getProperties(), otherConfig.getProperties());
+    }
+
+    private Properties buildPropertiesWithDefaults() {
+        Properties defaults = new Properties();
+        defaults.setProperty("key1", "value1");
+        Properties configProperties = new Properties(defaults);
+        configProperties.setProperty("key2", "value2");
+        return configProperties;
     }
 }


### PR DESCRIPTION
When starting a `HazelcastInstance` via `HazelcastStarter`, properties included in `Config` and its graph's objects are currently ignored. This PR copies properties to the config object on target Hazelcast version.