### PR TITLE
Upgraded Diagnostics file size to 50mb

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -71,10 +71,10 @@ public class Diagnostics {
      * <p/>
      * Every HazelcastInstance will get its own history of log files.
      * <p/>
-     * The default is 10.
+     * The default is 50.
      */
     @SuppressWarnings("checkstyle:magicnumber")
-    public static final HazelcastProperty MAX_ROLLED_FILE_SIZE_MB = new HazelcastProperty(PREFIX + ".max.rolled.file.size.mb", 10)
+    public static final HazelcastProperty MAX_ROLLED_FILE_SIZE_MB = new HazelcastProperty(PREFIX + ".max.rolled.file.size.mb", 50)
             .setDeprecatedName("hazelcast.performance.monitor.max.rolled.file.size.mb");
 
     /**


### PR DESCRIPTION
From 10mb.

I see that diagnostics files can fill up pretty quickly and then
you start to loose history due to rollover. So now we can keep
5x as much history by default.

This also means that the diagnostics disk usage per instance by default goes up from 100MB to 500MB. 