### PR TITLE
[BACKPORT] Notify invocations when a member leaves in FROZEN/PASSIVE cluster state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -623,12 +623,9 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                         membersRemovedInNotActiveStateRef
                                 .set(MemberMap.cloneAdding(membersRemovedInNotActiveState, deadMember));
                     }
-
-                    InternalPartitionServiceImpl partitionService = node.partitionService;
-                    partitionService.cancelReplicaSyncRequestsTo(deadAddress);
-                } else {
-                    onMemberRemove(deadMember, newMembers);
                 }
+
+                onMemberRemove(deadMember, newMembers);
 
                 // async events
                 sendMembershipEventNotifications(deadMember,

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -358,40 +358,31 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     @Override
     public void memberRemoved(final MemberImpl member) {
         logger.fine("Removing " + member);
-        final Address deadAddress = member.getAddress();
-        final Address thisAddress = node.getThisAddress();
-
         lock.lock();
         try {
-            partitionStateManager.updateMemberGroupsSize();
             migrationManager.onMemberRemove(member);
+            replicaManager.cancelReplicaSyncRequestsTo(member.getAddress());
 
-            boolean isThisNodeNewMaster = node.isMaster() && !thisAddress.equals(lastMaster);
+            ClusterState clusterState = node.getClusterService().getClusterState();
+            if (clusterState != ClusterState.ACTIVE) {
+                // If join is not allowed, partition table cannot be modified and we should have
+                // the most recent partition table already. Because cluster state cannot be changed
+                // when our partition table is stale.
+                return;
+            }
+
+            partitionStateManager.updateMemberGroupsSize();
+
+            boolean isThisNodeNewMaster = node.isMaster() && !node.getThisAddress().equals(lastMaster);
             if (isThisNodeNewMaster) {
                 assert !shouldFetchPartitionTables : "SOMETHING IS WRONG! Removed member: " + member;
                 shouldFetchPartitionTables = true;
             }
 
             lastMaster = node.getMasterAddress();
-
-            migrationManager.pauseMigration();
-
-            replicaManager.cancelReplicaSyncRequestsTo(deadAddress);
-
             if (node.isMaster()) {
                 migrationManager.triggerControlTask();
             }
-
-            migrationManager.resumeMigration();
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    public void cancelReplicaSyncRequestsTo(Address deadAddress) {
-        lock.lock();
-        try {
-            replicaManager.cancelReplicaSyncRequestsTo(deadAddress);
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
When cluster state doesn't allow new members to join, we don't modify
partition table if a member leaves. But invocations targeting that left
member, blocked operations belonging to that member should be notified.

Currently, those invocations doesn't get a response and fail with
OperationTimeoutException.

Backport of https://github.com/hazelcast/hazelcast/pull/11201