### PR TITLE
Added setAsync() and putAsync() methods to DataStructureAdapter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -21,12 +21,14 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Abstracts the Hazelcast data structures with Near Cache support for the Near Cache usage.
@@ -43,6 +45,16 @@ public interface DataStructureAdapter<K, V> {
     void set(K key, V value);
 
     V put(K key, V value);
+
+    ICompletableFuture<V> putAsync(K key, V value);
+
+    ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit);
+
+    ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy);
+
+    ICompletableFuture<Void> putAsyncVoid(K key, V value);
+
+    ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy);
 
     boolean putIfAbsent(K key, V value);
 
@@ -106,6 +118,11 @@ public interface DataStructureAdapter<K, V> {
         GET_ASYNC("getAsync", Object.class),
         SET("set", Object.class, Object.class),
         PUT("put", Object.class, Object.class),
+        PUT_ASYNC("putAsync", Object.class, Object.class),
+        PUT_ASYNC_WITH_TTL("putAsync", Object.class, Object.class, long.class, TimeUnit.class),
+        PUT_ASYNC_WITH_EXPIRY_POLICY("putAsync", Object.class, Object.class, ExpiryPolicy.class),
+        PUT_ASYNC_VOID("putAsyncVoid", Object.class, Object.class),
+        PUT_ASYNC_VOID_WITH_EXPIRY_POLICY("putAsyncVoid", Object.class, Object.class, ExpiryPolicy.class),
         PUT_IF_ABSENT("putIfAbsent", Object.class, Object.class),
         PUT_IF_ABSENT_ASYNC("putIfAbsentAsync", Object.class, Object.class),
         REPLACE("replace", Object.class, Object.class),

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -44,6 +44,12 @@ public interface DataStructureAdapter<K, V> {
 
     void set(K key, V value);
 
+    ICompletableFuture<Void> setAsync(K key, V value);
+
+    ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit);
+
+    ICompletableFuture<Void> setAsync(K key, V value, ExpiryPolicy expiryPolicy);
+
     V put(K key, V value);
 
     ICompletableFuture<V> putAsync(K key, V value);
@@ -51,10 +57,6 @@ public interface DataStructureAdapter<K, V> {
     ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit);
 
     ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy);
-
-    ICompletableFuture<Void> putAsyncVoid(K key, V value);
-
-    ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy);
 
     boolean putIfAbsent(K key, V value);
 
@@ -117,12 +119,13 @@ public interface DataStructureAdapter<K, V> {
         GET("get", Object.class),
         GET_ASYNC("getAsync", Object.class),
         SET("set", Object.class, Object.class),
+        SET_ASYNC("setAsync", Object.class, Object.class),
+        SET_ASYNC_WITH_AAL("setAsync", Object.class, Object.class, long.class, TimeUnit.class),
+        SET_ASYNC_WITH_EXPIRY_POLICY("setAsync", Object.class, Object.class, ExpiryPolicy.class),
         PUT("put", Object.class, Object.class),
         PUT_ASYNC("putAsync", Object.class, Object.class),
         PUT_ASYNC_WITH_TTL("putAsync", Object.class, Object.class, long.class, TimeUnit.class),
         PUT_ASYNC_WITH_EXPIRY_POLICY("putAsync", Object.class, Object.class, ExpiryPolicy.class),
-        PUT_ASYNC_VOID("putAsyncVoid", Object.class, Object.class),
-        PUT_ASYNC_VOID_WITH_EXPIRY_POLICY("putAsyncVoid", Object.class, Object.class, ExpiryPolicy.class),
         PUT_IF_ABSENT("putIfAbsent", Object.class, Object.class),
         PUT_IF_ABSENT_ASYNC("putIfAbsentAsync", Object.class, Object.class),
         REPLACE("replace", Object.class, Object.class),

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -21,12 +21,14 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
@@ -60,6 +62,32 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     public V put(K key, V value) {
         return cache.getAndPut(key, value);
+    }
+
+    @Override
+    public ICompletableFuture<V> putAsync(K key, V value) {
+        return cache.getAndPutAsync(key, value);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value, long time, TimeUnit unit) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        return cache.getAndPutAsync(key, value, expiryPolicy);
+    }
+
+    @Override
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
+        return cache.putAsync(key, value);
+    }
+
+    @Override
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
+        return cache.putAsync(key, value, expiryPolicy);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -60,6 +60,22 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     }
 
     @Override
+    public ICompletableFuture<Void> setAsync(K key, V value) {
+        return cache.putAsync(key, value);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    public ICompletableFuture<Void> setAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        return cache.putAsync(key, value, expiryPolicy);
+    }
+
+    @Override
     public V put(K key, V value) {
         return cache.getAndPut(key, value);
     }
@@ -78,16 +94,6 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
         return cache.getAndPutAsync(key, value, expiryPolicy);
-    }
-
-    @Override
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
-        return cache.putAsync(key, value);
-    }
-
-    @Override
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
-        return cache.putAsync(key, value, expiryPolicy);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -62,6 +62,22 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     }
 
     @Override
+    public ICompletableFuture<Void> setAsync(K key, V value) {
+        return map.setAsync(key, value);
+    }
+
+    @Override
+    public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        return map.setAsync(key, value, ttl, timeunit);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public V put(K key, V value) {
         return map.put(key, value);
     }
@@ -79,18 +95,6 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     @Override
     @MethodNotAvailable
     public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        throw new MethodNotAvailableException();
