### PR TITLE
Cache destroy test and fixes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -44,11 +44,14 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
 
 import javax.cache.CacheException;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.event.CacheEntryListener;
 import javax.cache.expiry.ExpiryPolicy;
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -136,12 +139,14 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
 
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
+    private final ConcurrentMap<String, Closeable> closeableListeners;
     private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
 
     AbstractClientInternalCacheProxy(CacheConfig<K, V> cacheConfig, ClientContext context) {
         super(cacheConfig, context);
         this.asyncListenerRegistrations = new ConcurrentHashMap<CacheEntryListenerConfiguration, String>();
         this.syncListenerRegistrations = new ConcurrentHashMap<CacheEntryListenerConfiguration, String>();
+        this.closeableListeners = new ConcurrentHashMap<String, Closeable>();
         this.syncLocks = new ConcurrentHashMap<Integer, CountDownLatch>();
     }
 
@@ -545,11 +550,16 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
     }
 
-    protected void addListenerLocally(String regId, CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+    protected void addListenerLocally(String regId, CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration,
+                                      CacheEventListenerAdaptor<K, V> adaptor) {
         if (cacheEntryListenerConfiguration.isSynchronous()) {
             syncListenerRegistrations.putIfAbsent(cacheEntryListenerConfiguration, regId);
         } else {
             asyncListenerRegistrations.putIfAbsent(cacheEntryListenerConfiguration, regId);
+        }
+        CacheEntryListener<K, V> entryListener = adaptor.getCacheEntryListener();
+        if (entryListener instanceof Closeable) {
+            closeableListeners.putIfAbsent(regId, (Closeable) entryListener);
         }
     }
 
@@ -560,7 +570,12 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         } else {
             regs = asyncListenerRegistrations;
         }
-        return regs.remove(cacheEntryListenerConfiguration);
+        String registrationId = regs.remove(cacheEntryListenerConfiguration);
+        if (registrationId != null) {
+            Closeable closeable = closeableListeners.remove(registrationId);
+            IOUtil.closeResource(closeable);
+        }
+        return registrationId;
     }
 
     protected String getListenerIdLocal(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
@@ -588,6 +603,9 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         syncListenerRegistrations.clear();
         asyncListenerRegistrations.clear();
         notifyAndClearSyncListenerLatches();
+        for (Closeable closeable : closeableListeners.values()) {
+            IOUtil.closeResource(closeable);
+        }
     }
 
     private void notifyAndClearSyncListenerLatches() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -397,7 +397,7 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V>
             if (addToConfig) {
                 cacheConfig.addCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
             }
