### PR TITLE
Add system property to process WAN map remove events as delete

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDeleteMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDeleteMessageTask.java
@@ -39,7 +39,7 @@ public class MapDeleteMessageTask
     @Override
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
-        MapOperation op = operationProvider.createDeleteOperation(parameters.name, parameters.key);
+        MapOperation op = operationProvider.createDeleteOperation(parameters.name, parameters.key, false);
         op.setThreadId(parameters.threadId);
         return op;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -49,6 +49,7 @@ import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.MemoryInfoAccessor;
 import com.hazelcast.util.RuntimeMemoryInfoAccessor;
+import com.hazelcast.wan.WANReplicationQueueFullException;
 import com.hazelcast.wan.WanReplicationPublisher;
 import com.hazelcast.wan.WanReplicationService;
 
@@ -240,6 +241,11 @@ public class MapContainer {
         return wanReplicationPublisher != null && wanMergePolicy != null;
     }
 
+    /**
+     * Checks if WAN replication is enabled and if the WAN queues have reached their capacity.
+     *
+     * @throws WANReplicationQueueFullException if WAN replication is enabled and queue capacity has been reached
+     */
     public void checkWanReplicationQueues() {
         if (isWanReplicationEnabled()) {
             wanReplicationPublisher.checkWanReplicationQueues();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -97,8 +97,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createDeleteOperation(String name, Data key) {
-        return new DeleteOperation(name, key);
+    public MapOperation createDeleteOperation(String name, Data key, boolean disableWanReplicationEvent) {
+        return new DeleteOperation(name, key, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
@@ -26,6 +26,10 @@ public class DeleteOperation extends BaseRemoveOperation {
         super(name, dataKey);
     }
 
+    public DeleteOperation(String name, Data dataKey, boolean disableWanReplicationEvent) {
+        super(name, dataKey, disableWanReplicationEvent);
+    }
+
     public DeleteOperation() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -54,7 +54,16 @@ public interface MapOperationProvider {
 
     MapOperation createReplaceIfSameOperation(String name, Data dataKey, Data expect, Data update);
 
-    MapOperation createDeleteOperation(String name, Data key);
+    /**
+     * Creates a delete operation for an entry with key equal to {@code key} from the map named {@code name}.
+     * You can also specify whether this operation should trigger a WAN replication event.
+     *
+     * @param name                       the map name
+     * @param key                        the entry key
+     * @param disableWanReplicationEvent if the delete operation should not send a WAN replication event
+     * @return the delete operation
+     */
+    MapOperation createDeleteOperation(String name, Data key, boolean disableWanReplicationEvent);
 
     MapOperation createClearOperation(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -89,8 +89,8 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createDeleteOperation(String name, Data key) {
-        return getDelegate().createDeleteOperation(name, key);
+    public MapOperation createDeleteOperation(String name, Data key, boolean disableWanReplicationEvent) {
+        return getDelegate().createDeleteOperation(name, key, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -23,6 +23,7 @@ import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.wan.WANReplicationQueueFullException;
 
 import java.util.List;
 import java.util.Set;
@@ -108,9 +109,9 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
-    public MapOperation createDeleteOperation(String name, Data key) {
+    public MapOperation createDeleteOperation(String name, Data key, boolean disableWanReplicationEvent) {
         checkWanReplicationQueues(name);
-        return getDelegate().createDeleteOperation(name, key);
+        return getDelegate().createDeleteOperation(name, key, disableWanReplicationEvent);
     }
 
     @Override
@@ -182,6 +183,14 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
         return getDelegate().createMultipleEntryOperationFactory(name, keys, entryProcessor);
     }
 
+    /**
+     * Checks if WAN replication is enabled for the provided map {@code name}
+     * and if the WAN queues have reached their capacity.
+     *
+     * @param name the map name
+     * @throws WANReplicationQueueFullException if WAN replication is enabled and queue
+     *                                          capacity has been reached
+     */
     private void checkWanReplicationQueues(String name) {
         mapServiceContext.getMapContainer(name).checkWanReplicationQueues();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -558,7 +558,7 @@ abstract class MapProxySupport<K, V>
 
     protected void deleteInternal(Object key) {
         Data keyData = toDataWithStrategy(key);
-        MapOperation operation = operationProvider.createDeleteOperation(name, keyData);
+        MapOperation operation = operationProvider.createDeleteOperation(name, keyData, false);
         invokeOperation(keyData, operation);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
@@ -50,7 +50,8 @@ public interface WanReplicationPublisher {
     void publishReplicationEvent(WanReplicationEvent wanReplicationEvent);
 
     /**
-     * Check the capacity of the WAN replication queues.
+     * Checks the size of the WAN replication queue and throws an
+     * exception if it has been reached or crossed.
      *
      * @throws WANReplicationQueueFullException if queue capacity has been reached and
      *                                          {@link WanPublisherConfig#getQueueFullBehavior()} is


### PR DESCRIPTION
If the receiving cluster does not have a class defined in it's
classloader and uses the BINARY in-memory format, we can run into
ClassNotFoundException. The entry will be removed nevertheless but the
event processing will be flagged as failed and the ACTIVE cluster will
try and resend the WAN event. The second time it is sent, there
will be no entry with that key. This does not cause consistency
issues but performance issues since the WAN event operation is sent
twice.

We introduce a new system property to use delete instead of remove
when processing remove events. This will avoid the
ClassNotFoundException since the delete operation does not try to
return the old value.

The system property is false by default, meaning it retains the old
behaviour unless explicitly set to true.

This new property also has the performance benefit that it does not
copy the old value from the partition owner. The WAN event processing
 code does not use the returned value which makes the old value
 unnecessary.

Fixes : https://github.com/hazelcast/hazelcast-enterprise/issues/1636
EE : https://github.com/hazelcast/hazelcast-enterprise/pull/1643
Backport : https://github.com/hazelcast/hazelcast/pull/11178