### PR TITLE
Minimal cleanup of ByteArrayObjectDataInput and parent classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -36,17 +36,12 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
     byte[] data;
-
     int size;
-
     int pos;
-
     int mark;
-
-    final InternalSerializationService service;
-
     char[] charBuffer;
 
+    private final InternalSerializationService service;
     private final boolean bigEndian;
 
     ByteArrayObjectDataInput(byte[] data, InternalSerializationService service, ByteOrder byteOrder) {
@@ -56,8 +51,8 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     ByteArrayObjectDataInput(byte[] data, int offset, InternalSerializationService service, ByteOrder byteOrder) {
         this.data = data;
         this.size = data != null ? data.length : 0;
-        this.service = service;
         this.pos = offset;
+        this.service = service;
         this.bigEndian = byteOrder == ByteOrder.BIG_ENDIAN;
     }
 
@@ -71,8 +66,8 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     @Override
     public void clear() {
         this.data = null;
-        this.pos = 0;
         this.size = 0;
+        this.pos = 0;
         this.mark = 0;
         if (charBuffer != null && charBuffer.length > UTF_BUFFER_SIZE * 8) {
             this.charBuffer = new char[UTF_BUFFER_SIZE * 8];
@@ -128,15 +123,14 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readByte</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readByte} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
      * @return the next byte of this input stream as a signed 8-bit
-     * <code>byte</code>.
-     * @throws java.io.EOFException if this input stream has reached the end.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * {@code byte}.
+     * @throws java.io.EOFException if this input stream has reached the end
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -158,15 +152,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readChar</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readChar} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next two bytes of this input stream as a Unicode character.
-     * @throws java.io.EOFException if this input stream reaches the end before reading two
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next two bytes of this input stream as a Unicode character
+     * @throws java.io.EOFException if this input stream reaches the end before reading two bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -183,16 +175,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readDouble</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readDouble} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next eight bytes of this input stream, interpreted as a
-     * <code>double</code>.
-     * @throws java.io.EOFException if this input stream reaches the end before reading eight
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next eight bytes of this input stream, interpreted as a {@code double}
+     * @throws java.io.EOFException if this input stream reaches the end before reading eight bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.DataInputStream#readLong()
      * @see Double#longBitsToDouble(long)
      */
@@ -217,16 +206,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readFloat</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readFloat} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next four bytes of this input stream, interpreted as a
-     * <code>float</code>.
-     * @throws java.io.EOFException if this input stream reaches the end before reading four
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next four bytes of this input stream, interpreted as a {@code float}
+     * @throws java.io.EOFException if this input stream reaches the end before reading four bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.DataInputStream#readInt()
      * @see Float#intBitsToFloat(int)
      */
@@ -265,16 +251,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readInt</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readInt} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next four bytes of this input stream, interpreted as an
-     * <code>int</code>.
-     * @throws java.io.EOFException if this input stream reaches the end before reading four
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next four bytes of this input stream, interpreted as an {@code int}
+     * @throws java.io.EOFException if this input stream reaches the end before reading four bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -308,16 +291,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readLong</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readLong} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next eight bytes of this input stream, interpreted as a
-     * <code>long</code>.
-     * @throws java.io.EOFException if this input stream reaches the end before reading eight
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next eight bytes of this input stream, interpreted as a {@code long}
+     * @throws java.io.EOFException if this input stream reaches the end before reading eight bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -346,16 +326,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readShort</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readShort} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next two bytes of this input stream, interpreted as a signed
-     * 16-bit number.
-     * @throws java.io.EOFException if this input stream reaches the end before reading two
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next two bytes of this input stream, interpreted as a signed 16-bit number
+     * @throws java.io.EOFException if this input stream reaches the end before reading two bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -527,15 +504,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readUnsignedByte</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readUnsignedByte} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next byte of this input stream, interpreted as an unsigned
-     * 8-bit number.
-     * @throws java.io.EOFException if this input stream has reached the end.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next byte of this input stream, interpreted as an unsigned 8-bit number
+     * @throws java.io.EOFException if this input stream has reached the end
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -544,16 +519,13 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readUnsignedShort</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readUnsignedShort} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
-     * @return the next two bytes of this input stream, interpreted as an
-     * unsigned 16-bit integer.
-     * @throws java.io.EOFException if this input stream reaches the end before reading two
-     *                              bytes.
-     * @throws java.io.IOException  if an I/O error occurs.
+     * @return the next two bytes of this input stream, interpreted as an unsigned 16-bit integer
+     * @throws java.io.EOFException if this input stream reaches the end before reading two bytes
+     * @throws java.io.IOException  if an I/O error occurs
      * @see java.io.FilterInputStream#in
      */
     @Override