-            addListenerLocally(regId, cacheEntryListenerConfiguration);
+            addListenerLocally(regId, cacheEntryListenerConfiguration, adaptor);
             if (addToConfig) {
                 updateCacheListenerConfigOnOtherNodes(cacheEntryListenerConfiguration, true);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl;
+
+import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.cache.impl.CacheCreateUseDestroyTest;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.After;
+import org.junit.Before;
+
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+
+public class ClientCacheCreateUseDestroyTest extends CacheCreateUseDestroyTest {
+
+    private TestHazelcastFactory factory;
+
+    @Override
+    @Before
+    public void setup() {
+        assumptions();
+        factory = new TestHazelcastFactory();
+        HazelcastInstance member = factory.newHazelcastInstance(getConfig());
+        CachingProvider provider = Caching.getCachingProvider();
+        defaultCacheManager = provider.getCacheManager(null, null,
+                HazelcastCachingProvider.propertiesByInstanceItself(factory.newHazelcastClient()));
+        cacheService = getNode(member).getNodeEngine().getService(ICacheService.SERVICE_NAME);
+        CacheEntryListenerFactory.listener = null;
+    }
+
+    @After
+    public void cleanup() {
+        if (factory != null) {
+            factory.terminateAll();
+        }
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -571,7 +571,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         cacheResources.add(resource);
     }
 
-    private void deleteCacheResources(String name) {
+    protected void deleteCacheResources(String name) {
         Set<Closeable> cacheResources;
         ContextMutexFactory.Mutex mutex = cacheResourcesMutexFactory.mutexFor(name);
         try {

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheCreateUseDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheCreateUseDestroyTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.cache.CacheUtil;
+import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.CacheSimpleEntryListenerConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NativeMemoryConfig;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.memory.MemorySize;
+import com.hazelcast.memory.MemoryUnit;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.Factory;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.spi.CachingProvider;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class})
+public class CacheCreateUseDestroyTest extends HazelcastTestSupport {
+
+    public static final MemorySize NATIVE_MEMORY_SIZE = new MemorySize(32, MemoryUnit.MEGABYTES);
+
+    @Parameters(name = "{0}")
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{OBJECT},
+                new Object[]{BINARY},
+                new Object[]{NATIVE}
+        );
+    }
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    protected CacheManager defaultCacheManager;
+    protected Cache<String, String> cache;
+    protected ICacheService cacheService;
+
+    @Before
+    public void setup() {
+        assumptions();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        HazelcastInstance member = factory.newHazelcastInstance(getConfig());
+        CachingProvider provider = Caching.getCachingProvider();
+        defaultCacheManager = provider.getCacheManager(null, null,
+                HazelcastCachingProvider.propertiesByInstanceItself(member));
+        cacheService = getNode(member).getNodeEngine().getService(ICacheService.SERVICE_NAME);
+        CacheEntryListenerFactory.listener = null;
+    }
+
+    protected void assumptions() {
+        Assume.assumeThat(inMemoryFormat, not(NATIVE));
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        CacheSimpleEntryListenerConfig entryListenerConfig = new CacheSimpleEntryListenerConfig();
+        entryListenerConfig.setCacheEntryListenerFactory("com.hazelcast.cache.impl.CacheCreateUseDestroyTest$CacheEntryListenerFactory");
+        entryListenerConfig.setOldValueRequired(true);
+        entryListenerConfig.setSynchronous(true);
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
+                .setName("cache*")
+                .setInMemoryFormat(inMemoryFormat)
+                .setStatisticsEnabled(true)
+                .setManagementEnabled(true)
+                .setCacheEntryListeners(Collections.singletonList(entryListenerConfig));
+        if (inMemoryFormat == NATIVE) {
+            EvictionConfig evictionConfig = new EvictionConfig(90, USED_NATIVE_MEMORY_PERCENTAGE, EvictionPolicy.LFU);
+            cacheSimpleConfig.setEvictionConfig(evictionConfig);
+
+            NativeMemoryConfig memoryConfig = new NativeMemoryConfig();
+            memoryConfig.setEnabled(true);
+            memoryConfig.setSize(NATIVE_MEMORY_SIZE);
+            memoryConfig.setAllocatorType(NativeMemoryConfig.MemoryAllocatorType.STANDARD);
+            config.setNativeMemoryConfig(memoryConfig);
+        }
+
+        config.addCacheConfig(cacheSimpleConfig);
+        return config;
+    }
+
+    @Test
+    public void testCache_whenDestroyedByCacheManager() {
+        String cacheName = randomMapName("cache");
+        cache = defaultCacheManager.getCache(cacheName);
+        cache.put("key", "value");
+        cache.get("key");
+        assertCreatedCache(cacheName);
+
+        defaultCacheManager.destroyCache(cacheName);
+        assertDestroyedCache(cacheName);
+    }
+
+    @Test
+    public void testCache_whenDestroyedByICache_destroy() {
+        String cacheName = randomMapName("cache");
+        cache = defaultCacheManager.getCache(cacheName);
+        DistributedObject internalCacheProxy = cache.unwrap(DistributedObject.class);
+        cache.put("key", "value");
+        cache.get("key");
+        assertCreatedCache(cacheName);
+
+        internalCacheProxy.destroy();
+        assertDestroyedCache(cacheName);
+    }
+
+    private void assertCreatedCache(String cacheName) {
+        assertStatistics(1);
+        assertListenerCount(1, cacheName);
+        assertMXBeanRegistrationStatus(true, cacheName, false);
+        assertMXBeanRegistrationStatus(true, cacheName, true);
+    }
+
+    private void assertDestroyedCache(String cacheName) {
+        assertStatistics(0);
+        assertListenerCount(0, cacheName);
+        assertTrue("CacheEntryListener was not properly closed", CacheEntryListenerFactory.listener.closed);
+        assertMXBeanRegistrationStatus(false, cacheName, false);
+        assertMXBeanRegistrationStatus(false, cacheName, true);
+    }
+
+    private void assertListenerCount(int expected, String cacheName) {
+        String fullyQualifiedCacheName = CacheUtil.getDistributedObjectName(cacheName);
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(fullyQualifiedCacheName);
+        assertEquals("Unexpected listener count", expected, cacheContext.getCacheEntryListenerCount());
+    }
+
+    private void assertStatistics(int expectedHits) {
+        ICache iCache = cache.unwrap(ICache.class);
+        assertEquals("Unexpected cache hits count", expectedHits, iCache.getLocalCacheStatistics().getCacheHits());
+    }
+
+    private void assertMXBeanRegistrationStatus(boolean expectedStatus, String cacheName, boolean forStats) {
+        CacheConfig cacheConfig = cacheService.findCacheConfig(cacheName);
+        String cacheManagerName = cacheConfig.getUriString();
+        assertEquals(format("Unexpected MXBean registration status for cacheManager %s and cacheName %s", cacheManagerName,
+                cacheName), expectedStatus, MXBeanUtil.isRegistered(cacheManagerName, cacheName, forStats));
+    }
+
+    public static class CacheEntryListener implements CacheEntryCreatedListener<String, String>,
+                                                      Serializable, Closeable {
+        volatile boolean closed;
+
+        @Override
+        public void onCreated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+    }
+
+    public static class CacheEntryListenerFactory implements Factory<CacheEntryListener> {
+
+        public static volatile CacheEntryListener listener;
+
+        @Override
+        public CacheEntryListener create() {
+            listener = new CacheEntryListener();
+            return listener;
+        }
+
+    }
+}


### PR DESCRIPTION
* Introduces a create-use-destroy test that asserts listeners are derigestered, `Closeable` listener is `close`d, stats are cleaned up and Statistics & Configuration MX beans are unregistered once a `Cache` is destroyed
* Fixes client-side `Closeable` listeners to be actually `close`d when `Cache` is destroyed

Partial fix for https://github.com/hazelcast/hazelcast-enterprise/issues/1620