### PR TITLE
[BACKPORT] If SSL is enabled, then enterprise should be used.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -155,6 +155,16 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         this.socketInterceptor = initSocketInterceptor(networkConfig.getSocketInterceptorConfig());
 
         this.credentials = client.getCredentials();
+        checkSslAllowed();
+    }
+
+    private void checkSslAllowed() {
+        SSLConfig sslConfig = client.getClientConfig().getNetworkConfig().getSSLConfig();
+        if (sslConfig != null && sslConfig.isEnabled()) {
+            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
+                throw new IllegalStateException("SSL/TLS requires Hazelcast Enterprise Edition");
+            }
+        }
     }
 
     protected void initIOThreads(HazelcastClientInstanceImpl client) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/SSLWithoutEnterpriseTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/SSLWithoutEnterpriseTest.java
@@ -1,0 +1,32 @@
+package com.hazelcast.client.io;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.hazelcast.nio.ssl.TestKeyStoreUtil.createSslProperties;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SSLWithoutEnterpriseTest extends HazelcastTestSupport {
+
+    @Test(expected = IllegalStateException.class)
+    public void test() throws IOException {
+        ClientConfig config = new ClientConfig();
+        SSLConfig sslConfig = new SSLConfig();
+        sslConfig.setEnabled(true)
+                .setProperties(createSslProperties());
+
+        config.getNetworkConfig().setSSLConfig(sslConfig);
+
+        HazelcastClient.newHazelcastClient(config);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.cluster.impl.BindMessage;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
@@ -150,6 +152,16 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         this.socketChannelWrapperFactory = ioService.getSocketChannelWrapperFactory();
         this.metricsRegistry = metricsRegistry;
         metricsRegistry.scanAndRegister(this, "tcp.connection");
+        checkSslAllowed();
+    }
+
+    private void checkSslAllowed() {
+        SSLConfig sslConfig = ioService.getSSLConfig();
+        if (sslConfig != null && sslConfig.isEnabled()) {
+            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
+                throw new IllegalStateException("SSL/TLS requires Hazelcast Enterprise Edition");
+            }
+        }
     }
 
     public IOService getIoService() {

--- a/hazelcast/src/test/java/com/hazelcast/nio/ssl/SSLWithoutEnterpriseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ssl/SSLWithoutEnterpriseTest.java
@@ -1,0 +1,33 @@
+package com.hazelcast.nio.ssl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.hazelcast.nio.ssl.TestKeyStoreUtil.createSslProperties;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SSLWithoutEnterpriseTest extends HazelcastTestSupport {
+
+    @Test(expected = IllegalStateException.class)
+    public void test() throws IOException {
+        Config config = new Config();
+        SSLConfig sslConfig = new SSLConfig();
+        sslConfig.setEnabled(true)
+                .setProperties(createSslProperties());
+
+        config.getNetworkConfig().setSSLConfig(sslConfig);
+
+        Hazelcast.newHazelcastInstance(config);
+    }
+}


### PR DESCRIPTION
Currently the SSL configuration is ignored when enterprise isn't loaded. This causes
confusion and potentially can cause security risks.

So instead of ignoring the situation, an exception is thrown (fail fast). This check is
done on both the client and the member.

Fixes enterprise issue: https://github.com/hazelcast/hazelcast-enterprise/issues/1626

Backport of https://github.com/hazelcast/hazelcast/pull/11123