### PR TITLE
Add forgotten public address check from cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -61,7 +61,7 @@ public class DiscoveryAddressTranslator
 
         privateToPublic = this.privateToPublic;
         Address publicAddress = privateToPublic.get(address);
-        if (!alreadyRefreshed) {
+        if (publicAddress == null && !alreadyRefreshed) {
             refresh();
             privateToPublic = this.privateToPublic;
             publicAddress = privateToPublic.get(address);


### PR DESCRIPTION
Aws address translator was calling refresh unnecessarily in each
call. It was causing rest to not response after some time and hang.

backport of https://github.com/hazelcast/hazelcast/pull/11151