### PR TITLE
Use inherited runner in MembershipFailureTest_withTCP

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest_withTCP.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest_withTCP.java
@@ -33,8 +33,7 @@ import java.util.Collection;
 
 import static com.hazelcast.instance.HazelcastInstanceFactory.createInstanceName;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category({SlowTest.class})
+@Category(SlowTest.class)
 public class MembershipFailureTest_withTCP extends MembershipFailureTest {
 
     @After

--- a/pom.xml
+++ b/pom.xml
@@ -974,6 +974,13 @@
                                 -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                                 -Dlog4j.skipJansi=true
                             </argLine>
+                            <includes>
+                                <include>**/**.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/jsr/**.java</exclude>
+                                <exclude>**/**IT.java</exclude>
+                            </excludes>
                             <groups>
                                 com.hazelcast.test.annotation.NightlyTest,
                                 com.hazelcast.test.annotation.SlowTest


### PR DESCRIPTION
Fixes #11119

Also the same file pattern when search for nightly tests as for quick test. I believe the `MembershipFailureTest_withTCP` was never executed on Jenkins due not ending with `-Test` suffix. That's why @Donnerbart discovered the NPE when running it locally. 