### PR TITLE
Enhance HazelcastStarter

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/EnumConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/EnumConstructor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import java.lang.reflect.Method;
+
+/**
+ * Construct enum instances using name() / valueOf() methods.
+ */
+public class EnumConstructor extends AbstractStarterObjectConstructor {
+
+    public EnumConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate)
+            throws Exception {
+        // obtain delegate as string
+        Method nameMethod = delegate.getClass().getMethod("name");
+        String delegateAsString = (String) nameMethod.invoke(delegate);
+        // construct new instance at target classloader via valueof
+        Method valueOf = targetClass.getMethod("valueOf", String.class);
+        Object targetObject = valueOf.invoke(null, delegateAsString);
+        return targetObject;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -259,7 +259,7 @@ public class HazelcastProxyFactory {
             return RETURN_SAME;
         }
 
-        if (NO_PROXYING_WHITELIST.contains(className)) {
+        if (NO_PROXYING_WHITELIST.contains(className) || delegateClass.isEnum()) {
             return ProxyPolicy.NO_PROXY;
         }
 
@@ -292,6 +292,8 @@ public class HazelcastProxyFactory {
                             return new ConfigConstructor(input);
                         } else if (className.equals(CLASS_NAME_VERSION)) {
                             return new VersionConstructor(input);
+                        } else if (input.isEnum()) {
+                            return new EnumConstructor(input);
                         } else {
                             throw new UnsupportedOperationException("Cannot construct target object "
                                     + "for target class" + input + " on classloader " + input.getClassLoader());


### PR DESCRIPTION
Add support for enum arguments / return types across instances started by HazelcastStarter.

Required for https://github.com/hazelcast/hazelcast-enterprise/pull/1593