### PR TITLE
Introduce "fail on indeterminate operation state" configuration

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndeterminateOperationStateExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndeterminateOperationStateExceptionTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IndeterminateOperationStateException;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.spi.properties.GroupProperty.FAIL_ON_INDETERMINATE_OPERATION_STATE;
+import static com.hazelcast.spi.properties.GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientIndeterminateOperationStateExceptionTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private HazelcastInstance instance1;
+
+    private HazelcastInstance instance2;
+
+    private HazelcastInstance client;
+
+    @Before
+    public void init() {
+        Config config = new Config();
+        config.setProperty(OPERATION_BACKUP_TIMEOUT_MILLIS.getName(), String.valueOf(1000));
+        config.setProperty(FAIL_ON_INDETERMINATE_OPERATION_STATE.getName(), String.valueOf(true));
+
+        instance1 = factory.newHazelcastInstance(config);
+        instance2 = factory.newHazelcastInstance(config);
+        client = factory.newHazelcastClient();
+
+        warmUpPartitions(instance1, instance2);
+    }
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void shouldFail_whenBackupAckMissed() throws InterruptedException, TimeoutException {
+        dropOperationsBetween(instance1, instance2, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
+
+        String key = generateKeyOwnedBy(instance1);
+
+        IMap<Object, Object> map = client.getMap(randomMapName());
+        try {
+            map.put(key, key);
+            fail();
+        } catch (IndeterminateOperationStateException expected) {
+        }
+
+        assertEquals(key, map.get(key));
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -29,6 +29,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.core.LocalMemberResetException;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
@@ -630,7 +631,12 @@ public class ClientExceptionFactory {
                 return new LocalMemberResetException(message);
             }
         });
