### PR TITLE
MapLoader null keys

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -49,6 +49,8 @@ public interface MapLoader<K, V> {
      * Loads given keys. This is batch load operation so that implementation can
      * optimize the multiple loads.
      *
+     * The returned Map should not contain any <code>null</code> keys or values.
+     *
      * @param keys keys of the values entries to load
      * @return map of loaded key-value pairs.
      */
@@ -59,6 +61,8 @@ public interface MapLoader<K, V> {
      * by loading them in batches. The {@link Iterator} of this {@link Iterable} may implement the
      * {@link Closeable} interface in which case it will be closed once iteration is over.
      * This is intended for releasing resources such as closing a JDBC result set.
+     *
+     * The returned Iterable should not contain any <code>null</code> keys.
      *
      * @return all the keys
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -65,6 +65,7 @@ import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
 import static com.hazelcast.map.impl.mapstore.MapDataStores.EMPTY_MAP_DATA_STORE;
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.Collections.emptyList;
 
 /**
@@ -222,7 +223,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public Record getRecord(Data key) {
-        return storage.get(key);
+        return storage.get(checkNotNull(key, "key can't be null"));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -164,6 +164,13 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
 
     boolean merge(Data dataKey, EntryView mergingEntryView, MapMergePolicy mergePolicy);
 
+    /**
+     * Gets a record for the given key.
+     *
+     * @param key the key
+     * @return the record
+     * @throw NullPointerException if key is null.
+     */
     R getRecord(Data key);
 
     /**


### PR DESCRIPTION
Documentation has been added to the MapLoader.loadAllKeys that no null keys should be returned.

Documentation has been added to MapLoader.loadAll(keys) should not return a map with any null keys.

And a precondition check has been added to the DefaultRecordStore.getRecord to verify that no
null is passed as argument.