### PR TITLE
Decrease partition count on schedexec test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
@@ -160,6 +160,8 @@ public class ScheduledExecutorServiceSlowTest
                 .setDurability(2);
 
         Config config = new Config();
+        // Keep the partition count low, makes test faster, and chances of partition loss, less.
+        config.setProperty("hazelcast.partition.count", "10");
         config.addScheduledExecutorConfig(scheduledExecutorConfig);
 
         HazelcastInstance[] instances = createClusterWithCount(4, config);


### PR DESCRIPTION
Further to https://github.com/hazelcast/hazelcast/pull/11083 @mmedenjak suggested to decrease partition count, to avoid similar failure scenarios, makes test faster, and chances of the failure reoccurring, less.