-
+        register(ClientProtocolErrorCodes.INDETERMINATE_OPERATION_STATE, IndeterminateOperationStateException.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new IndeterminateOperationStateException(message, cause);
+            }
+        });
     }
 
     public Throwable createException(ClientMessage clientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -106,6 +106,7 @@ public final class ClientProtocolErrorCodes {
     public static final int DUPLICATE_TASK = 81;
     public static final int STALE_TASK = 82;
     public static final int LOCAL_MEMBER_RESET = 83;
+    public static final int INDETERMINATE_OPERATION_STATE = 84;
 
     // These exception codes are reserved to by used by hazelcast-jet project
     public static final int JET_EXCEPTIONS_RANGE_START = 500;

--- a/hazelcast/src/main/java/com/hazelcast/core/IndeterminateOperationStateException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IndeterminateOperationStateException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+import com.hazelcast.spi.properties.GroupProperty;
+
+/**
+ * IndeterminateOperationStateException is thrown when an invocation doesn't receive enough ACKs from the backup replicas in time.
+ * This timeout is defined by configuration property {@link GroupProperty#OPERATION_BACKUP_TIMEOUT_MILLIS}.
+ * <p>
+ * Similarly, if the member, which owns the primary replica of the operation's target partition, leaves the cluster
+ * before a response is returned, then operation is not retried but fails with IndeterminateOperationStateException.
+ * However, there will not be any rollback on other successful replicas.
+ * <p>
+ * IndeterminateOperationStateException only informs the caller that the operation may not be executed on all requested backup
+ * replicas, hence durability of the written / updated value may not be guaranteed immediately.
+ *
+ * @see GroupProperty#OPERATION_BACKUP_TIMEOUT_MILLIS
+ * @see GroupProperty#FAIL_ON_INDETERMINATE_OPERATION_STATE
+ */
+public class IndeterminateOperationStateException extends HazelcastException {
+
+    public IndeterminateOperationStateException() {
+    }
+
+    public IndeterminateOperationStateException(String message) {
+        super(message);
+    }
+
+    public IndeterminateOperationStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
@@ -113,6 +115,11 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
             if (value == null) {
                 return null;
             }
+        }
+
+        if (invocation.shouldFailOnIndeterminateOperationState() && (value instanceof MemberLeftException)) {
+            String message = invocation + " failed because the target has left the cluster before response is received";
+            value = new IndeterminateOperationStateException(message, (MemberLeftException) value);
         }
 
         if (value instanceof Throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -66,6 +66,7 @@ import static com.hazelcast.spi.InvocationBuilder.DEFAULT_CALL_TIMEOUT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
+import static com.hazelcast.spi.properties.GroupProperty.FAIL_ON_INDETERMINATE_OPERATION_STATE;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.util.CollectionUtil.toIntegerList;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
@@ -445,6 +446,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 node.connectionManager,
                 node.nodeEngine.getExecutionService(),
                 nodeEngine.getProperties().getMillis(OPERATION_CALL_TIMEOUT_MILLIS),
+                nodeEngine.getProperties().getBoolean(FAIL_ON_INDETERMINATE_OPERATION_STATE),
                 invocationRegistry,
                 invocationMonitor,
                 nodeEngine.getLogger(Invocation.class),

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
@@ -46,7 +47,16 @@ final class PartitionInvocation extends Invocation {
     }
 
     @Override
+    protected boolean shouldFailOnIndeterminateOperationState() {
+        return context.failOnIndeterminateOperationState;
+    }
+
+    @Override
     ExceptionAction onException(Throwable t) {
+        if (shouldFailOnIndeterminateOperationState() && (t instanceof MemberLeftException)) {
+            return THROW_EXCEPTION;
+        }
+
         ExceptionAction action = op.onInvocationException(t);
         return action != null ? action : THROW_EXCEPTION;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.properties;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.diagnostics.HealthMonitorLevel;
@@ -235,11 +236,20 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.operation.call.timeout.millis", 60000, MILLISECONDS);
 
     /**
-     * If an operation has backups and the backups don't complete in time, then some cleanup logic can be executed.
-     * This property specifies that timeout for backups to complete.
+     * If an operation has backups, this property specifies how long the invocation will wait for acks from the backup replicas.
+     * If acks are not received from some backups, there will not be any rollback on other successful replicas.
      */
     public static final HazelcastProperty OPERATION_BACKUP_TIMEOUT_MILLIS
             = new HazelcastProperty("hazelcast.operation.backup.timeout.millis", 5000, MILLISECONDS);
+
+    /**
+     * When this configuration is enabled, if an operation has sync backups and acks are not received from backup replicas
+     * in time, or the member which owns primary replica of the target partition leaves the cluster, then the invocation fails
+     * with {@link IndeterminateOperationStateException}. However, even if the invocation fails,
+     * there will not be any rollback on other successful replicas.
+     */
+    public static final HazelcastProperty FAIL_ON_INDETERMINATE_OPERATION_STATE
+            = new HazelcastProperty("hazelcast.operation.fail.on.indeterminate.state", false);
 
     /**
      * Maximum number of retries for an invocation. After threshold is reached, invocation is assumed as failed.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.core.LocalMemberResetException;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.durableexecutor.StaleTaskIdException;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
@@ -264,7 +265,8 @@ public class ClientExceptionFactoryTest extends HazelcastTestSupport {
                 new Object[]{new RuntimeException("fun", new RuntimeException("codec \n is \n not \n pwned"))},
                 new Object[]{new RuntimeException("fun",
                         new RuntimeException("!@#$%^&*()'][/.,l;§!|`]:\\ľščťž /sᵻˈrɪlɪk/ Áзбука 中华民族 \n \r \t \r\n"))},
-                new Object[]{new LocalMemberResetException(randomString())}
+                new Object[]{new LocalMemberResetException(randomString())},
+                new Object[]{new IndeterminateOperationStateException(randomString())}
         );
 
     }

--- a/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
@@ -1,0 +1,196 @@
+package com.hazelcast.partition;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.core.IndeterminateOperationStateException;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.spi.properties.GroupProperty.FAIL_ON_INDETERMINATE_OPERATION_STATE;
+import static com.hazelcast.spi.properties.GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IndeterminateOperationStateExceptionTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance1;
+
+    private HazelcastInstance instance2;
+
+    @Before
+    public void init() {
+        Config config = new Config();
+        config.setProperty(OPERATION_BACKUP_TIMEOUT_MILLIS.getName(), String.valueOf(1000));
+        config.setProperty(FAIL_ON_INDETERMINATE_OPERATION_STATE.getName(), String.valueOf(true));
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance1 = factory.newHazelcastInstance(config);
+        instance2 = factory.newHazelcastInstance(config);
+        warmUpPartitions(instance1, instance2);
+    }
+
+    @Test
+    public void partitionInvocation_shouldFail_whenBackupTimeoutOccurs() throws InterruptedException, TimeoutException {
+        dropOperationsBetween(instance1, instance2, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
+        int partitionId = getPartitionId(instance1);
+
+        InternalOperationService operationService = getNodeEngineImpl(instance1).getOperationService();
+        InternalCompletableFuture<Object> future = operationService
+                .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new PrimaryOperation(), partitionId).invoke();
+        try {
+            future.get(2, TimeUnit.MINUTES);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IndeterminateOperationStateException);
+        }
+    }
+
+    @Test
+    public void partitionInvocation_shouldFail_whenPartitionPrimaryLeaves() throws InterruptedException, TimeoutException {
+        int partitionId = getPartitionId(instance2);
+        InternalOperationService operationService = getNodeEngineImpl(instance1).getOperationService();
+        InternalCompletableFuture<Object> future = operationService
+                .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new SilentOperation(), partitionId).invoke();
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                instance2.getLifecycleService().terminate();
+            }
+        });
+        try {
+            future.get(2, TimeUnit.MINUTES);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IndeterminateOperationStateException);
+        }
+    }
+
+
+    @Test
+    public void transaction_shouldFail_whenBackupTimeoutOccurs() throws InterruptedException, TimeoutException {
+        dropOperationsBetween(instance1, instance2, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
+        dropOperationsBetween(instance2, instance1, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
+
+        String name = randomMapName();
+        String key1 = generateKeyOwnedBy(instance1);
+        String key2 = generateKeyOwnedBy(instance2);
+
+        TransactionContext context = instance1.newTransactionContext();
+        context.beginTransaction();
+
+        try {
+            TransactionalMap<Object, Object> map = context.getMap(name);
+            map.put(key1, "value");
+            map.put(key2, "value");
+
+            context.commitTransaction();
+            fail("Should fail with IndeterminateOperationStateException");
+        } catch (IndeterminateOperationStateException e) {
+            context.rollbackTransaction();
+        }
+
+        IMap<Object, Object> map = instance1.getMap(name);
+        assertNull(map.get(key1));
+        assertNull(map.get(key2));
+    }
+
+    @Test(expected = MemberLeftException.class)
+    public void targetInvocation_shouldFailWithMemberLeftException_onTargetMemberLeave() throws Exception {
+        InternalOperationService operationService = getNodeEngineImpl(instance1).getOperationService();
+        Address target = getAddress(instance2);
+        InternalCompletableFuture<Object> future = operationService
+                .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new SilentOperation(), target).invoke();
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                instance2.getLifecycleService().terminate();
+            }
+        });
+
+        future.get(2, TimeUnit.MINUTES);
+    }
+
+    public static class PrimaryOperation extends Operation implements BackupAwareOperation {
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return true;
+        }
+
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            return 1;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new BackupOperation();
+        }
+
+    }
+
+    public static class BackupOperation extends Operation {
+
+        @Override
+        public void run() throws Exception {
+
+        }
+
+    }
+
+    public static class SilentOperation extends Operation {
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return false;
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -59,7 +59,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         Invocation.Context context = new Context(null, null, null, null, null,
-                1000, invocationRegistry, null, logger, null, null, null, null, null, null, null, null, null);
+                1000, false, invocationRegistry, null, logger, null, null, null, null, null, null, null, null, null);
         return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 


### PR DESCRIPTION
If `MemberLeftException` is received before the ack from the target of a partition, the operation is retried, which could cause the operation to be executed more than once in some racy scenarios. Additionally, if a partition operation has sync backups, the caller waits until acks are received from specified number of backup replicas. If the acks are not received within the configured duration, the operation returns silently.

When this configuration is enabled, the invocation throws `IndeterminateOperationStateException `if:
1) the operation fails on partition primary replica node with `MemberLeftException`,
2) there is at least one missing ack from backup replicas for the given timeout duration.

When `IndeterminateOperationStateException` is thrown, the system does not try to rollback changes. Hence, this new behaviour does not guarantee linearizability.
However, if an invocation completes without `IndeterminateOperationStateException` when the new configuration is enabled, it is guaranteed that the operation is executed exactly once on the primary partition and specified number of backup partitions.

Invocations which are done with `InvokeOnPartitions` class are not effected by this new configuration because `PartitionIteratingOperation` doesn’t wait for sync backup acks under the hood.