### PR TITLE
updated url paths at *CheckDependenciesIT tests

### DIFF
--- a/hazelcast-all/src/test/java/com/hazelcast/it/CheckAllDependenciesIT.java
+++ b/hazelcast-all/src/test/java/com/hazelcast/it/CheckAllDependenciesIT.java
@@ -6,6 +6,6 @@ public class CheckAllDependenciesIT extends CheckDependenciesIT {
 
     @Override
     protected boolean isMatching(String urlString) {
-        return urlString.contains("hazelcast-all-") && urlString.contains("target");
+        return urlString.contains("hazelcast/hazelcast/") && !urlString.contains("test");
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/osgi/ClientCheckDependenciesIT.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/osgi/ClientCheckDependenciesIT.java
@@ -6,6 +6,6 @@ public class ClientCheckDependenciesIT extends CheckDependenciesIT {
 
     @Override
     protected boolean isMatching(String urlString) {
-        return urlString.contains("hazelcast-client-") && urlString.contains("target");
+        return urlString.contains("hazelcast-client/target/classes/META-INF/MANIFEST.MF");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -100,7 +100,7 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
                 if (matchedUrl == null) {
                     matchedUrl = url;
                 } else {
-                    throw new AssertionError("Found multiple matching URLs: " + url +" and " + matchedUrl);
+                    throw new AssertionError("Found multiple matching URLs: " + url + " and " + matchedUrl);
                 }
             }
         }
@@ -115,6 +115,6 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
     }
 
     protected boolean isMatching(String urlString) {
-        return urlString.contains("hazelcast-3.") && urlString.contains("target");
+        return urlString.contains("hazelcast/target/classes/META-INF/MANIFEST.MF");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1020,7 +1020,6 @@
                             </includes>
                             <excludes>
                                 <exclude>**/jsr/**.java</exclude>
-                                <exclude>**/**IT.java</exclude>
                             </excludes>
                             <groups>
                                 com.hazelcast.test.annotation.NightlyTest,


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/11093 except `com.hazelcast.it.CheckAllDependenciesIT.testNoMandatoryDependencyDeclared` because we do not create `MANIFEST.MF` at `hazelcast-all` module. To create manifest file, we need to update pom.xml with https://github.com/hazelcast/hazelcast/blob/master/hazelcast/pom.xml#L161 .

These tests are not running with `default` profile because they are excluded:
https://github.com/hazelcast/hazelcast/blob/master/pom.xml#L264