### PR TITLE
Fixes NPE on Nio.close

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.networking.nio.iobalancer.IOBalancer;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -30,7 +31,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
 public abstract class AbstractHandler
-        implements SelectionHandler, MigratableHandler {
+        implements SelectionHandler, MigratableHandler, Closeable {
 
     protected static final int LOAD_BALANCING_HANDLE = 0;
     protected static final int LOAD_BALANCING_BYTE = 1;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -21,6 +21,8 @@ import com.hazelcast.internal.networking.OutboundFrame;
 
 import java.nio.channels.SocketChannel;
 
+import static com.hazelcast.nio.IOUtil.closeResource;
+
 /**
  * A {@link com.hazelcast.internal.networking.Channel} implementation tailored for non blocking IO using
  * {@link java.nio.channels.Selector} in combination with a non blocking {@link SocketChannel}.
@@ -76,8 +78,8 @@ public class NioChannel extends AbstractChannel {
 
     @Override
     protected void onClose() {
-        reader.close();
-        writer.close();
+        closeResource(reader);
+        closeResource(writer);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
@@ -177,6 +177,7 @@ public final class NioChannelReader extends AbstractHandler {
         handleCountLastPublish = handleCount.get();
     }
 
+    @Override
     public void close() {
         ioThread.addTaskAndWakeup(new Runnable() {
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
@@ -363,6 +363,7 @@ public final class NioChannelWriter extends AbstractHandler implements Runnable 
         }
     }
 
+    @Override
     public void close() {
         writeQueue.clear();
         urgentWriteQueue.clear();


### PR DESCRIPTION
It can happen that a NioChannel is created but the reader/writer has not been set.
If a close is called, a NPE is thrown since the close if forwarded to the reader/writer.

This PR fixes that by adding a null check on the read/writer before calling close.