### PR TITLE
Added create and destroy tests for the Near Cache preloader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -85,7 +85,6 @@ public class NearCachePreloader<K> {
     private static final int LOAD_BATCH_SIZE = 100;
 
     private final ILogger logger = Logger.getLogger(NearCachePreloader.class);
-    private final ByteBuffer buf = allocate(BUFFER_SIZE);
     private final byte[] tmpBytes = new byte[INT_SIZE_IN_BYTES];
 
     private final String nearCacheName;
@@ -96,6 +95,7 @@ public class NearCachePreloader<K> {
     private final File storeFile;
     private final File tmpStoreFile;
 
+    private ByteBuffer buf;
     private int lastWrittenBytes;
     private int lastKeyCount;
 
@@ -170,6 +170,7 @@ public class NearCachePreloader<K> {
         long startedNanos = System.nanoTime();
         FileOutputStream fos = null;
         try {
+            buf = allocate(BUFFER_SIZE);
             lastWrittenBytes = 0;
             lastKeyCount = 0;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -79,6 +79,7 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
     protected static final int TEST_TIMEOUT = 10 * 60 * 1000;
     protected static final int KEY_COUNT = 10023;
     protected static final int THREAD_COUNT = 10;
+    protected static final int CREATE_AND_DESTROY_RUNS = 5000;
 
     protected final String defaultNearCache = randomName();
 
@@ -335,6 +336,32 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
 
         assertOpenEventually(finishLatch);
         pool.shutdownNow();
+    }
+
+    @Test(timeout = TEST_TIMEOUT)
+    public void testCreateAndDestroyDataStructure_withSameName() {
+        nearCacheConfig.setName("createDestroyNearCache");
+
+        NearCacheTestContext<Object, String, NK, NV> context = createContext(true, KEY_COUNT, INTEGER);
+        DataStructureAdapter<Object, String> adapter = context.nearCacheAdapter;
+
+        for (int i = 0; i < CREATE_AND_DESTROY_RUNS; i++) {
+            adapter.destroy();
+            adapter = getDataStructure(context, "createDestroyNearCache");
+        }
+    }
+
+    @Test(timeout = TEST_TIMEOUT)
+    public void testCreateAndDestroyDataStructure_withDifferentNames() {
+        nearCacheConfig.setName("createDestroyNearCache-*");
+
+        NearCacheTestContext<Object, String, NK, NV> context = createContext(true, KEY_COUNT, INTEGER);
+        DataStructureAdapter<Object, String> adapter = context.nearCacheAdapter;
+
+        for (int i = 0; i < CREATE_AND_DESTROY_RUNS; i++) {
+            adapter.destroy();
+            adapter = getDataStructure(context, "createDestroyNearCache-" + i);
+        }
     }
 
     protected final NearCacheConfig getNearCacheConfig(InMemoryFormat inMemoryFormat, boolean serializeKeys,


### PR DESCRIPTION
I've added new integration tests for the create-and-destroy-scenario, which failed here: https://github.com/hazelcast/hazelcast/issues/10759

Also the `ByteBuf` used by the `NearCachePreloader` was changed from a final field to a normal field. I did some profiling with both variants and with and without the new tests. The GC profile looks better with the dynamic field, because the buffer is not propagated to the old gen so fast. This leads to cheaper GC collections and less total GC time.

The `NearCachePreloader` shares some IO logic with `HotRestart`, but it's not running permanently, so we don't benefit that much from a final buffer in this scenario. Of course creating a new buffer looks like more litter, but per default this is only done every 5 minutes (default storage interval). So I guess the benefit of a GC collection in young space is bigger than having a final buffer in the end.

Closes https://github.com/hazelcast/hazelcast/issues/10759

**Master with final buffer**
![master_final_buffer](https://user-images.githubusercontent.com/4196298/29561303-49bc69a4-8735-11e7-905c-ca23730df186.png)

**Master with non-final buffer**
![master_dynamic_buffer](https://user-images.githubusercontent.com/4196298/29561322-53f69dea-8735-11e7-9857-5a38c7957bb4.png)

**PR branch with final buffer**
![pr_final_buffer](https://user-images.githubusercontent.com/4196298/29561335-5bccdb1a-8735-11e7-9b0c-736a39af2c0f.png)

**PR branch with non-final buffer**
![pr_dynamic_buffer](https://user-images.githubusercontent.com/4196298/29561344-61ed7ce8-8735-11e7-94fa-e710e4a4f688.png)
