### PR TITLE
Fix AbstractChannel.close forwarding to reader/writer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -115,6 +115,14 @@ public abstract class AbstractChannel implements Channel {
             return;
         }
 
+        // we execute this in its own try/catch block because we don't want to skip closing the socketChannel in case
+        // of problems.
+        try {
+            onClose();
+        } catch (Exception e) {
+            getLogger().severe(format("Failed to call 'onClose' on channel [%s]", this), e);
+        }
+
         try {
             socketChannel.close();
         } finally {
@@ -124,11 +132,23 @@ public abstract class AbstractChannel implements Channel {
                 try {
                     closeListener.onClose(this);
                 } catch (Exception e) {
-                    ILogger logger = Logger.getLogger(getClass());
-                    logger.severe(format("Failed to process closeListener [%s] on channel [%s]", closeListener, this), e);
+                    getLogger().severe(format("Failed to process closeListener [%s] on channel [%s]", closeListener, this), e);
                 }
             }
         }
+    }
+
+    private ILogger getLogger() {
+        return Logger.getLogger(getClass());
+    }
+
+    /**
+     * Template method that is called when the socket channel closed. It is called before the <code>socketChannel</code> is
+     * closed.
+     *
+     * It will be called only once.
+     */
+    protected void onClose() throws IOException {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -75,6 +75,12 @@ public class NioChannel extends AbstractChannel {
     }
 
     @Override
+    protected void onClose() {
+        reader.close();
+        writer.close();
+    }
+
+    @Override
     public String toString() {
         return "NioChannel{" + getLocalSocketAddress() + "->" + getRemoteSocketAddress() + '}';
     }


### PR DESCRIPTION
A bug was introduced by me in the 3.9 io changes where the forwarding of
the close to the underlying channel reader/writer is skipped.

This pr restores these closes by adding a template method to the AbstractChannel
which is implemented by the NioChannel.