### PR TITLE
Removed invalidation listener in post-destroy method

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -131,6 +131,10 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
         if (!isClosed.compareAndSet(false, true)) {
             return;
         }
+        closeInternal();
+    }
+
+    protected void closeInternal() {
         waitOnGoingLoadAllCallsToFinish();
         closeListeners();
     }
@@ -153,10 +157,10 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
 
     @Override
     protected boolean preDestroy() {
-        close();
         if (!isDestroyed.compareAndSet(false, true)) {
             return false;
         }
+        closeInternal();
         isClosed.set(true);
         return true;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -461,11 +461,13 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     }
 
     @Override
-    protected void onDestroy() {
-        removeInvalidationListener();
-        nearCacheManager.destroyNearCache(nearCache.getName());
-
-        super.onDestroy();
+    protected void postDestroy() {
+        try {
+            removeInvalidationListener();
+            nearCacheManager.destroyNearCache(nearCache.getName());
+        } finally {
+            super.postDestroy();
+        }
     }
 
     private Object getCachedValue(Object key, boolean deserializeValue) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -113,10 +113,14 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     }
 
     @Override
-    protected void onDestroy() {
-        if (nearCache != null) {
-            removeNearCacheInvalidationListener();
-            getContext().getNearCacheManager().destroyNearCache(name);
+    protected void postDestroy() {
+        try {
+            if (nearCache != null) {
+                removeNearCacheInvalidationListener();
+                getContext().getNearCacheManager().destroyNearCache(name);
+            }
+        } finally {
+            super.postDestroy();
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -554,11 +554,13 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected void onDestroy() {
-        removeNearCacheInvalidationListener();
-        getContext().getNearCacheManager().destroyNearCache(name);
-
-        super.onDestroy();
+    protected void postDestroy() {
+        try {
+            removeNearCacheInvalidationListener();
+            getContext().getNearCacheManager().destroyNearCache(name);
+        } finally {
+            super.postDestroy();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -311,8 +311,8 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     public void deleteCache(String name, String callerUuid, boolean destroy) {
         CacheConfig config = deleteCacheConfig(name);
         if (destroy) {
-            destroySegments(name);
             cacheEventHandler.destroy(name, SOURCE_NOT_AVAILABLE);
+            destroySegments(name);
         } else {
             closeSegments(name);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -545,12 +545,15 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected boolean preDestroy() {
-        if (invalidateOnChange) {
-            mapNearCacheManager.deregisterRepairingHandler(name);
-            removeEntryListener(invalidationListenerId);
+    protected void postDestroy() {
+        try {
+            if (invalidateOnChange) {
+                mapNearCacheManager.deregisterRepairingHandler(name);
+                removeEntryListener(invalidationListenerId);
+            }
+        } finally {
+            super.postDestroy();
         }
-        return super.preDestroy();
     }
 
     protected void invalidateNearCache(Object key) {


### PR DESCRIPTION
otherwise invalidation event on destroy can be lost since invalidation-listener can be removed before invalidation-event generation. If there is no listener registered, we don't generate any event.