### PR TITLE
The SlowOperationPlugin has a unit error

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
@@ -106,7 +106,8 @@ public class SlowOperationPlugin extends DiagnosticsPlugin {
         writer.startSection("slowInvocations");
         for (SlowOperationInvocationDTO invocation : slowOperation.invocations) {
             writer.writeKeyValueEntry("startedAt", invocation.startedAt);
-            writer.writeKeyValueEntry("durationNs", invocation.durationMs);
+            writer.writeKeyValueEntryAsDateTime("started(date-time)", invocation.startedAt);
+            writer.writeKeyValueEntry("duration(ms)", invocation.durationMs);
             writer.writeKeyValueEntry("operationDetails", invocation.operationDetails);
         }
         writer.endSection();

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
@@ -79,7 +79,7 @@ public class SlowOperationPluginTest extends AbstractDiagnosticsPluginTest {
                 assertContains("stackTrace");
                 assertContains("invocations=1");
                 assertContains("startedAt=");
-                assertContains("durationNs=");
+                assertContains("duration(ms)=");
                 assertContains("operationDetails=");
             }
         });


### PR DESCRIPTION
It should be miliseconds, not nanoseconds.

Also a human readable output was added for the start time of the operation.