### PR TITLE
Added EventQueuePlugin to sample events in the event queues

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -102,6 +102,7 @@ import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.diagnostics.BuildInfoPlugin;
 import com.hazelcast.internal.diagnostics.ConfigPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.Diagnostics;
+import com.hazelcast.internal.diagnostics.EventQueuePlugin;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
@@ -420,6 +421,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         }
 
         diagnostics.start();
+        diagnostics.register(
+                new EventQueuePlugin(loggingService.getLogger(EventQueuePlugin.class), listenerService.getEventExecutor(),
+                        properties));
         diagnostics.register(
                 new BuildInfoPlugin(loggingService.getLogger(BuildInfoPlugin.class)));
         diagnostics.register(

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
@@ -71,4 +71,12 @@ public class QueueEvent implements IdentifiedDataSerializable {
     public int getId() {
         return QueueDataSerializerHook.QUEUE_EVENT;
     }
+
+    public String getName() {
+        return name;
+    }
+
+    public ItemEventType getEventType() {
+        return eventType;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.cache.impl.CacheEventData;
+import com.hazelcast.cache.impl.CacheEventSet;
+import com.hazelcast.collection.impl.collection.CollectionEvent;
+import com.hazelcast.collection.impl.list.ListService;
+import com.hazelcast.collection.impl.queue.QueueEvent;
+import com.hazelcast.collection.impl.set.SetService;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.event.EntryEventData;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.LocalEventDispatcher;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+import com.hazelcast.util.ItemCounter;
+import com.hazelcast.util.executor.StripedExecutor;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+
+import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * The EventQueuePlugin checks the event queue and samples the event types if the size is above a certain threshold.
+ * This is very useful to figure out why the event queue is running full.
+ */
+public class EventQueuePlugin extends DiagnosticsPlugin {
+
+    /**
+     * The period in seconds this plugin runs.
+     *
+     * With the EventQueuePlugin one can see what is going on inside the event queue.
+     * It makes use of sampling to give some impression of the content.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty(PREFIX + ".event.queue.period.seconds", 0, SECONDS);
+
+    /**
+     * The minimum number of events in the queue before it is being sampled.
+     */
+    public static final HazelcastProperty THRESHOLD
+            = new HazelcastProperty(PREFIX + ".event.queue.threshold", 1000);
+
+    /**
+     * The number of samples to take from the event queue. Increasing the number of samples gives
+     * more accuracy of the content, but it will come at greater price.
+     */
+    public static final HazelcastProperty SAMPLES
+            = new HazelcastProperty(PREFIX + ".event.queue.samples", 100);
+
+    private final ItemCounter<String> occurrenceMap = new ItemCounter<String>();
+    private final Random random = new Random();
+    private final NumberFormat defaultFormat = NumberFormat.getPercentInstance();
+
+    private final StripedExecutor eventExecutor;
+    private final long periodMillis;
+    private final int threshold;
+    private final int samples;
+
+    private int eventCount;
+
+    public EventQueuePlugin(NodeEngineImpl nodeEngine, StripedExecutor eventExecutor) {
+        this(nodeEngine.getLogger(EventQueuePlugin.class), eventExecutor, nodeEngine.getProperties());
+    }
+
+    public EventQueuePlugin(ILogger logger, StripedExecutor eventExecutor, HazelcastProperties props) {
+        super(logger);
+
+        this.defaultFormat.setMinimumFractionDigits(3);
+        this.eventExecutor = eventExecutor;
+
+        this.periodMillis = props.getMillis(PERIOD_SECONDS);
+        this.threshold = props.getInteger(THRESHOLD);
+        this.samples = props.getInteger(SAMPLES);
+    }
+
+    @Override
+    public long getPeriodMillis() {
+        return periodMillis;
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("Plugin:active, period-millis:" + periodMillis + " threshold:" + threshold + " samples:" + samples);
+    }
+
+    @Override
+    public void run(DiagnosticsLogWriter writer) {
+        writer.startSection("EventQueues");
+
+        int index = 1;
+        List<BlockingQueue<Runnable>> eventQueues = getEventQueues();
+        for (BlockingQueue<Runnable> eventQueue : eventQueues) {
+            scan(writer, eventQueue, index++);
+        }
+
+        writer.endSection();
+    }
+
+    // just for testing
+    ItemCounter<String> getOccurrenceMap() {
+        return occurrenceMap;
+    }
+
+    private List<BlockingQueue<Runnable>> getEventQueues() {
+        return eventExecutor.getWorkQueues();
+    }
+
+    private void scan(DiagnosticsLogWriter writer, BlockingQueue<Runnable> eventQueue, int index) {
+        int sampleCount = sample(eventQueue);
+        if (sampleCount < 0) {
+            return;
+        }
+
+        render(writer, sampleCount, index);
+    }
+
+    private void render(DiagnosticsLogWriter writer, int sampleCount, int index) {
+        writer.startSection("worker=" + index);
+
+        writer.writeKeyValueEntry("eventCount", eventCount);
+        writer.writeKeyValueEntry("sampleCount", sampleCount);
+        renderSamples(writer, sampleCount);
+
+        writer.endSection();
+    }
+
+    private void renderSamples(DiagnosticsLogWriter writer, int sampleCount) {
+        writer.startSection("samples");
+
+        for (String key : occurrenceMap.keySet()) {
+            long value = occurrenceMap.get(key);
+            if (value == 0) {
+                continue;
+            }
+
+            double percentage = (1d * value) / sampleCount;
+            writer.writeEntry(key + " sampleCount=" + value + " " + defaultFormat.format(percentage));
+        }
+        occurrenceMap.reset();
+
+        writer.endSection();
+    }
+
+    /**
+     * Samples the queue.
+     *
+     * @param queue the queue to sample
+     * @return the number of samples, or -1 if there were not sufficient samples
+     */
+    private int sample(BlockingQueue<Runnable> queue) {
+        ArrayList<Runnable> events = new ArrayList<Runnable>(queue);
+        eventCount = events.size();
+        if (eventCount < threshold) {
+            return -1;
+        }
+
+        int sampleCount = min(samples, eventCount);
+        int actualSampleCount = 0;
+        while (actualSampleCount < sampleCount) {
+            Runnable runnable = events.get(random.nextInt(eventCount));
+            actualSampleCount += sampleRunnable(runnable);
+        }
+
+        return actualSampleCount;
+    }
+
+    int sampleRunnable(Runnable runnable) {
+        if (runnable instanceof LocalEventDispatcher) {
+            LocalEventDispatcher eventDispatcher = (LocalEventDispatcher) runnable;
+            return sampleLocalDispatcherEvent(eventDispatcher);
+        }
+        occurrenceMap.add(runnable.getClass().getName(), 1);
+        return 1;
+    }
+
+    private int sampleLocalDispatcherEvent(LocalEventDispatcher eventDispatcher) {
+        Object dispatcherEvent = eventDispatcher.getEvent();
+        if (dispatcherEvent instanceof EntryEventData) {
+            // IMap event
+            EntryEventData event = (EntryEventData) dispatcherEvent;
+            EntryEventType type = EntryEventType.getByType(event.getEventType());
+            String mapName = event.getMapName();
+            occurrenceMap.add(format("IMap '%s' %s", mapName, type), 1);
+            return 1;
+        } else if (dispatcherEvent instanceof CacheEventSet) {
+            // ICache event
+            CacheEventSet eventSet = (CacheEventSet) dispatcherEvent;
+            Set<CacheEventData> events = eventSet.getEvents();
+            for (CacheEventData event : events) {
+                occurrenceMap.add(format("ICache '%s' %s", event.getName(), event.getCacheEventType()), 1);
+            }
+            return events.size();
+        } else if (dispatcherEvent instanceof QueueEvent) {
+            // IQueue event
+            QueueEvent event = (QueueEvent) dispatcherEvent;
+            occurrenceMap.add(format("IQueue '%s' %s", event.getName(), event.getEventType()), 1);
+            return 1;
+        } else if (dispatcherEvent instanceof CollectionEvent) {
+            // ISet or IList event
+            CollectionEvent event = (CollectionEvent) dispatcherEvent;
+            String serviceName = eventDispatcher.getServiceName();
+            if (SetService.SERVICE_NAME.equals(serviceName)) {
+                serviceName = "ISet";
+            } else if (ListService.SERVICE_NAME.equals(serviceName)) {
+                serviceName = "IList";
+            }
+            occurrenceMap.add(format("%s '%s' %s", serviceName, event.getName(), event.getEventType()), 1);
+            return 1;
+        }
+        occurrenceMap.add(dispatcherEvent.getClass().getSimpleName(), 1);
+        return 1;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -32,6 +32,7 @@ import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
 import com.hazelcast.internal.diagnostics.OperationHeartbeatPlugin;
 import com.hazelcast.internal.diagnostics.OverloadedConnectionsPlugin;
+import com.hazelcast.internal.diagnostics.EventQueuePlugin;
 import com.hazelcast.internal.diagnostics.PendingInvocationsPlugin;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
@@ -247,6 +248,7 @@ public class NodeEngineImpl implements NodeEngine {
 
         // periodic loggers
         diagnostics.register(new OverloadedConnectionsPlugin(this));
+        diagnostics.register(new EventQueuePlugin(this, eventService.getEventExecutor()));
         diagnostics.register(new PendingInvocationsPlugin(this));
         diagnostics.register(new MetricsPlugin(this));
         diagnostics.register(new SlowOperationPlugin(this));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -322,6 +322,10 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
         }
     }
 
+    public StripedExecutor getEventExecutor() {
+        return eventExecutor;
+    }
+
     /**
      * Sends a {@link RegistrationOperation} to other cluster members to register the listener.
      * The method waits for {@value REGISTRATION_TIMEOUT_SECONDS} seconds before invoking the

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
@@ -30,15 +30,16 @@ import java.util.concurrent.TimeUnit;
  * @see EventPublishingService#dispatchEvent(Object, Object)
  */
 public final class LocalEventDispatcher implements StripedRunnable, TimeoutRunnable {
-    private EventServiceImpl eventService;
+
+    private final EventServiceImpl eventService;
     private final String serviceName;
     private final Object event;
     private final Object listener;
     private final int orderKey;
     private final long timeoutMs;
 
-    LocalEventDispatcher(EventServiceImpl eventService, String serviceName, Object event, Object listener,
-                         int orderKey, long timeoutMs) {
+    public LocalEventDispatcher(EventServiceImpl eventService, String serviceName, Object event, Object listener,
+                                int orderKey, long timeoutMs) {
         this.eventService = eventService;
         this.serviceName = serviceName;
         this.event = event;
@@ -66,5 +67,13 @@ public final class LocalEventDispatcher implements StripedRunnable, TimeoutRunna
     @Override
     public int getKey() {
         return orderKey;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public Object getEvent() {
+        return event;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -31,6 +31,7 @@ import static java.util.Collections.sort;
  * @param <T>
  */
 public final class ItemCounter<T> {
+
     private final Map<T, MutableLong> map = new HashMap<T, MutableLong>();
 
     /**
@@ -41,7 +42,6 @@ public final class ItemCounter<T> {
     public Set<T> keySet() {
         return map.keySet();
     }
-
 
     /**
      * Returns a List of keys in descending value order.
@@ -123,6 +123,13 @@ public final class ItemCounter<T> {
     }
 
     /**
+     * Clears the counter.
+     */
+    public void clear() {
+        map.clear();
+    }
+
+    /**
      * Set counter for item and return previous value
      *
      * @param item
@@ -157,11 +164,9 @@ public final class ItemCounter<T> {
         }
 
         ItemCounter that = (ItemCounter) o;
-
         if (!map.equals(that.map)) {
             return false;
         }
-
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
@@ -20,6 +20,8 @@ import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
@@ -87,8 +89,6 @@ public final class StripedExecutor implements Executor {
 
     /**
      * Returns the total number of processed events.
-     *
-     * @return
      */
     public long processedCount() {
         long size = 0;
@@ -100,9 +100,9 @@ public final class StripedExecutor implements Executor {
 
     /**
      * Shuts down this StripedExecutor.
-     * <p/>
+     * <p>
      * No checking is done to see if the StripedExecutor already is shut down, so it should be called only once.
-     * <p/>
+     * <p>
      * If there is any pending work, it will be thrown away.
      */
     public void shutdown() {
@@ -149,7 +149,15 @@ public final class StripedExecutor implements Executor {
         return workers[index];
     }
 
-    // used in tests.
+    public List<BlockingQueue<Runnable>> getWorkQueues() {
+        List<BlockingQueue<Runnable>> workQueues = new ArrayList<BlockingQueue<Runnable>>(workers.length);
+        for (Worker worker : workers) {
+            workQueues.add(worker.workQueue);
+        }
+        return workQueues;
+    }
+
+    // used in tests
     Worker[] getWorkers() {
         return workers;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
@@ -28,7 +28,7 @@ public class AbstractDiagnosticsPluginTest extends HazelcastTestSupport {
     private CharArrayWriter out;
 
     @Before
-    public void setupLogWriter() {
+    public final void setupLogWriter() {
         logWriter = new DiagnosticsLogWriterImpl();
         out = new CharArrayWriter();
         logWriter.init(new PrintWriter(out));

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheEventData;
+import com.hazelcast.cache.impl.CacheEventDataImpl;
+import com.hazelcast.cache.impl.CacheEventSet;
+import com.hazelcast.cache.impl.CacheEventType;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.collection.impl.collection.CollectionEvent;
+import com.hazelcast.collection.impl.list.ListService;
+import com.hazelcast.collection.impl.queue.QueueEvent;
+import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.collection.impl.set.SetService;
+import com.hazelcast.concurrent.atomiclong.AtomicLongService;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IList;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.ISet;
+import com.hazelcast.core.ItemEvent;
+import com.hazelcast.core.ItemEventType;
+import com.hazelcast.core.ItemListener;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.event.EntryEventData;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
+import com.hazelcast.spi.impl.eventservice.impl.LocalEventDispatcher;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.ItemCounter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.event.CacheEntryRemovedListener;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.core.EntryEventType.ADDED;
+import static com.hazelcast.core.EntryEventType.REMOVED;
+import static com.hazelcast.core.EntryEventType.UPDATED;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EventQueuePluginTest extends AbstractDiagnosticsPluginTest {
+
+    private static final int EVENT_COUNTER = 1000;
+
+    private static final String MAP_NAME = "myMap";
+    private static final String CACHE_NAME = "myCache";
+    private static final String QUEUE_NAME = "myQueue";
+    private static final String LIST_NAME = "myList";
+    private static final String SET_NAME = "mySet";
+
+    private final CountDownLatch listenerLatch = new CountDownLatch(1);
+
+    private HazelcastInstance hz;
+    private EventQueuePlugin plugin;
+    private ItemCounter<String> itemCounter;
+
+    @Before
+    public void setup() {
+        Config config = new Config()
+                .setProperty(EventQueuePlugin.PERIOD_SECONDS.getName(), "1")
+                .setProperty(EventQueuePlugin.SAMPLES.getName(), "100")
+                .setProperty(EventQueuePlugin.THRESHOLD.getName(), "10");
+
+        hz = createHazelcastInstance(config);
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        EventServiceImpl eventService = (EventServiceImpl) nodeEngine.getEventService();
+
+        plugin = new EventQueuePlugin(nodeEngine, eventService.getEventExecutor());
+        plugin.onStart();
+
+        itemCounter = plugin.getOccurrenceMap();
+
+        warmUpPartitions(hz);
+    }
+
+    @Test
+    public void testMap() {
+        final IMap<Integer, Integer> map = hz.getMap(MAP_NAME);
+        map.addLocalEntryListener(new EntryAddedListener<Integer, Integer>() {
+            @Override
+            public void entryAdded(EntryEvent<Integer, Integer> event) {
+                assertOpenEventually(listenerLatch);
+            }
+        });
+        map.addLocalEntryListener(new EntryRemovedListener() {
+            @Override
+            public void entryRemoved(EntryEvent event) {
+                assertOpenEventually(listenerLatch);
+            }
+        });
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                Random random = new Random();
+                for (int i = 0; i < EVENT_COUNTER; i++) {
+                    int key = random.nextInt(Integer.MAX_VALUE);
+                    map.putAsync(key, 23);
+                    map.removeAsync(key);
+                }
+            }
+        });
+
+        assertContainsEventually(
+                "IMap '" + MAP_NAME + "' ADDED sampleCount=",
+                "IMap '" + MAP_NAME + "' REMOVED sampleCount=");
+    }
+
+    @Test
+    public void testCache() {
+        CompleteConfiguration<Integer, Integer> cacheConfig = new MutableConfiguration<Integer, Integer>()
+                .addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration<Integer, Integer>(
+                        FactoryBuilder.factoryOf(new TestCacheListener()), null, true, true));
+
+        CachingProvider memberProvider = HazelcastServerCachingProvider.createCachingProvider(hz);
+        HazelcastServerCacheManager memberCacheManager = (HazelcastServerCacheManager) memberProvider.getCacheManager();
+        final ICache<Integer, Integer> cache = memberCacheManager.createCache(CACHE_NAME, cacheConfig);
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                Random random = new Random();
+                for (int i = 0; i < EVENT_COUNTER; i++) {
+                    int key = random.nextInt(Integer.MAX_VALUE);
+                    cache.putAsync(key, 23);
+                    cache.removeAsync(key);
+                }
+            }
+        });
+
+        assertContainsEventually(
+                "ICache '/hz/" + CACHE_NAME + "' CREATED sampleCount=",
+                "ICache '/hz/" + CACHE_NAME + "' REMOVED sampleCount=");
+    }
+
+    @Test
+    public void testQueue() {
+        final IQueue<Integer> queue = hz.getQueue(QUEUE_NAME);
+        queue.addItemListener(new TestItemListener(), true);
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                Random random = new Random();
+                for (int i = 0; i < EVENT_COUNTER; i++) {
+                    int key = random.nextInt(Integer.MAX_VALUE);
+                    queue.add(key);
+                    queue.poll();
+                }
+            }
+        });
+
+        assertContainsEventually(
+                "IQueue '" + QUEUE_NAME + "' ADDED sampleCount=",
+                "IQueue '" + QUEUE_NAME + "' REMOVED sampleCount=");
+    }
+
+    @Test
+    public void testList() {
+        final IList<Integer> list = hz.getList(LIST_NAME);
+        list.addItemListener(new TestItemListener(), true);
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                Random random = new Random();
+                for (int i = 0; i < EVENT_COUNTER; i++) {
+                    int key = random.nextInt(EVENT_COUNTER);
+                    list.add(key);
+                }
+            }
+        });
+
+        assertContainsEventually("IList '" + LIST_NAME + "' ADDED sampleCount=");
+    }
+
+    @Test
+    public void testSet() {
+        final ISet<Integer> set = hz.getSet(SET_NAME);
+        set.addItemListener(new TestItemListener(), true);
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                Random random = new Random();
+                for (int i = 0; i < EVENT_COUNTER; i++) {
+                    int key = random.nextInt(Integer.MAX_VALUE);
+                    set.add(key);
+                    set.remove(key);
+                }
+            }
+        });
+
+        assertContainsEventually(
+                "ISet '" + SET_NAME + "' ADDED sampleCount=",
+                "ISet '" + SET_NAME + "' REMOVED sampleCount=");
+    }
+
+    @Test
+    public void testSampleRunnable() {
+        Address caller = new Address();
+        Data data = mock(Data.class);
+
+        EntryEventData mapEventAdded = new EntryEventData("source", "mapName", caller, data, data, data, ADDED.getType());
+        EntryEventData mapEventUpdated = new EntryEventData("source", "mapName", caller, data, data, data, UPDATED.getType());
+        EntryEventData mapEventRemoved = new EntryEventData("source", "mapName", caller, data, data, data, REMOVED.getType());
+        assertSampleRunnable("IMap 'mapName' ADDED", mapEventAdded, MapService.SERVICE_NAME);
+        assertSampleRunnable("IMap 'mapName' UPDATED", mapEventUpdated, MapService.SERVICE_NAME);
+        assertSampleRunnable("IMap 'mapName' REMOVED", mapEventRemoved, MapService.SERVICE_NAME);
+
+        CacheEventData cacheEventCreated = new CacheEventDataImpl("cacheName", CacheEventType.CREATED, data, data, data, true);
+        CacheEventData cacheEventUpdated = new CacheEventDataImpl("cacheName", CacheEventType.UPDATED, data, data, data, true);
+        CacheEventData cacheEventRemoved = new CacheEventDataImpl("cacheName", CacheEventType.REMOVED, data, data, data, true);
+        CacheEventSet CacheEventSetCreated = new CacheEventSet(CacheEventType.CREATED, singleton(cacheEventCreated), 1);
+        CacheEventSet CacheEventSetUpdated = new CacheEventSet(CacheEventType.UPDATED, singleton(cacheEventUpdated), 1);
+        CacheEventSet cacheEventSetRemoved = new CacheEventSet(CacheEventType.REMOVED, singleton(cacheEventRemoved), 1);
+        assertSampleRunnable("ICache 'cacheName' CREATED", CacheEventSetCreated, CacheService.SERVICE_NAME);
+        assertSampleRunnable("ICache 'cacheName' UPDATED", CacheEventSetUpdated, CacheService.SERVICE_NAME);
+        assertSampleRunnable("ICache 'cacheName' REMOVED", cacheEventSetRemoved, CacheService.SERVICE_NAME);
+
+        List<CacheEventData> cacheEventData = asList(cacheEventCreated, cacheEventUpdated, cacheEventRemoved);
+        Set<CacheEventData> cacheEvents = new HashSet<CacheEventData>(cacheEventData);
+        CacheEventSet cacheEventSetAll = new CacheEventSet(CacheEventType.EXPIRED, cacheEvents, 1);
+        assertCacheEventSet(cacheEventSetAll,
+                "ICache 'cacheName' CREATED",
+                "ICache 'cacheName' UPDATED",
+                "ICache 'cacheName' REMOVED");
+
+        QueueEvent queueEventAdded = new QueueEvent("queueName", data, ItemEventType.ADDED, caller);
+        QueueEvent queueEventRemoved = new QueueEvent("queueName", data, ItemEventType.REMOVED, caller);
+        assertSampleRunnable("IQueue 'queueName' ADDED", queueEventAdded, QueueService.SERVICE_NAME);
+        assertSampleRunnable("IQueue 'queueName' REMOVED", queueEventRemoved, QueueService.SERVICE_NAME);
+
+        CollectionEvent setEventAdded = new CollectionEvent("setName", data, ItemEventType.ADDED, caller);
+        CollectionEvent setEventRemoved = new CollectionEvent("setName", data, ItemEventType.REMOVED, caller);
+        assertSampleRunnable("ISet 'setName' ADDED", setEventAdded, SetService.SERVICE_NAME);
+        assertSampleRunnable("ISet 'setName' REMOVED", setEventRemoved, SetService.SERVICE_NAME);
+
+        CollectionEvent listEventAdded = new CollectionEvent("listName", data, ItemEventType.ADDED, caller);
+        CollectionEvent listEventRemoved = new CollectionEvent("listName", data, ItemEventType.REMOVED, caller);
+        assertSampleRunnable("IList 'listName' ADDED", listEventAdded, ListService.SERVICE_NAME);
+        assertSampleRunnable("IList 'listName' REMOVED", listEventRemoved, ListService.SERVICE_NAME);
+
+        assertSampleRunnable("Object", new Object(), AtomicLongService.SERVICE_NAME);
+
+        assertSampleRunnable(new TestEvent(), TestEvent.class.getName());
+    }
+
+    private void assertContainsEventually(final String... messages) {
+        try {
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() throws Exception {
+                    plugin.run(logWriter);
+
+                    //System.out.println(getContent());
+
+                    for (String message : messages) {
+                        assertContains(message);
+                    }
+                }
+            });
+        } finally {
+            listenerLatch.countDown();
+        }
+    }
+
+    private void assertCacheEventSet(CacheEventSet cacheEventSet, String... expectedKeys) {
+        LocalEventDispatcher e = createLocalEventDispatcher(cacheEventSet, CacheService.SERVICE_NAME);
+        assertSampleRunnable(e, expectedKeys);
+    }
+
+    private void assertSampleRunnable(String expectedKey, Object event, String serviceName) {
+        assertSampleRunnable(createLocalEventDispatcher(event, serviceName), expectedKey);
+    }
+
+    private void assertSampleRunnable(Runnable runnable, String... expectedKeys) {
+        assertEqualsStringFormat("Expected to sample %d keys, but got %d", expectedKeys.length, plugin.sampleRunnable(runnable));
+        Set<String> actualKeys = itemCounter.keySet();
+        for (String expectedKey : expectedKeys) {
+            assertTrue("Expected to find key [" + expectedKey + "] in " + actualKeys, actualKeys.contains(expectedKey));
+        }
+
+        itemCounter.clear();
+    }
+
+    private LocalEventDispatcher createLocalEventDispatcher(Object event, String serviceName) {
+        EventServiceImpl eventService = mock(EventServiceImpl.class);
+        return new LocalEventDispatcher(eventService, serviceName, event, null, 1, 1);
+    }
+
+    private final class TestCacheListener
+            implements CacheEntryCreatedListener<Integer, Integer>, CacheEntryRemovedListener<Integer, Integer>, Serializable {
+
+        public TestCacheListener() {
+        }
+
+        @Override
+        public void onCreated(Iterable<CacheEntryEvent<? extends Integer, ? extends Integer>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+            assertOpenEventually(listenerLatch);
+        }
+
+        @Override
+        public void onRemoved(Iterable<CacheEntryEvent<? extends Integer, ? extends Integer>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+            assertOpenEventually(listenerLatch);
+        }
+    }
+
+    private final class TestItemListener implements ItemListener<Integer> {
+
+        @Override
+        public void itemAdded(ItemEvent<Integer> item) {
+            assertOpenEventually(listenerLatch);
+        }
+
+        @Override
+        public void itemRemoved(ItemEvent<Integer> item) {
+            assertOpenEventually(listenerLatch);
+        }
+    }
+
+    private static class TestEvent implements Runnable {
+
+        @Override
+        public void run() {
+        }
+    }
+}


