### PR TITLE
The client should not use localhost if it is not explicitly configured and the discovery is configured

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -208,9 +208,6 @@ public class ClientNetworkConfig {
      * @return list of addresses
      */
     public List<String> getAddresses() {
-        if (addressList.size() == 0) {
-            addAddress("localhost");
-        }
         return addressList;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -288,7 +288,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         final ClientAwsConfig awsConfig = networkConfig.getAwsConfig();
         Collection<AddressProvider> addressProviders = new LinkedList<AddressProvider>();
 
-        addressProviders.add(new DefaultAddressProvider(networkConfig));
         if (externalAddressProvider != null) {
             addressProviders.add(externalAddressProvider);
         }
@@ -306,6 +305,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                 throw e;
             }
         }
+
+        addressProviders.add(new DefaultAddressProvider(networkConfig, addressProviders.isEmpty()));
         return addressProviders;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -33,14 +33,19 @@ import java.util.List;
 public class DefaultAddressProvider implements AddressProvider {
 
     private ClientNetworkConfig networkConfig;
+    private boolean noOtherAddressProviderExist;
 
-    public DefaultAddressProvider(ClientNetworkConfig networkConfig) {
+    public DefaultAddressProvider(ClientNetworkConfig networkConfig, boolean noOtherAddressProviderExist) {
         this.networkConfig = networkConfig;
+        this.noOtherAddressProviderExist = noOtherAddressProviderExist;
     }
 
     @Override
     public Collection<InetSocketAddress> loadAddresses() {
         final List<String> addresses = networkConfig.getAddresses();
+        if (addresses.isEmpty() && noOtherAddressProviderExist) {
+            addresses.add("localhost");
+        }
         final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
 
         for (String address : addresses) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -84,9 +84,10 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         String illegalAddress = randomString();
 
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        Address serverAddress = server.getCluster().getLocalMember().getAddress();
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
-        config.getNetworkConfig().addAddress(illegalAddress).addAddress("localhost");
+        config.getNetworkConfig().addAddress(illegalAddress).addAddress(serverAddress.getHost() + ":" + serverAddress.getPort());
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
 
         Collection<Client> connectedClients = server.getClientService().getConnectedClients();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -17,16 +17,19 @@
 package com.hazelcast.client.test;
 
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.impl.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
@@ -84,9 +87,18 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     }
 
     private AddressProvider createAddressProvider(ClientConfig config) {
+        boolean discoveryEnabled = new HazelcastProperties(config.getProperties())
+                .getBoolean(ClientProperty.DISCOVERY_SPI_ENABLED);
+
+        ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
+
         List<String> userConfiguredAddresses = config.getNetworkConfig().getAddresses();
-        if (!userConfiguredAddresses.contains("localhost")) {
-            // addresses are set explicitly, don't add more addresses
+
+        boolean isAtLeastAProviderConfigured =
+                discoveryEnabled || (awsConfig != null ? awsConfig.isEnabled() : false) || !userConfiguredAddresses.isEmpty();
+
+        if (isAtLeastAProviderConfigured) {
+            // address providers or addresses are configured explicitly, don't add more addresses
             return null;
         }
 

--- a/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
@@ -23,10 +23,6 @@
 
 <network>
     <connection-attempt-limit>9999</connection-attempt-limit>
-    <cluster-members>
-        <address>8.8.8.8</address>
-        <address>localhost</address>
-    </cluster-members>
 </network>
     <listeners>
         <listener>com.hazelcast.client.connectionstrategy.ConfiguredBehaviourTestXmlConfig$AsyncStartListener</listener>

--- a/hazelcast-client/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.9.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <properties>
+        <property name="hazelcast.discovery.enabled">true</property>
+    </properties>
+
+    <network>
+        <aws enabled="false"/>
+        <connection-timeout>5000</connection-timeout>
+        <connection-attempt-period>500</connection-attempt-period>
+        <connection-attempt-limit>1</connection-attempt-limit>
+        <smart-routing>true</smart-routing>
+        <redo-operation>true</redo-operation>
+        <discovery-strategies>
+            <discovery-strategy class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy" enabled="true">
+                <properties>
+                    <property name="port">9999</property>
+                    <property name="group">230.18.0.255</property>
+                </properties>
+            </discovery-strategy>
+        </discovery-strategies>
+    </network>
+
+</hazelcast-client>


### PR DESCRIPTION
The client now adds the localhost to the address list very selectively if only no other provider is configured (inlcuding aws and discovery strategy config), and no member tcp/ip address is added in the config.

ClientDiscoveryTest is added to test the test factory. The real network test is at ClientDiscoverySpiTest.

fixes #10606