### PR TITLE
Fixed fluent interface of config classes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -350,7 +350,7 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+    public Config setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
@@ -370,7 +370,7 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public void setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
+    public Config setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -490,8 +490,9 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
      * @param mergePolicy the class name of {@link com.hazelcast.cache.CacheMergePolicy} implementation to be set to this cache
      *                    config
      */
-    public void setMergePolicy(String mergePolicy) {
+    public CacheConfig<K, V> setMergePolicy(String mergePolicy) {
         this.mergePolicy = mergePolicy;
+        return this;
     }
 
     /**
@@ -509,8 +510,9 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
      * @param disablePerEntryInvalidationEvents disables invalidation event sending behaviour if it is {@code true},
      *                                          otherwise enables it
      */
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheConfig<K, V> setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         this.disablePerEntryInvalidationEvents = disablePerEntryInvalidationEvents;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -161,7 +161,7 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
     }
 
     @Override
-    public void setMergePolicy(String mergePolicy) {
+    public CacheConfig<K, V> setMergePolicy(String mergePolicy) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
@@ -192,7 +192,7 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
     }
 
     @Override
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheConfig<K, V> setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -568,8 +568,9 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
      *
      * @param wanReplicationRef the WAN target replication reference
      */
-    public void setWanReplicationRef(WanReplicationRef wanReplicationRef) {
+    public CacheSimpleConfig setWanReplicationRef(WanReplicationRef wanReplicationRef) {
         this.wanReplicationRef = wanReplicationRef;
+        return this;
     }
 
     /**
@@ -640,8 +641,9 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
      * @param mergePolicy the class name of {@link com.hazelcast.cache.CacheMergePolicy} implementation
      *                    to be set to this cache config
      */
-    public void setMergePolicy(String mergePolicy) {
+    public CacheSimpleConfig setMergePolicy(String mergePolicy) {
         this.mergePolicy = mergePolicy;
+        return this;
     }
 
     /**
@@ -679,8 +681,9 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
      * @param disablePerEntryInvalidationEvents Disables invalidation event sending behaviour if it is {@code true},
      *                                          otherwise enables it
      */
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheSimpleConfig setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         this.disablePerEntryInvalidationEvents = disablePerEntryInvalidationEvents;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -137,7 +137,7 @@ public class CacheSimpleConfigReadOnly extends CacheSimpleConfig {
     }
 
     @Override
-    public void setWanReplicationRef(WanReplicationRef wanReplicationRef) {
+    public CacheSimpleConfig setWanReplicationRef(WanReplicationRef wanReplicationRef) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
@@ -147,7 +147,7 @@ public class CacheSimpleConfigReadOnly extends CacheSimpleConfig {
     }
 
     @Override
-    public void setMergePolicy(String mergePolicy) {
+    public CacheSimpleConfig setMergePolicy(String mergePolicy) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
@@ -163,7 +163,7 @@ public class CacheSimpleConfigReadOnly extends CacheSimpleConfig {
     }
 
     @Override
-    public void setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
+    public CacheSimpleConfig setDisablePerEntryInvalidationEvents(boolean disablePerEntryInvalidationEvents) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -161,8 +161,7 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
     }
 
     @Override
-    public void writeData(ObjectDataOutput out)
-            throws IOException {
+    public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(cacheEntryEventFilterFactory);
         out.writeUTF(cacheEntryListenerFactory);
         out.writeBoolean(oldValueRequired);
@@ -170,8 +169,7 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
     }
 
     @Override
-    public void readData(ObjectDataInput in)
-            throws IOException {
+    public void readData(ObjectDataInput in) throws IOException {
         cacheEntryEventFilterFactory = in.readUTF();
         cacheEntryListenerFactory = in.readUTF();
         oldValueRequired = in.readBoolean();

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -217,8 +217,9 @@ public abstract class CollectionConfig<T extends CollectionConfig>
      *
      * @param itemListenerConfig the item listener to add to this collection
      */
-    public void addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
+    public CollectionConfig addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
         getItemListenerConfigs().add(itemListenerConfig);
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -177,11 +177,12 @@ public class Config {
         return configPatternMatcher;
     }
 
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+    public Config setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
         if (configPatternMatcher == null) {
             throw new IllegalArgumentException("ConfigPatternMatcher is not allowed to be null!");
         }
         this.configPatternMatcher = configPatternMatcher;
+        return this;
     }
 
     /**
@@ -211,8 +212,9 @@ public class Config {
         return memberAttributeConfig;
     }
 
-    public void setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
+    public Config setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
         this.memberAttributeConfig = memberAttributeConfig;
+        return this;
     }
 
     public Properties getProperties() {

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -62,8 +62,9 @@ public class DiscoveryConfig {
         return readonly;
     }
 
-    public void setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
+    public DiscoveryConfig setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
         this.discoveryServiceProvider = discoveryServiceProvider;
+        return this;
     }
 
     public DiscoveryServiceProvider getDiscoveryServiceProvider() {
@@ -74,16 +75,18 @@ public class DiscoveryConfig {
         return nodeFilter;
     }
 
-    public void setNodeFilter(NodeFilter nodeFilter) {
+    public DiscoveryConfig setNodeFilter(NodeFilter nodeFilter) {
         this.nodeFilter = nodeFilter;
+        return this;
     }
 
     public String getNodeFilterClass() {
         return nodeFilterClass;
     }
 
-    public void setNodeFilterClass(String nodeFilterClass) {
+    public DiscoveryConfig setNodeFilterClass(String nodeFilterClass) {
         this.nodeFilterClass = nodeFilterClass;
+        return this;
     }
 
     public boolean isEnabled() {
@@ -104,8 +107,9 @@ public class DiscoveryConfig {
         return discoveryStrategyConfigs;
     }
 
-    public void setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+    public DiscoveryConfig setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
         this.discoveryStrategyConfigs = discoveryStrategyConfigs;
+        return this;
     }
 
     /**
@@ -116,8 +120,9 @@ public class DiscoveryConfig {
      *
      * @param discoveryStrategyConfig the {@link DiscoveryStrategyConfig} to add
      */
-    public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+    public DiscoveryConfig addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         discoveryStrategyConfigs.add(discoveryStrategyConfig);
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
@@ -34,27 +34,27 @@ public class DiscoveryConfigReadOnly extends DiscoveryConfig {
     }
 
     @Override
-    public void setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
+    public DiscoveryConfig setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void setNodeFilter(NodeFilter nodeFilter) {
+    public DiscoveryConfig setNodeFilter(NodeFilter nodeFilter) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void setNodeFilterClass(String nodeFilterClass) {
+    public DiscoveryConfig setNodeFilterClass(String nodeFilterClass) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+    public DiscoveryConfig addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 
     @Override
-    public void setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+    public DiscoveryConfig setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -62,12 +62,14 @@ public class DiscoveryStrategyConfig {
         return discoveryStrategyFactory;
     }
 
-    public void addProperty(String key, Comparable value) {
+    public DiscoveryStrategyConfig addProperty(String key, Comparable value) {
         properties.put(key, value);
+        return this;
     }
 
-    public void removeProperty(String key) {
+    public DiscoveryStrategyConfig removeProperty(String key) {
         properties.remove(key);
+        return this;
     }
 
     public Map<String, Comparable> getProperties() {

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
@@ -104,8 +104,9 @@ public class JobTrackerConfig {
      *
      * @param maxThreadSize the maximum thread pool size of the {@link com.hazelcast.mapreduce.JobTracker}
      */
-    public void setMaxThreadSize(int maxThreadSize) {
+    public JobTrackerConfig setMaxThreadSize(int maxThreadSize) {
         this.maxThreadSize = maxThreadSize;
+        return this;
     }
 
     /**
@@ -120,8 +121,9 @@ public class JobTrackerConfig {
      * retry count is currently not used but reserved for later use where the framework will
      * automatically try to restart / retry operations from a available savepoint.
      */
-    public void setRetryCount(int retryCount) {
+    public JobTrackerConfig setRetryCount(int retryCount) {
         this.retryCount = retryCount;
+        return this;
     }
 
     /**
@@ -152,8 +154,9 @@ public class JobTrackerConfig {
      *
      * @param chunkSize the number of emitted values before a chunk is sent to the reducers
      */
-    public void setChunkSize(int chunkSize) {
+    public JobTrackerConfig setChunkSize(int chunkSize) {
         this.chunkSize = chunkSize;
+        return this;
     }
 
     /**
@@ -182,8 +185,9 @@ public class JobTrackerConfig {
      *
      * @param queueSize the maximum size of the queue
      */
-    public void setQueueSize(int queueSize) {
+    public JobTrackerConfig setQueueSize(int queueSize) {
         this.queueSize = queueSize;
+        return this;
     }
 
     /**
@@ -208,8 +212,9 @@ public class JobTrackerConfig {
      * @param communicateStats {@code true} if statistics (for example, about processed entries) are transmitted to the job
      *                         emitter, {@code false} otherwise.
      */
-    public void setCommunicateStats(boolean communicateStats) {
+    public JobTrackerConfig setCommunicateStats(boolean communicateStats) {
         this.communicateStats = communicateStats;
+        return this;
     }
 
     /**
@@ -234,7 +239,8 @@ public class JobTrackerConfig {
      * @param topologyChangedStrategy How the map reduce framework will react on topology
      *                                changes while executing a job.
      */
-    public void setTopologyChangedStrategy(TopologyChangedStrategy topologyChangedStrategy) {
+    public JobTrackerConfig setTopologyChangedStrategy(TopologyChangedStrategy topologyChangedStrategy) {
         this.topologyChangedStrategy = topologyChangedStrategy;
+        return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfigReadOnly.java
@@ -30,37 +30,37 @@ public class JobTrackerConfigReadOnly extends JobTrackerConfig {
     }
 
     @Override
-    public JobTrackerConfigReadOnly setName(String name) {
+    public JobTrackerConfig setName(String name) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setMaxThreadSize(int maxThreadSize) {
+    public JobTrackerConfig setMaxThreadSize(int maxThreadSize) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setRetryCount(int retryCount) {
+    public JobTrackerConfig setRetryCount(int retryCount) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setChunkSize(int chunkSize) {
+    public JobTrackerConfig setChunkSize(int chunkSize) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setQueueSize(int queueSize) {
+    public JobTrackerConfig setQueueSize(int queueSize) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setCommunicateStats(boolean communicateStats) {
+    public JobTrackerConfig setCommunicateStats(boolean communicateStats) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setTopologyChangedStrategy(TopologyChangedStrategy topologyChangedStrategy) {
+    public JobTrackerConfig setTopologyChangedStrategy(TopologyChangedStrategy topologyChangedStrategy) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
@@ -73,7 +73,7 @@ public class ListConfigReadOnly extends ListConfig {
     }
 
     @Override
-    public void addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
+    public ListConfig addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
         throw new UnsupportedOperationException("This config is read-only list: " + getName());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -724,8 +724,9 @@ public class MapConfig implements IdentifiedDataSerializable {
     /**
      * Sets {@link QueryCacheConfig} instances to this {@code MapConfig}.
      */
-    public void setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
+    public MapConfig setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
         this.queryCacheConfigs = queryCacheConfigs;
+        return this;
     }
 
     public PartitioningStrategyConfig getPartitioningStrategyConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
@@ -250,7 +250,7 @@ public class MapConfigReadOnly extends MapConfig {
     }
 
     @Override
-    public void setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
+    public MapConfig setQueryCacheConfigs(List<QueryCacheConfig> queryCacheConfigs) {
         throw new UnsupportedOperationException("This config is read-only map: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
@@ -38,79 +38,89 @@ public class MemberAttributeConfig {
         return attributes;
     }
 
-    public void setAttributes(Map<String, Object> attributes) {
+    public MemberAttributeConfig setAttributes(Map<String, Object> attributes) {
         this.attributes.clear();
         if (attributes != null) {
             this.attributes.putAll(attributes);
         }
+        return this;
     }
 
     public String getStringAttribute(String key) {
         return (String) getAttribute(key);
     }
 
-    public void setStringAttribute(String key, String value) {
+    public MemberAttributeConfig setStringAttribute(String key, String value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Boolean getBooleanAttribute(String key) {
         return (Boolean) getAttribute(key);
     }
 
-    public void setBooleanAttribute(String key, boolean value) {
+    public MemberAttributeConfig setBooleanAttribute(String key, boolean value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Byte getByteAttribute(String key) {
         return (Byte) getAttribute(key);
     }
 
-    public void setByteAttribute(String key, byte value) {
+    public MemberAttributeConfig setByteAttribute(String key, byte value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Short getShortAttribute(String key) {
         return (Short) getAttribute(key);
     }
 
-    public void setShortAttribute(String key, short value) {
+    public MemberAttributeConfig setShortAttribute(String key, short value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Integer getIntAttribute(String key) {
         return (Integer) getAttribute(key);
     }
 
-    public void setIntAttribute(String key, int value) {
+    public MemberAttributeConfig setIntAttribute(String key, int value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Long getLongAttribute(String key) {
         return (Long) getAttribute(key);
     }
 
-    public void setLongAttribute(String key, long value) {
+    public MemberAttributeConfig setLongAttribute(String key, long value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Float getFloatAttribute(String key) {
         return (Float) getAttribute(key);
     }
 
-    public void setFloatAttribute(String key, float value) {
+    public MemberAttributeConfig setFloatAttribute(String key, float value) {
         setAttribute(key, value);
+        return this;
     }
 
     public Double getDoubleAttribute(String key) {
         return (Double) getAttribute(key);
     }
 
-    public void setDoubleAttribute(String key, double value) {
+    public MemberAttributeConfig setDoubleAttribute(String key, double value) {
         setAttribute(key, value);
+        return this;
     }
 
-    public void removeAttribute(String key) {
+    public MemberAttributeConfig removeAttribute(String key) {
         attributes.remove(key);
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
@@ -31,52 +31,52 @@ public class MemberAttributeConfigReadOnly extends MemberAttributeConfig {
     }
 
     @Override
-    public void setStringAttribute(String key, String value) {
+    public MemberAttributeConfig setStringAttribute(String key, String value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setBooleanAttribute(String key, boolean value) {
+    public MemberAttributeConfig setBooleanAttribute(String key, boolean value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setByteAttribute(String key, byte value) {
+    public MemberAttributeConfig setByteAttribute(String key, byte value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setShortAttribute(String key, short value) {
+    public MemberAttributeConfig setShortAttribute(String key, short value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setIntAttribute(String key, int value) {
+    public MemberAttributeConfig setIntAttribute(String key, int value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setLongAttribute(String key, long value) {
+    public MemberAttributeConfig setLongAttribute(String key, long value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setFloatAttribute(String key, float value) {
+    public MemberAttributeConfig setFloatAttribute(String key, float value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setDoubleAttribute(String key, double value) {
+    public MemberAttributeConfig setDoubleAttribute(String key, double value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void removeAttribute(String key) {
+    public MemberAttributeConfig removeAttribute(String key) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public void setAttributes(Map<String, Object> attributes) {
+    public MemberAttributeConfig setAttributes(Map<String, Object> attributes) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -111,11 +111,12 @@ public class NetworkConfig {
      * @param portCount the maximum number of ports allowed to use
      * @see #setPortAutoIncrement(boolean) for more information
      */
-    public void setPortCount(int portCount) {
+    public NetworkConfig setPortCount(int portCount) {
         if (portCount < 1) {
             throw new IllegalArgumentException("port count can't be smaller than 0");
         }
         this.portCount = portCount;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
@@ -159,10 +159,11 @@ public class PredicateConfig implements IdentifiedDataSerializable {
      *
      * @param sql sql string for this config
      */
-    public void setSql(String sql) {
+    public PredicateConfig setSql(String sql) {
         this.sql = sql;
         this.className = null;
         this.implementation = null;
+        return this;
     }
 
     //CHECKSTYLE:OFF

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
@@ -41,7 +41,7 @@ class PredicateConfigReadOnly extends PredicateConfig {
     }
 
     @Override
-    public void setSql(String sql) {
+    public PredicateConfig setSql(String sql) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -269,8 +269,9 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable {
      * @param asyncFillup {@code true} if the replicated map is available for reads before the initial
      *                    replication is completed, {@code false} otherwise
      */
-    public void setAsyncFillup(boolean asyncFillup) {
+    public ReplicatedMapConfig setAsyncFillup(boolean asyncFillup) {
         this.asyncFillup = asyncFillup;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
@@ -59,7 +59,7 @@ class ReplicatedMapConfigReadOnly extends ReplicatedMapConfig {
     }
 
     @Override
-    public void setAsyncFillup(boolean asyncFillup) {
+    public ReplicatedMapConfig setAsyncFillup(boolean asyncFillup) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -48,8 +48,9 @@ public class SecurityConfig {
         return securityInterceptorConfigs;
     }
 
-    public void setSecurityInterceptorConfigs(final List<SecurityInterceptorConfig> securityInterceptorConfigs) {
+    public SecurityConfig setSecurityInterceptorConfigs(final List<SecurityInterceptorConfig> securityInterceptorConfigs) {
         this.securityInterceptorConfigs = securityInterceptorConfigs;
+        return this;
     }
 
     public boolean isEnabled() {

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityInterceptorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityInterceptorConfig.java
@@ -30,11 +30,11 @@ public class SecurityInterceptorConfig {
     public SecurityInterceptorConfig() {
     }
 
-    public SecurityInterceptorConfig(final String className) {
+    public SecurityInterceptorConfig(String className) {
         this.className = className;
     }
 
-    public SecurityInterceptorConfig(final SecurityInterceptor implementation) {
+    public SecurityInterceptorConfig(SecurityInterceptor implementation) {
         this.implementation = implementation;
     }
 
@@ -42,15 +42,17 @@ public class SecurityInterceptorConfig {
         return className;
     }
 
-    public void setClassName(final String className) {
+    public SecurityInterceptorConfig setClassName(String className) {
         this.className = className;
+        return this;
     }
 
     public SecurityInterceptor getImplementation() {
         return implementation;
     }
 
-    public void setImplementation(final SecurityInterceptor implementation) {
+    public SecurityInterceptorConfig setImplementation(SecurityInterceptor implementation) {
         this.implementation = implementation;
+        return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
@@ -73,7 +73,7 @@ public class SetConfigReadOnly extends SetConfig {
     }
 
     @Override
-    public void addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
+    public SetConfig addItemListenerConfig(ItemListenerConfig itemListenerConfig) {
         throw new UnsupportedOperationException("This config is read-only set: " + getName());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -59,10 +59,11 @@ public class WanReplicationConfig implements IdentifiedDataSerializable {
         return wanPublisherConfigs;
     }
 
-    public void setWanPublisherConfigs(List<WanPublisherConfig> wanPublisherConfigs) {
+    public WanReplicationConfig setWanPublisherConfigs(List<WanPublisherConfig> wanPublisherConfigs) {
         if (wanPublisherConfigs != null && !wanPublisherConfigs.isEmpty()) {
             this.wanPublisherConfigs = wanPublisherConfigs;
         }
+        return this;
     }
 
     public WanReplicationConfig addWanPublisherConfig(WanPublisherConfig wanPublisherConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -100,8 +100,8 @@ public class DynamicConfigurationAwareConfig extends Config {
     }
 
     @Override
-    public void setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
-        staticConfig.setConfigPatternMatcher(configPatternMatcher);
+    public Config setConfigPatternMatcher(ConfigPatternMatcher configPatternMatcher) {
+        return staticConfig.setConfigPatternMatcher(configPatternMatcher);
     }
 
     @Override
@@ -120,8 +120,8 @@ public class DynamicConfigurationAwareConfig extends Config {
     }
 
     @Override
-    public void setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
-        staticConfig.setMemberAttributeConfig(memberAttributeConfig);
+    public Config setMemberAttributeConfig(MemberAttributeConfig memberAttributeConfig) {
+        return staticConfig.setMemberAttributeConfig(memberAttributeConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -56,7 +56,7 @@ public class DynamicSecurityConfig extends SecurityConfig {
     }
 
     @Override
-    public void setSecurityInterceptorConfigs(List<SecurityInterceptorConfig> securityInterceptorConfigs) {
+    public SecurityConfig setSecurityInterceptorConfigs(List<SecurityInterceptorConfig> securityInterceptorConfigs) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 


### PR DESCRIPTION
Added missing `return this` statements to setter methods.

The fluent interface of our config classes was broken in several places. This makes it hard to write good test code, since you could not chain all setter methods of a config.

This should not break any compatibility, since the return type is not part of the method signature in Java. The compatibility tests are also still passing.