-    }
-
-    @Override
-    @MethodNotAvailable
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
-        throw new MethodNotAvailableException();
-    }
-
-    @Override
-    @MethodNotAvailable
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -23,12 +23,14 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
 
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
@@ -62,6 +64,34 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     @Override
     public V put(K key, V value) {
         return map.put(key, value);
+    }
+
+    @Override
+    public ICompletableFuture<V> putAsync(K key, V value) {
+        return map.putAsync(key, value);
+    }
+
+    @Override
+    public ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        return map.putAsync(key, value, ttl, timeunit);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -63,6 +63,24 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     }
 
     @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public V put(K key, V value) {
         return map.put(key, value);
     }
@@ -82,18 +100,6 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     @MethodNotAvailable
     public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        throw new MethodNotAvailableException();
-    }
-
-    @Override
-    @MethodNotAvailable
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
-        throw new MethodNotAvailableException();
-    }
-
-    @Override
-    @MethodNotAvailable
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
@@ -28,6 +29,7 @@ import javax.cache.processor.EntryProcessorResult;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
@@ -63,6 +65,36 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     public V put(K key, V value) {
         return map.put(key, value);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -23,12 +23,14 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.transaction.TransactionContext;
 
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class TransactionalMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
@@ -79,6 +81,36 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
         V oldValue = transactionalMap.put(key, value);
         commit();
         return oldValue;
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -76,6 +76,24 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     }
 
     @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Void> setAsync(K key, V value, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public V put(K key, V value) {
         begin();
         V oldValue = transactionalMap.put(key, value);
@@ -98,18 +116,6 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     @Override
     @MethodNotAvailable
     public ICompletableFuture<V> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        throw new MethodNotAvailableException();
-    }
-
-    @Override
-    @MethodNotAvailable
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value) {
-        throw new MethodNotAvailableException();
-    }
-
-    @Override
-    @MethodNotAvailable
-    public ICompletableFuture<Void> putAsyncVoid(K key, V value, ExpiryPolicy expiryPolicy) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -86,6 +86,22 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
         adapter.set(23, "test");
     }
 
+    @Test(expected = MethodNotAvailableException.class)
+    public void testSetAsync() {
+        adapter.setAsync(42, "value");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testSetAsyncWithTtl() {
+        adapter.setAsync(42, "value", 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testSetAsyncWithExpiryPolicy() {
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
+        adapter.setAsync(42, "value", expiryPolicy);
+    }
+
     @Test
     public void testPut() {
         map.put(42, "oldValue");
@@ -110,17 +126,6 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
     public void testPutAsyncWithExpiryPolicy() {
         ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
         adapter.putAsync(42, "value", expiryPolicy);
-    }
-
-    @Test(expected = MethodNotAvailableException.class)
-    public void testPutAsyncVoid() {
-        adapter.putAsyncVoid(42, "value");
-    }
-
-    @Test(expected = MethodNotAvailableException.class)
-    public void testPutAsyncVoidWithExpiryPolicy() {
-        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
-        adapter.putAsyncVoid(42, "value", expiryPolicy);
     }
 
     @Test(expected = MethodNotAvailableException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.adapter;
 
+import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.query.TruePredicate;
@@ -29,11 +30,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.cache.expiry.ExpiryPolicy;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -91,6 +94,33 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
 
         assertEquals("oldValue", oldValue);
         assertEquals("newValue", map.get(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsync() {
+        adapter.putAsync(42, "newValue");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncWithTtl() {
+        adapter.putAsync(42, "value", 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncWithExpiryPolicy() {
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
+        adapter.putAsync(42, "value", expiryPolicy);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncVoid() {
+        adapter.putAsyncVoid(42, "value");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncVoidWithExpiryPolicy() {
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
+        adapter.putAsyncVoid(42, "value", expiryPolicy);
     }
 
     @Test(expected = MethodNotAvailableException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.adapter;
 
+import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.TruePredicate;
@@ -29,11 +30,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.cache.expiry.ExpiryPolicy;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -95,6 +98,33 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
 
         assertEquals("oldValue", oldValue);
         assertEquals("newValue", map.get(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsync() {
+        adapter.putAsync(42, "newValue");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncWithTtl() {
+        adapter.putAsync(42, "value", 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncWithExpiryPolicy() {
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
+        adapter.putAsync(42, "value", expiryPolicy);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncVoid() {
+        adapter.putAsyncVoid(42, "value");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testPutAsyncVoidWithExpiryPolicy() {
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
+        adapter.putAsyncVoid(42, "value", expiryPolicy);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -90,6 +90,22 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
         assertEquals("test", map.get(23));
     }
 
+    @Test(expected = MethodNotAvailableException.class)
+    public void testSetAsync() {
+        adapter.setAsync(42, "value");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testSetAsyncWithTtl() {
+        adapter.setAsync(42, "value", 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testSetAsyncWithExpiryPolicy() {
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
+        adapter.setAsync(42, "value", expiryPolicy);
+    }
+
     @Test
     public void testPut() {
         map.put(42, "oldValue");
@@ -114,17 +130,6 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
     public void testPutAsyncWithExpiryPolicy() {
         ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
         adapter.putAsync(42, "value", expiryPolicy);
-    }
-
-    @Test(expected = MethodNotAvailableException.class)
-    public void testPutAsyncVoid() {
-        adapter.putAsyncVoid(42, "value");
-    }
-
-    @Test(expected = MethodNotAvailableException.class)
-    public void testPutAsyncVoidWithExpiryPolicy() {
-        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1, TimeUnit.MILLISECONDS);
-        adapter.putAsyncVoid(42, "value", expiryPolicy);
     }
 
     @Test


### PR DESCRIPTION
The `setAsync()` and `putAsync()` methods are not testable in the unified Near Cache tests, unless they are added to the `DataStructureAdapter`.