### PR TITLE
Fixes wrong property name restriction for hazelcast.partition.count

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -2002,7 +2002,7 @@
             <xs:enumeration value="hazelcast.max.no.heartbeat.seconds"/>
             <xs:enumeration value="hazelcast.initial.wait.seconds"/>
             <xs:enumeration value="hazelcast.restart.on.max.idle"/>
-            <xs:enumeration value="hazelcast.map.partition.count"/>
+            <xs:enumeration value="hazelcast.partition.count"/>
             <xs:enumeration value="hazelcast.map.remove.delay.seconds"/>
             <xs:enumeration value="hazelcast.map.cleanup.delay.seconds"/>
             <xs:enumeration value="hazelcast.executor.query.thread.count"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -135,6 +135,7 @@ import java.util.concurrent.ExecutorService;
 import static com.hazelcast.config.HotRestartClusterDataRecoveryPolicy.PARTIAL_RECOVERY_MOST_COMPLETE;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -695,12 +696,14 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(properties);
         assertEquals("5", properties.get(MERGE_FIRST_RUN_DELAY_SECONDS.getName()));
         assertEquals("5", properties.get(MERGE_NEXT_RUN_DELAY_SECONDS.getName()));
+        assertEquals("277", properties.get(PARTITION_COUNT.getName()));
 
         Config config2 = instance.getConfig();
         Properties properties2 = config2.getProperties();
         assertNotNull(properties2);
         assertEquals("5", properties2.get(MERGE_FIRST_RUN_DELAY_SECONDS.getName()));
         assertEquals("5", properties2.get(MERGE_NEXT_RUN_DELAY_SECONDS.getName()));
+        assertEquals("277", properties2.get(PARTITION_COUNT.getName()));
     }
 
     @Test
@@ -713,6 +716,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(5700, inetSocketAddress.getPort());
         assertEquals("test-instance", config.getInstanceName());
         assertEquals("HAZELCAST_ENTERPRISE_LICENSE_KEY", config.getLicenseKey());
+        assertEquals(277, instance.getPartitionService().getPartitions().size());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -56,6 +56,7 @@
             <hz:properties>
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
                 <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
+                <hz:property name="hazelcast.partition.count">277</hz:property>
             </hz:properties>
             <hz:wan-replication name="testWan">
                 <hz:wan-publisher group-name="tokyo" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">


### PR DESCRIPTION
`GroupProperty` `hazelcast.partition.count` was added as `hazelcast.map.partition.count`.

fixes #10544