### PR TITLE
Do not allow overwriting a Cache's CacheManager

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -47,6 +47,7 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.serialization.Data;
 
 import javax.cache.CacheException;
+import javax.cache.CacheManager;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.expiry.ExpiryPolicy;
 import java.util.Collection;
@@ -58,6 +59,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateConfiguredTypes;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
@@ -131,7 +133,8 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
     };
 
-    protected HazelcastClientCacheManager cacheManager;
+    protected final AtomicReference<HazelcastClientCacheManager> cacheManagerRef
+            = new AtomicReference<HazelcastClientCacheManager>();
     protected int partitionCount;
 
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
@@ -157,11 +160,18 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     public void setCacheManager(HazelcastCacheManager cacheManager) {
         assert cacheManager instanceof HazelcastClientCacheManager;
 
-        this.cacheManager = (HazelcastClientCacheManager) cacheManager;
+        if (cacheManagerRef.get() == cacheManager) {
+            return;
+        }
+
+        if (!cacheManagerRef.compareAndSet(null, (HazelcastClientCacheManager) cacheManager)) {
+            throw new IllegalStateException("Cannot overwrite a Cache's CacheManager.");
+        }
     }
 
     @Override
     protected void postDestroy() {
+        CacheManager cacheManager = cacheManagerRef.get();
         if (cacheManager != null) {
             cacheManager.destroyCache(getName());
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -366,7 +366,7 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V>
 
     @Override
     public CacheManager getCacheManager() {
-        return cacheManager;
+        return cacheManagerRef.get();
     }
 
     @Override


### PR DESCRIPTION
Once a `Cache`'s `CacheManager` field has been already set, it doesn't make sense to allow changing it to another `CacheManager`.

Fixes #10200 