### PR TITLE
Fixes testOperationTimeoutForLongRunningRemoteOperation

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -190,7 +190,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
 
     @Test
     public void testOperationTimeoutForLongRunningRemoteOperation() throws Exception {
-        int callTimeoutMillis = 3000;
+        int callTimeoutMillis = 6000;
         Config config = new Config().setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMillis);
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);


### PR DESCRIPTION
This test relies very much on time and the timings are very thight 3s call timeout. This
can cause spurious failures when the system is executing many tests in parallel and all
tests are contending for resources.

So instead of 3s timeout, the timeout has been doubled to 6s.

fix #7940