### PR TITLE
Notify invocations when a member leaves in FROZEN/PASSIVE cluster state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -26,7 +26,6 @@ import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.FetchMembersViewOp;
 import com.hazelcast.internal.cluster.impl.operations.MembersUpdateOp;
-import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -572,12 +571,9 @@ public class MembershipManager {
                 membersRemovedInNotJoinableStateRef
                         .set(MemberMap.cloneAdding(membersRemovedInNotJoinableState, removedMember));
             }
-
-            InternalPartitionServiceImpl partitionService = node.partitionService;
-            partitionService.cancelReplicaSyncRequestsTo(removedMember.getAddress());
-        } else {
-            onMemberRemove(removedMember);
         }
+
+        onMemberRemove(removedMember);
 
         // async events
         sendMembershipEventNotifications(removedMember,


### PR DESCRIPTION
When cluster state doesn't allow new members to join, we don't modify
partition table if a member leaves. But invocations targeting that left
member, blocked operations belonging to that member should be notified.

Currently, those invocations doesn't get a response and fail with
OperationTimeoutException.

Fixes https://github.com/hazelcast/hazelcast/issues/8227