### PR TITLE
Fix NPE on ScheduledExecutor when handling multiple migration requests on the same source

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -143,8 +143,11 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
     void stopForMigration() {
         // Result is not set, allowing task to get re-scheduled, if/when needed.
         this.isTaskOwner = false;
-        this.future.cancel(true);
-        this.future = null;
+
+        if (future != null) {
+            this.future.cancel(true);
+            this.future = null;
+        }
     }
 
     boolean cancel(boolean mayInterrupt)


### PR DESCRIPTION
When handling multiple migration requests on the same source, NPE can occur due to the null future  reference from the previous migration processing.
Fixes #11047 