### PR TITLE
BuildInfo diagnostics plugin missing on client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -99,6 +99,7 @@ import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.diagnostics.BuildInfoPlugin;
 import com.hazelcast.internal.diagnostics.ConfigPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
@@ -418,6 +419,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         }
 
         diagnostics.start();
+        diagnostics.register(
+                new BuildInfoPlugin(loggingService.getLogger(BuildInfoPlugin.class)));
         diagnostics.register(
                 new ConfigPropertiesPlugin(loggingService.getLogger(ConfigPropertiesPlugin.class), properties));
         diagnostics.register(

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.diagnostics;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.JetBuildInfo;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 /**
@@ -29,7 +30,11 @@ public class BuildInfoPlugin extends DiagnosticsPlugin {
     private final BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
 
     public BuildInfoPlugin(NodeEngineImpl nodeEngine) {
-        super(nodeEngine.getLogger(BuildInfoPlugin.class));
+        this(nodeEngine.getLogger(BuildInfoPlugin.class));
+    }
+
+    public BuildInfoPlugin(ILogger logger) {
+        super(logger);
     }
 
     @Override


### PR DESCRIPTION
So when we receive client diagnostics file, we have no way of knowing
what the version is.