### PR TITLE
Diagnostics include epoch time

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -89,6 +89,12 @@ public class Diagnostics {
             .setDeprecatedName("hazelcast.performance.monitor.max.rolled.file.count");
 
     /**
+     * True if the epoch time should be included in the 'top' section. This makes it easy to determine the time in epoch format
+     * and prevents needing to parse the date-format section. The default is false since it will cause more noise.
+     */
+    public static final HazelcastProperty INCLUDE_EPOCH_TIME = new HazelcastProperty(PREFIX + ".include.epoch", true);
+
+    /**
      * Configures the output directory of the performance log files.
      *
      * Defaults to the 'user.dir'.
@@ -105,6 +111,7 @@ public class Diagnostics {
 
     final ILogger logger;
     final String fileName;
+    final boolean includeEpochTime;
     private final String hzName;
     private final boolean enabled;
     private ScheduledExecutorService scheduler;
@@ -118,6 +125,7 @@ public class Diagnostics {
         this.properties = properties;
         this.enabled = properties.getBoolean(ENABLED);
         this.directory = properties.getString(DIRECTORY);
+        this.includeEpochTime = properties.getBoolean(INCLUDE_EPOCH_TIME);
     }
 
     // just for testing. Returns the current file the system is writing to.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -55,12 +55,13 @@ final class DiagnosticsLogFile {
     private PrintWriter printWriter;
     private int maxRollingFileCount;
     private int maxRollingFileSizeBytes;
-    private final DiagnosticsLogWriterImpl logWriter =  new DiagnosticsLogWriterImpl();
+    private final DiagnosticsLogWriterImpl logWriter;
 
     DiagnosticsLogFile(Diagnostics diagnostics) {
         this.diagnostics = diagnostics;
         this.logger = diagnostics.logger;
         this.fileName = diagnostics.fileName + "-%03d.log";
+        this.logWriter = new DiagnosticsLogWriterImpl(diagnostics.includeEpochTime);
 
         this.maxRollingFileCount = diagnostics.properties.getInteger(MAX_ROLLED_FILE_COUNT);
         // we accept a float so it becomes easier to testing to create a small file

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
@@ -52,6 +52,7 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
     private static final int CHARS_LENGTH = 32;
 
     private final StringBuffer tmpSb = new StringBuffer();
+    private final boolean includeEpochTime;
 
     private int sectionLevel = -1;
     private PrintWriter printWriter;
@@ -65,6 +66,14 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
 
     // used to write primitives without causing litter.
     private StringBuilder stringBuilder = new StringBuilder();
+
+    public DiagnosticsLogWriterImpl() {
+        this(false);
+    }
+
+    public DiagnosticsLogWriterImpl(boolean includeEpochTime) {
+        this.includeEpochTime = includeEpochTime;
+    }
 
     @Override
     public void writeSectionKeyValue(String sectionName, long timeMillis, String key, long value) {
@@ -102,6 +111,11 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
         if (sectionLevel == -1) {
             appendDateTime(timeMillis);
             write(' ');
+
+            if (includeEpochTime) {
+                write(timeMillis);
+                write(' ');
+            }
         }
 
         if (sectionLevel >= 0) {


### PR DESCRIPTION
 Added option to diagnostics to include epoch time
    
This is useful if you don't want to parse the date-time when a plugin is rendered;
you can just grab the epoch time.
