### PR TITLE
Fixed CacheCreateUseDestroyTest and ClientCacheCreateUseDestroyTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.cache.impl;
 
-import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.CacheCreateUseDestroyTest;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -27,19 +26,20 @@ import org.junit.Before;
 import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
 
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
+
 public class ClientCacheCreateUseDestroyTest extends CacheCreateUseDestroyTest {
 
     private TestHazelcastFactory factory;
 
-    @Override
     @Before
+    @Override
     public void setup() {
         assumptions();
         factory = new TestHazelcastFactory();
         HazelcastInstance member = factory.newHazelcastInstance(getConfig());
         CachingProvider provider = Caching.getCachingProvider();
-        defaultCacheManager = provider.getCacheManager(null, null,
-                HazelcastCachingProvider.propertiesByInstanceItself(factory.newHazelcastClient()));
+        defaultCacheManager = provider.getCacheManager(null, null, propertiesByInstanceItself(factory.newHazelcastClient()));
         cacheService = getNode(member).getNodeEngine().getService(ICacheService.SERVICE_NAME);
         CacheEntryListenerFactory.listener = null;
     }
@@ -49,7 +49,6 @@ public class ClientCacheCreateUseDestroyTest extends CacheCreateUseDestroyTest {
         if (factory != null) {
             factory.terminateAll();
         }
+        Caching.getCachingProvider().close();
     }
-
-
 }


### PR DESCRIPTION
The tests have to close the `CachingProvider` again, otherwise it will
be left in a static registry and a next test in the same JVM may fail.

(cherry picked from commit 0200f75)

Backport of https://github.com/hazelcast/hazelcast/pull/11203
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1653