### PR TITLE
Add support for properties in RingbufferStoreConfig xml

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -641,6 +641,12 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleRingbufferStoreConfig(Node node, BeanDefinitionBuilder ringbufferConfigBuilder) {
             final BeanDefinitionBuilder builder = createBeanBuilder(RingbufferStoreConfig.class);
+            for (Node child : childElements(node)) {
+                if ("properties".equals(cleanNodeName(child))) {
+                    handleProperties(child, builder);
+                    break;
+                }
+            }
             extractBasicStoreConfig(node, builder);
             ringbufferConfigBuilder.addPropertyValue("ringbufferStoreConfig", builder.getBeanDefinition());
         }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -240,6 +240,10 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="properties" type="properties" minOccurs="0"
+                                                            maxOccurs="1"/>
+                                            </xs:sequence>
                                             <xs:attribute name="enabled" use="required" type="parameterized-boolean"/>
                                             <xs:attributeGroup ref="class-or-bean-name">
                                                 <xs:annotation>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -468,6 +468,9 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         RingbufferStoreConfig store2 = testRingbuffer2.getRingbufferStoreConfig();
         assertNotNull(store2);
         assertEquals(DummyRingbufferStoreFactory.class.getName(), store2.getFactoryClassName());
+        assertFalse(store2.getProperties().isEmpty());
+        assertEquals("value", store2.getProperty("dummy.property"));
+        assertEquals("value2", store2.getProperty("dummy.property.2"));
 
         RingbufferConfig testRingbuffer3 = config.getRingbufferConfig("testRingbuffer3");
         assertNotNull(testRingbuffer3);

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -242,7 +242,12 @@
             </hz:ringbuffer>
 
             <hz:ringbuffer name="testRingbuffer2">
-                <hz:ringbuffer-store enabled="true" factory-class-name="com.hazelcast.spring.DummyRingbufferStoreFactory"/>
+                <hz:ringbuffer-store enabled="true" factory-class-name="com.hazelcast.spring.DummyRingbufferStoreFactory">
+                    <hz:properties>
+                        <hz:property name="dummy.property">value</hz:property>
+                        <hz:property name="dummy.property.2">value2</hz:property>
+                    </hz:properties>
+                </hz:ringbuffer-store>
             </hz:ringbuffer>
 
             <hz:ringbuffer name="testRingbuffer3">

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1712,7 +1712,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 config.setClassName(getTextContent(n).trim());
             } else if ("factory-class-name".equals(nodeName)) {
                 config.setFactoryClassName(getTextContent(n).trim());
+            } else if ("properties".equals(nodeName)) {
+                fillProperties(n, config.getProperties());
             }
+
         }
         return config;
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -1221,6 +1221,7 @@
     <xs:complexType name="ringbuffer-store">
         <xs:all>
             <xs:element ref="factory-or-class-name" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="enabled" default="true" type="xs:boolean"/>
     </xs:complexType>

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -398,6 +398,12 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "        <async-backup-count>1</async-backup-count>"
                 + "        <time-to-live-seconds>9</time-to-live-seconds>"
                 + "        <in-memory-format>OBJECT</in-memory-format>"
+                + "        <ringbuffer-store>"
+                + "            <class-name>com.hazelcast.RingbufferStoreImpl</class-name>"
+                + "            <properties>"
+                + "                <property name=\"store-path\">.//tmp//bufferstore</property>"
+                + "            </properties>"
+                + "        </ringbuffer-store>"
                 + "    </ringbuffer>"
                 + HAZELCAST_END_TAG;
         Config config = buildConfig(xml);
@@ -407,6 +413,10 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(1, ringbufferConfig.getAsyncBackupCount());
         assertEquals(9, ringbufferConfig.getTimeToLiveSeconds());
         assertEquals(InMemoryFormat.OBJECT, ringbufferConfig.getInMemoryFormat());
+        RingbufferStoreConfig ringbufferStoreConfig = ringbufferConfig.getRingbufferStoreConfig();
+        assertEquals("com.hazelcast.RingbufferStoreImpl", ringbufferStoreConfig.getClassName());
+        Properties ringbufferStoreProperties = ringbufferStoreConfig.getProperties();
+        assertEquals(".//tmp//bufferstore", ringbufferStoreProperties.get("store-path"));
     }
 
     @Test


### PR DESCRIPTION
RingbufferStoreConfig contains a properties collection and this collection is passed to a configured Factory class.  However, the current xml configuration doesn't allow for properties to be defined for the RingbufferStoreConfig.  This change adds a properties element to the ringbuffer-store xsd type and adds configured properties read from the xml configuration to the store config being built in XmlConfigBuilder. 