### PR TITLE
Fixed missing invalidation on ICache.getAndRemove()

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -240,7 +240,9 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         validateConfiguredTypes(cacheConfig, key);
 
         Data keyData = toData(key);
-        return getAndRemoveInternal(keyData, true);
+        ClientDelegatingFuture<T> delegatingFuture = getAndRemoveInternal(keyData, true);
+        onGetAndRemoveAsyncInternal(key, keyData, delegatingFuture, null);
+        return delegatingFuture;
     }
 
     private <T> ClientDelegatingFuture<T> getAndRemoveInternal(Data keyData, boolean withCompletionEvent) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -66,11 +66,15 @@ public interface DataStructureAdapter<K, V> {
 
     boolean replace(K key, V oldValue, V newValue);
 
-    void remove(K key);
+    V remove(K key);
 
     boolean remove(K key, V oldValue);
 
     ICompletableFuture<V> removeAsync(K key);
+
+    void delete(K key);
+
+    ICompletableFuture<Boolean> deleteAsync(K key);
 
     boolean evict(K key);
 
@@ -133,6 +137,8 @@ public interface DataStructureAdapter<K, V> {
         REMOVE("remove", Object.class),
         REMOVE_WITH_OLD_VALUE("remove", Object.class, Object.class),
         REMOVE_ASYNC("removeAsync", Object.class),
+        DELETE("delete", Object.class),
+        DELETE_ASYNC("deleteAsync", Object.class),
         EVICT("evict", Object.class),
         INVOKE("invoke", Object.class, EntryProcessor.class, Object[].class),
         EXECUTE_ON_KEY("executeOnKey", Object.class, com.hazelcast.map.EntryProcessor.class),

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -117,8 +117,8 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     }
 
     @Override
-    public void remove(K key) {
-        cache.remove(key);
+    public V remove(K key) {
+        return cache.getAndRemove(key);
     }
 
     @Override
@@ -129,6 +129,16 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     public ICompletableFuture<V> removeAsync(K key) {
         return cache.getAndRemoveAsync(key);
+    }
+
+    @Override
+    public void delete(K key) {
+        cache.remove(key);
+    }
+
+    @Override
+    public ICompletableFuture<Boolean> deleteAsync(K key) {
+        return cache.removeAsync(key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -120,8 +120,8 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     }
 
     @Override
-    public void remove(K key) {
-        map.remove(key);
+    public V remove(K key) {
+        return map.remove(key);
     }
 
     @Override
@@ -132,6 +132,17 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     @Override
     public ICompletableFuture<V> removeAsync(K key) {
         return map.removeAsync(key);
+    }
+
+    @Override
+    public void delete(K key) {
+        map.delete(key);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Boolean> deleteAsync(K key) {
+        throw new MethodNotAvailableException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -127,8 +127,8 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
         throw new MethodNotAvailableException();
     }
 
-    public void remove(K key) {
-        map.remove(key);
+    public V remove(K key) {
+        return map.remove(key);
     }
 
     @Override
@@ -140,6 +140,18 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     @MethodNotAvailable
     public ICompletableFuture<V> removeAsync(K key) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public void delete(K key) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Boolean> deleteAsync(K key) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -150,10 +150,11 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     }
 
     @Override
-    public void remove(K key) {
+    public V remove(K key) {
         begin();
-        transactionalMap.remove(key);
+        V oldValue = transactionalMap.remove(key);
         commit();
+        return oldValue;
     }
 
     @Override
@@ -167,6 +168,19 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     @Override
     @MethodNotAvailable
     public ICompletableFuture<V> removeAsync(K key) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    public void delete(K key) {
+        begin();
+        transactionalMap.delete(key);
+        commit();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public ICompletableFuture<Boolean> deleteAsync(K key) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
@@ -237,7 +237,7 @@ public class ICacheDataStructureAdapterTest extends HazelcastTestSupport {
         cache.put(23, "value-23");
         assertTrue(cache.containsKey(23));
 
-        adapter.remove(23);
+        assertEquals("value-23", adapter.remove(23));
         assertFalse(cache.containsKey(23));
     }
 
@@ -258,6 +258,25 @@ public class ICacheDataStructureAdapterTest extends HazelcastTestSupport {
 
         String value = adapter.removeAsync(23).get();
         assertEquals("value-23", value);
+
+        assertFalse(cache.containsKey(23));
+    }
+
+    @Test
+    public void testDelete() {
+        cache.put(23, "value-23");
+        assertTrue(cache.containsKey(23));
+
+        adapter.delete(23);
+        assertFalse(cache.containsKey(23));
+    }
+
+    @Test
+    public void testDeleteAsync() throws Exception {
+        cache.put(23, "value-23");
+        assertTrue(cache.containsKey(23));
+
+        adapter.deleteAsync(23).get();
 
         assertFalse(cache.containsKey(23));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
@@ -231,7 +231,7 @@ public class IMapDataStructureAdapterTest extends HazelcastTestSupport {
         map.put(23, "value-23");
         assertTrue(map.containsKey(23));
 
-        adapter.remove(23);
+        assertEquals("value-23", adapter.remove(23));
         assertFalse(map.containsKey(23));
     }
 
@@ -254,6 +254,20 @@ public class IMapDataStructureAdapterTest extends HazelcastTestSupport {
         assertEquals("value-23", value);
 
         assertFalse(map.containsKey(23));
+    }
+
+    @Test
+    public void testDelete() {
+        map.put(23, "value-23");
+        assertTrue(map.containsKey(23));
+
+        adapter.delete(23);
+        assertFalse(map.containsKey(23));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testDeleteAsync() {
+        adapter.deleteAsync(23);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -153,7 +153,7 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
         map.put(23, "value-23");
         assertTrue(map.containsKey(23));
 
-        adapter.remove(23);
+        assertEquals("value-23", adapter.remove(23));
         assertFalse(map.containsKey(23));
     }
 
@@ -165,6 +165,16 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAsync() {
         adapter.removeAsync(23);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testDelete() {
+        adapter.delete(23);
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testDeleteAsync() {
+        adapter.deleteAsync(23);
     }
 
     @Test(expected = MethodNotAvailableException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -173,7 +173,7 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
         map.put(23, "value-23");
         assertTrue(map.containsKey(23));
 
-        adapter.remove(23);
+        assertEquals("value-23", adapter.remove(23));
         assertFalse(map.containsKey(23));
     }
 
@@ -190,6 +190,20 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAsync() {
         adapter.removeAsync(23);
+    }
+
+    @Test
+    public void testDelete() {
+        map.put(23, "value-23");
+        assertTrue(map.containsKey(23));
+
+        adapter.delete(23);
+        assertFalse(map.containsKey(23));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testDeleteAsync() {
+        adapter.deleteAsync(23);
     }
 
     @Test(expected = MethodNotAvailableException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -1025,6 +1025,38 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
     }
 
     /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#DELETE} is used.
+     */
+    @Test
+    public void whenDeleteIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
+        whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.DELETE);
+    }
+
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#DELETE} is used.
+     */
+    @Test
+    public void whenDeleteIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter() {
+        whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.DELETE);
+    }
+
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#DELETE_ASYNC} is used.
+     */
+    @Test
+    public void whenDeleteAsyncIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
+        whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.DELETE_ASYNC);
+    }
+
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#DELETE_ASYNC} is used.
+     */
+    @Test
+    public void whenDeleteAsyncIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter() {
+        whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.DELETE_ASYNC);
+    }
+
+    /**
      * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#REMOVE_ALL)} is used.
      */
     @Test
@@ -1109,13 +1141,19 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
                 String value = "value-" + i;
                 switch (method) {
                     case REMOVE:
-                        adapter.remove(i);
+                        assertEquals(value, adapter.remove(i));
                         break;
                     case REMOVE_WITH_OLD_VALUE:
                         assertTrue(adapter.remove(i, value));
                         break;
                     case REMOVE_ASYNC:
                         assertEquals(value, getFuture(adapter.removeAsync(i), "Could not remove entry via removeAsync()"));
+                        break;
+                    case DELETE:
+                        adapter.delete(i);
+                        break;
+                    case DELETE_ASYNC:
+                        assertTrue(value, getFuture(adapter.deleteAsync(i), "Could not remove entry via deleteAsync()"));
                         break;
                     case REMOVE_ALL_WITH_KEYS:
                         removeKeys.add(i);


### PR DESCRIPTION
* added missing call to `onGetAndRemoveAsyncInternal()` in `AbstractClientInternalCacheProxy` to call invalidations in `NearCachedClientCacheProxy`
* added a proper callback for `onGetAndRemoveAsyncInternal()`
* added `delete()` and `deleteAsync()` methods to unified Near Cache tests

The failure looks like this:
**com.hazelcast.client.cache.nearcache.ClientCacheNearCacheBasicTest.whenRemoveIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter[format:BINARY serializeKeys:true localUpdatePolicy:INVALIDATE]**
```java
java.lang.AssertionError: Invalidation is not working on remove() Near Cache size didn't reach the desired value (0 vs. 1000) (NearCacheStatsImpl{ownedEntryCount=1000, ownedEntryMemoryCost=152890, creationTime=1502813394008, hits=0, misses=1000, ratio=0.0%, evictions=0, expirations=0, lastPersistenceTime=0, persistenceCount=0, lastPersistenceDuration=0, lastPersistenceWrittenBytes=0, lastPersistenceKeyCount=0, lastPersistenceFailure=''}) expected:<0> but was:<1000>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSize(NearCacheTestUtils.java:401)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils$4.run(NearCacheTestUtils.java:421)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:1086)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:1103)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually(NearCacheTestUtils.java:418)
	at com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest.whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(AbstractNearCacheBasicTest.java:1194)
	at com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest.whenRemoveIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter(AbstractNearCacheBasicTest.java:984)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:105)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:97)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.lang.Thread.run(Thread.java:745)
```

Fixes https://github.com/hazelcast/hazelcast/issues/11110

This adds the missing tests for `delete()` and `deleteAsync()` method to the unified Near Cache tests. After this PR we can remove those duplicated tests from the standalone test classes, which still suffer from the racy test setup.