### PR TITLE
Wildcard usage for query cache configuration at the client does not work as expected

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathXmlConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathXmlConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * A {@link ClientConfig} which is initialized by loading an XML configuration file from the classpath.
+ *
+ */
+public class ClientClasspathXmlConfig extends ClientConfig {
+    private static final ILogger LOGGER = Logger.getLogger(ClientClasspathXmlConfig.class);
+
+    /**
+     * Creates a config which is loaded from a classpath resource using the
+     * Thread.currentThread contextClassLoader. The System.properties are used to resolve variables
+     * in the XML.
+     *
+     * @param resource the resource, an XML configuration file from the classpath
+     * @throws IllegalArgumentException if the resource could not be found
+     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     */
+    public ClientClasspathXmlConfig(String resource) {
+        this(resource, System.getProperties());
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource using the
+     * Thread.currentThread contextClassLoader.
+     *
+     * @param resource   the resource, an XML configuration file from the classpath
+     * @param properties the Properties to resolve variables in the XML
+     * @throws IllegalArgumentException if the resource could not be found or if properties is {@code null}
+     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     */
+    public ClientClasspathXmlConfig(String resource, Properties properties) {
+        this(Thread.currentThread().getContextClassLoader(), resource, properties);
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource. The System.properties are used to
+     * resolve variables in the XML.
+     *
+     * @param classLoader the ClassLoader used to load the resource
+     * @param resource    the resource, an XML configuration file from the classpath
+     * @throws IllegalArgumentException if classLoader or resource is {@code null}, or if the resource is not found
+     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     */
+    public ClientClasspathXmlConfig(ClassLoader classLoader, String resource) {
+        this(classLoader, resource, System.getProperties());
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource.
+     *
+     * @param classLoader the ClassLoader used to load the resource
+     * @param resource    the resource, an XML configuration file from the classpath
+     * @param properties  the properties used to resolve variables in the XML
+     * @throws IllegalArgumentException if classLoader or resource is {@code null}, or if the resource is not found
+     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     */
+    public ClientClasspathXmlConfig(ClassLoader classLoader, String resource, Properties properties) {
+        if (classLoader == null) {
+            throw new IllegalArgumentException("classLoader can't be null");
+        }
+        if (resource == null) {
+            throw new IllegalArgumentException("resource can't be null");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+
+        LOGGER.info("Configuring Hazelcast Client from '" + resource + "'.");
+        InputStream in = classLoader.getResourceAsStream(resource);
+        if (in == null) {
+            throw new IllegalArgumentException("Specified resource '" + resource + "' could not be found!");
+        }
+        XmlClientConfigBuilder xmlClientConfigBuilder = new XmlClientConfigBuilder(in);
+        xmlClientConfigBuilder.setProperties(properties);
+        xmlClientConfigBuilder.build(this, classLoader);
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -31,6 +31,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.security.Credentials;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -758,5 +759,48 @@ public class ClientConfig {
     public ClientConfig setUserCodeDeploymentConfig(ClientUserCodeDeploymentConfig userCodeDeploymentConfig) {
         this.userCodeDeploymentConfig = userCodeDeploymentConfig;
         return this;
+    }
+
+    /**
+     *
+     * @param mapName The name of the map for which the query cache config is to be returned.
+     * @param cacheName The name of the query cache config.
+     * @return The query cache config. If the config does not exist, it is created.
+     */
+    public QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String cacheName) {
+        Map<String, Map<String, QueryCacheConfig>> allQueryCacheConfig = getQueryCacheConfigs();
+
+        Map<String, QueryCacheConfig> mapQueryCacheConfig = lookupByPattern(allQueryCacheConfig, mapName);
+        if (mapQueryCacheConfig == null) {
+            mapQueryCacheConfig = new HashMap<String, QueryCacheConfig>();
+            allQueryCacheConfig.put(mapName, mapQueryCacheConfig);
+        }
+
+        QueryCacheConfig queryCacheConfig = lookupByPattern(mapQueryCacheConfig, cacheName);
+        if (queryCacheConfig == null) {
+            queryCacheConfig = new QueryCacheConfig(cacheName);
+            mapQueryCacheConfig.put(cacheName, queryCacheConfig);
+        }
+
+        return queryCacheConfig;
+    }
+
+    /**
+     *
+     * @param mapName The name of the map for which the query cache config is to be returned.
+     * @param cacheName The name of the query cache config.
+     * @return The query cache config. If no such config exist null is returned.
+     */
+    public QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String cacheName) {
+        if (queryCacheConfigs == null) {
+            return null;
+        }
+
+        Map<String, QueryCacheConfig> mapQueryCacheConfig = lookupByPattern(queryCacheConfigs, mapName);
+        if (mapQueryCacheConfig == null) {
+            return null;
+        }
+
+        return lookupByPattern(mapQueryCacheConfig, cacheName);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -764,22 +764,22 @@ public class ClientConfig {
     /**
      *
      * @param mapName The name of the map for which the query cache config is to be returned.
-     * @param cacheName The name of the query cache config.
+     * @param queryCacheName The name of the query cache config.
      * @return The query cache config. If the config does not exist, it is created.
      */
-    public QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String cacheName) {
+    public QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String queryCacheName) {
         Map<String, Map<String, QueryCacheConfig>> allQueryCacheConfig = getQueryCacheConfigs();
 
-        Map<String, QueryCacheConfig> mapQueryCacheConfig = lookupByPattern(allQueryCacheConfig, mapName);
-        if (mapQueryCacheConfig == null) {
-            mapQueryCacheConfig = new HashMap<String, QueryCacheConfig>();
-            allQueryCacheConfig.put(mapName, mapQueryCacheConfig);
+        Map<String, QueryCacheConfig> queryCacheConfigsForMap = lookupByPattern(allQueryCacheConfig, mapName);
+        if (queryCacheConfigsForMap == null) {
+            queryCacheConfigsForMap = new HashMap<String, QueryCacheConfig>();
+            allQueryCacheConfig.put(mapName, queryCacheConfigsForMap);
         }
 
-        QueryCacheConfig queryCacheConfig = lookupByPattern(mapQueryCacheConfig, cacheName);
+        QueryCacheConfig queryCacheConfig = lookupByPattern(queryCacheConfigsForMap, queryCacheName);
         if (queryCacheConfig == null) {
-            queryCacheConfig = new QueryCacheConfig(cacheName);
-            mapQueryCacheConfig.put(cacheName, queryCacheConfig);
+            queryCacheConfig = new QueryCacheConfig(queryCacheName);
+            queryCacheConfigsForMap.put(queryCacheName, queryCacheConfig);
         }
 
         return queryCacheConfig;
@@ -788,19 +788,19 @@ public class ClientConfig {
     /**
      *
      * @param mapName The name of the map for which the query cache config is to be returned.
-     * @param cacheName The name of the query cache config.
+     * @param queryCacheName The name of the query cache config.
      * @return The query cache config. If no such config exist null is returned.
      */
-    public QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String cacheName) {
+    public QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String queryCacheName) {
         if (queryCacheConfigs == null) {
             return null;
         }
 
-        Map<String, QueryCacheConfig> mapQueryCacheConfig = lookupByPattern(queryCacheConfigs, mapName);
-        if (mapQueryCacheConfig == null) {
+        Map<String, QueryCacheConfig> queryCacheConfigsForMap = lookupByPattern(queryCacheConfigs, mapName);
+        if (queryCacheConfigsForMap == null) {
             return null;
         }
 
-        return lookupByPattern(mapQueryCacheConfig, cacheName);
+        return lookupByPattern(queryCacheConfigsForMap, queryCacheName);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -172,10 +172,14 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
 
     public ClientConfig build(ClassLoader classLoader) {
         ClientConfig clientConfig = new ClientConfig();
+        build(clientConfig, classLoader);
+        return clientConfig;
+    }
+
+    void build(ClientConfig clientConfig, ClassLoader classLoader) {
         clientConfig.setClassLoader(classLoader);
         try {
             parseAndBuildConfig(clientConfig);
-            return clientConfig;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         } finally {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
@@ -22,7 +22,6 @@ import com.hazelcast.map.impl.querycache.QueryCacheConfigurator;
 import com.hazelcast.map.impl.querycache.QueryCacheEventService;
 import com.hazelcast.map.impl.querycache.subscriber.AbstractQueryCacheConfigurator;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -42,19 +41,7 @@ public class ClientQueryCacheConfigurator extends AbstractQueryCacheConfigurator
 
     @Override
     public QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName) {
-        Map<String, Map<String, QueryCacheConfig>> allQueryCacheConfig = clientConfig.getQueryCacheConfigs();
-
-        Map<String, QueryCacheConfig> mapQueryCacheConfig = allQueryCacheConfig.get(mapName);
-        if (mapQueryCacheConfig == null) {
-            mapQueryCacheConfig = new HashMap<String, QueryCacheConfig>();
-            allQueryCacheConfig.put(mapName, mapQueryCacheConfig);
-        }
-
-        QueryCacheConfig config = mapQueryCacheConfig.get(cacheName);
-        if (config == null) {
-            config = new QueryCacheConfig(cacheName);
-            mapQueryCacheConfig.put(cacheName, config);
-        }
+        QueryCacheConfig config = clientConfig.getOrCreateQueryCacheConfig(mapName, cacheName);
 
         setPredicateImpl(config);
         setEntryListener(mapName, cacheName, config);
@@ -64,14 +51,7 @@ public class ClientQueryCacheConfigurator extends AbstractQueryCacheConfigurator
 
     @Override
     public QueryCacheConfig getOrNull(String mapName, String cacheName) {
-        Map<String, Map<String, QueryCacheConfig>> allQueryCacheConfig = clientConfig.getQueryCacheConfigs();
-
-        Map<String, QueryCacheConfig> mapQueryCacheConfig = allQueryCacheConfig.get(mapName);
-        if (mapQueryCacheConfig == null) {
-            return null;
-        }
-
-        return mapQueryCacheConfig.get(cacheName);
+        return clientConfig.getOrNullQueryCacheConfig(mapName, cacheName);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.querycache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.querycache.QueryCacheConfigTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientQueryCacheConfigTest extends QueryCacheConfigTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Before
+    public void setUp() throws Exception {
+        factory.newHazelcastInstance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Override
+    protected HazelcastInstance createInstanceWithQueryCacheConfig(String mapName, QueryCacheConfig queryCacheConfig) {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addQueryCacheConfig(mapName, queryCacheConfig);
+        return factory.newHazelcastClient(clientConfig);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheXmlConfigWithWildcardTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheXmlConfigWithWildcardTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.map.querycache;
 
+import com.hazelcast.client.config.ClientClasspathXmlConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.impl.querycache.QueryCacheXmlConfigWildcardTest;
@@ -24,7 +25,6 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -36,18 +36,18 @@ public class ClientQueryCacheXmlConfigWithWildcardTest extends QueryCacheXmlConf
 
     @Before
     public void setUp() throws Exception {
-        System.setProperty("hazelcast.client.config", "classpath:hazelcast-client-querycache-xml-config-wildcard-test.xml");
         factory.newHazelcastInstance();
     }
 
     @After
     public void tearDown() throws Exception {
         factory.shutdownAll();
-        System.clearProperty("hazelcast.client.config");
     }
 
     @Override
     protected HazelcastInstance createInstance() {
-        return factory.newHazelcastClient();
+        ClientClasspathXmlConfig clientConfig = new ClientClasspathXmlConfig(
+                "hazelcast-client-querycache-xml-config-wildcard-test.xml");
+        return factory.newHazelcastClient(clientConfig);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheXmlConfigWithWildcardTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheXmlConfigWithWildcardTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.querycache;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.querycache.QueryCacheXmlConfigWildcardTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientQueryCacheXmlConfigWithWildcardTest extends QueryCacheXmlConfigWildcardTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("hazelcast.client.config", "classpath:hazelcast-client-querycache-xml-config-wildcard-test.xml");
+        factory.newHazelcastInstance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+        System.clearProperty("hazelcast.client.config");
+    }
+
+    @Override
+    protected HazelcastInstance createInstance() {
+        return factory.newHazelcastClient();
+    }
+}

--- a/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    The default Hazelcast configuration. This is used when no hazelcast.xml is present.
+    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.9.xsd
+    or the documentation at https://hazelcast.org/documentation/
+-->
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.9.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <query-caches>
+        <query-cache mapName="testQueryCacheXmlConfigWithWildCardMap*" name="queryCacheName*">
+            <in-memory-format>OBJECT</in-memory-format>
+            <buffer-size>50</buffer-size>
+            <batch-size>5</batch-size>
+            <delay-seconds>0</delay-seconds>
+            <coalesce>true</coalesce>
+            <include-value>true</include-value>
+            <populate>true</populate>
+            <predicate type="class-name">com.hazelcast.query.TruePredicate</predicate>
+        </query-cache>
+    </query-caches>
+</hazelcast-client>

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -261,6 +261,11 @@ public class Config {
         return getMapConfig("default").getAsReadOnly();
     }
 
+    public MapConfig getMapConfigOrNull(String name) {
+        String baseName = getBaseName(name);
+        return lookupByPattern(configPatternMatcher, mapConfigs, baseName);
+    }
+
     public MapConfig getMapConfig(String name) {
         String baseName = getBaseName(name);
         MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, baseName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -174,6 +174,30 @@ public class DynamicConfigurationAwareConfig extends Config {
         return getMapConfigInternal(name, name);
     }
 
+    @Override
+    public MapConfig getMapConfigOrNull(String name) {
+        return getMapConfigOrNullInternal(name);
+    }
+
+    private MapConfig getMapConfigOrNullInternal(String name) {
+        return getMapConfigOrNullInternal(name, name);
+    }
+
+    private MapConfig getMapConfigOrNullInternal(String name, String fallbackName) {
+        String baseName = getBaseName(name);
+        Map<String, MapConfig> staticMapConfigs = staticConfig.getMapConfigs();
+        MapConfig mapConfig = lookupByPattern(configPatternMatcher, staticMapConfigs, baseName);
+        if (mapConfig == null) {
+            mapConfig = configurationService.findMapConfig(baseName);
+        } else {
+            initDefaultMaxSizeForOnHeapMaps(mapConfig.getNearCacheConfig());
+        }
+        if (mapConfig == null) {
+            mapConfig = staticConfig.getMapConfigOrNull(fallbackName);
+        }
+        return mapConfig;
+    }
+
     private MapConfig getMapConfigInternal(String name, String fallbackName) {
         String baseName = getBaseName(name);
         Map<String, MapConfig> staticMapConfigs = staticConfig.getMapConfigs();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheXmlConfigWildcardTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheXmlConfigWildcardTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache;
 
+import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.QueryCache;
@@ -23,8 +24,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,17 +33,6 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueryCacheXmlConfigWildcardTest extends HazelcastTestSupport {
-
-    @Before
-    public void setUp() throws Exception {
-        System.setProperty("hazelcast.config", "classpath:hazelcast-querycache-xml-config-wildcard-test.xml");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        System.clearProperty("hazelcast.config");
-    }
-
     @Test
     public void testQueryCacheXmlConfigWithWildCard() {
         HazelcastInstance hazelcastInstance = createInstance();
@@ -55,6 +43,7 @@ public class QueryCacheXmlConfigWildcardTest extends HazelcastTestSupport {
     }
 
     protected HazelcastInstance createInstance() {
-        return createHazelcastInstance(null);
+        ClasspathXmlConfig config = new ClasspathXmlConfig("hazelcast-querycache-xml-config-wildcard-test.xml");
+        return createHazelcastInstance(config);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheXmlConfigWildcardTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheXmlConfigWildcardTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.querycache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.QueryCache;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryCacheXmlConfigWildcardTest extends HazelcastTestSupport {
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("hazelcast.config", "classpath:hazelcast-querycache-xml-config-wildcard-test.xml");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty("hazelcast.config");
+    }
+
+    @Test
+    public void testQueryCacheXmlConfigWithWildCard() {
+        HazelcastInstance hazelcastInstance = createInstance();
+        IMap<Integer, Integer> map = hazelcastInstance.getMap("testQueryCacheXmlConfigWithWildCardMap1");
+        QueryCache<Integer, Integer> queryCache = map.getQueryCache("queryCacheName1");
+
+        assertNotNull(queryCache);
+    }
+
+    protected HazelcastInstance createInstance() {
+        return createHazelcastInstance(null);
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <map name="testQueryCacheXmlConfigWithWildCardMap*">
+        <backup-count>1</backup-count>
+        <eviction-policy>LRU</eviction-policy>
+
+        <query-caches>
+            <query-cache name="queryCacheName*">
+                <in-memory-format>OBJECT</in-memory-format>
+                <buffer-size>50</buffer-size>
+                <batch-size>5</batch-size>
+                <delay-seconds>0</delay-seconds>
+                <coalesce>true</coalesce>
+                <include-value>true</include-value>
+                <populate>true</populate>
+                <predicate type="class-name">com.hazelcast.query.TruePredicate</predicate>
+            </query-cache>
+        </query-caches>
+    </map>
+
+</hazelcast>


### PR DESCRIPTION
Fixes the wildcard usage for query cache configuration at the ClientConfig. Adds two methods to ClientConfig.

fixes #9990