### PR DESCRIPTION
We experienced a `WARNING: [10.0.0.87]:5701 [HZ] [3.9-SNAPSHOT] EventQueue overloaded! Failed to process event packet sent from: [10.0.0.174]:5701` issue, which is hard to debug without insight what is queuing up in the event system. The `EventQueuePlugin` samples the event queues to give more insight, what's going on.

Sample output for IMap events:
```
17-08-2017 17:36:37 EventQueues[
                          worker=1[
                                  eventCount=441
                                  sampleCount=100
                                  samples[
                                          IMap 'myMap' ADDED sampleCount=51 51.000%
                                          IMap 'myMap' REMOVED sampleCount=49 49.000%]]
                          worker=2[
                                  eventCount=405
                                  sampleCount=100
                                  samples[
                                          IMap 'myMap' ADDED sampleCount=41 41.000%
                                          IMap 'myMap' REMOVED sampleCount=59 59.000%]]
                          worker=3[
                                  eventCount=375
                                  sampleCount=100
                                  samples[
                                          IMap 'myMap' ADDED sampleCount=46 46.000%
                                          IMap 'myMap' REMOVED sampleCount=54 54.000%]]
                          worker=4[
                                  eventCount=385
                                  sampleCount=100
                                  samples[
                                          IMap 'myMap' ADDED sampleCount=55 55.000%
                                          IMap 'myMap' REMOVED sampleCount=45 45.000%]]
                          worker=5[
                                  eventCount=389
                                  sampleCount=100
                                  samples[
                                          IMap 'myMap' ADDED sampleCount=48 48.000%
                                          IMap 'myMap' REMOVED sampleCount=52 52.000%]]]
```

Sample output for ICache events:
```
17-08-2017 17:36:42 EventQueues[
                          worker=1[
                                  eventCount=1,999
                                  sampleCount=100
                                  samples[
                                          ICache '/hz/myCache' REMOVED sampleCount=47 47.000%
                                          ICache '/hz/myCache' CREATED sampleCount=53 53.000%]]]
```