### PR TITLE
Improvements for fast failure detection in client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceImpl.java
@@ -36,9 +36,7 @@ import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,7 +52,6 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
     private static final HazelcastProperty IDLE_STRATEGY
             = new HazelcastProperty("hazelcast.client.responsequeue.idlestrategy", "block");
 
-    private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD = 5000;
     private static final int CLEAN_RESOURCES_INTERVAL_MILLIS = 100;
 
     protected final HazelcastClientInstanceImpl client;
@@ -183,7 +180,6 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
         @Override
         public void run() {
             Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
-            Collection<ClientConnection> expiredConnections = null;
             while (iter.hasNext()) {
                 Map.Entry<Long, ClientInvocation> entry = iter.next();
                 ClientInvocation invocation = entry.getValue();
@@ -196,25 +192,9 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
                     continue;
                 }
 
-                if (connection.getPendingPacketCount() != 0) {
-                    long closedTime = connection.getClosedTime();
-                    long elapsed = System.currentTimeMillis() - closedTime;
-                    if (elapsed < WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD) {
-                        continue;
-                    } else {
-                        if (expiredConnections == null) {
-                            expiredConnections = new LinkedList<ClientConnection>();
-                        }
-                        expiredConnections.add(connection);
-                    }
-                }
-
                 iter.remove();
 
                 notifyException(invocation, connection);
-            }
-            if (expiredConnections != null) {
-                logExpiredConnections(expiredConnections);
             }
         }
 
@@ -234,16 +214,6 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
             invocation.notifyException(ex);
         }
 
-        private void logExpiredConnections(Collection<ClientConnection> expiredConnections) {
-            for (ClientConnection expiredConnection : expiredConnections) {
-                int pendingPacketCount = expiredConnection.getPendingPacketCount();
-                if (pendingPacketCount != 0) {
-                    invocationLogger.warning("There are " + pendingPacketCount
-                            + " packets which are not processed on "
-                            + expiredConnection.getEndPoint());
-                }
-            }
-        }
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceImpl.java
@@ -55,6 +55,7 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
             = new HazelcastProperty("hazelcast.client.responsequeue.idlestrategy", "block");
 
     private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD = 5000;
+    private static final int CLEAN_RESOURCES_INTERVAL_MILLIS = 100;
 
     protected final HazelcastClientInstanceImpl client;
     protected final ILogger invocationLogger;
@@ -91,7 +92,8 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
         responseThread = new ResponseThread(client.getName() + ".response-", classLoader);
         responseThread.start();
         ClientExecutionService executionService = client.getClientExecutionService();
-        executionService.scheduleWithRepetition(new CleanResourcesTask(), 1, 1, TimeUnit.SECONDS);
+        executionService.scheduleWithRepetition(new CleanResourcesTask(), CLEAN_RESOURCES_INTERVAL_MILLIS,
+                CLEAN_RESOURCES_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -74,6 +74,12 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.client.invocation.timeout.seconds", 120, SECONDS);
 
     /**
+     * Pause time between each retry cycle of an invocation in milliseconds.
+     */
+    public static final HazelcastProperty INVOCATION_RETRY_PAUSE_MILLIS
+            = new HazelcastProperty("hazelcast.client.invocation.retry.pause.millis", 1000, MILLISECONDS);
+
+    /**
      * The maximum number of concurrent invocations allowed.
      * <p/>
      * To prevent the system from overloading, user can apply a constraint on the number of concurrent invocations.


### PR DESCRIPTION


1. Adding progressive and configurable retry pause to client

Property "hazelcast.client.invocation.retry.puase.millis" is added.

Fast retries without delay for first 5 retries are added.
After those, delay will be increased progressively until it reaches
user configured value.

ported from https://github.com/hazelcast/hazelcast/pull/10977

2. Hardcoded value WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD (5000ms) delay is removed

ported from https://github.com/hazelcast/hazelcast/pull/10985


3. Hardcoded value 1 second to check a invocation if its connection
is changed  as 100 ms

ported from https://github.com/hazelcast/hazelcast/pull/10978