### PR TITLE
Converted cacheName to cacheId

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -764,10 +764,10 @@ public class ClientConfig {
     /**
      *
      * @param mapName The name of the map for which the query cache config is to be returned.
-     * @param queryCacheName The name of the query cache config.
+     * @param cacheName The name of the query cache.
      * @return The query cache config. If the config does not exist, it is created.
      */
-    public QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String queryCacheName) {
+    public QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String cacheName) {
         Map<String, Map<String, QueryCacheConfig>> allQueryCacheConfig = getQueryCacheConfigs();
 
         Map<String, QueryCacheConfig> queryCacheConfigsForMap = lookupByPattern(allQueryCacheConfig, mapName);
@@ -776,10 +776,10 @@ public class ClientConfig {
             allQueryCacheConfig.put(mapName, queryCacheConfigsForMap);
         }
 
-        QueryCacheConfig queryCacheConfig = lookupByPattern(queryCacheConfigsForMap, queryCacheName);
+        QueryCacheConfig queryCacheConfig = lookupByPattern(queryCacheConfigsForMap, cacheName);
         if (queryCacheConfig == null) {
-            queryCacheConfig = new QueryCacheConfig(queryCacheName);
-            queryCacheConfigsForMap.put(queryCacheName, queryCacheConfig);
+            queryCacheConfig = new QueryCacheConfig(cacheName);
+            queryCacheConfigsForMap.put(cacheName, queryCacheConfig);
         }
 
         return queryCacheConfig;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
@@ -51,7 +51,7 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
             createPublishAccumulatorWithoutIncludeValue(info);
         }
         if (info.isPopulate()) {
-            madePublishable(info.getMapName(), info.getCacheName());
+            madePublishable(info.getMapName(), info.getCacheId());
             info.setPublishable(true);
         }
     }
