### PR TITLE
Fixed JCache test setup

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -20,13 +20,13 @@ import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.jsr.JsrClientTestUtil;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -58,6 +58,8 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
 
     @Before
     public void init() {
+        JsrClientTestUtil.setup();
+
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getNetworkConfig().setPort(5701);
@@ -77,8 +79,7 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        HazelcastClient.shutdownAll();
-        HazelcastInstanceFactory.terminateAll();
+        JsrClientTestUtil.cleanup();
     }
 
     @Test
@@ -120,7 +121,6 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
         assertNotNull(cacheManager2);
 
         assertEquals(2, HazelcastClient.getAllHazelcastClients().size());
-        Caching.getCachingProvider().close();
     }
 
     @Test
@@ -144,8 +144,6 @@ public class ClientCacheConfigTest extends HazelcastTestSupport {
 
         assertEquals(1, HazelcastClient.getAllHazelcastClients().size());
         client.shutdown();
-
-        Caching.getCachingProvider().close();
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.cache.impl;
 
 import com.hazelcast.cache.impl.CacheCreateUseDestroyTest;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.client.cache.jsr.JsrClientTestUtil;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import org.junit.After;
@@ -36,6 +37,8 @@ public class ClientCacheCreateUseDestroyTest extends CacheCreateUseDestroyTest {
     @Override
     public void setup() {
         assumptions();
+        JsrClientTestUtil.setup();
+
         factory = new TestHazelcastFactory();
         HazelcastInstance member = factory.newHazelcastInstance(getConfig());
         CachingProvider provider = Caching.getCachingProvider();
@@ -45,10 +48,11 @@ public class ClientCacheCreateUseDestroyTest extends CacheCreateUseDestroyTest {
     }
 
     @After
-    public void cleanup() {
+    @Override
+    public void tearDown() {
         if (factory != null) {
             factory.terminateAll();
         }
-        Caching.getCachingProvider().close();
+        JsrClientTestUtil.cleanup();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerClientServerTest.java
@@ -23,25 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheEntryListenerClientServerTest
-        extends org.jsr107.tck.event.CacheEntryListenerClientServerTest {
-
-    /*
-    These system propreties are necessary if you run jsr tests from IDEA
-    static {
-        System.setProperty("javax.management.builder.initial", "com.hazelcast.cache.impl.TCKMBeanServerBuilder");
-        System.setProperty("org.jsr107.tck.management.agentId", "TCKMbeanServer");
-        System.setProperty(Cache.class.getName(), "com.hazelcast.cache.ICache");
-        System.setProperty(Cache.Entry.class.getCanonicalName(), "com.hazelcast.cache.impl.CacheEntry");
-    }
-    */
+public class CacheEntryListenerClientServerTest extends org.jsr107.tck.event.CacheEntryListenerClientServerTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerExceptionTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheEntryListenerExceptionTest
-        extends javax.cache.expiry.ExpiryPolicyTest {
+public class CacheEntryListenerExceptionTest extends javax.cache.expiry.ExpiryPolicyTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheExpiryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheExpiryTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheExpiryTest
-        extends org.jsr107.tck.expiry.CacheExpiryTest {
+public class CacheExpiryTest extends org.jsr107.tck.expiry.CacheExpiryTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheInvokeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheInvokeTest.java
@@ -25,12 +25,11 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheInvokeTest
-        extends org.jsr107.tck.processor.CacheInvokeTest {
+public class CacheInvokeTest extends org.jsr107.tck.processor.CacheInvokeTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheListenerTest.java
@@ -23,17 +23,14 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheListenerTest
-        extends org.jsr107.tck.event.CacheListenerTest {
+public class CacheListenerTest extends org.jsr107.tck.event.CacheListenerTest {
 
     @BeforeClass
     public static void setup() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
-
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderClientServerTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderClientServerTest
-        extends org.jsr107.tck.integration.CacheLoaderClientServerTest {
+public class CacheLoaderClientServerTest extends org.jsr107.tck.integration.CacheLoaderClientServerTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderExceptionTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderExceptionTest
-        extends javax.cache.integration.CacheLoaderExceptionTest {
+public class CacheLoaderExceptionTest extends javax.cache.integration.CacheLoaderExceptionTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderTest
-        extends org.jsr107.tck.integration.CacheLoaderTest {
+public class CacheLoaderTest extends org.jsr107.tck.integration.CacheLoaderTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithExpiryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithExpiryTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderWithExpiryTest
-        extends org.jsr107.tck.integration.CacheLoaderWithExpiryTest {
+public class CacheLoaderWithExpiryTest extends org.jsr107.tck.integration.CacheLoaderWithExpiryTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithoutReadThroughTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithoutReadThroughTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderWithoutReadThroughTest
-        extends org.jsr107.tck.integration.CacheLoaderWithoutReadThroughTest {
+public class CacheLoaderWithoutReadThroughTest extends org.jsr107.tck.integration.CacheLoaderWithoutReadThroughTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWriterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWriterTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderWriterTest
-        extends org.jsr107.tck.integration.CacheLoaderWriterTest {
+public class CacheLoaderWriterTest extends org.jsr107.tck.integration.CacheLoaderWriterTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMBStatisticsBeanTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMBStatisticsBeanTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheMBStatisticsBeanTest
-        extends org.jsr107.tck.management.CacheMBStatisticsBeanTest {
+public class CacheMBStatisticsBeanTest extends org.jsr107.tck.management.CacheMBStatisticsBeanTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMXBeanTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMXBeanTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheMXBeanTest
-        extends org.jsr107.tck.management.CacheMXBeanTest {
+public class CacheMXBeanTest extends org.jsr107.tck.management.CacheMXBeanTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerManagementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerManagementTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheManagerManagementTest
-        extends org.jsr107.tck.management.CacheManagerManagementTest {
+public class CacheManagerManagementTest extends org.jsr107.tck.management.CacheManagerManagementTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheManagerTest
-        extends org.jsr107.tck.CacheManagerTest {
+public class CacheManagerTest extends org.jsr107.tck.CacheManagerTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheTest.java
@@ -23,16 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheTest
-        extends org.jsr107.tck.CacheTest {
-
+public class CacheTest extends org.jsr107.tck.CacheTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterClientServerTest.java
@@ -19,14 +19,18 @@ package com.hazelcast.client.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheWriterClientServerTest
-        extends org.jsr107.tck.integration.CacheWriterClientServerTest {
+public class CacheWriterClientServerTest extends org.jsr107.tck.integration.CacheWriterClientServerTest {
+
+    @BeforeClass
+    public static void setupInstance() {
+        JsrClientTestUtil.setupWithHazelcastInstance();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterExceptionTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheWriterExceptionTest
-        extends javax.cache.integration.CacheWriterExceptionTest {
+public class CacheWriterExceptionTest extends javax.cache.integration.CacheWriterExceptionTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheWriterTest
-        extends org.jsr107.tck.integration.CacheWriterTest {
+public class CacheWriterTest extends org.jsr107.tck.integration.CacheWriterTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderClassLoaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderClassLoaderTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CachingProviderClassLoaderTest
-        extends org.jsr107.tck.spi.CachingProviderClassLoaderTest {
+public class CachingProviderClassLoaderTest extends org.jsr107.tck.spi.CachingProviderClassLoaderTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CachingProviderTest
-        extends org.jsr107.tck.spi.CachingProviderTest {
+public class CachingProviderTest extends org.jsr107.tck.spi.CachingProviderTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingTest.java
@@ -24,15 +24,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CachingTest
-        extends org.jsr107.tck.CachingTest {
+public class CachingTest extends org.jsr107.tck.CachingTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass
@@ -44,5 +42,4 @@ public class CachingTest
     @Override
     public void dummyTest() {
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ClientServerTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClientServerTest
-        extends org.jsr107.tck.support.ClientServerTest {
+public class ClientServerTest extends org.jsr107.tck.support.ClientServerTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CompletionListenerFutureTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CompletionListenerFutureTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CompletionListenerFutureTest
-        extends javax.cache.integration.CompletionListenerFutureTest {
+public class CompletionListenerFutureTest extends javax.cache.integration.CompletionListenerFutureTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ConfigurationTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ConfigurationTest
-        extends javax.cache.configuration.ConfigurationTest {
+public class ConfigurationTest extends javax.cache.configuration.ConfigurationTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/DurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/DurationTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class DurationTest
-        extends javax.cache.expiry.DurationTest {
+public class DurationTest extends javax.cache.expiry.DurationTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/EntryProcessorExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/EntryProcessorExceptionTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class EntryProcessorExceptionTest
-        extends org.jsr107.tck.processor.EntryProcessorExceptionTest {
+public class EntryProcessorExceptionTest extends org.jsr107.tck.processor.EntryProcessorExceptionTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ExpiryPolicyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ExpiryPolicyTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ExpiryPolicyTest
-        extends javax.cache.expiry.ExpiryPolicyTest {
+public class ExpiryPolicyTest extends javax.cache.expiry.ExpiryPolicyTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/FactoryBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/FactoryBuilderTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class FactoryBuilderTest
-        extends javax.cache.configuration.FactoryBuilderTest {
+public class FactoryBuilderTest extends javax.cache.configuration.FactoryBuilderTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/GetTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/GetTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class GetTest
-        extends org.jsr107.tck.GetTest {
+public class GetTest extends org.jsr107.tck.GetTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
@@ -19,9 +19,11 @@ package com.hazelcast.client.cache.jsr;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 
-import javax.cache.Cache;
-import javax.cache.Caching;
+import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
+import static com.hazelcast.cache.jsr.JsrTestUtil.clearSystemProperties;
+import static com.hazelcast.cache.jsr.JsrTestUtil.setSystemProperties;
 
 /**
  * Utility class responsible for setup/cleanup of client JSR tests.
@@ -31,22 +33,24 @@ public final class JsrClientTestUtil {
     private JsrClientTestUtil() {
     }
 
-    static {
-        System.setProperty("javax.management.builder.initial", "com.hazelcast.cache.impl.TCKMBeanServerBuilder");
-        System.setProperty("org.jsr107.tck.management.agentId", "TCKMbeanServer");
-        System.setProperty(Cache.class.getName(), "com.hazelcast.cache.ICache");
-        System.setProperty(Cache.Entry.class.getCanonicalName(), "com.hazelcast.cache.impl.CacheEntry");
+    public static void setup() {
+        setSystemProperties("client");
     }
 
-    public static void setup() {
+    public static void setupWithHazelcastInstance() {
+        setSystemProperties("client");
+
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         Hazelcast.newHazelcastInstance(config);
     }
 
     public static void cleanup() {
-        Caching.getCachingProvider().close();
+        clearSystemProperties();
+        clearCachingProviderRegistry();
+
         HazelcastClient.shutdownAll();
         Hazelcast.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
@@ -23,7 +23,6 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class MutableCacheEntryListenerConfigurationTest
@@ -31,7 +30,7 @@ public class MutableCacheEntryListenerConfigurationTest
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableConfigurationTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class MutableConfigurationTest
-        extends javax.cache.configuration.MutableConfigurationTest {
+public class MutableConfigurationTest extends javax.cache.configuration.MutableConfigurationTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/PutTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/PutTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class PutTest
-        extends org.jsr107.tck.PutTest {
+public class PutTest extends org.jsr107.tck.PutTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/RemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/RemoveTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class RemoveTest
-        extends org.jsr107.tck.RemoveTest {
+public class RemoveTest extends org.jsr107.tck.RemoveTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ReplaceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ReplaceTest.java
@@ -23,20 +23,17 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ReplaceTest
-        extends org.jsr107.tck.ReplaceTest {
+public class ReplaceTest extends org.jsr107.tck.ReplaceTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass
     public static void cleanup() {
         JsrClientTestUtil.cleanup();
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByReferenceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByReferenceTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class StoreByReferenceTest
-        extends org.jsr107.tck.StoreByReferenceTest {
+public class StoreByReferenceTest extends org.jsr107.tck.StoreByReferenceTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByValueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByValueTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class StoreByValueTest
-        extends org.jsr107.tck.StoreByValueTest {
+public class StoreByValueTest extends org.jsr107.tck.StoreByValueTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/TypesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/TypesTest.java
@@ -23,15 +23,13 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class TypesTest
-        extends org.jsr107.tck.TypesTest {
+public class TypesTest extends org.jsr107.tck.TypesTest {
 
     @BeforeClass
     public static void setupInstance() {
-        JsrClientTestUtil.setup();
+        JsrClientTestUtil.setupWithHazelcastInstance();
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheCreateUseDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheCreateUseDestroyTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheUtil;
 import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.jsr.JsrTestUtil;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CacheSimpleEntryListenerConfig;
@@ -72,10 +73,10 @@ import static org.junit.Assume.assumeThat;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@Category(QuickTest.class)
 public class CacheCreateUseDestroyTest extends HazelcastTestSupport {
 
-    public static final MemorySize NATIVE_MEMORY_SIZE = new MemorySize(32, MemoryUnit.MEGABYTES);
+    private static final MemorySize NATIVE_MEMORY_SIZE = new MemorySize(32, MemoryUnit.MEGABYTES);
 
     @Parameters(name = "{0}")
     public static Collection parameters() {
@@ -96,6 +97,8 @@ public class CacheCreateUseDestroyTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         assumptions();
+        JsrTestUtil.setup();
+
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
         HazelcastInstance member = factory.newHazelcastInstance(getConfig());
         CachingProvider provider = Caching.getCachingProvider();
@@ -106,7 +109,7 @@ public class CacheCreateUseDestroyTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        Caching.getCachingProvider().close();
+        JsrTestUtil.cleanup();
     }
 
     protected void assumptions() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerClientServerTest.java
@@ -19,23 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheEntryListenerClientServerTest
-        extends org.jsr107.tck.event.CacheEntryListenerClientServerTest {
+public class CacheEntryListenerClientServerTest extends org.jsr107.tck.event.CacheEntryListenerClientServerTest {
 
-    /*
-    These system propreties are necessary if you run jsr tests from IDEA
-    static {
-        System.setProperty("javax.management.builder.initial", "com.hazelcast.cache.impl.TCKMBeanServerBuilder");
-        System.setProperty("org.jsr107.tck.management.agentId", "TCKMbeanServer");
-        System.setProperty(Cache.class.getName(), "com.hazelcast.cache.ICache");
-        System.setProperty(Cache.Entry.class.getCanonicalName(), "com.hazelcast.cache.impl.CacheEntry");
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
     }
-    */
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerExceptionTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheEntryListenerExceptionTest
-        extends javax.cache.expiry.ExpiryPolicyTest {
+public class CacheEntryListenerExceptionTest extends javax.cache.expiry.ExpiryPolicyTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheExpiryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheExpiryTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheExpiryTest
-        extends org.jsr107.tck.expiry.CacheExpiryTest {
+public class CacheExpiryTest extends org.jsr107.tck.expiry.CacheExpiryTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheInvokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheInvokeTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheInvokeTest
-        extends org.jsr107.tck.processor.CacheInvokeTest {
+public class CacheInvokeTest extends org.jsr107.tck.processor.CacheInvokeTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheListenerTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheListenerTest
-        extends org.jsr107.tck.event.CacheListenerTest {
+public class CacheListenerTest extends org.jsr107.tck.event.CacheListenerTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderClientServerTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderClientServerTest
-        extends org.jsr107.tck.integration.CacheLoaderClientServerTest {
+public class CacheLoaderClientServerTest extends org.jsr107.tck.integration.CacheLoaderClientServerTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderExceptionTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderExceptionTest
-        extends javax.cache.integration.CacheLoaderExceptionTest {
+public class CacheLoaderExceptionTest extends javax.cache.integration.CacheLoaderExceptionTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderTest
-        extends org.jsr107.tck.integration.CacheLoaderTest {
+public class CacheLoaderTest extends org.jsr107.tck.integration.CacheLoaderTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithExpiryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithExpiryTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderWithExpiryTest
-        extends org.jsr107.tck.integration.CacheLoaderWithExpiryTest {
+public class CacheLoaderWithExpiryTest extends org.jsr107.tck.integration.CacheLoaderWithExpiryTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithoutReadThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithoutReadThroughTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderWithoutReadThroughTest
-        extends org.jsr107.tck.integration.CacheLoaderWithoutReadThroughTest {
+public class CacheLoaderWithoutReadThroughTest extends org.jsr107.tck.integration.CacheLoaderWithoutReadThroughTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWriterTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheLoaderWriterTest
-        extends org.jsr107.tck.integration.CacheLoaderWriterTest {
+public class CacheLoaderWriterTest extends org.jsr107.tck.integration.CacheLoaderWriterTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMBStatisticsBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMBStatisticsBeanTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheMBStatisticsBeanTest
-        extends org.jsr107.tck.management.CacheMBStatisticsBeanTest {
+public class CacheMBStatisticsBeanTest extends org.jsr107.tck.management.CacheMBStatisticsBeanTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMXBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMXBeanTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheMXBeanTest
-        extends org.jsr107.tck.management.CacheMXBeanTest {
+public class CacheMXBeanTest extends org.jsr107.tck.management.CacheMXBeanTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerManagementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerManagementTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheManagerManagementTest
-        extends org.jsr107.tck.management.CacheManagerManagementTest {
+public class CacheManagerManagementTest extends org.jsr107.tck.management.CacheManagerManagementTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheManagerTest
-        extends org.jsr107.tck.CacheManagerTest {
+public class CacheManagerTest extends org.jsr107.tck.CacheManagerTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheTest.java
@@ -19,18 +19,21 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheTest
-        extends org.jsr107.tck.CacheTest {
+public class CacheTest extends org.jsr107.tck.CacheTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {
         JsrTestUtil.cleanup();
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterClientServerTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheWriterClientServerTest
-        extends org.jsr107.tck.integration.CacheWriterClientServerTest {
+public class CacheWriterClientServerTest extends org.jsr107.tck.integration.CacheWriterClientServerTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterExceptionTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheWriterExceptionTest
-        extends javax.cache.integration.CacheWriterExceptionTest {
+public class CacheWriterExceptionTest extends javax.cache.integration.CacheWriterExceptionTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CacheWriterTest
-        extends org.jsr107.tck.integration.CacheWriterTest {
+public class CacheWriterTest extends org.jsr107.tck.integration.CacheWriterTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanupJsr() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderClassLoaderTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CachingProviderClassLoaderTest
-        extends org.jsr107.tck.spi.CachingProviderClassLoaderTest {
+public class CachingProviderClassLoaderTest extends org.jsr107.tck.spi.CachingProviderClassLoaderTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CachingProviderTest
-        extends org.jsr107.tck.spi.CachingProviderTest {
+public class CachingProviderTest extends org.jsr107.tck.spi.CachingProviderTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingTest.java
@@ -19,14 +19,19 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CachingTest
-        extends org.jsr107.tck.CachingTest {
+public class CachingTest extends org.jsr107.tck.CachingTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {
@@ -37,5 +42,4 @@ public class CachingTest
     @Override
     public void dummyTest() {
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ClientServerTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClientServerTest
-        extends org.jsr107.tck.support.ClientServerTest {
+public class ClientServerTest extends org.jsr107.tck.support.ClientServerTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CompletionListenerFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CompletionListenerFutureTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class CompletionListenerFutureTest
-        extends javax.cache.integration.CompletionListenerFutureTest {
+public class CompletionListenerFutureTest extends javax.cache.integration.CompletionListenerFutureTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ConfigurationTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ConfigurationTest
-        extends javax.cache.configuration.ConfigurationTest {
+public class ConfigurationTest extends javax.cache.configuration.ConfigurationTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/DurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/DurationTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class DurationTest
-        extends javax.cache.expiry.DurationTest {
+public class DurationTest extends javax.cache.expiry.DurationTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/EntryProcessorExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/EntryProcessorExceptionTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class EntryProcessorExceptionTest
-        extends org.jsr107.tck.processor.EntryProcessorExceptionTest {
+public class EntryProcessorExceptionTest extends org.jsr107.tck.processor.EntryProcessorExceptionTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ExpiryPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ExpiryPolicyTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ExpiryPolicyTest
-        extends javax.cache.expiry.ExpiryPolicyTest {
+public class ExpiryPolicyTest extends javax.cache.expiry.ExpiryPolicyTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/FactoryBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/FactoryBuilderTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class FactoryBuilderTest
-        extends javax.cache.configuration.FactoryBuilderTest {
+public class FactoryBuilderTest extends javax.cache.configuration.FactoryBuilderTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/GetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/GetTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class GetTest
-        extends org.jsr107.tck.GetTest {
+public class GetTest extends org.jsr107.tck.GetTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -17,19 +17,124 @@
 package com.hazelcast.cache.jsr;
 
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 
 import javax.cache.Caching;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.fail;
 
 /**
- * Utility class responsible for setup/cleanup or member JSR tests.
+ * Utility class responsible for setup/cleanup of JSR member tests.
  */
 public final class JsrTestUtil {
+
+    /**
+     * Keeps track of system properties set by this utility.
+     * <p>
+     * We have to manage the System properties by ourselves, since they are set in {@link org.junit.BeforeClass} methods,
+     * which are invoked before our Hazelcast {@link org.junit.runner.Runner} classes are copying the System properties
+     * to restore them for us.
+     */
+    private static final List<String> SYSTEM_PROPERTY_REGISTRY = new LinkedList<String>();
 
     private JsrTestUtil() {
     }
 
+    public static void setup() {
+        setSystemProperties("server");
+    }
+
     public static void cleanup() {
-        Caching.getCachingProvider().close();
+        clearSystemProperties();
+        clearCachingProviderRegistry();
+
         Hazelcast.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    /**
+     * Sets the System properties for JSR related tests.
+     * <p>
+     * Uses plain strings to avoid triggering any classloading of JSR classes with static code initializations.
+     *
+     * @param providerType "server" or "client" according to your test type
+     */
+    public static void setSystemProperties(String providerType) {
+        /*
+        If we don't set this parameter the HazelcastCachingProvider will try to determine if it has to
+        create a client or server CachingProvider by looking for the client class. If you run the testsuite
+        from IDEA across all modules, that class is available (even though you might want to start a server
+        side test). This leads to a ClassCastException for server side tests, since a client CachingProvider
+        will be created. So we explicitly set this property to ease the test setups for IDEA environments.
+         */
+        setSystemProperty("hazelcast.jcache.provider.type", providerType);
+
+        setSystemProperty("javax.management.builder.initial", "com.hazelcast.cache.impl.TCKMBeanServerBuilder");
+        setSystemProperty("CacheManagerImpl", "com.hazelcast.cache.HazelcastCacheManager");
+        setSystemProperty("javax.cache.Cache", "com.hazelcast.cache.ICache");
+        setSystemProperty("javax.cache.Cache.Entry", "com.hazelcast.cache.impl.CacheEntry");
+        setSystemProperty("org.jsr107.tck.management.agentId", "TCKMbeanServer");
+        setSystemProperty("javax.cache.annotation.CacheInvocationContext",
+                "javax.cache.annotation.impl.cdi.CdiCacheKeyInvocationContextImpl");
+    }
+
+    /**
+     * Clears the System properties for JSR related tests.
+     */
+    public static void clearSystemProperties() {
+        for (String key : SYSTEM_PROPERTY_REGISTRY) {
+            System.clearProperty(key);
+        }
+        SYSTEM_PROPERTY_REGISTRY.clear();
+    }
+
+    /**
+     * Closes and removes the {@link javax.cache.spi.CachingProvider} from the static registry in {@link Caching}.
+     */
+    public static void clearCachingProviderRegistry() {
+        try {
+            Caching.getCachingProvider().close();
+
+            // retrieve the CachingProviderRegistry instance
+            Field providerRegistryField = Caching.class.getDeclaredField("CACHING_PROVIDERS");
+            providerRegistryField.setAccessible(true);
+
+            Class<?> providerRegistryClass = providerRegistryField.getType();
+            Object providerRegistryInstance = providerRegistryField.get(Caching.class);
+
+            // retrieve the map with the CachingProvider instances
+            Field providerMapField = providerRegistryClass.getDeclaredField("cachingProviders");
+            providerMapField.setAccessible(true);
+
+            Class<?> providerMapClass = providerMapField.getType();
+            Object providerMap = providerMapField.get(providerRegistryInstance);
+
+            // clear the map
+            Method clearMethod = providerMapClass.getDeclaredMethod("clear");
+            clearMethod.invoke(providerMap);
+
+            // retrieve the ClassLoader of the CachingProviderRegistry
+            Field classLoaderField = providerRegistryClass.getDeclaredField("classLoader");
+            classLoaderField.setAccessible(true);
+
+            // set the ClassLoader to null
+            classLoaderField.set(providerRegistryInstance, null);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Could not cleanup CachingProvider registry: " + e.getMessage());
+        }
+    }
+
+    private static void setSystemProperty(String key, String value) {
+        // we just want to set a System property, which has not been set already
+        // this way you can always override a JSR setting manually
+        if (System.getProperty(key) == null) {
+            System.setProperty(key, value);
+            SYSTEM_PROPERTY_REGISTRY.add(key);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -26,6 +27,11 @@ import org.junit.runner.RunWith;
 @Category(QuickTest.class)
 public class MutableCacheEntryListenerConfigurationTest
         extends javax.cache.configuration.MutableCacheEntryListenerConfigurationTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableConfigurationTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class MutableConfigurationTest
-        extends javax.cache.configuration.MutableConfigurationTest {
+public class MutableConfigurationTest extends javax.cache.configuration.MutableConfigurationTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/PutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/PutTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class PutTest
-        extends org.jsr107.tck.PutTest {
+public class PutTest extends org.jsr107.tck.PutTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/RemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/RemoveTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class RemoveTest
-        extends org.jsr107.tck.RemoveTest {
+public class RemoveTest extends org.jsr107.tck.RemoveTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ReplaceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ReplaceTest.java
@@ -19,17 +19,21 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ReplaceTest
-        extends org.jsr107.tck.ReplaceTest {
+public class ReplaceTest extends org.jsr107.tck.ReplaceTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {
         JsrTestUtil.cleanup();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByReferenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByReferenceTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class StoreByReferenceTest
-        extends org.jsr107.tck.StoreByReferenceTest {
+public class StoreByReferenceTest extends org.jsr107.tck.StoreByReferenceTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByValueTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class StoreByValueTest
-        extends org.jsr107.tck.StoreByValueTest {
+public class StoreByValueTest extends org.jsr107.tck.StoreByValueTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/TypesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/TypesTest.java
@@ -19,13 +19,18 @@ package com.hazelcast.cache.jsr;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class TypesTest
-        extends org.jsr107.tck.TypesTest {
+public class TypesTest extends org.jsr107.tck.TypesTest {
+
+    @BeforeClass
+    public static void init() {
+        JsrTestUtil.setup();
+    }
 
     @AfterClass
     public static void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.jsr.JsrTestUtil;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
@@ -81,10 +82,14 @@ public class CacheConfigTest extends HazelcastTestSupport {
     private final URL configUrl2 = getClass().getClassLoader().getResource("test-hazelcast-jcache2.xml");
 
     @Before
+    public void setUp() {
+        JsrTestUtil.setup();
+    }
+
     @After
     public void cleanup() {
         HazelcastInstanceFactory.terminateAll();
-        Caching.getCachingProvider().close();
+        JsrTestUtil.cleanup();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,6 @@
         <sonar.verbose>true</sonar.verbose>
 
         <jsr107.api.version>1.0.0</jsr107.api.version>
-        <CacheManagerImpl>com.hazelcast.cache.HazelcastCacheManager</CacheManagerImpl>
-        <CacheImpl>com.hazelcast.cache.ICache</CacheImpl>
-        <CacheEntryImpl>com.hazelcast.cache.impl.CacheEntry</CacheEntryImpl>
-        <javax.management.builder.initial>com.hazelcast.cache.impl.TCKMBeanServerBuilder
-        </javax.management.builder.initial>
-        <org.jsr107.tck.management.agentId>TCKMbeanServer</org.jsr107.tck.management.agentId>
-        <javax.cache.annotation.CacheInvocationContext>javax.cache.annotation.impl.cdi.CdiCacheKeyInvocationContextImpl
-        </javax.cache.annotation.CacheInvocationContext>
 
         <h2.version>1.3.160</h2.version>
         <atomikos.version>3.9.3</atomikos.version>
@@ -523,12 +515,6 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
-                                -Djavax.management.builder.initial=${javax.management.builder.initial}
-                                -DCacheManagerImpl=${CacheManagerImpl}
-                                -Djavax.cache.Cache=${CacheImpl}
-                                -Djavax.cache.Cache.Entry=${CacheEntryImpl}
-                                -Dorg.jsr107.tck.management.agentId=${org.jsr107.tck.management.agentId}
-                                -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                                 -Dlog4j.skipJansi=true
                             </argLine>
                             <includes>
@@ -565,12 +551,6 @@
                     -Dhazelcast.mancenter.enabled=false
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
-                    -Djavax.management.builder.initial=${javax.management.builder.initial}
-                    -DCacheManagerImpl=${CacheManagerImpl}
-                    -Djavax.cache.Cache=${CacheImpl}
-                    -Djavax.cache.Cache.Entry=${CacheEntryImpl}
-                    -Dorg.jsr107.tck.management.agentId=${org.jsr107.tck.management.agentId}
-                    -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                     -Dlog4j.skipJansi=true
                 </argLine>
             </properties>
@@ -740,12 +720,6 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
-                                -Djavax.management.builder.initial=${javax.management.builder.initial}
-                                -DCacheManagerImpl=${CacheManagerImpl}
-                                -Djavax.cache.Cache=${CacheImpl}
-                                -Djavax.cache.Cache.Entry=${CacheEntryImpl}
-                                -Dorg.jsr107.tck.management.agentId=${org.jsr107.tck.management.agentId}
-                                -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                                 -Dlog4j.skipJansi=true
                             </argLine>
 
@@ -1007,12 +981,6 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
-                                -Djavax.management.builder.initial=${javax.management.builder.initial}
-                                -DCacheManagerImpl=${CacheManagerImpl}
-                                -Djavax.cache.Cache=${CacheImpl}
-                                -Djavax.cache.Cache.Entry=${CacheEntryImpl}
-                                -Dorg.jsr107.tck.management.agentId=${org.jsr107.tck.management.agentId}
-                                -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                                 -Dlog4j.skipJansi=true
                             </argLine>
                             <includes>
@@ -1086,12 +1054,6 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
-                                -Djavax.management.builder.initial=${javax.management.builder.initial}
-                                -DCacheManagerImpl=${CacheManagerImpl}
-                                -Djavax.cache.Cache=${CacheImpl}
-                                -Djavax.cache.Cache.Entry=${CacheEntryImpl}
-                                -Dorg.jsr107.tck.management.agentId=${org.jsr107.tck.management.agentId}
-                                -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                                 -Dlog4j.skipJansi=true
                             </argLine>
                             <includes>


### PR DESCRIPTION
* fixed cleanup of `CachingProvider` registry via reflection
* added `JsrTestUtil.setup()` call to JSR related tests
* added JCache system properties to `JsrTestUtil` and `JsrClientTestUtil`
* removed JCache system properties from Maven profiles

This PR addresses two issues:
* **Fix cleanup of the static `CachingProvider` registry**
  The `Caching` class from JCache has a static `CachingProviderRegistry`, which has no API to remove `CachingProvider`s again. You can just close them, but then they will be reused in the next test. This will lead to problems, when another test in the same JVM defines a different `CachingProvider` for the same classloader, this can e.g. cause a `CacheException("Multiple CachingProviders have been configured when only a single CachingProvider is expected")`. The `CachingProvider`s are also server/client specific. This leads to a `ClassCastException` of the `HazelcastInstance` whenever you run a member and client test in the same JVM after another. In general the tests are violating the independence principle, since they don't leave a clean state. This PR does a proper cleanup of the `CachingProviderRegistry`.
* **Unify and ease the JCache configuration of JSR tests**
  It was always painful to run the JSR related tests in IDEA, since the needed System properties were only set in the Maven profiles. This was already addressed for some client tests, which set the properties in the `JsrClientTestUtil`. This PR unifies the settings in the `JsrTestUtil`, so there is a single place were those System properties are defined.

Part of https://github.com/hazelcast/hazelcast-enterprise/issues/1653