### PR TITLE
Fixed invalidation race in Near Cache serialization count tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -34,6 +34,7 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -159,23 +160,43 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
 
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
-        Config config = getConfig();
+        Config config = getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
+                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)
                 .setBackupCount(0)
                 .setAsyncBackupCount(0);
         prepareSerializationConfig(config.getSerializationConfig());
 
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheTestContextBuilder<K, V, Data, String> contextBuilder = createNearCacheContextBuilder();
+        return contextBuilder
+                .setDataInstance(member)
+                .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
+                .build();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createNearCacheContext() {
+        NearCacheTestContextBuilder<K, V, Data, String> contextBuilder = createNearCacheContextBuilder();
+        return contextBuilder.build();
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
         ClientConfig clientConfig = getClientConfig();
         if (nearCacheConfig != null) {
             clientConfig.addNearCacheConfig(nearCacheConfig);
         }
         prepareSerializationConfig(clientConfig.getSerializationConfig());
 
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
         HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
-
-        IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
         IMap<K, V> clientMap = client.getMap(DEFAULT_NEAR_CACHE_NAME);
 
         NearCacheManager nearCacheManager = client.client.getNearCacheManager();
@@ -183,15 +204,8 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
 
         return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
                 .setNearCacheInstance(client)
-                .setDataInstance(member)
                 .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(clientMap))
-                .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
                 .setNearCache(nearCache)
-                .setNearCacheManager(nearCacheManager)
-                .build();
-    }
-
-    protected ClientConfig getClientConfig() {
-        return new ClientConfig();
+                .setNearCacheManager(nearCacheManager);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -189,6 +189,16 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
     }
 
     /**
+     * Checks if the {@link NearCacheConfig#isInvalidateOnChange()} of a {@link NearCacheConfig} is {@code true}.
+     *
+     * @param nearCacheConfig the {@link NearCacheConfig} to check
+     * @return {@code true} if the {@code LocalUpdatePolicy} is {@code CACHE_ON_UPDATE}, {@code false} otherwise
+     */
+    static boolean isInvalidateOnChange(NearCacheConfig nearCacheConfig) {
+        return nearCacheConfig != null && nearCacheConfig.isInvalidateOnChange();
+    }
+
+    /**
      * Checks if the given {@link DataStructureAdapter} implements a specified {@link DataStructureMethods}.
      *
      * @param adapter the {@link DataStructureAdapter} to test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -139,30 +140,25 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
 
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
-        Config configWithNearCache = getConfig(true);
-        Config config = getConfig(false);
+        HazelcastInstance dataMember = hazelcastFactory.newHazelcastInstance(getConfig(false));
 
-        HazelcastInstance nearCacheMember = hazelcastFactory.newHazelcastInstance(configWithNearCache);
-        HazelcastInstance dataMember = hazelcastFactory.newHazelcastInstance(config);
-
-        // this creates the Near Cache instance
-        nearCacheMember.getMap(DEFAULT_NEAR_CACHE_NAME);
-
-        NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheMember);
-        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
-
-        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(nearCacheMember))
-                .setNearCacheInstance(nearCacheMember)
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder
                 .setDataInstance(dataMember)
-                .setNearCacheAdapter(new TransactionalMapDataStructureAdapter<K, V>(nearCacheMember, DEFAULT_NEAR_CACHE_NAME))
                 .setDataAdapter(new TransactionalMapDataStructureAdapter<K, V>(dataMember, DEFAULT_NEAR_CACHE_NAME))
-                .setNearCache(nearCache)
-                .setNearCacheManager(nearCacheManager)
                 .build();
     }
 
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createNearCacheContext() {
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder.build();
+    }
+
     private Config getConfig(boolean withNearCache) {
-        Config config = getConfig();
+        Config config = getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
+                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)
                 .setBackupCount(0)
@@ -172,5 +168,20 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
         }
         prepareSerializationConfig(config.getSerializationConfig());
         return config;
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
+        HazelcastInstance nearCacheMember = hazelcastFactory.newHazelcastInstance(getConfig(true));
+        // this creates the Near Cache instance
+        nearCacheMember.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheMember);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(nearCacheMember))
+                .setNearCacheInstance(nearCacheMember)
+                .setNearCacheAdapter(new TransactionalMapDataStructureAdapter<K, V>(nearCacheMember, DEFAULT_NEAR_CACHE_NAME))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager);
     }
 }


### PR DESCRIPTION
The fix is the same like in the other unified tests: Create the Near Cache instance after the initial population, to have a race-free setup. The difference to the other Near Cache test setups is, that we do the initial population on a Near Cache instance as well (since we want to measure the (de)serialization counts of `put()` and `putAll()` operations).

So `createNearCacheContext()` creates two instances (the data instance and the Near Cache instance) and `createNearCacheContext()` creates a Near Cache instance. In total we will have up to 3 running instances per test, but just when invalidations are configured (optimization to speed up the test).

This requires some more changes, since we cannot have partition migrations on a members-only test (this would introduce additional (de)serializations, which we don't want to measure). So we e.g. set the partition count to 1, so the first node being created will be and stay the partition owner etc.

Depends on a fix of https://github.com/hazelcast/hazelcast/issues/11147

Fixes https://github.com/hazelcast/hazelcast/issues/10970