### PR TITLE
Override failsafe plugin in LOCAL profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,37 @@
                             </dependency>
                         </dependencies>
                     </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven.failsafe.plugin.version}</version>
+                        <configuration combine.self="override">
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <useFile>false</useFile>
+                            <argLine>
+                                -Xms129m -Xmx1G -XX:MaxPermSize=129M
+                                -Dhazelcast.phone.home.enabled=false
+                                -Dhazelcast.mancenter.enabled=false
+                                -Dhazelcast.test.use.network=false
+                            </argLine>
+                            <useManifestOnlyJar>false</useManifestOnlyJar>
+                            <useSystemClassLoader>true</useSystemClassLoader>
+                            <groups>com.hazelcast.test.annotation.QuickTest</groups>
+                            <excludedGroups>
+                                com.hazelcast.test.annotation.SlowTest,
+                                com.hazelcast.test.annotation.NightlyTest
+                            </excludedGroups>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
IDEA uses both surefire and failsafe plugins while executing unit tests.
Failsafe plugin configuration in default profile uses network and suppresses
logging. That makes difficult to run tests locally.

Added failsafe plugin config to LOCAL profile similar to surefire.

This change is required after https://github.com/hazelcast/hazelcast/pull/10910