### PR TITLE
Display info message when diagnostics is disabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.hazelcast.internal.diagnostics.DiagnosticsPlugin.DISABLED;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
+import static java.lang.String.format;
 import static java.lang.System.arraycopy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -203,7 +204,7 @@ public class Diagnostics {
 
     public void start() {
         if (!enabled) {
-            logger.finest("Diagnostics is disabled");
+            logger.info(format("Diagnostics disabled. To enable add -D%s=true to the JVM arguments.", ENABLED.getName()));
             return;
         }
 


### PR DESCRIPTION
Diagnostics should be turned on by default because it will speed up
resolving problems. However turning it on by default currently might
be a step to far; so lets print an info message that diagnostics
is disabled and how it can be enabled.