### PR TITLE
Rewrote Near Cache tests to reliably populate the Near Cache

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -110,26 +110,30 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
     }
 
     @Override
-    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(boolean createClient) {
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(boolean createNearCacheInstance, int keyCount,
+                                                                            KeyType keyType) {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance(getConfig());
         IMap<K, V> memberMap = member.getMap(nearCacheConfig.getName());
+        IMapDataStructureAdapter<K, V> dataAdapter = new IMapDataStructureAdapter<K, V>(memberMap);
 
-        if (createClient) {
-            NearCacheTestContextBuilder<K, V, Data, String> contextBuilder = createClientContextBuilder();
+        populateDataAdapter(dataAdapter, keyCount, keyType);
+
+        if (createNearCacheInstance) {
+            NearCacheTestContextBuilder<K, V, Data, String> contextBuilder = createNearCacheContextBuilder();
             return contextBuilder
                     .setDataInstance(member)
-                    .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
+                    .setDataAdapter(dataAdapter)
                     .build();
         }
         return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(member))
                 .setDataInstance(member)
-                .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
+                .setDataAdapter(dataAdapter)
                 .build();
     }
 
     @Override
-    protected <K, V> NearCacheTestContext<K, V, Data, String> createClientContext() {
-        NearCacheTestContextBuilder<K, V, Data, String> contextBuilder = createClientContextBuilder();
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createNearCacheContext() {
+        NearCacheTestContextBuilder<K, V, Data, String> contextBuilder = createNearCacheContextBuilder();
         return contextBuilder.build();
     }
 
@@ -137,7 +141,7 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
         return new ClientConfig();
     }
 
-    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createClientContextBuilder() {
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
         ClientConfig clientConfig = getClientConfig()
                 .addNearCacheConfig(nearCacheConfig);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -101,13 +101,17 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
     }
 
     @Override
-    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(boolean loaderEnabled) {
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size, boolean loaderEnabled) {
         Config configWithNearCache = createConfig(true);
         Config config = createConfig(false);
 
-        HazelcastInstance nearCacheInstance = hazelcastFactory.newHazelcastInstance(configWithNearCache);
         HazelcastInstance dataInstance = hazelcastFactory.newHazelcastInstance(config);
+        TransactionalMapDataStructureAdapter<K, V> dataAdapter
+                = new TransactionalMapDataStructureAdapter<K, V>(dataInstance, DEFAULT_NEAR_CACHE_NAME);
 
+        populateDataAdapter(dataAdapter, size);
+
+        HazelcastInstance nearCacheInstance = hazelcastFactory.newHazelcastInstance(configWithNearCache);
         // this creates the Near Cache instance
         IMap<K, V> nearCacheMap = nearCacheInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
 
@@ -118,7 +122,7 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
                 .setNearCacheInstance(nearCacheInstance)
                 .setDataInstance(dataInstance)
                 .setNearCacheAdapter(new TransactionalMapDataStructureAdapter<K, V>(nearCacheInstance, DEFAULT_NEAR_CACHE_NAME))
-                .setDataAdapter(new TransactionalMapDataStructureAdapter<K, V>(dataInstance, DEFAULT_NEAR_CACHE_NAME))
+                .setDataAdapter(dataAdapter)
                 .setNearCache(nearCache)
                 .setNearCacheManager(nearCacheManager)
                 .setInvalidationListener(createInvalidationEventHandler(nearCacheMap))
@@ -144,7 +148,6 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
         NearCacheTestContext<Integer, String, Data, String> context = createContext();
 
         // populate the data structure
-        populateDataAdapter(context);
         assertNearCacheSize(context, 0);
         assertNearCacheStats(context, 0, 0, 0);
 


### PR DESCRIPTION
The idea behind this refactoring is to have a race free setup to test
the Near Cache. There is some unreliableness in the event listener
lifecycle and a race between the initial data structure population
(which creates invalidation events) and the Near Cache population.

The easiest solution is to create a member first, populate the backing
data structure and then create the member, lite member or client with
the configured Near Cache. In this case no invalidations are created
from the initial data population, since no event listeners are
registered.

Old test logic was:
* create member
* create another member, lite member or client with Near Cache
* populate data structure
* wait for invalidations <-- this is not reliable
* populate Near Cache

The test logic flow is:
* create member
* populate data structure
* no need to wait for anything, since no invalidation listeners are registered
* create another member, lite member or client with Near Cache
* populate Near Cache

To achieve this I moved the `populateDataAdapter()` call into the `createContext()` method, which gets a new `size` parameter. I did this for the `AbstractNearCacheBasicTest` and `AbstractNearCachePreloaderTest` and their implementations.

This PR refactors all unified Near Cache tests as a first step. There is no EE adaptation needed.