### PR TITLE
Wait till the end of partition assignments

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheEventHandler;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -173,14 +174,9 @@ public class CacheGetInvalidationMetaDataOperation extends Operation implements 
     }
 
     private List<Integer> getOwnedPartitions() {
-        List<Integer> ownedPartitions = new ArrayList<Integer>();
         IPartitionService partitionService = getNodeEngine().getPartitionService();
-        for (int i = 0; i < partitionService.getPartitionCount(); i++) {
-            if (partitionService.isPartitionOwner(i)) {
-                ownedPartitions.add(i);
-            }
-        }
-        return ownedPartitions;
+        Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
+        return memberPartitionsMap.get(getNodeEngine().getThisAddress());
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -177,7 +178,8 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
 
     private List<Integer> getOwnedPartitions() {
         IPartitionService partitionService = getNodeEngine().getPartitionService();
-        return partitionService.getMemberPartitions(getNodeEngine().getThisAddress());
+        Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
+        return memberPartitionsMap.get(getNodeEngine().getThisAddress());
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator() {


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/11124

Otherwise returning some incomplete partition list can trigger stale read detector.