### PR TITLE
Only 1 log entry for op thread-count on startup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -508,11 +508,9 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
 
     @Override
     public void start() {
-        logger.info("Starting " + partitionThreads.length + " partition threads");
+        logger.info("Starting " + partitionThreads.length + " partition threads and "
+                + genericThreads.length + " generic threads (" + priorityThreadCount + " dedicated for priority tasks)");
         startAll(partitionThreads);
-
-        logger.info("Starting " + genericThreads.length + " generic threads ("
-                + priorityThreadCount + " dedicated for priority tasks)");
         startAll(genericThreads);
     }
 


### PR DESCRIPTION
So instead of have 2 log entries for operation threads (1 for partiton, 1 for generic),
it is compressed into a single log entry to reduce the amount of logging noise.