### PR TITLE
[BACKPORT] Fixes wrong property name restriction for hazelcast.partition.count

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -1948,7 +1948,7 @@
             <xs:enumeration value="hazelcast.max.no.heartbeat.seconds"/>
             <xs:enumeration value="hazelcast.initial.wait.seconds"/>
             <xs:enumeration value="hazelcast.restart.on.max.idle"/>
-            <xs:enumeration value="hazelcast.map.partition.count"/>
+            <xs:enumeration value="hazelcast.partition.count"/>
             <xs:enumeration value="hazelcast.map.remove.delay.seconds"/>
             <xs:enumeration value="hazelcast.map.cleanup.delay.seconds"/>
             <xs:enumeration value="hazelcast.executor.query.thread.count"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -134,6 +134,7 @@ import java.util.concurrent.ExecutorService;
 import static com.hazelcast.config.HotRestartClusterDataRecoveryPolicy.PARTIAL_RECOVERY_MOST_COMPLETE;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -690,12 +691,14 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(properties);
         assertEquals("5", properties.get(MERGE_FIRST_RUN_DELAY_SECONDS.getName()));
         assertEquals("5", properties.get(MERGE_NEXT_RUN_DELAY_SECONDS.getName()));
+        assertEquals("277", properties.get(PARTITION_COUNT.getName()));
 
         Config config2 = instance.getConfig();
         Properties properties2 = config2.getProperties();
         assertNotNull(properties2);
         assertEquals("5", properties2.get(MERGE_FIRST_RUN_DELAY_SECONDS.getName()));
         assertEquals("5", properties2.get(MERGE_NEXT_RUN_DELAY_SECONDS.getName()));
+        assertEquals("277", properties2.get(PARTITION_COUNT.getName()));
     }
 
     @Test
@@ -708,6 +711,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(5700, inetSocketAddress.getPort());
         assertEquals("test-instance", config.getInstanceName());
         assertEquals("HAZELCAST_ENTERPRISE_LICENSE_KEY", config.getLicenseKey());
+        assertEquals(277, instance.getPartitionService().getPartitions().size());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -48,6 +48,7 @@
             <hz:properties>
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
                 <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
+                <hz:property name="hazelcast.partition.count">277</hz:property>
             </hz:properties>
             <hz:wan-replication name="testWan">
                 <hz:wan-publisher group-name="tokyo" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">


### PR DESCRIPTION
backport of #11167 
fixes #10544