### PR TITLE
Fixed dependency of TransactionalMapProxy on MapContainer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -66,6 +66,7 @@ import static java.lang.System.getProperty;
  * Map container for a map with a specific name. Contains config and supporting structures for
  * all of the maps' functionalities.
  */
+@SuppressWarnings("WeakerAccess")
 public class MapContainer {
 
     protected final String name;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -17,12 +17,13 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
+import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.query.IndexProvider;
@@ -31,6 +32,7 @@ import com.hazelcast.map.impl.query.PartitionScanRunner;
 import com.hazelcast.map.impl.query.QueryRunner;
 import com.hazelcast.map.impl.query.ResultProcessorRegistry;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
+import com.hazelcast.map.impl.record.RecordComparator;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
@@ -60,6 +62,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see MapManagedService
  */
 public interface MapServiceContext extends MapServiceContextInterceptorSupport, MapServiceContextEventListenerSupport {
+
+    RecordComparator getRecordComparator(InMemoryFormat inMemoryFormat);
 
     Object toObject(Object data);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordComparator.java
@@ -16,36 +16,28 @@
 
 package com.hazelcast.map.impl.record;
 
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
-public class ObjectRecordFactory implements RecordFactory<Object> {
+public class DataRecordComparator implements RecordComparator {
 
     private final SerializationService serializationService;
-    private final boolean statisticsEnabled;
 
-    public ObjectRecordFactory(MapConfig config, SerializationService serializationService) {
+    public DataRecordComparator(SerializationService serializationService) {
         this.serializationService = serializationService;
-        this.statisticsEnabled = config.isStatisticsEnabled();
     }
 
     @Override
-    public Record<Object> newRecord(Object value) {
-        assert value != null : "value can not be null";
-
-        Object objectValue = serializationService.toObject(value);
-        return statisticsEnabled ? new ObjectRecordWithStats(objectValue) : new ObjectRecord(objectValue);
-    }
-
-    @Override
-    public void setValue(Record<Object> record, Object value) {
-        assert value != null : "value can not be null";
-
-        Object v = value;
-        if (value instanceof Data) {
-            v = serializationService.toObject(value);
+    public boolean isEqual(Object value1, Object value2) {
+        if (value1 == value2) {
+            return true;
         }
-        record.setValue(v);
+        if (value1 == null || value2 == null) {
+            return false;
+        }
+        // the PartitioningStrategy is not needed here, since `Data.equals()` only checks the payload, not the partitionHash
+        Data data1 = serializationService.toData(value1);
+        Data data2 = serializationService.toData(value2);
+        return data1.equals(data2);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
@@ -62,18 +62,4 @@ public class DataRecordFactory implements RecordFactory<Data> {
         }
         record.setValue(v);
     }
-
-    @Override
-    public boolean isEquals(Object value1, Object value2) {
-        if (value1 == value2) {
-            return true;
-        }
-        if (value1 == null || value2 == null) {
-            return false;
-        }
-        // the PartitioningStrategy is not needed here, since `Data.equals()` only checks the payload, not the partitionHash
-        Data data1 = serializationService.toData(value1);
-        Data data2 = serializationService.toData(value2);
-        return data1.equals(data2);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
@@ -65,16 +65,15 @@ public class DataRecordFactory implements RecordFactory<Data> {
 
     @Override
     public boolean isEquals(Object value1, Object value2) {
-        if (value1 == null && value2 == null) {
+        if (value1 == value2) {
             return true;
         }
-        if (value1 == null) {
+        if (value1 == null || value2 == null) {
             return false;
         }
-        if (value2 == null) {
-            return false;
-        }
-
-        return serializationService.toData(value1).equals(serializationService.toData(value2));
+        // the PartitioningStrategy is not needed here, since `Data.equals()` only checks the payload, not the partitionHash
+        Data data1 = serializationService.toData(value1);
+        Data data2 = serializationService.toData(value2);
+        return data1.equals(data2);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordComparator.java
@@ -16,36 +16,27 @@
 
 package com.hazelcast.map.impl.record;
 
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
-public class ObjectRecordFactory implements RecordFactory<Object> {
+public class ObjectRecordComparator implements RecordComparator {
 
     private final SerializationService serializationService;
-    private final boolean statisticsEnabled;
 
-    public ObjectRecordFactory(MapConfig config, SerializationService serializationService) {
+    public ObjectRecordComparator(SerializationService serializationService) {
         this.serializationService = serializationService;
-        this.statisticsEnabled = config.isStatisticsEnabled();
     }
 
     @Override
-    public Record<Object> newRecord(Object value) {
-        assert value != null : "value can not be null";
-
-        Object objectValue = serializationService.toObject(value);
-        return statisticsEnabled ? new ObjectRecordWithStats(objectValue) : new ObjectRecord(objectValue);
-    }
-
-    @Override
-    public void setValue(Record<Object> record, Object value) {
-        assert value != null : "value can not be null";
-
-        Object v = value;
-        if (value instanceof Data) {
-            v = serializationService.toObject(value);
+    public boolean isEqual(Object value1, Object value2) {
+        if (value1 == value2) {
+            return true;
         }
-        record.setValue(v);
+        if (value1 == null || value2 == null) {
+            return false;
+        }
+        Object v1 = value1 instanceof Data ? serializationService.toObject(value1) : value1;
+        Object v2 = value2 instanceof Data ? serializationService.toObject(value2) : value2;
+        return v1 != null ? v1.equals(v2) : v2 == null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
@@ -51,17 +51,14 @@ public class ObjectRecordFactory implements RecordFactory<Object> {
 
     @Override
     public boolean isEquals(Object value1, Object value2) {
-        Object v1 = value1 instanceof Data ? serializationService.toObject(value1) : value1;
-        Object v2 = value2 instanceof Data ? serializationService.toObject(value2) : value2;
-        if (v1 == null && v2 == null) {
+        if (value1 == value2) {
             return true;
         }
-        if (v1 == null) {
+        if (value1 == null || value2 == null) {
             return false;
         }
-        if (v2 == null) {
-            return false;
-        }
-        return v1.equals(v2);
+        Object v1 = value1 instanceof Data ? serializationService.toObject(value1) : value1;
+        Object v2 = value2 instanceof Data ? serializationService.toObject(value2) : value2;
+        return v1 != null ? v1.equals(v2) : v2 == null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordComparator.java
@@ -16,14 +16,7 @@
 
 package com.hazelcast.map.impl.record;
 
-/**
- * Factory for creating records. Created for every partition.
- *
- * @param <T> the type of object which is going to be created.
- */
-public interface RecordFactory<T> {
+public interface RecordComparator {
 
-    Record<T> newRecord(Object value);
-
-    void setValue(Record<T> record, Object value);
+    boolean isEqual(Object value1, Object value2);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -348,7 +348,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             if (getOrNullIfExpired(record, now, false) == null) {
                 continue;
             }
-            if (recordFactory.isEquals(value, record.getValue())) {
+            if (recordComparator.isEqual(value, record.getValue())) {
                 return true;
             }
         }
@@ -583,7 +583,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         } else {
             oldValue = record.getValue();
         }
-        if (recordFactory.isEquals(testValue, oldValue)) {
+        if (recordComparator.isEqual(testValue, oldValue)) {
             mapServiceContext.interceptRemove(name, oldValue);
             removeIndex(record);
             mapDataStore.remove(key, now);
@@ -820,7 +820,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 mergeRecordExpiration(record, mergingEntry);
             }
             // same with the existing entry so no need to map-store etc operations.
-            if (recordFactory.isEquals(newValue, oldValue)) {
+            if (recordComparator.isEqual(newValue, oldValue)) {
                 return true;
             }
             newValue = mapDataStore.add(key, newValue, now);
@@ -863,11 +863,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
         final MapServiceContext mapServiceContext = this.mapServiceContext;
         final Object current = record.getValue();
-        final String mapName = this.name;
-        if (!recordFactory.isEquals(expect, current)) {
+        if (!recordComparator.isEqual(expect, current)) {
             return false;
         }
-        update = mapServiceContext.interceptPut(mapName, current, update);
+        update = mapServiceContext.interceptPut(name, current, update);
         update = mapDataStore.add(key, update, now);
         onStore(record);
         updateRecord(key, record, update, now);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordComparatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.record;
+
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractRecordComparatorTest extends HazelcastTestSupport {
+
+    SerializationService serializationService;
+    PartitioningStrategy partitioningStrategy;
+
+    RecordComparator comparator;
+
+    Person object1;
+    Person object2;
+
+    Data data1;
+    Data data2;
+    Data nullData;
+
+    @Before
+    public final void init() {
+        serializationService = createSerializationService();
+        partitioningStrategy = new DefaultPartitioningStrategy();
+
+        object1 = new Person("Alice");
+        object2 = new Person("Bob");
+
+        data1 = serializationService.toData(object1);
+        data2 = serializationService.toData(object2);
+        nullData = new HeapData(new byte[0]);
+    }
+
+    @Test
+    public void testIsEquals() {
+        newRecordComparator();
+
+        assertTrue(comparator.isEqual(null, null));
+        assertTrue(comparator.isEqual(object1, object1));
+        assertTrue(comparator.isEqual(object1, data1));
+        assertTrue(comparator.isEqual(data1, data1));
+        assertTrue(comparator.isEqual(data1, object1));
+        assertTrue(comparator.isEqual(nullData, nullData));
+
+        assertFalse(comparator.isEqual(null, object1));
+        assertFalse(comparator.isEqual(null, data1));
+        assertFalse(comparator.isEqual(null, nullData));
+        assertFalse(comparator.isEqual(object1, null));
+        assertFalse(comparator.isEqual(object1, nullData));
+        assertFalse(comparator.isEqual(object1, object2));
+        assertFalse(comparator.isEqual(object1, data2));
+        assertFalse(comparator.isEqual(data1, null));
+        assertFalse(comparator.isEqual(data1, nullData));
+        assertFalse(comparator.isEqual(data1, object2));
+        assertFalse(comparator.isEqual(data1, data2));
+        assertFalse(comparator.isEqual(nullData, null));
+        assertFalse(comparator.isEqual(nullData, object1));
+        assertFalse(comparator.isEqual(nullData, data1));
+    }
+
+    @Test
+    public void testIsEquals_withCustomPartitioningStrategy() {
+        partitioningStrategy = new PersonPartitioningStrategy();
+
+        data1 = serializationService.toData(object1, partitioningStrategy);
+        data2 = serializationService.toData(object2, partitioningStrategy);
+
+        testIsEquals();
+    }
+
+    abstract void newRecordComparator();
+
+    InternalSerializationService createSerializationService() {
+        return new DefaultSerializationServiceBuilder().build();
+    }
+
+    static class PersonPartitioningStrategy implements PartitioningStrategy<Person> {
+
+        @Override
+        public Object getPartitionKey(Person key) {
+            return key.name;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordFactoryTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.record;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractRecordFactoryTest<T> extends HazelcastTestSupport {
+
+    SerializationService serializationService;
+    PartitioningStrategy partitioningStrategy;
+    RecordFactory<T> factory;
+
+    Person object1;
+    Person object2;
+
+    Data data1;
+    Data data2;
+    Data nullData;
+
+    Record<T> record;
+
+    @Before
+    public final void init() {
+        serializationService = createSerializationService();
+        partitioningStrategy = new DefaultPartitioningStrategy();
+
+        object1 = new Person("Alice");
+        object2 = new Person("Bob");
+
+        data1 = serializationService.toData(object1);
+        data2 = serializationService.toData(object2);
+        nullData = new HeapData(new byte[0]);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsDisabledAndCacheDeserializedValuesIsALWAYS() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getCachedRecordClass(), record);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsDisabledAndCacheDeserializedValuesIsNEVER() {
+        newRecordFactory(false, CacheDeserializedValues.NEVER);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getRecordClass(), record);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsEnabledAndCacheDeserializedValuesIsALWAYS() {
+        newRecordFactory(true, CacheDeserializedValues.ALWAYS);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getCachedRecordWithStatsClass(), record);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsEnabledAndCacheDeserializedValuesIsNEVER() {
+        newRecordFactory(true, CacheDeserializedValues.NEVER);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getRecordWithStatsClass(), record);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testNewRecord_withNullValue() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+
+        newRecord(factory, data1, null);
+    }
+
+    @Test
+    public void testSetValue() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = factory.newRecord(object1);
+
+        factory.setValue(record, object2);
+
+        assertEquals(getValue(data2, object2), record.getValue());
+    }
+
+    @Test
+    public void testSetValue_withData() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = factory.newRecord(object1);
+
+        factory.setValue(record, data2);
+
+        assertEquals(getValue(data2, object2), record.getValue());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testSetValue_withNull() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = factory.newRecord(object1);
+
+        factory.setValue(record, null);
+    }
+
+    @Test
+    public void testIsEquals() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+
+        assertTrue(factory.isEquals(null, null));
+        assertTrue(factory.isEquals(object1, object1));
+        assertTrue(factory.isEquals(object1, data1));
+        assertTrue(factory.isEquals(data1, data1));
+        assertTrue(factory.isEquals(data1, object1));
+        assertTrue(factory.isEquals(nullData, nullData));
+
+        assertFalse(factory.isEquals(null, object1));
+        assertFalse(factory.isEquals(null, data1));
+        assertFalse(factory.isEquals(null, nullData));
+        assertFalse(factory.isEquals(object1, null));
+        assertFalse(factory.isEquals(object1, nullData));
+        assertFalse(factory.isEquals(object1, object2));
+        assertFalse(factory.isEquals(object1, data2));
+        assertFalse(factory.isEquals(data1, null));
+        assertFalse(factory.isEquals(data1, nullData));
+        assertFalse(factory.isEquals(data1, object2));
+        assertFalse(factory.isEquals(data1, data2));
+        assertFalse(factory.isEquals(nullData, null));
+        assertFalse(factory.isEquals(nullData, object1));
+        assertFalse(factory.isEquals(nullData, data1));
+    }
+
+    @Test
+    public void testIsEquals_withCustomPartitioningStrategy() {
+        partitioningStrategy = new PersonPartitioningStrategy();
+
+        data1 = serializationService.toData(object1, partitioningStrategy);
+        data2 = serializationService.toData(object2, partitioningStrategy);
+
+        testIsEquals();
+    }
+
+    abstract void newRecordFactory(boolean isStatisticsEnabled, CacheDeserializedValues cacheDeserializedValues);
+
+    abstract Class<?> getRecordClass();
+
+    abstract Class<?> getRecordWithStatsClass();
+
+    abstract Class<?> getCachedRecordClass();
+
+    abstract Class<?> getCachedRecordWithStatsClass();
+
+    abstract Object getValue(Data dataValue, Object objectValue);
+
+    InternalSerializationService createSerializationService() {
+        return new DefaultSerializationServiceBuilder().build();
+    }
+
+    Record<T> newRecord(RecordFactory<T> factory, Data key, Object value) {
+        Record<T> record = factory.newRecord(value);
+        ((AbstractRecord) record).setKey(key);
+        return record;
+    }
+
+    static class Person implements Serializable {
+
+        private final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Person)) {
+                return false;
+            }
+
+            Person person = (Person) o;
+            return name != null ? name.equals(person.name) : person.name == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return name != null ? name.hashCode() : 0;
+        }
+    }
+
+    static class PersonPartitioningStrategy implements PartitioningStrategy<Person> {
+
+        @Override
+        public Object getPartitionKey(Person key) {
+            return key.name;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordComparatorTest.java
@@ -16,14 +16,18 @@
 
 package com.hazelcast.map.impl.record;
 
-/**
- * Factory for creating records. Created for every partition.
- *
- * @param <T> the type of object which is going to be created.
- */
-public interface RecordFactory<T> {
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
-    Record<T> newRecord(Object value);
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DataRecordComparatorTest extends AbstractRecordComparatorTest {
 
-    void setValue(Record<T> record, Object value);
+    @Override
+    void newRecordComparator() {
+        comparator = new DataRecordComparator(serializationService);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordComparatorTest.java
@@ -16,14 +16,18 @@
 
 package com.hazelcast.map.impl.record;
 
-/**
- * Factory for creating records. Created for every partition.
- *
- * @param <T> the type of object which is going to be created.
- */
-public interface RecordFactory<T> {
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
-    Record<T> newRecord(Object value);
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ObjectRecordComparatorTest extends AbstractRecordComparatorTest {
 
-    void setValue(Record<T> record, Object value);
+    @Override
+    void newRecordComparator() {
+        comparator = new ObjectRecordComparator(serializationService);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordFactoryTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class DataRecordFactoryTest extends AbstractRecordFactoryTest<Data> {
+public class ObjectRecordFactoryTest extends AbstractRecordFactoryTest<Object> {
 
     @Override
     void newRecordFactory(boolean isStatisticsEnabled, CacheDeserializedValues cacheDeserializedValues) {
@@ -35,31 +35,31 @@ public class DataRecordFactoryTest extends AbstractRecordFactoryTest<Data> {
                 .setStatisticsEnabled(isStatisticsEnabled)
                 .setCacheDeserializedValues(cacheDeserializedValues);
 
-        factory = new DataRecordFactory(mapConfig, serializationService, partitioningStrategy);
+        factory = new ObjectRecordFactory(mapConfig, serializationService);
     }
 
     @Override
     Class<?> getRecordClass() {
-        return DataRecord.class;
+        return ObjectRecord.class;
     }
 
     @Override
     Class<?> getRecordWithStatsClass() {
-        return DataRecordWithStats.class;
+        return ObjectRecordWithStats.class;
     }
 
     @Override
     Class<?> getCachedRecordClass() {
-        return CachedDataRecord.class;
+        return ObjectRecord.class;
     }
 
     @Override
     Class<?> getCachedRecordWithStatsClass() {
-        return CachedDataRecordWithStats.class;
+        return ObjectRecordWithStats.class;
     }
 
     @Override
     Object getValue(Data dataValue, Object objectValue) {
-        return dataValue;
+        return objectValue;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/Person.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/Person.java
@@ -16,14 +16,31 @@
 
 package com.hazelcast.map.impl.record;
 
-/**
- * Factory for creating records. Created for every partition.
- *
- * @param <T> the type of object which is going to be created.
- */
-public interface RecordFactory<T> {
+import java.io.Serializable;
 
-    Record<T> newRecord(Object value);
+class Person implements Serializable {
 
-    void setValue(Record<T> record, Object value);
+    final String name;
+
+    Person(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Person)) {
+            return false;
+        }
+
+        Person person = (Person) o;
+        return name != null ? name.equals(person.name) : person.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TransactionalMapProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TransactionalMapProxyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.tx;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig.InitialLoadMode;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.EAGER;
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.LAZY;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the creation of a transactional map proxy.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TransactionalMapProxyTest extends HazelcastTestSupport {
+
+    private String mapName = randomMapName();
+
+    @Test
+    public void whenMapProxyIsCreated_mapContainerIsNotCreated() {
+        Config config = new Config();
+
+        TransactionalMapProxy mapProxy = getTransactionalMapProxy(config);
+        assertNoMapContainersExist(mapProxy);
+    }
+
+    @Test
+    public void whenMapProxyWithLazyMapStoreIsCreated_mapContainerIsNotCreated() {
+        Config config = getConfigWithMapStore(LAZY);
+
+        TransactionalMapProxy mapProxy = getTransactionalMapProxy(config);
+        assertNoMapContainersExist(mapProxy);
+    }
+
+    @Test
+    @Ignore(value = "PartitionContainer#createRecordStore() creates a MapContainer, which we cannot avoid for now")
+    public void whenMapProxyWithEagerMapStoreIsCreated_mapContainerIsNotCreated() {
+        Config config = getConfigWithMapStore(EAGER);
+
+        TransactionalMapProxy mapProxy = getTransactionalMapProxy(config);
+        assertNoMapContainersExist(mapProxy);
+    }
+
+    @Test
+    public void whenNearCachedMapProxyIsCreated_mapContainerIsNotCreated() {
+        Config config = new Config();
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setName(mapName)
+                .setInMemoryFormat(BINARY)
+                .setInvalidateOnChange(false);
+        config.getMapConfig(mapName).setNearCacheConfig(nearCacheConfig);
+
+        TransactionalMapProxy mapProxy = getTransactionalMapProxy(config);
+        assertNoMapContainersExist(mapProxy);
+    }
+
+    private Config getConfigWithMapStore(InitialLoadMode loadMode) {
+        Config config = new Config();
+        config.getMapConfig(mapName)
+                .getMapStoreConfig().setClassName("com.hazelcast.config.helpers.DummyMapStore")
+                .setInitialLoadMode(loadMode)
+                .setEnabled(true);
+        return config;
+    }
+
+    private TransactionalMapProxy getTransactionalMapProxy(Config config) {
+        HazelcastInstance hz = createHazelcastInstance(config);
+        TransactionContext transactionContext = hz.newTransactionContext();
+        transactionContext.beginTransaction();
+        return (TransactionalMapProxy) transactionContext.getMap(mapName);
+    }
+
+    private void assertNoMapContainersExist(TransactionalMapProxy map) {
+        MapServiceContext mapServiceContext = map.getService().getMapServiceContext();
+        assertEquals(0, mapServiceContext.getMapContainers().size());
+    }
+}


### PR DESCRIPTION
My solution to this issue is to move some logic from the `MapContainer` to the `MapServiceContext`. Since the context is shared between all maps, I used a `ConcurrentMap<String, ?>` to cache the migrated state in the context. So it doesn't matter if the `MapContainer` or `TransactionalMapProxy` wants to access the field first. The cached data is destroyed when the map is destroyed, so there should be no leak.

Fixes https://github.com/hazelcast/hazelcast/issues/10254

This test is still failing, which is passing on the original `MapProxyImplTest`:
**TransactionalMapProxyTest.whenMapProxyWithEagerMapStoreIsCreated_mapContainerIsNotCreated()**
```java
java.lang.AssertionError: expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at com.hazelcast.map.impl.tx.TransactionalMapProxyTest.assertNoMapContainersExist(TransactionalMapProxyTest.java:102)
	at com.hazelcast.map.impl.tx.TransactionalMapProxyTest.whenMapProxyWithEagerMapStoreIsCreated_mapContainerIsNotCreated(TransactionalMapProxyTest.java:68)
```