### PR TITLE
Fixed ClientNearCacheInvalidationTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
@@ -395,13 +395,16 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
     }
 
     private void assertNoFurtherInvalidationThan(final int expectedInvalidationCount) {
-        assertTrueAllTheTime(new AssertTask() {
+        AssertTask assertTask = new AssertTask() {
             @Override
             public void run() throws Exception {
                 long invalidationCount = testContext.invalidationListener.getInvalidationCount();
                 assertEquals(expectedInvalidationCount, invalidationCount);
             }
-        }, TIMEOUT);
+        };
+
+        assertTrueEventually(assertTask);
+        assertTrueAllTheTime(assertTask, TIMEOUT);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
@@ -405,6 +405,7 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
 
         assertTrueEventually(assertTask);
         assertTrueAllTheTime(assertTask, TIMEOUT);
+        testContext.invalidationListener.resetInvalidationCount();
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
@@ -59,6 +59,7 @@ import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListen
 import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -394,15 +395,13 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
     }
 
     private void assertNoFurtherInvalidationThan(final int expectedInvalidationCount) {
-        AssertTask assertTask = new AssertTask() {
+        assertTrueAllTheTime(new AssertTask() {
             @Override
             public void run() throws Exception {
                 long invalidationCount = testContext.invalidationListener.getInvalidationCount();
                 assertEquals(expectedInvalidationCount, invalidationCount);
             }
-        };
-
-        assertTrueAllTheTime(assertTask, TIMEOUT);
+        }, TIMEOUT);
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -411,12 +410,14 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
             @Override
             public void run() throws Exception {
                 long invalidationCount = testContext.invalidationListener.getInvalidationCount();
-                assertTrue("invalidationCount = [" + invalidationCount + "] " +
-                        "but should be >= [" + leastInvalidationCount + "]", invalidationCount >= leastInvalidationCount);
+                assertTrue(format("invalidationCount is %d, but should be >= %d", invalidationCount, leastInvalidationCount),
+                        invalidationCount >= leastInvalidationCount);
             }
         };
 
+        assertTrueEventually(assertTask);
         assertTrueAllTheTime(assertTask, TIMEOUT);
+        testContext.invalidationListener.resetInvalidationCount();
     }
 
     protected ClientConfig createClientConfig() {


### PR DESCRIPTION
Used `assertTrueEventually()` before of `assertTrueAllTheTime()` in
`assertNoFurtherInvalidationThan()` and `assertLeastInvalidationCount()`,
since it can take a bit time until the invalidation count is correct.

Fixes https://github.com/hazelcast/hazelcast/issues/10988
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1624
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1640