@@ -59,7 +59,7 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
     private void createPublishAccumulatorWithIncludeValue(AccumulatorInfo info) {
         Data data = context.getSerializationService().toData(info.getPredicate());
         ClientMessage request = ContinuousQueryPublisherCreateWithValueCodec.encodeRequest(info.getMapName(),
-                info.getCacheName(), data,
+                info.getCacheId(), data,
                 info.getBatchSize(), info.getBufferSize(), info.getDelaySeconds(),
                 info.isPopulate(), info.isCoalesce());
 
@@ -76,7 +76,7 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
     private void createPublishAccumulatorWithoutIncludeValue(AccumulatorInfo info) {
         Data data = context.getSerializationService().toData(info.getPredicate());
         ClientMessage request = ContinuousQueryPublisherCreateCodec.encodeRequest(info.getMapName(),
-                info.getCacheName(), data,
+                info.getCacheId(), data,
                 info.getBatchSize(), info.getBufferSize(), info.getDelaySeconds(),
                 info.isPopulate(), info.isCoalesce());
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContextSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContextSupport.java
@@ -32,8 +32,8 @@ public class ClientSubscriberContextSupport implements SubscriberContextSupport 
     }
 
     @Override
-    public Object createRecoveryOperation(String mapName, String cacheName, long sequence, int partitionId) {
-        return ContinuousQuerySetReadCursorCodec.encodeRequest(mapName, cacheName, sequence);
+    public Object createRecoveryOperation(String mapName, String cacheId, long sequence, int partitionId) {
+        return ContinuousQuerySetReadCursorCodec.encodeRequest(mapName, cacheId, sequence);
     }
 
     @Override
@@ -42,7 +42,7 @@ public class ClientSubscriberContextSupport implements SubscriberContextSupport 
     }
 
     @Override
-    public Object createDestroyQueryCacheOperation(String mapName, String cacheName) {
-        return ContinuousQueryDestroyCacheCodec.encodeRequest(mapName, cacheName);
+    public Object createDestroyQueryCacheOperation(String mapName, String cacheId) {
+        return ContinuousQueryDestroyCacheCodec.encodeRequest(mapName, cacheId);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/QueryCacheToListenerMapper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/QueryCacheToListenerMapper.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.CollectionUtil.isEmpty;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
 /**
- * This class includes mappings of {@code cacheName --to--> listener collections}.
+ * This class includes mappings of {@code cacheId --to--> listener collections}.
  */
 public class QueryCacheToListenerMapper {
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1474,8 +1474,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V>, Eve
     private QueryCache<K, V> getQueryCacheInternal(String name, MapListener listener, Predicate predicate, Boolean includeValue,
                                                    IMap map) {
         QueryCacheRequest request = newQueryCacheRequest()
-                .withUserGivenCacheName(name)
-                .withCacheName(UuidUtil.newUnsecureUuidString())
+                .withCacheName(name)
+                .withCacheId(UuidUtil.newUnsecureUuidString())
                 .withListener(listener)
                 .withPredicate(predicate)
                 .withIncludeValue(includeValue)
@@ -1492,7 +1492,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V>, Eve
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
         return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(),
-                request.getUserGivenCacheName(), constructorFunction);
+                request.getCacheName(), constructorFunction);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
@@ -39,7 +39,7 @@ import java.util.Set;
  *
  *     IMap map = hzInstance.getMap("mapName");
  *     Predicate predicate = TruePredicate.INSTANCE;
- *     QueryCache cache = map.getQueryCache(cacheName, predicate, includeValue);
+ *     QueryCache cache = map.getQueryCache(cacheId, predicate, includeValue);
  *
  * </code>
  * </pre>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AccumulatorConsumerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AccumulatorConsumerOperation.java
@@ -119,7 +119,7 @@ public class AccumulatorConsumerOperation extends Operation implements Partition
         MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
         AccumulatorInfo info = accumulator.getInfo();
         String mapName = info.getMapName();
-        String cacheName = info.getCacheName();
+        String cacheName = info.getCacheId();
 
         PublisherRegistry publisherRegistry = mapPublisherRegistry.getOrNull(mapName);
         if (publisherRegistry == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -190,7 +190,7 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
             addAccumulatorInfo(queryCacheContext, info);
 
             PublisherRegistry publisherRegistry = mapPublisherRegistry.getOrCreate(info.getMapName());
-            publisherRegistry.getOrCreate(info.getCacheName());
+            publisherRegistry.getOrCreate(info.getCacheId());
             // marker listener.
             mapServiceContext.addLocalListenerAdapter(new ListenerAdapter<IMapEvent>() {
                 @Override
@@ -204,7 +204,7 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     private void addAccumulatorInfo(QueryCacheContext context, AccumulatorInfo info) {
         PublisherContext publisherContext = context.getPublisherContext();
         AccumulatorInfoSupplier infoSupplier = publisherContext.getAccumulatorInfoSupplier();
-        infoSupplier.putIfAbsent(info.getMapName(), info.getCacheName(), info);
+        infoSupplier.putIfAbsent(info.getMapName(), info.getCacheId(), info);
     }
 
     public void setInfoList(List<AccumulatorInfo> infoList) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -1028,8 +1028,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
         QueryCacheRequest request = newQueryCacheRequest()
                 .forMap(map)
-                .withCacheName(UuidUtil.newUnsecureUuidString())
-                .withUserGivenCacheName(name)
+                .withCacheId(UuidUtil.newUnsecureUuidString())
+                .withCacheName(name)
                 .withListener(listener)
                 .withPredicate(predicate)
                 .withIncludeValue(includeValue)
@@ -1043,7 +1043,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         QueryCacheContext queryCacheContext = request.getContext();
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
-        return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getUserGivenCacheName(),
+        return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getCacheName(),
                 constructorFunction);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/ListenerRegistrationHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/ListenerRegistrationHelper.java
@@ -27,7 +27,7 @@ public final class ListenerRegistrationHelper {
     private ListenerRegistrationHelper() {
     }
 
-    public static String generateListenerName(String mapName, String cacheName) {
-        return mapName + PLACE_HOLDER + cacheName;
+    public static String generateListenerName(String mapName, String cacheId) {
+        return mapName + PLACE_HOLDER + cacheId;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
@@ -25,25 +25,25 @@ import com.hazelcast.config.QueryCacheConfig;
 public interface QueryCacheConfigurator {
 
     /**
-     * Returns {@link QueryCacheConfig} for the requested query cache with cacheName.
+     * Returns {@link QueryCacheConfig} for the requested {@code cacheName}
      *
      * @param mapName   underlying IMap name for query cache.
      * @param cacheName query cache name.
-     * @return {@link QueryCacheConfig} for the requested #cacheName.
+     * @return {@link QueryCacheConfig} for the requested {@code cacheName}.
      */
     QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName);
 
     /**
-     * Returns {@link QueryCacheConfig} for the requested query cache with cacheName or null.
+     * Returns {@link QueryCacheConfig} for the requested {@code cacheName} or null
      *
      * @param mapName   underlying IMap name for query cache.
      * @param cacheName query cache name.
-     * @return {@link QueryCacheConfig} for the requested #cacheName.
+     * @return {@link QueryCacheConfig} for the requested {@code cacheName}.
      */
     QueryCacheConfig getOrNull(String mapName, String cacheName);
 
     /**
-     * Removes corresponding configuration for the supplied cache name.
+     * Removes corresponding configuration for the supplied {@code cacheName}
      *
      * @param mapName   underlying IMap name for query cache.
      * @param cacheName query cache name.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
@@ -34,22 +34,22 @@ public interface QueryCacheEventService<E> {
     /**
      * Publishes query-cache events locally.
      *
-     * @param mapName   underlying map name of query cache
-     * @param cacheName name of the query cache
-     * @param event     event to publish
-     * @param orderKey  use same order key for events which are required to be ordered
+     * @param mapName  underlying map name of query cache
+     * @param cacheId  id of the query cache
+     * @param event    event to publish
+     * @param orderKey use same order key for events which are required to be ordered
      */
-    void publish(String mapName, String cacheName, E event, int orderKey);
+    void publish(String mapName, String cacheId, E event, int orderKey);
 
     /**
      * Adds the listener to listen underlying IMap on all nodes.
      *
      * @param mapName         underlying map name of query cache
-     * @param cacheName       name of the query cache
+     * @param cacheId         id of the query cache
      * @param listenerAdapter listener adapter for the query-cache
      * @return ID of registered event listener
      */
-    String listenPublisher(String mapName, String cacheName, ListenerAdapter listenerAdapter);
+    String listenPublisher(String mapName, String cacheId, ListenerAdapter listenerAdapter);
 
     /**
      * Removes listener from underlying IMap
@@ -64,43 +64,43 @@ public interface QueryCacheEventService<E> {
      * Adds a user-defined listener to a query-cache. This listener is registered as a local listener
      * on subscriber side.
      *
-     * @param mapName   underlying IMap name of query-cache
-     * @param cacheName name of the query-cache
-     * @param listener  listener for receiving events
+     * @param mapName  underlying IMap name of query-cache
+     * @param cacheId  id of the query-cache
+     * @param listener listener for receiving events
      * @return ID of registered event listener
      */
-    String addListener(String mapName, String cacheName, MapListener listener);
+    String addListener(String mapName, String cacheId, MapListener listener);
 
     /**
      * Adds a user-defined listener to a query-cache. This listener is registered as a local listener
      * on subscriber side.
      *
-     * @param mapName   underlying IMap name of query-cache
-     * @param cacheName name of the query-cache
-     * @param listener  listener for receiving events
-     * @param filter    used to filter events
+     * @param mapName  underlying IMap name of query-cache
+     * @param cacheId  id of the query-cache
+     * @param listener listener for receiving events
+     * @param filter   used to filter events
      * @return ID of registered event listener
      */
-    String addListener(String mapName, String cacheName, MapListener listener, EventFilter filter);
+    String addListener(String mapName, String cacheId, MapListener listener, EventFilter filter);
 
     /**
      * Removes listener from this event service.
      *
-     * @param mapName   underlying IMap name of query-cache
-     * @param cacheName name of the query cache
-     * @param id        ID of listener
+     * @param mapName underlying IMap name of query-cache
+     * @param cacheId id of the query cache
+     * @param id      ID of listener
      * @return {@code true} if listener is removed successfully, {@code false} otherwise
      */
-    boolean removeListener(String mapName, String cacheName, String id);
+    boolean removeListener(String mapName, String cacheId, String id);
 
     /**
      * Returns {@code true} if this query-cache has at least one registered listener otherwise returns {@code false}.
      *
-     * @param mapName   underlying IMap name of query-cache
-     * @param cacheName name of the query-cache
+     * @param mapName underlying IMap name of query-cache
+     * @param cacheId id of the query-cache
      * @return {@code true} if this query-cache has at least one registered listener otherwise returns {@code false}
      */
-    boolean hasListener(String mapName, String cacheName);
+    boolean hasListener(String mapName, String cacheId);
 
     /**
      * Only sends events which wrap data to be put in a query cache.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Metadata for an {@link Accumulator}.
- *
+ * <p>
  * This metadata is used in communications between: node <--> node and client <--> node.
  *
  * @see QueryCacheConfig
@@ -39,7 +39,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 public class AccumulatorInfo implements Portable {
 
     private String mapName;
-    private String cacheName;
+    private String cacheId;
     private Predicate predicate;
     private int batchSize;
     private int bufferSize;
@@ -50,18 +50,18 @@ public class AccumulatorInfo implements Portable {
 
     /**
      * Used to enable/disable {@link Accumulator} event sending functionality.
-     *
+     * <p>
      * Used in the phase of initial population for preventing any event to be sent before taking the snapshot of {@code IMap}.
      */
     private volatile boolean publishable;
 
-    public static AccumulatorInfo createAccumulatorInfo(QueryCacheConfig config, String mapName, String cacheName,
+    public static AccumulatorInfo createAccumulatorInfo(QueryCacheConfig config, String mapName, String cacheId,
                                                         Predicate predicate) {
         checkNotNull(config, "config cannot be null");
 
         AccumulatorInfo info = new AccumulatorInfo();
         info.mapName = mapName;
-        info.cacheName = cacheName;
+        info.cacheId = cacheId;
         info.batchSize = calculateBatchSize(config);
         info.bufferSize = config.getBufferSize();
         info.delaySeconds = config.getDelaySeconds();
@@ -74,12 +74,12 @@ public class AccumulatorInfo implements Portable {
     }
 
     @SuppressWarnings("checkstyle:parameternumber")
-    public static AccumulatorInfo createAccumulatorInfo(String mapName, String cacheName, Predicate predicate, int batchSize,
+    public static AccumulatorInfo createAccumulatorInfo(String mapName, String cacheId, Predicate predicate, int batchSize,
                                                         int bufferSize, long delaySeconds, boolean includeValue, boolean populate,
                                                         boolean coalesce) {
         AccumulatorInfo info = new AccumulatorInfo();
         info.mapName = mapName;
-        info.cacheName = cacheName;
+        info.cacheId = cacheId;
         info.batchSize = batchSize;
         info.bufferSize = bufferSize;
         info.delaySeconds = delaySeconds;
@@ -131,8 +131,8 @@ public class AccumulatorInfo implements Portable {
         return mapName;
     }
 
-    public String getCacheName() {
-        return cacheName;
+    public String getCacheId() {
+        return cacheId;
     }
 
     public Predicate getPredicate() {
@@ -168,7 +168,7 @@ public class AccumulatorInfo implements Portable {
     @Override
     public void writePortable(PortableWriter writer) throws IOException {
         writer.writeUTF("mn", mapName);
-        writer.writeUTF("cn", cacheName);
+        writer.writeUTF("cn", cacheId);
         writer.writeInt("bas", batchSize);
         writer.writeInt("bus", bufferSize);
         writer.writeLong("ds", delaySeconds);
@@ -183,7 +183,7 @@ public class AccumulatorInfo implements Portable {
     @Override
     public void readPortable(PortableReader reader) throws IOException {
         mapName = reader.readUTF("mn");
-        cacheName = reader.readUTF("cn");
+        cacheId = reader.readUTF("cn");
         batchSize = reader.readInt("bas");
         bufferSize = reader.readInt("bus");
         delaySeconds = reader.readLong("ds");
@@ -200,7 +200,7 @@ public class AccumulatorInfo implements Portable {
         return "AccumulatorInfo{"
                 + "batchSize=" + batchSize
                 + ", mapName='" + mapName + '\''
-                + ", cacheName='" + cacheName + '\''
+                + ", cacheId='" + cacheId + '\''
                 + ", predicate=" + predicate
                 + ", bufferSize=" + bufferSize
                 + ", delaySeconds=" + delaySeconds

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfoSupplier.java
@@ -25,24 +25,24 @@ public interface AccumulatorInfoSupplier {
      * Returns {@link AccumulatorInfo} for cache of ma{@code IMap}p.
      *
      * @param mapName   map name.
-     * @param cacheName cache name.
+     * @param cacheId cache name.
      * @return {@link AccumulatorInfo} for cache of map.
      */
-    AccumulatorInfo getAccumulatorInfoOrNull(String mapName, String cacheName);
+    AccumulatorInfo getAccumulatorInfoOrNull(String mapName, String cacheId);
 
     /**
      * Adds a new {@link AccumulatorInfo} for the query-cache of {@code IMap}.
      *
      * @param mapName   map name.
-     * @param cacheName cache name.
+     * @param cacheId cache name.
      */
-    void putIfAbsent(String mapName, String cacheName, AccumulatorInfo info);
+    void putIfAbsent(String mapName, String cacheId, AccumulatorInfo info);
 
     /**
      * Removes {@link AccumulatorInfo} from this supplier.
      *
      * @param mapName   map name.
-     * @param cacheName cache name.
+     * @param cacheId cache name.
      */
-    void remove(String mapName, String cacheName);
+    void remove(String mapName, String cacheId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
@@ -47,23 +47,23 @@ public class DefaultAccumulatorInfoSupplier implements AccumulatorInfoSupplier {
     }
 
     @Override
-    public AccumulatorInfo getAccumulatorInfoOrNull(String mapName, String cacheName) {
+    public AccumulatorInfo getAccumulatorInfoOrNull(String mapName, String cacheId) {
         ConcurrentMap<String, AccumulatorInfo> cacheToInfoMap = cacheInfoPerMap.get(mapName);
-        return cacheToInfoMap.get(cacheName);
+        return cacheToInfoMap.get(cacheId);
     }
 
     @Override
-    public void putIfAbsent(String mapName, String cacheName, AccumulatorInfo info) {
+    public void putIfAbsent(String mapName, String cacheId, AccumulatorInfo info) {
         ConcurrentMap<String, AccumulatorInfo> cacheToInfoMap = getOrPutIfAbsent(cacheInfoPerMap, mapName, INFO_CTOR);
-        cacheToInfoMap.putIfAbsent(cacheName, info);
+        cacheToInfoMap.putIfAbsent(cacheId, info);
     }
 
     @Override
-    public void remove(String mapName, String cacheName) {
+    public void remove(String mapName, String cacheId) {
         ConcurrentMap<String, AccumulatorInfo> cacheToInfoMap = cacheInfoPerMap.get(mapName);
         if (cacheToInfoMap == null) {
             return;
         }
-        cacheToInfoMap.remove(cacheName);
+        cacheToInfoMap.remove(cacheId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/DefaultPublisherContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/DefaultPublisherContext.java
@@ -144,7 +144,7 @@ public class DefaultPublisherContext implements PublisherContext {
     private PartitionAccumulatorRegistry removePartitionAccumulatorRegistry(PartitionAccumulatorRegistry registry) {
         AccumulatorInfo info = registry.getInfo();
         String mapName = info.getMapName();
-        String cacheName = info.getCacheName();
+        String cacheId = info.getCacheId();
 
         MapPublisherRegistry mapPublisherRegistry = getMapPublisherRegistry();
         PublisherRegistry publisherRegistry = mapPublisherRegistry.getOrNull(mapName);
@@ -152,7 +152,7 @@ public class DefaultPublisherContext implements PublisherContext {
             return null;
         }
 
-        return publisherRegistry.remove(cacheName);
+        return publisherRegistry.remove(cacheId);
     }
 
     private void startRemovalTask(final Collection<PartitionAccumulatorRegistry> removalCandidates, String uuid) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/EventPublisherAccumulatorProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/EventPublisherAccumulatorProcessor.java
@@ -47,7 +47,7 @@ public class EventPublisherAccumulatorProcessor implements AccumulatorProcessor<
 
     @Override
     public void process(Sequenced sequenced) {
-        String listenerName = generateListenerName(info.getMapName(), info.getCacheName());
+        String listenerName = generateListenerName(info.getMapName(), info.getCacheId());
         eventService.sendEventToSubscriber(listenerName, sequenced, sequenced.getPartitionId());
 
         if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherRegistry.java
@@ -33,7 +33,7 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * Registry of mappings like {@code cacheName} to {@code PartitionAccumulatorRegistry}.
+ * Registry of mappings like {@code cacheId} to {@code PartitionAccumulatorRegistry}.
  *
  * @see PartitionAccumulatorRegistry
  */
@@ -42,8 +42,8 @@ public class PublisherRegistry implements Registry<String, PartitionAccumulatorR
     private final ConstructorFunction<String, PartitionAccumulatorRegistry> partitionAccumulatorRegistryConstructor =
             new ConstructorFunction<String, PartitionAccumulatorRegistry>() {
                 @Override
-                public PartitionAccumulatorRegistry createNew(String cacheName) {
-                    AccumulatorInfo info = getAccumulatorInfo(cacheName);
+                public PartitionAccumulatorRegistry createNew(String cacheId) {
+                    AccumulatorInfo info = getAccumulatorInfo(cacheId);
                     checkNotNull(info, "info cannot be null");
 
                     AccumulatorFactory accumulatorFactory = createPublisherAccumulatorFactory();
@@ -64,13 +64,13 @@ public class PublisherRegistry implements Registry<String, PartitionAccumulatorR
     }
 
     @Override
-    public PartitionAccumulatorRegistry getOrCreate(String cacheName) {
-        return getOrPutIfAbsent(partitionAccumulators, cacheName, partitionAccumulatorRegistryConstructor);
+    public PartitionAccumulatorRegistry getOrCreate(String cacheId) {
+        return getOrPutIfAbsent(partitionAccumulators, cacheId, partitionAccumulatorRegistryConstructor);
     }
 
     @Override
-    public PartitionAccumulatorRegistry getOrNull(String cacheName) {
-        return partitionAccumulators.get(cacheName);
+    public PartitionAccumulatorRegistry getOrNull(String cacheId) {
+        return partitionAccumulators.get(cacheId);
     }
 
     @Override
@@ -79,8 +79,8 @@ public class PublisherRegistry implements Registry<String, PartitionAccumulatorR
     }
 
     @Override
-    public PartitionAccumulatorRegistry remove(String cacheName) {
-        return partitionAccumulators.remove(cacheName);
+    public PartitionAccumulatorRegistry remove(String cacheId) {
+        return partitionAccumulators.remove(cacheId);
     }
 
     /**
@@ -104,10 +104,10 @@ public class PublisherRegistry implements Registry<String, PartitionAccumulatorR
 
     }
 
-    private AccumulatorInfo getAccumulatorInfo(String cacheName) {
+    private AccumulatorInfo getAccumulatorInfo(String cacheId) {
         PublisherContext publisherContext = context.getPublisherContext();
         AccumulatorInfoSupplier infoSupplier = publisherContext.getAccumulatorInfoSupplier();
-        return infoSupplier.getAccumulatorInfoOrNull(mapName, cacheName);
+        return infoSupplier.getAccumulatorInfoOrNull(mapName, cacheId);
     }
 
     protected PublisherAccumulatorFactory createPublisherAccumulatorFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/QueryCacheListenerRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/QueryCacheListenerRegistry.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentMap;
  * Holds IDs of registered listeners which are registered to listen underlying
  * {@code IMap} events to feed {@link com.hazelcast.map.QueryCache QueryCache}.
  * <p>
- * This class contains mappings like: cacheName ---> registered listener IDs for underlying {@code IMap}.
+ * This class contains mappings like: cacheId ---> registered listener IDs for underlying {@code IMap}.
  */
 public class QueryCacheListenerRegistry implements Registry<String, String> {
 
@@ -55,13 +55,13 @@ public class QueryCacheListenerRegistry implements Registry<String, String> {
     }
 
     @Override
-    public String getOrCreate(String cacheName) {
-        return ConcurrencyUtil.getOrPutIfAbsent(listeners, cacheName, registryConstructorFunction);
+    public String getOrCreate(String cacheId) {
+        return ConcurrencyUtil.getOrPutIfAbsent(listeners, cacheId, registryConstructorFunction);
     }
 
     @Override
-    public String getOrNull(String cacheName) {
-        return listeners.get(cacheName);
+    public String getOrNull(String cacheId) {
+        return listeners.get(cacheId);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class QueryCacheListenerRegistry implements Registry<String, String> {
     }
 
     @Override
-    public String remove(String cacheName) {
-        return listeners.remove(cacheName);
+    public String remove(String cacheId) {
+        return listeners.remove(cacheId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -49,8 +49,8 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     protected final boolean includeValue;
     protected final String mapName;
+    protected final String cacheId;
     protected final String cacheName;
-    protected final String userGivenCacheName;
     protected final IMap delegate;
     protected final QueryCacheContext context;
     protected final QueryCacheRecordStore recordStore;
@@ -63,9 +63,9 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
      */
     protected String publisherListenerId;
 
-    public AbstractInternalQueryCache(String cacheName, String userGivenCacheName, IMap delegate, QueryCacheContext context) {
+    public AbstractInternalQueryCache(String cacheId, String cacheName, IMap delegate, QueryCacheContext context) {
+        this.cacheId = cacheId;
         this.cacheName = cacheName;
-        this.userGivenCacheName = userGivenCacheName;
         this.mapName = delegate.getName();
         this.delegate = delegate;
         this.context = context;
@@ -86,8 +86,8 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
     }
 
     @Override
-    public String getCacheName() {
-        return cacheName;
+    public String getCacheId() {
+        return cacheId;
     }
 
     protected Predicate getPredicate() {
@@ -96,14 +96,14 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     private QueryCacheConfig getQueryCacheConfig() {
         QueryCacheConfigurator queryCacheConfigurator = context.getQueryCacheConfigurator();
-        return queryCacheConfigurator.getOrCreateConfiguration(mapName, userGivenCacheName);
+        return queryCacheConfigurator.getOrCreateConfiguration(mapName, cacheName);
     }
 
     private EvictionListener getEvictionListener() {
         return new EvictionListener<Data, QueryCacheRecord>() {
             @Override
             public void onEvict(Data dataKey, QueryCacheRecord record, boolean wasExpired) {
-                EventPublisherHelper.publishEntryEvent(context, mapName, cacheName, dataKey, null, record, EVICTED);
+                EventPublisherHelper.publishEntryEvent(context, mapName, cacheId, dataKey, null, record, EVICTED);
             }
         };
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheConfigurator.java
@@ -49,12 +49,12 @@ public abstract class AbstractQueryCacheConfigurator implements QueryCacheConfig
         this.eventService = eventService;
     }
 
-    protected void setEntryListener(String mapName, String cacheName, QueryCacheConfig config) {
+    protected void setEntryListener(String mapName, String cacheId, QueryCacheConfig config) {
         for (EntryListenerConfig listenerConfig : config.getEntryListenerConfigs()) {
             MapListener listener = getListener(listenerConfig);
             if (listener != null) {
                 EventFilter filter = new EntryEventFilter(listenerConfig.isIncludeValue(), null);
-                eventService.addListener(mapName, cacheName, listener, filter);
+                eventService.addListener(mapName, cacheId, listener, filter);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
@@ -63,7 +63,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
     public final void createSubscriberAccumulator(AccumulatorInfo info) {
         QueryCacheEventService eventService = context.getQueryCacheEventService();
         ListenerAdapter listener = new SubscriberListener(context, info);
-        publisherListenerId = eventService.listenPublisher(info.getMapName(), info.getCacheName(), listener);
+        publisherListenerId = eventService.listenPublisher(info.getMapName(), info.getCacheId(), listener);
     }
 
     /**
@@ -81,7 +81,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
             // when calling `IMap.getQueryCache` method
             addListener(request);
 
-            AccumulatorInfo info = createAccumulatorInfo(queryCacheConfig, mapName, request.getCacheName(), predicate);
+            AccumulatorInfo info = createAccumulatorInfo(queryCacheConfig, mapName, request.getCacheId(), predicate);
             addInfoToSubscriberContext(info);
 
             info.setPublishable(true);
@@ -92,7 +92,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
             queryCache.setPublisherListenerId(publisherListenerId);
 
         } catch (Throwable throwable) {
-            removeQueryCacheConfig(mapName, request.getUserGivenCacheName());
+            removeQueryCacheConfig(mapName, request.getCacheName());
             throw rethrow(throwable);
         }
 
@@ -111,7 +111,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
     private void addInfoToSubscriberContext(AccumulatorInfo info) {
         SubscriberContext subscriberContext = context.getSubscriberContext();
         AccumulatorInfoSupplier accumulatorInfoSupplier = subscriberContext.getAccumulatorInfoSupplier();
-        accumulatorInfoSupplier.putIfAbsent(info.getMapName(), info.getCacheName(), info);
+        accumulatorInfoSupplier.putIfAbsent(info.getMapName(), info.getCacheId(), info);
     }
 
     private String addListener(QueryCacheRequest request) {
@@ -120,11 +120,11 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
             return null;
         }
         QueryCacheEventService eventService = subscriberContext.getEventService();
-        return eventService.addListener(request.getMapName(), request.getCacheName(), listener);
+        return eventService.addListener(request.getMapName(), request.getCacheId(), listener);
     }
 
     public String getCacheName() {
-        return request.getCacheName();
+        return request.getCacheId();
     }
 
     protected Object toObject(Object data) {
@@ -137,9 +137,9 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
         QueryCacheConfig queryCacheConfig;
 
         if (predicate == null) {
-            queryCacheConfig = getOrNullQueryCacheConfig(mapName, request.getUserGivenCacheName());
+            queryCacheConfig = getOrNullQueryCacheConfig(mapName, request.getCacheName());
         } else {
-            queryCacheConfig = getOrCreateQueryCacheConfig(mapName, request.getUserGivenCacheName());
+            queryCacheConfig = getOrCreateQueryCacheConfig(mapName, request.getCacheName());
             queryCacheConfig.setIncludeValue(request.isIncludeValue());
             queryCacheConfig.getPredicateConfig().setImplementation(predicate);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRequest.java
@@ -34,13 +34,13 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 class DefaultQueryCacheRequest implements QueryCacheRequest {
 
     private IMap map;
-    private String cacheName;
     private Predicate predicate;
     private Boolean includeValue;
     private MapListener listener;
     private QueryCacheContext context;
     private String mapName;
-    private String userGivenCacheName;
+    private String cacheId;
+    private String cacheName;
 
     DefaultQueryCacheRequest() {
     }
@@ -53,14 +53,14 @@ class DefaultQueryCacheRequest implements QueryCacheRequest {
     }
 
     @Override
-    public QueryCacheRequest withCacheName(String cacheName) {
-        this.cacheName = checkHasText(cacheName, "cacheName");
+    public QueryCacheRequest withCacheId(String cacheId) {
+        this.cacheId = checkHasText(cacheId, "cacheId");
         return this;
     }
 
     @Override
-    public QueryCacheRequest withUserGivenCacheName(String userGivenCacheName) {
-        this.userGivenCacheName = checkHasText(userGivenCacheName, "userGivenCacheName");
+    public QueryCacheRequest withCacheName(String cacheName) {
+        this.cacheName = checkHasText(cacheName, "cacheName");
         return this;
     }
 
@@ -101,13 +101,13 @@ class DefaultQueryCacheRequest implements QueryCacheRequest {
     }
 
     @Override
-    public String getCacheName() {
-        return cacheName;
+    public String getCacheId() {
+        return cacheId;
     }
 
     @Override
-    public String getUserGivenCacheName() {
-        return userGivenCacheName;
+    public String getCacheName() {
+        return cacheName;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/EventPublisherHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/EventPublisherHelper.java
@@ -45,46 +45,46 @@ public final class EventPublisherHelper {
      * Publishes event upon a change on a key in {@code QueryCache}.
      *
      * @param mapName      the name of underlying map.
-     * @param cacheName    the name of {@code QueryCache}
+     * @param cacheId    the name of {@code QueryCache}
      * @param dataKey      the key in {@code Data} format.
      * @param dataNewValue the value in {@code Data} format.
      * @param oldRecord    the relevant {@code QueryCacheEntry}
      * @param context      the {@code QueryCacheContext}
      */
-    static void publishEntryEvent(QueryCacheContext context, String mapName, String cacheName, Data dataKey, Data dataNewValue,
+    static void publishEntryEvent(QueryCacheContext context, String mapName, String cacheId, Data dataKey, Data dataNewValue,
                                   QueryCacheRecord oldRecord, EntryEventType eventType) {
         QueryCacheEventService eventService = getQueryCacheEventService(context);
-        if (!eventService.hasListener(mapName, cacheName)) {
+        if (!eventService.hasListener(mapName, cacheId)) {
             return;
         }
 
         Object oldValue = getOldValue(oldRecord);
 
-        LocalEntryEventData eventData = createLocalEntryEventData(cacheName, dataKey, dataNewValue, oldValue,
+        LocalEntryEventData eventData = createLocalEntryEventData(cacheId, dataKey, dataNewValue, oldValue,
                 eventType.getType(), -1, context);
-        eventService.publish(mapName, cacheName, eventData, dataKey.hashCode());
+        eventService.publish(mapName, cacheId, eventData, dataKey.hashCode());
     }
 
-    static void publishCacheWideEvent(QueryCacheContext context, String mapName, String cacheName,
+    static void publishCacheWideEvent(QueryCacheContext context, String mapName, String cacheId,
                                       int numberOfEntriesAffected, EntryEventType eventType) {
         QueryCacheEventService eventService = getQueryCacheEventService(context);
-        if (!eventService.hasListener(mapName, cacheName)) {
+        if (!eventService.hasListener(mapName, cacheId)) {
             return;
         }
 
-        LocalCacheWideEventData eventData = new LocalCacheWideEventData(cacheName, eventType.getType(), numberOfEntriesAffected);
-        eventService.publish(mapName, cacheName, eventData, cacheName.hashCode());
+        LocalCacheWideEventData eventData = new LocalCacheWideEventData(cacheId, eventType.getType(), numberOfEntriesAffected);
+        eventService.publish(mapName, cacheId, eventData, cacheId.hashCode());
     }
 
     private static Object getOldValue(QueryCacheRecord oldRecord) {
         return oldRecord == null ? null : oldRecord.getValue();
     }
 
-    private static LocalEntryEventData createLocalEntryEventData(String cacheName, Data dataKey, Data dataNewValue,
+    private static LocalEntryEventData createLocalEntryEventData(String cacheId, Data dataKey, Data dataNewValue,
                                                                  Object oldValue, int eventType,
                                                                  int partitionId, QueryCacheContext context) {
         SerializationService serializationService = context.getSerializationService();
-        return new LocalEntryEventData(serializationService, cacheName, eventType, dataKey, oldValue, dataNewValue, partitionId);
+        return new LocalEntryEventData(serializationService, cacheId, eventType, dataKey, oldValue, dataNewValue, partitionId);
     }
 
     private static QueryCacheEventService getQueryCacheEventService(QueryCacheContext context) {
@@ -92,12 +92,12 @@ public final class EventPublisherHelper {
         return subscriberContext.getEventService();
     }
 
-    public static void publishEventLost(QueryCacheContext context, String mapName, String cacheName, int partitionId) {
+    public static void publishEventLost(QueryCacheContext context, String mapName, String cacheId, int partitionId) {
         QueryCacheEventService eventService = getQueryCacheEventService(context);
-        int orderKey = cacheName.hashCode();
+        int orderKey = cacheId.hashCode();
 
-        eventService.publish(mapName, cacheName,
-                createLocalEntryEventData(cacheName, null, null, null,
+        eventService.publish(mapName, cacheId,
+                createLocalEntryEventData(cacheId, null, null, null,
                         EventLostEvent.EVENT_TYPE, partitionId, context), orderKey);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
@@ -44,7 +44,7 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
     void setPublisherListenerId(String publisherListenerId);
 
     /**
-     * @return internally used uuid for this query cache.
+     * @return internally used id for this query cache.
      */
-    String getCacheName();
+    String getCacheId();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEndToEndConstructor.java
@@ -62,7 +62,7 @@ public class NodeQueryCacheEndToEndConstructor extends AbstractQueryCacheEndToEn
         }
 
         if (populate) {
-            madePublishable(info.getMapName(), info.getCacheName());
+            madePublishable(info.getMapName(), info.getCacheId());
         }
     }
 
@@ -78,13 +78,13 @@ public class NodeQueryCacheEndToEndConstructor extends AbstractQueryCacheEndToEn
         return returnWithDeadline(futures, OPERATION_WAIT_TIMEOUT_MINUTES, MINUTES);
     }
 
-    private void madePublishable(String mapName, String cacheName) throws Exception {
+    private void madePublishable(String mapName, String cacheId) throws Exception {
         InvokerWrapper invokerWrapper = context.getInvokerWrapper();
 
         Collection<Member> memberList = context.getMemberList();
         List<Future> futures = new ArrayList<Future>(memberList.size());
         for (Member member : memberList) {
-            Operation operation = new MadePublishableOperation(mapName, cacheName);
+            Operation operation = new MadePublishableOperation(mapName, cacheId);
             Future future = invokerWrapper.invokeOnTarget(operation, member.getAddress());
             futures.add(future);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
@@ -63,22 +63,22 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
 
     // TODO not used order key
     @Override
-    public void publish(String mapName, String cacheName, EventData eventData, int orderKey) {
+    public void publish(String mapName, String cacheId, EventData eventData, int orderKey) {
         checkHasText(mapName, "mapName");
-        checkHasText(cacheName, "cacheName");
+        checkHasText(cacheId, "cacheId");
         checkNotNull(eventData, "eventData cannot be null");
 
-        publishLocalEvent(mapName, cacheName, eventData);
+        publishLocalEvent(mapName, cacheId, eventData);
     }
 
     @Override
-    public String addListener(String mapName, String cacheName, MapListener listener) {
-        return addListener(mapName, cacheName, listener, null);
+    public String addListener(String mapName, String cacheId, MapListener listener) {
+        return addListener(mapName, cacheId, listener, null);
     }
 
     @Override
-    public String listenPublisher(String mapName, String cacheName, ListenerAdapter listenerAdapter) {
-        String listenerName = generateListenerName(mapName, cacheName);
+    public String listenPublisher(String mapName, String cacheId, ListenerAdapter listenerAdapter) {
+        String listenerName = generateListenerName(mapName, cacheId);
         return mapServiceContext.addListenerAdapter(listenerName, listenerAdapter);
     }
 
@@ -88,9 +88,9 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
     }
 
     @Override
-    public String addListener(String mapName, String cacheName, MapListener listener, EventFilter filter) {
+    public String addListener(String mapName, String cacheId, MapListener listener, EventFilter filter) {
         checkHasText(mapName, "mapName");
-        checkHasText(cacheName, "cacheName");
+        checkHasText(cacheId, "cacheId");
         checkNotNull(listener, "listener cannot be null");
 
         ListenerAdapter queryCacheListenerAdaptor = createQueryCacheListenerAdaptor(listener);
@@ -98,7 +98,7 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         EventService eventService = nodeEngine.getEventService();
 
-        String listenerName = generateListenerName(mapName, cacheName);
+        String listenerName = generateListenerName(mapName, cacheId);
         EventRegistration registration;
         if (filter == null) {
             registration = eventService.registerLocalListener(MapService.SERVICE_NAME,
@@ -111,16 +111,16 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
     }
 
     @Override
-    public boolean removeListener(String mapName, String cacheName, String id) {
-        String listenerName = generateListenerName(mapName, cacheName);
+    public boolean removeListener(String mapName, String cacheId, String id) {
+        String listenerName = generateListenerName(mapName, cacheId);
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         EventService eventService = nodeEngine.getEventService();
         return eventService.deregisterListener(MapService.SERVICE_NAME, listenerName, id);
     }
 
     @Override
-    public boolean hasListener(String mapName, String cacheName) {
-        String listenerName = generateListenerName(mapName, cacheName);
+    public boolean hasListener(String mapName, String cacheId) {
+        String listenerName = generateListenerName(mapName, cacheId);
         Collection<EventRegistration> eventRegistrations = getRegistrations(listenerName);
         if (eventRegistrations.isEmpty()) {
             return false;
@@ -138,8 +138,8 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
     }
 
     // TODO needs refactoring.
-    private void publishLocalEvent(String mapName, String cacheName, Object eventData) {
-        String listenerName = generateListenerName(mapName, cacheName);
+    private void publishLocalEvent(String mapName, String cacheId, Object eventData) {
+        String listenerName = generateListenerName(mapName, cacheId);
         Collection<EventRegistration> eventRegistrations = getRegistrations(listenerName);
         if (eventRegistrations.isEmpty()) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContextSupport.java
@@ -34,8 +34,8 @@ public class NodeSubscriberContextSupport implements SubscriberContextSupport {
     }
 
     @Override
-    public Object createRecoveryOperation(String mapName, String cacheName, long sequence, int partitionId) {
-        return new SetReadCursorOperation(mapName, cacheName, sequence, partitionId);
+    public Object createRecoveryOperation(String mapName, String cacheId, long sequence, int partitionId) {
+        return new SetReadCursorOperation(mapName, cacheId, sequence, partitionId);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class NodeSubscriberContextSupport implements SubscriberContextSupport {
     }
 
     @Override
-    public Object createDestroyQueryCacheOperation(String mapName, String cacheName) {
-        return new DestroyQueryCacheOperation(mapName, cacheName);
+    public Object createDestroyQueryCacheOperation(String mapName, String cacheId) {
+        return new DestroyQueryCacheOperation(mapName, cacheId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
@@ -71,7 +71,7 @@ public final class NullQueryCache implements InternalQueryCache {
     }
 
     @Override
-    public String getCacheName() {
+    public String getCacheId() {
         return null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
@@ -42,12 +42,12 @@ public class QueryCacheFactory {
 
         @Override
         public InternalQueryCache createNew(String ignored) {
+            String cacheId = request.getCacheId();
             String cacheName = request.getCacheName();
-            String userGivenCacheName = request.getUserGivenCacheName();
             IMap delegate = request.getMap();
             QueryCacheContext context = request.getContext();
 
-            return new DefaultQueryCache(cacheName, userGivenCacheName, delegate, context);
+            return new DefaultQueryCache(cacheId, cacheName, delegate, context);
         }
     }
 
@@ -59,15 +59,15 @@ public class QueryCacheFactory {
 
     public InternalQueryCache create(QueryCacheRequest request) {
         return ConcurrencyUtil.getOrPutIfAbsent(internalQueryCaches,
-                request.getCacheName(), new InternalQueryCacheConstructor(request));
+                request.getCacheId(), new InternalQueryCacheConstructor(request));
     }
 
     public boolean remove(InternalQueryCache queryCache) {
-        return internalQueryCaches.remove(queryCache.getCacheName(), queryCache);
+        return internalQueryCaches.remove(queryCache.getCacheId(), queryCache);
     }
 
-    public InternalQueryCache getOrNull(String cacheName) {
-        return internalQueryCaches.get(cacheName);
+    public InternalQueryCache getOrNull(String cacheId) {
+        return internalQueryCaches.get(cacheId);
     }
 
     // only used for testing

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequest.java
@@ -37,19 +37,19 @@ public interface QueryCacheRequest {
     /**
      * Setter for name of the {@link com.hazelcast.map.QueryCache QueryCache}.
      *
-     * @param cacheName name of {@link com.hazelcast.map.QueryCache QueryCache}
+     * @param cacheId name of {@link com.hazelcast.map.QueryCache QueryCache}
      * @return this request object.
      */
-    QueryCacheRequest withCacheName(String cacheName);
+    QueryCacheRequest withCacheId(String cacheId);
 
 
     /**
      * Sets the user given name for the {@link com.hazelcast.map.QueryCache QueryCache}.
      *
-     * @param userGivenCacheName name of {@link com.hazelcast.map.QueryCache QueryCache}
+     * @param cacheName name of {@link com.hazelcast.map.QueryCache QueryCache}
      * @return this request object.
      */
-    QueryCacheRequest withUserGivenCacheName(String userGivenCacheName);
+    QueryCacheRequest withCacheName(String cacheName);
 
     /**
      * Setter for the predicate which will be used to filter underlying {@link IMap}
@@ -105,14 +105,14 @@ public interface QueryCacheRequest {
      *
      * @return name of the {@link com.hazelcast.map.QueryCache QueryCache} to be created.
      */
-    String getCacheName();
+    String getCacheId();
 
     /**
      * Returns the name which is given by the user.
      *
      * @return user given name of the {@link com.hazelcast.map.QueryCache QueryCache} to be created.
      */
-    String getUserGivenCacheName();
+    String getCacheName();
 
     /**
      * Returns predicate which is set.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -130,7 +130,7 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
 
     private void handleUnexpectedEvent(QueryCacheEventData event) {
         addEventSequenceToBrokenSequences(event);
-        publishEventLost(context, info.getMapName(), info.getCacheName(), event.getPartitionId());
+        publishEventLost(context, info.getMapName(), info.getCacheId(), event.getPartitionId());
     }
 
     private void addEventSequenceToBrokenSequences(QueryCacheEventData event) {
@@ -165,10 +165,10 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
 
     private InternalQueryCache getQueryCache() {
         AccumulatorInfo info = getInfo();
-        String cacheName = info.getCacheName();
+        String cacheId = info.getCacheId();
         SubscriberContext subscriberContext = context.getSubscriberContext();
         QueryCacheFactory queryCacheFactory = subscriberContext.getQueryCacheFactory();
-        return queryCacheFactory.getOrNull(cacheName);
+        return queryCacheFactory.getOrNull(cacheId);
     }
 
     private SubscriberAccumulatorHandler createAccumulatorHandler() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContextSupport.java
@@ -27,13 +27,13 @@ public interface SubscriberContextSupport {
      * Creates recovery operation for event loss cases.
      *
      * @param mapName     map name.
-     * @param cacheName   cache name.
+     * @param cacheId     id of cache.
      * @param sequence    sequence to be set.
      * @param partitionId partitions ID of broken sequence
      * @return operation or request according to context.
      * @see QueryCache#tryRecover()
      */
-    Object createRecoveryOperation(String mapName, String cacheName, long sequence, int partitionId);
+    Object createRecoveryOperation(String mapName, String cacheId, long sequence, int partitionId);
 
     /**
      * Resolves response of recoveryOperation.
@@ -46,10 +46,10 @@ public interface SubscriberContextSupport {
     /**
      * Creates recovery operation for event loss cases.
      *
-     * @param mapName   map name.
-     * @param cacheName cache name.
+     * @param mapName map name.
+     * @param cacheId id of cache.
      * @return operation or request according to context.
      * @see QueryCache#tryRecover()
      */
-    Object createDestroyQueryCacheOperation(String mapName, String cacheName);
+    Object createDestroyQueryCacheOperation(String mapName, String cacheId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberListener.java
@@ -70,6 +70,6 @@ class SubscriberListener implements ListenerAdapter<IMapEvent> {
     private Accumulator createAccumulator() {
         MapSubscriberRegistry mapSubscriberRegistry = subscriberContext.getMapSubscriberRegistry();
         SubscriberRegistry subscriberRegistry = mapSubscriberRegistry.getOrCreate(info.getMapName());
-        return subscriberRegistry.getOrCreate(info.getCacheName());
+        return subscriberRegistry.getOrCreate(info.getCacheId());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberRegistry.java
@@ -43,8 +43,8 @@ public class SubscriberRegistry implements Registry<String, Accumulator> {
     private final ConstructorFunction<String, Accumulator> accumulatorConstructor =
             new ConstructorFunction<String, Accumulator>() {
                 @Override
-                public Accumulator createNew(String cacheName) {
-                    AccumulatorInfo info = getAccumulatorInfo(cacheName);
+                public Accumulator createNew(String cacheId) {
+                    AccumulatorInfo info = getAccumulatorInfo(cacheId);
                     checkNotNull(info, "info cannot be null");
 
                     AccumulatorFactory accumulatorFactory = createSubscriberAccumulatorFactory();
@@ -63,13 +63,13 @@ public class SubscriberRegistry implements Registry<String, Accumulator> {
     }
 
     @Override
-    public Accumulator getOrCreate(String cacheName) {
-        return getOrPutIfAbsent(accumulators, cacheName, accumulatorConstructor);
+    public Accumulator getOrCreate(String cacheId) {
+        return getOrPutIfAbsent(accumulators, cacheId, accumulatorConstructor);
     }
 
     @Override
-    public Accumulator getOrNull(String cacheName) {
-        return accumulators.get(cacheName);
+    public Accumulator getOrNull(String cacheId) {
+        return accumulators.get(cacheId);
     }
 
     @Override
@@ -78,14 +78,14 @@ public class SubscriberRegistry implements Registry<String, Accumulator> {
     }
 
     @Override
-    public Accumulator remove(String cacheName) {
-        return accumulators.remove(cacheName);
+    public Accumulator remove(String cacheId) {
+        return accumulators.remove(cacheId);
     }
 
-    private AccumulatorInfo getAccumulatorInfo(String cacheName) {
+    private AccumulatorInfo getAccumulatorInfo(String cacheId) {
         SubscriberContext subscriberContext = context.getSubscriberContext();
         AccumulatorInfoSupplier infoSupplier = subscriberContext.getAccumulatorInfoSupplier();
-        return infoSupplier.getAccumulatorInfoOrNull(mapName, cacheName);
+        return infoSupplier.getAccumulatorInfoOrNull(mapName, cacheId);
     }
 
     protected SubscriberAccumulatorFactory createSubscriberAccumulatorFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
@@ -36,15 +36,15 @@ import java.io.IOException;
  */
 public class DestroyQueryCacheOperation extends MapOperation {
 
-    private String cacheName;
+    private String cacheId;
     private transient boolean result;
 
     public DestroyQueryCacheOperation() {
     }
 
-    public DestroyQueryCacheOperation(String mapName, String cacheName) {
+    public DestroyQueryCacheOperation(String mapName, String cacheId) {
         super(mapName);
-        this.cacheName = cacheName;
+        this.cacheId = cacheId;
     }
 
     @Override
@@ -67,13 +67,13 @@ public class DestroyQueryCacheOperation extends MapOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheName);
+        out.writeUTF(cacheId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheName = in.readUTF();
+        cacheId = in.readUTF();
     }
 
     private void deregisterLocalIMapListener() {
@@ -83,14 +83,14 @@ public class DestroyQueryCacheOperation extends MapOperation {
         if (listenerRegistry == null) {
             return;
         }
-        String listenerId = listenerRegistry.remove(cacheName);
+        String listenerId = listenerRegistry.remove(cacheId);
         mapService.getMapServiceContext().removeEventListener(name, listenerId);
     }
 
     private void removeAccumulatorInfo() {
         PublisherContext publisherContext = getPublisherContext();
         AccumulatorInfoSupplier infoSupplier = publisherContext.getAccumulatorInfoSupplier();
-        infoSupplier.remove(name, cacheName);
+        infoSupplier.remove(name, cacheId);
     }
 
     private void removePublisherAccumulators() {
@@ -100,7 +100,7 @@ public class DestroyQueryCacheOperation extends MapOperation {
         if (publisherRegistry == null) {
             return;
         }
-        publisherRegistry.remove(cacheName);
+        publisherRegistry.remove(cacheId);
     }
 
     private PublisherContext getPublisherContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperation.java
@@ -39,16 +39,16 @@ public class MadePublishableOperation extends MapOperation {
 
     private final ILogger logger = Logger.getLogger(getClass());
 
-    private String cacheName;
+    private String cacheId;
 
     private transient boolean done;
 
     public MadePublishableOperation() {
     }
 
-    public MadePublishableOperation(String mapName, String cacheName) {
+    public MadePublishableOperation(String mapName, String cacheId) {
         super(mapName);
-        this.cacheName = cacheName;
+        this.cacheId = cacheId;
     }
 
     @Override
@@ -57,7 +57,7 @@ public class MadePublishableOperation extends MapOperation {
     }
 
     private void setPublishable() {
-        PartitionAccumulatorRegistry registry = QueryCacheUtil.getAccumulatorRegistryOrNull(getContext(), name, cacheName);
+        PartitionAccumulatorRegistry registry = QueryCacheUtil.getAccumulatorRegistryOrNull(getContext(), name, cacheId);
         if (registry == null) {
             return;
         }
@@ -86,13 +86,13 @@ public class MadePublishableOperation extends MapOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheName);
+        out.writeUTF(cacheId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheName = in.readUTF();
+        cacheId = in.readUTF();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperationFactory.java
@@ -34,34 +34,34 @@ import static com.hazelcast.util.Preconditions.checkHasText;
 public class MadePublishableOperationFactory implements OperationFactory {
 
     private String mapName;
-    private String cacheName;
+    private String cacheId;
 
     public MadePublishableOperationFactory() {
     }
 
-    public MadePublishableOperationFactory(String mapName, String cacheName) {
+    public MadePublishableOperationFactory(String mapName, String cacheId) {
         checkHasText(mapName, "mapName");
-        checkHasText(cacheName, "cacheName");
+        checkHasText(cacheId, "cacheId");
 
-        this.cacheName = cacheName;
+        this.cacheId = cacheId;
         this.mapName = mapName;
     }
 
     @Override
     public Operation createOperation() {
-        return new MadePublishableOperation(mapName, cacheName);
+        return new MadePublishableOperation(mapName, cacheId);
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(mapName);
-        out.writeUTF(cacheName);
+        out.writeUTF(cacheId);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
-        cacheName = in.readUTF();
+        cacheId = in.readUTF();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/ReadAndResetAccumulatorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/ReadAndResetAccumulatorOperation.java
@@ -41,21 +41,21 @@ import static com.hazelcast.map.impl.querycache.utils.QueryCacheUtil.getAccumula
  */
 public class ReadAndResetAccumulatorOperation extends MapOperation implements PartitionAwareOperation {
 
-    private String cacheName;
+    private String cacheId;
     private List<Sequenced> eventDataList;
 
     public ReadAndResetAccumulatorOperation() {
     }
 
-    public ReadAndResetAccumulatorOperation(String mapName, String cacheName) {
+    public ReadAndResetAccumulatorOperation(String mapName, String cacheId) {
         super(mapName);
-        this.cacheName = cacheName;
+        this.cacheId = cacheId;
     }
 
     @Override
     public void run() throws Exception {
         QueryCacheContext context = getQueryCacheContext();
-        Map<Integer, Accumulator> accumulators = getAccumulators(context, name, cacheName);
+        Map<Integer, Accumulator> accumulators = getAccumulators(context, name, cacheId);
         Accumulator<Sequenced> accumulator = accumulators.get(getPartitionId());
         if (accumulator.isEmpty()) {
             return;
@@ -82,13 +82,13 @@ public class ReadAndResetAccumulatorOperation extends MapOperation implements Pa
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheName);
+        out.writeUTF(cacheId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheName = in.readUTF();
+        cacheId = in.readUTF();
     }
 
     private QueryCacheContext getQueryCacheContext() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/SetReadCursorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/SetReadCursorOperation.java
@@ -38,18 +38,18 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 public class SetReadCursorOperation extends MapOperation implements PartitionAwareOperation {
 
     private long sequence;
-    private String cacheName;
+    private String cacheId;
 
     private transient boolean result;
 
     public SetReadCursorOperation() {
     }
 
-    public SetReadCursorOperation(String mapName, String cacheName, long sequence, int ignored) {
+    public SetReadCursorOperation(String mapName, String cacheId, long sequence, int ignored) {
         super(checkHasText(mapName, "mapName"));
         checkPositive(sequence, "sequence");
 
-        this.cacheName = checkHasText(cacheName, "cacheName");
+        this.cacheId = checkHasText(cacheId, "cacheId");
         this.sequence = sequence;
     }
 
@@ -66,20 +66,20 @@ public class SetReadCursorOperation extends MapOperation implements PartitionAwa
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(cacheName);
+        out.writeUTF(cacheId);
         out.writeLong(sequence);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        cacheName = in.readUTF();
+        cacheId = in.readUTF();
         sequence = in.readLong();
     }
 
     private boolean setReadCursor() {
         QueryCacheContext context = getContext();
-        Accumulator accumulator = getAccumulatorOrNull(context, name, cacheName, getPartitionId());
+        Accumulator accumulator = getAccumulatorOrNull(context, name, cacheId, getPartitionId());
         if (accumulator == null) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/utils/QueryCacheUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/utils/QueryCacheUtil.java
@@ -37,8 +37,8 @@ public final class QueryCacheUtil {
     /**
      * Returns accumulators of a {@code QueryCache}.
      */
-    public static Map<Integer, Accumulator> getAccumulators(QueryCacheContext context, String mapName, String cacheName) {
-        PartitionAccumulatorRegistry partitionAccumulatorRegistry = getAccumulatorRegistryOrNull(context, mapName, cacheName);
+    public static Map<Integer, Accumulator> getAccumulators(QueryCacheContext context, String mapName, String cacheId) {
+        PartitionAccumulatorRegistry partitionAccumulatorRegistry = getAccumulatorRegistryOrNull(context, mapName, cacheId);
         if (partitionAccumulatorRegistry == null) {
             return Collections.emptyMap();
         }
@@ -51,14 +51,14 @@ public final class QueryCacheUtil {
      * @see PartitionAccumulatorRegistry
      */
     public static PartitionAccumulatorRegistry getAccumulatorRegistryOrNull(QueryCacheContext context,
-                                                                            String mapName, String cacheName) {
+                                                                            String mapName, String cacheId) {
         PublisherContext publisherContext = context.getPublisherContext();
         MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
         PublisherRegistry publisherRegistry = mapPublisherRegistry.getOrNull(mapName);
         if (publisherRegistry == null) {
             return null;
         }
-        return publisherRegistry.getOrNull(cacheName);
+        return publisherRegistry.getOrNull(cacheId);
     }
 
     /**
@@ -67,8 +67,8 @@ public final class QueryCacheUtil {
      * @see Accumulator
      */
     public static Accumulator getAccumulatorOrNull(QueryCacheContext context,
-                                                   String mapName, String cacheName, int partitionId) {
-        PartitionAccumulatorRegistry accumulatorRegistry = getAccumulatorRegistryOrNull(context, mapName, cacheName);
+                                                   String mapName, String cacheId, int partitionId) {
+        PartitionAccumulatorRegistry accumulatorRegistry = getAccumulatorRegistryOrNull(context, mapName, cacheId);
         if (accumulatorRegistry == null) {
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContextTest.java
@@ -63,7 +63,7 @@ public class NodeQueryCacheContextTest extends HazelcastTestSupport {
     @Test
     @SuppressWarnings("unchecked")
     public void testInvokerWrapper_invokeOnAllPartitions() throws Exception {
-        MadePublishableOperationFactory factory = new MadePublishableOperationFactory("mapName", "cacheName");
+        MadePublishableOperationFactory factory = new MadePublishableOperationFactory("mapName", "cacheId");
 
         Map<Integer, Object> result = (Map<Integer, Object>) context.getInvokerWrapper().invokeOnAllPartitions(factory);
         assertEquals(partitionCount, result.size());


### PR DESCRIPTION
apriori work to fix the issue: https://github.com/hazelcast/hazelcast/issues/11185

this pr makes naming more clear.

__Changes:__
cacheName --> cacheId
userGivenCacheName --> cacheName