@@ -562,17 +534,14 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
     }
 
     /**
-     * See the general contract of the <code>readUTF</code> method of
-     * <code>DataInput</code>.
-     * <p/>
+     * See the general contract of the {@code readUTF} method of {@code DataInput}.
+     * <p>
      * Bytes for this operation are read from the contained input stream.
      *
      * @return a Unicode string.
-     * @throws java.io.EOFException           if this input stream reaches the end before reading all
-     *                                        the bytes.
-     * @throws java.io.IOException            if an I/O error occurs.
-     * @throws java.io.UTFDataFormatException if the bytes do not represent a valid modified UTF-8
-     *                                        encoding of a string.
+     * @throws java.io.EOFException           if this input stream reaches the end before reading all the bytes
+     * @throws java.io.IOException            if an I/O error occurs
+     * @throws java.io.UTFDataFormatException if the bytes do not represent a valid modified UTF-8 encoding of a string
      * @see java.io.DataInputStream#readUTF(java.io.DataInput)
      */
     @Override
@@ -609,7 +578,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
 
     @Override
     public <T> T readDataAsObject() throws IOException {
-        // a future optimization would be to skip the construction of the Data object.
+        // a future optimization would be to skip the construction of the Data object
         Data data = readData();
         return data == null ? null : (T) service.toObject(data);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInput.java
@@ -17,17 +17,17 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.VersionAware;
 import com.hazelcast.version.Version;
 
 import java.io.InputStream;
 
 /**
  * Base class for ObjectDataInput that is VersionAware and allows mutating the version.
+ * <p>
  * What the version means it's up to the Serializer/Deserializer.
  * If the serializer supports versioning it may set the version to use for the serialization on this object.
  */
-abstract class VersionedObjectDataInput extends InputStream implements ObjectDataInput, VersionAware {
+abstract class VersionedObjectDataInput extends InputStream implements ObjectDataInput {
 
     protected Version version = Version.UNKNOWN;
 
@@ -42,13 +42,13 @@ abstract class VersionedObjectDataInput extends InputStream implements ObjectDat
 
     /**
      * If the serializer supports versioning it may set the version to use for the serialization on this object.
+     * <p>
      * This method makes the version available for the user.
      *
-     * @return the version of Version.UNKNOWN if the version is unknown to the object.
+     * @return the version of {@code Version.UNKNOWN} if the version is unknown to the object
      */
     @Override
     public Version getVersion() {
         return version;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 
 /**
- * Provides serialization methods for arrays of primitive types
+ * Provides serialization methods for arrays of primitive types.
  */
 public interface ObjectDataInput extends DataInput, VersionAware {
 
@@ -82,7 +82,7 @@ public interface ObjectDataInput extends DataInput, VersionAware {
     String[] readUTFArray() throws IOException;
 
     /**
-     * @param <T> type of the object in array to be read
+     * @param <T> type of the object to be read
      * @return object array read
      * @throws IOException if it reaches end of file before finish reading
      */
@@ -90,20 +90,20 @@ public interface ObjectDataInput extends DataInput, VersionAware {
 
     /**
      * Reads to stored Data as an object instead of a Data instance.
-     *
-     * The reason this method exists is that in some cases 'Data' is stored on serialization, but on deserialization the
-     * actual object instance is needed. Getting access to the Data is easy by calling the {@link #readData()} method. But
-     * deserializing the Data to an object instance is impossible because there is no reference to the
+     * <p>
+     * The reason this method exists is that in some cases {@link Data} is stored on serialization, but on deserialization
+     * the actual object instance is needed. Getting access to the {@link Data} is easy by calling the {@link #readData()}
+     * method. But de-serializing the {@link Data} to an object instance is impossible because there is no reference to the
      * {@link com.hazelcast.spi.serialization.SerializationService}.
      *
-     * @param <T>
+     * @param <T> type of the object to be read
      * @return the read Object
      * @throws IOException if it reaches end of file before finish reading
      */
     <T> T readDataAsObject() throws IOException;
 
     /**
-     * @param <T> type of the object in array to be read
+     * @param <T>    type of the object to be read
      * @param aClass the type of the class to use when reading
      * @return object array read
      * @throws IOException if it reaches end of file before finish reading
@@ -117,7 +117,7 @@ public interface ObjectDataInput extends DataInput, VersionAware {
     Data readData() throws IOException;
 
     /**
-     * Returns class loader that internally used for objects
+     * Returns class loader that internally used for objects.
      *
      * @return classLoader
      */
@@ -127,5 +127,4 @@ public interface ObjectDataInput extends DataInput, VersionAware {
      * @return ByteOrder BIG_ENDIAN or LITTLE_ENDIAN
      */
     ByteOrder getByteOrder();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/VersionAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/VersionAware.java
@@ -20,15 +20,15 @@ import com.hazelcast.version.Version;
 
 /**
  * Enables getting the version from the implementing object.
- * It may be any Version (cluster version, node version, custom version, etc.) It's up to the implementer.
+ * <p>
+ * It may be any version (cluster version, node version, custom version, etc.), that is up to the implementer.
  *
  * @since 3.8
  */
 public interface VersionAware {
 
     /**
-     * @return the version or Version.UNKNOWN if version is unknown to the object.
+     * @return the version or {@code Version.UNKNOWN} if version is unknown to the object
      */
     Version getVersion();
-
 }


### PR DESCRIPTION
* fixed JavaDoc of `ByteArrayObjectDataInput` and dependent classes
* fixed field order in `ByteArrayObjectDataInput`
* removed redundant implements `VersionAware` in `VersionedObjectDataInput`
* made service field private (checked with EE, it can be private)