### PR TITLE
Assign lost partitions to members when cluster in NO_MIGRATION state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOp;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.LockGuard;
@@ -335,6 +336,11 @@ public class ClusterStateManager {
 
     void changeClusterState(ClusterStateChange newState, MemberMap memberMap,
             TransactionOptions options, int partitionStateVersion, boolean isTransient) {
+
+        if (clusterVersion.isLessThan(Versions.V3_9) && newState.getNewState() == ClusterState.NO_MIGRATION) {
+            throw new UnsupportedOperationException("NO_MIGRATION cluster state is not available before 3.9!");
+        }
+
         checkParameters(newState, options);
         if (isCurrentStateEqualToRequestedOne(newState)) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateGenerator.java
@@ -36,4 +36,22 @@ public interface PartitionStateGenerator {
      * @return proposed partition table
      */
     Address[][] arrange(Collection<MemberGroup> groups, InternalPartition[] currentState);
+
+    /**
+     * Arranges the partition layout.
+     * <p/>
+     * This method does not actually change the partitions, but send back the updated layout.
+     * <p/>
+     * A two-dimensional array of addresses is returned where the first index is the partition ID, and
+     * the second index is the replica index.
+     * <p/>
+     * When null partitions is given, all partitions will be arranged,
+     * similar to {@link #arrange(Collection, InternalPartition[])}.
+     *
+     * @param groups       member groups
+     * @param currentState current partition state.
+     * @param partitions Partitions to be arranged only.
+     * @return proposed partition table
+     */
+    Address[][] arrange(Collection<MemberGroup> groups, InternalPartition[] currentState, Collection<Integer> partitions);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -294,12 +294,12 @@ public class PartitionStateManager {
         return partitions[partitionId];
     }
 
-    Address[][] repartition(Set<Address> excludedAddresses) {
+    Address[][] repartition(Set<Address> excludedAddresses, Collection<Integer> partitionInclusionSet) {
         if (!initialized) {
             return null;
         }
         Collection<MemberGroup> memberGroups = createMemberGroups(excludedAddresses);
-        Address[][] newState = partitionStateGenerator.arrange(memberGroups, partitions);
+        Address[][] newState = partitionStateGenerator.arrange(memberGroups, partitions, partitionInclusionSet);
 
         if (newState == null) {
             if (logger.isFinestEnabled()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -34,6 +35,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -221,6 +223,16 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
                 service.assertNoReplication();
             }
         }, 10);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    // RU_COMPAT_WITH_3_8
+    public void noMigration_notSupported_beforeV39()  {
+        System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Version.of(3, 8).toString());
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+
+        hz.getCluster().changeClusterState(ClusterState.NO_MIGRATION);
     }
 
     private Config newConfigWithMigrationAwareService() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.cluster.impl.operations.PromoteLiteMemberOp;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.nio.Address;
@@ -36,6 +37,7 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.UuidUtil;
+import com.hazelcast.version.Version;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -321,6 +323,17 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         } catch (ExecutionException e) {
             assertInstanceOf(IllegalStateException.class, e.getCause());
         }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    // RU_COMPAT_WITH_3_8
+    public void liteMemberPromotion_notSupported_beforeV39()  {
+        System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Version.of(3, 8).toString());
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz = factory.newHazelcastInstance(new Config().setLiteMember(true));
+
+        hz.getCluster().promoteLocalLiteMember();
     }
 
     private void assertPromotionInvocationStarted(HazelcastInstance instance) {


### PR DESCRIPTION
Lost partitions should be assigned to available members when cluster is in NO_MIGRATION state. This assignment won't cause any data movement and increase availability of the cluster.


