### PR TITLE
Avoid NullPointerException in HazelcastStarter

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java
@@ -81,7 +81,8 @@ public class HazelcastStarter {
      * @return               a {@link HazelcastInstance} proxying the started Hazelcast instance.
      */
     public static HazelcastInstance newHazelcastInstance(String version, Config configTemplate, boolean enterprise) {
-        HazelcastAPIDelegatingClassloader versionClassLoader = getTargetVersionClassloader(version, enterprise, configTemplate.getClassLoader());
+        HazelcastAPIDelegatingClassloader versionClassLoader = getTargetVersionClassloader(version, enterprise,
+                configTemplate == null ? null : configTemplate.getClassLoader());
 
         ClassLoader contextClassLoader = currentThread().getContextClassLoader();
         currentThread().setContextClassLoader(null);


### PR DESCRIPTION
Fixes a `NullPointerException` since `configTemplate` argument [can be `null`](https://github.com/vbekiaris/hazelcast/blob/48757e9b297bea947a1168d33a173f77caf29747/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java#L78)