### PR TITLE
PartitionIteratingOperation forces unnecessary list conversion

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareFactoryAccessor.extractPartitionAware;
+import static com.hazelcast.util.CollectionUtil.toIntArray;
 
 /**
  * Executes an operation on a set of partitions.
@@ -85,8 +86,8 @@ final class InvokeOnPartitions {
         for (Map.Entry<Address, List<Integer>> mp : memberPartitions.entrySet()) {
             Address address = mp.getKey();
             List<Integer> partitions = mp.getValue();
-            PartitionIteratingOperation operation = new PartitionIteratingOperation(operationFactory, partitions);
-            Future future = operationService.createInvocationBuilder(serviceName, operation, address)
+            PartitionIteratingOperation op = new PartitionIteratingOperation(operationFactory, toIntArray(partitions));
+            Future future = operationService.createInvocationBuilder(serviceName, op, address)
                     .setTryCount(TRY_COUNT)
                     .setTryPauseMillis(TRY_PAUSE_MILLIS)
                     .invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -33,13 +33,11 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareFactoryAccessor.extractPartitionAware;
-import static com.hazelcast.util.CollectionUtil.toIntArray;
 
 /**
  * Executes Operations on one or more partitions.
@@ -69,9 +67,9 @@ public final class PartitionIteratingOperation extends Operation implements Iden
      * @param operationFactory operation factory to use
      * @param partitions       partitions to invoke on
      */
-    public PartitionIteratingOperation(OperationFactory operationFactory, List<Integer> partitions) {
+    public PartitionIteratingOperation(OperationFactory operationFactory, int[] partitions) {
         this.operationFactory = operationFactory;
-        this.partitions = toIntArray(partitions);
+        this.partitions = partitions;
     }
 
     public OperationFactory getOperationFactory() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
@@ -68,7 +68,7 @@ public class OperationDescriptorsTest extends HazelcastTestSupport {
 
     @Test
     public void testPartitionIteratingOperation() throws UnknownHostException {
-        PartitionIteratingOperation op = new PartitionIteratingOperation(new DummyOperationFactory(), new LinkedList<Integer>());
+        PartitionIteratingOperation op = new PartitionIteratingOperation(new DummyOperationFactory(), new int[0]);
         String result = toOperationDesc(op);
         assertEquals(format("PartitionIteratingOperation(%s)", DummyOperationFactory.class.getName()), result);
     }


### PR DESCRIPTION
even when an array is available.