### PR TITLE
[Backport] PR #11146 : The client should not use localhost if it is not explicitly configured and the discovery is configured

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -208,9 +208,6 @@ public class ClientNetworkConfig {
      * @return list of addresses
      */
     public List<String> getAddresses() {
-        if (addressList.size() == 0) {
-            addAddress("localhost");
-        }
         return addressList;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -265,7 +265,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         final ClientAwsConfig awsConfig = networkConfig.getAwsConfig();
         Collection<AddressProvider> addressProviders = new LinkedList<AddressProvider>();
 
-        addressProviders.add(new DefaultAddressProvider(networkConfig));
         if (externalAddressProvider != null) {
             addressProviders.add(externalAddressProvider);
         }
@@ -283,6 +282,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                 throw e;
             }
         }
+
+        addressProviders.add(new DefaultAddressProvider(networkConfig, addressProviders.isEmpty()));
         return addressProviders;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -182,9 +182,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     private void checkIfClientStillRuning(String shutdownMessage) {
         if (!client.getLifecycleService().isRunning()) {
-            if (!client.getLifecycleService().isRunning()) {
-                throw new IllegalStateException(shutdownMessage);
-            }
+            throw new IllegalStateException(shutdownMessage);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -33,14 +33,19 @@ import java.util.List;
 public class DefaultAddressProvider implements AddressProvider {
 
     private ClientNetworkConfig networkConfig;
+    private boolean noOtherAddressProviderExist;
 
-    public DefaultAddressProvider(ClientNetworkConfig networkConfig) {
+    public DefaultAddressProvider(ClientNetworkConfig networkConfig, boolean noOtherAddressProviderExist) {
         this.networkConfig = networkConfig;
+        this.noOtherAddressProviderExist = noOtherAddressProviderExist;
     }
 
     @Override
     public Collection<InetSocketAddress> loadAddresses() {
         final List<String> addresses = networkConfig.getAddresses();
+        if (addresses.isEmpty() && noOtherAddressProviderExist) {
+            addresses.add("localhost");
+        }
         final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
 
         for (String address : addresses) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -84,9 +84,10 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         String illegalAddress = randomString();
 
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        Address serverAddress = server.getCluster().getLocalMember().getAddress();
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
-        config.getNetworkConfig().addAddress(illegalAddress).addAddress("localhost");
+        config.getNetworkConfig().addAddress(illegalAddress).addAddress(serverAddress.getHost() + ":" + serverAddress.getPort());
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
 
         Collection<Client> connectedClients = server.getClientService().getConnectedClients();


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast/pull/11146 . The client should not use localhost if it is not explicitly configured and the discovery is configured.