### PR TITLE
Fix TcpIpConnectionManager transfer test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnection_TransferStressTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-@Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10660")
 public class SelectNow_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressBaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_TransferStressTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-@Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10660")
 public class SelectWithSelectorFix_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressBaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnection_TransferStressTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-@Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10660")
 public class Select_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressBaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_TransferStressTest.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-@Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10660")
 public class Spinning_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressBaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressBaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressBaseTest.java
@@ -28,9 +28,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 public abstract class TcpIpConnection_TransferStressBaseTest extends TcpIpConnection_AbstractTest {
 
     // total running time for writer threads
-    private static final long WRITER_THREAD_RUNNING_TIME_IN_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+    private static final long WRITER_THREAD_RUNNING_TIME_IN_SECONDS = MINUTES.toSeconds(2);
     // maximum number of pending packets
     private static final int maxPendingPacketCount = 10000;
     // we create the payloads up front and select randomly from them. This is the number of payloads we are creating
@@ -222,7 +222,8 @@ public abstract class TcpIpConnection_TransferStressBaseTest extends TcpIpConnec
                 } else {
                     normalPackets++;
                 }
-                //  writeHandler.write(packet);
+
+                c.getChannel().write(packet);
 
                 long now = System.currentTimeMillis();
                 if (now > prev + 2000) {


### PR DESCRIPTION
fix #10660

The problem was that the packets were not written to the channel, so nothing
is received and hence the tests fails with a timeout.