### PR TITLE
[BACKPORT] If security enabled and not running enterprise, then error

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.PartitioningStrategy;
@@ -85,8 +86,18 @@ public class DefaultNodeExtension implements NodeExtension {
 
     public DefaultNodeExtension(Node node) {
         this.node = node;
-        logger = node.getLogger(NodeExtension.class);
-        systemLogger = node.getLogger("com.hazelcast.system");
+        this.logger = node.getLogger(NodeExtension.class);
+        this.systemLogger = node.getLogger("com.hazelcast.system");
+        checkSecurityAllowed();
+    }
+
+    private void checkSecurityAllowed() {
+        SecurityConfig securityConfig =  node.getConfig().getSecurityConfig();
+        if (securityConfig != null && securityConfig.isEnabled()) {
+            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
+                throw new IllegalStateException("Security requires Hazelcast Enterprise Edition");
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/security/SecurityWithoutEnterpriseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/SecurityWithoutEnterpriseTest.java
@@ -1,0 +1,24 @@
+package com.hazelcast.security;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.SecurityConfig;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SecurityWithoutEnterpriseTest extends HazelcastTestSupport {
+
+    @Test(expected = IllegalStateException.class)
+    public void test() throws IOException {
+        Config config = new Config()
+                .setSecurityConfig(new SecurityConfig().setEnabled(true));
+        createHazelcastInstance(config);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -51,6 +51,7 @@ import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THR
 import static java.util.Collections.synchronizedList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
  * Abstract test support to test the {@link OperationExecutorImpl}.
@@ -81,7 +82,9 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         config.setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "10");
         config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "10");
         thisAddress = new Address("localhost", 5701);
-        nodeExtension = new DefaultNodeExtension(Mockito.mock(Node.class));
+        Node node = Mockito.mock(Node.class);
+        when(node.getConfig()).thenReturn(config);
+        nodeExtension = new DefaultNodeExtension(node);
         handlerFactory = new DummyOperationRunnerFactory();
 
         responsePacketHandler = new DummyResponsePacketHandler();


### PR DESCRIPTION
Currently it is silently ignored which can lead to security issues if by accident
the enterprise jars are missing from the classpath.

It is best to fail fast. So a check has been added on node startup to verify that
enterprise is enabled if security is enabled. Otherwise an exception is thrown
that prevents the node from starting.

fix https://github.com/hazelcast/hazelcast-enterprise/issues/1626

Backport of https://github.com/hazelcast/hazelcast/pull/11143