### PR TITLE
[Backport] Abstract Serialization Test can not be reused for EE test (backports #11056)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -60,9 +60,12 @@ public class AbstractSerializationServiceTest {
 
     @Before
     public void setup() {
+        abstractSerializationService = newAbstractSerializationService();
+    }
+
+    protected AbstractSerializationService newAbstractSerializationService() {
         DefaultSerializationServiceBuilder defaultSerializationServiceBuilder = new DefaultSerializationServiceBuilder();
-        abstractSerializationService = defaultSerializationServiceBuilder
-                .setVersion(InternalSerializationService.VERSION_1).build();
+        return defaultSerializationServiceBuilder.setVersion(InternalSerializationService.VERSION_1).build();
     }
 
     @Test


### PR DESCRIPTION
Abstract Serialization Test can not be reused for EE test: backports: (#11056)
* Refactored the serialization test so that the derived test at the enterprise can use the enterprise serializer by overriding the protected getter method.