### PR TITLE
Fixed NPE in MapGetInvalidationMetaDataOperation if no partitions owned

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.partition.IPartitionService;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,6 +148,23 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
         }
     }
 
+    private List<Integer> getOwnedPartitions() {
+        IPartitionService partitionService = getNodeEngine().getPartitionService();
+        Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
+        List<Integer> ownedPartitions = memberPartitionsMap.get(getNodeEngine().getThisAddress());
+        return ownedPartitions == null ? Collections.<Integer>emptyList() : ownedPartitions;
+    }
+
+    private Map<Integer, UUID> getPartitionUuidList(List<Integer> ownedPartitionIds) {
+        MetaDataGenerator metaDataGenerator = getPartitionMetaDataGenerator();
+        Map<Integer, UUID> partitionUuids = createHashMap(ownedPartitionIds.size());
+        for (Integer partitionId : ownedPartitionIds) {
+            UUID uuid = metaDataGenerator.getOrCreateUuid(partitionId);
+            partitionUuids.put(partitionId, uuid);
+        }
+        return partitionUuids;
+    }
+
     private Map<String, List<Map.Entry<Integer, Long>>> getNamePartitionSequenceList(List<Integer> ownedPartitionIds) {
         MetaDataGenerator metaDataGenerator = getPartitionMetaDataGenerator();
         Map<String, List<Map.Entry<Integer, Long>>> sequences = new HashMap<String, List<Map.Entry<Integer, Long>>>(
@@ -163,23 +181,6 @@ public class MapGetInvalidationMetaDataOperation extends Operation implements Id
             sequences.put(name, mapSequences);
         }
         return sequences;
-    }
-
-    private Map<Integer, UUID> getPartitionUuidList(List<Integer> ownedPartitionIds) {
-        MetaDataGenerator metaDataGenerator = getPartitionMetaDataGenerator();
-
-        Map<Integer, UUID> partitionUuids = createHashMap(ownedPartitionIds.size());
-        for (Integer partitionId : ownedPartitionIds) {
-            UUID uuid = metaDataGenerator.getOrCreateUuid(partitionId);
-            partitionUuids.put(partitionId, uuid);
-        }
-        return partitionUuids;
-    }
-
-    private List<Integer> getOwnedPartitions() {
-        IPartitionService partitionService = getNodeEngine().getPartitionService();
-        Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
-        return memberPartitionsMap.get(getNodeEngine().getThisAddress());
     }
 
     private MetaDataGenerator getPartitionMetaDataGenerator() {


### PR DESCRIPTION
I think it's a valid assumption that a node might not have owned partitions
* before migrations are completed
* if there are less partitions than members (test scenarios)

Partial forward port of https://github.com/hazelcast/hazelcast/pull/11200
Fixes https://github.com/hazelcast/hazelcast/issues/11147