### PR TITLE
Client fails to reconnect when domain names are used in member list

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
@@ -16,7 +16,8 @@
 
 package com.hazelcast.client.connection;
 
-import java.net.InetSocketAddress;
+import com.hazelcast.nio.Address;
+
 import java.util.Collection;
 
 /**
@@ -25,8 +26,8 @@ import java.util.Collection;
 public interface AddressProvider {
 
     /**
-     * @return Collection of InetSocketAddress
+     * @return The possible member addresses to connect to.
      */
-    Collection<InetSocketAddress> loadAddresses();
+    Collection<Address> loadAddresses();
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -813,13 +813,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             attempt++;
             long nextTry = Clock.currentTimeMillis() + connectionAttemptPeriod;
 
-            Collection<Address> socketAddresses = getSocketAddresses();
-            for (Address inetSocketAddress : socketAddresses) {
+            Collection<Address> addresses = getPossibleMemberAddresses();
+            for (Address address : addresses) {
                 if (!client.getLifecycleService().isRunning()) {
                     throw new IllegalStateException("Giving up on retrying to connect to cluster since client is shutdown.");
                 }
-                triedAddresses.add(inetSocketAddress);
-                if (connectAsOwner(inetSocketAddress) != null) {
+                triedAddresses.add(address);
+                if (connectAsOwner(address) != null) {
                     return;
                 }
             }
@@ -877,7 +877,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
     }
 
-    private Collection<Address> getSocketAddresses() {
+    private Collection<Address> getPossibleMemberAddresses() {
         final List<Address> addresses = new LinkedList<Address>();
 
         Collection<Member> memberList = client.getClientClusterService().getMemberList();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -420,10 +420,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         return connection;
     }
 
-    private Connection connectAsOwner(InetSocketAddress ownerInetSocketAddress) {
+    private Connection connectAsOwner(Address address) {
         Connection connection = null;
         try {
-            Address address = new Address(ownerInetSocketAddress);
             logger.info("Trying to connect to " + address + " as owner member");
             connection = getOrConnect(address, true);
             client.onClusterConnect(connection);
@@ -432,9 +431,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
             connectionStrategy.onConnectToCluster();
         } catch (Exception e) {
-            logger.warning("Exception during initial connection to " + ownerInetSocketAddress + ", exception " + e);
+            logger.warning("Exception during initial connection to " + address + ", exception " + e);
             if (null != connection) {
-                connection.close("Could not connect to " + ownerInetSocketAddress + " as owner", e);
+                connection.close("Could not connect to " + address + " as owner", e);
             }
             return null;
         }
@@ -808,14 +807,14 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
     private void connectToClusterInternal() {
         int attempt = 0;
-        Set<InetSocketAddress> triedAddresses = new HashSet<InetSocketAddress>();
+        Set<Address> triedAddresses = new HashSet<Address>();
 
         while (attempt < connectionAttemptLimit) {
             attempt++;
             long nextTry = Clock.currentTimeMillis() + connectionAttemptPeriod;
 
-            Collection<InetSocketAddress> socketAddresses = getSocketAddresses();
-            for (InetSocketAddress inetSocketAddress : socketAddresses) {
+            Collection<Address> socketAddresses = getSocketAddresses();
+            for (Address inetSocketAddress : socketAddresses) {
                 if (!client.getLifecycleService().isRunning()) {
                     throw new IllegalStateException("Giving up on retrying to connect to cluster since client is shutdown.");
                 }
@@ -878,23 +877,23 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
     }
 
-    private Collection<InetSocketAddress> getSocketAddresses() {
-        final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
+    private Collection<Address> getSocketAddresses() {
+        final List<Address> addresses = new LinkedList<Address>();
 
         Collection<Member> memberList = client.getClientClusterService().getMemberList();
         for (Member member : memberList) {
-            socketAddresses.add(member.getSocketAddress());
+            addresses.add(member.getAddress());
         }
 
         for (AddressProvider addressProvider : addressProviders) {
-            socketAddresses.addAll(addressProvider.loadAddresses());
+            addresses.addAll(addressProvider.loadAddresses());
         }
 
         if (shuffleMemberList) {
-            Collections.shuffle(socketAddresses);
+            Collections.shuffle(addresses);
         }
 
-        return socketAddresses;
+        return addresses;
     }
 
     private ExecutorService createSingleThreadExecutorService(HazelcastClientInstanceImpl client) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
@@ -22,8 +22,8 @@ import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,10 +44,10 @@ public class AwsAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         updateLookupTable();
         final Map<String, String> lookupTable = getLookupTable();
-        final Collection<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(lookupTable.size());
+        final Collection<Address> addresses = new ArrayList<Address>(lookupTable.size());
 
         for (String privateAddress : lookupTable.keySet()) {
             addresses.addAll(AddressHelper.getSocketAddresses(privateAddress));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -19,8 +19,8 @@ package com.hazelcast.client.spi.impl;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
+import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,16 +41,16 @@ public class DefaultAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         final List<String> addresses = networkConfig.getAddresses();
         if (addresses.isEmpty() && noOtherAddressProviderExist) {
-            addresses.add("localhost");
+            addresses.add("127.0.0.1");
         }
-        final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
+        final List<Address> possibleAddresses = new LinkedList<Address>();
 
         for (String address : addresses) {
-            socketAddresses.addAll(AddressHelper.getSocketAddresses(address));
+            possibleAddresses.addAll(AddressHelper.getSocketAddresses(address));
         }
-        return socketAddresses;
+        return possibleAddresses;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -23,8 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -42,18 +40,13 @@ public class DiscoveryAddressProvider
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
                 "Discovered nodes cannot be null!");
 
-        Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
+        Collection<Address> possibleMembers = new ArrayList<Address>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {
-            Address discoveredAddress = discoveryNode.getPrivateAddress();
-            try {
-                possibleMembers.add(discoveredAddress.getInetSocketAddress());
-            } catch (UnknownHostException e) {
-                logger.warning("Unresolvable host exception", e);
-            }
+            possibleMembers.add(discoveryNode.getPrivateAddress());
         }
         return possibleMembers;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -54,7 +54,7 @@ public class ClientStateListener
      *
      * @param clientConfig The client configuration to which this listener will be registered
      */
-    ClientStateListener(ClientConfig clientConfig) {
+    public ClientStateListener(ClientConfig clientConfig) {
         clientConfig.addListenerConfig(new ListenerConfig(this));
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -106,12 +106,12 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         config.getNetworkConfig().setSmartRouting(false);
 
-        InetSocketAddress socketAddress1 = server1.getCluster().getLocalMember().getSocketAddress();
-        InetSocketAddress socketAddress2 = server2.getCluster().getLocalMember().getSocketAddress();
+        Address address1 = server1.getCluster().getLocalMember().getAddress();
+        Address address2 = server2.getCluster().getLocalMember().getAddress();
 
         config.getNetworkConfig().
-                addAddress(socketAddress1.getHostName() + ":" + socketAddress1.getPort()).
-                addAddress(socketAddress2.getHostName() + ":" + socketAddress2.getPort());
+                addAddress(address1.getHost() + ":" + address1.getPort()).
+                addAddress(address2.getHost() + ":" + address2.getPort());
 
         hazelcastFactory.newHazelcastClient(config);
 
@@ -133,7 +133,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
         connectionManager.addConnectionListener(listener);
 
-        final Address serverAddress = new Address(server.getCluster().getLocalMember().getSocketAddress());
+        final Address serverAddress = server.getCluster().getLocalMember().getAddress();
         final Connection connectionToServer = connectionManager.getActiveConnection(serverAddress);
 
         final CountDownLatch isConnected = new CountDownLatch(1);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -17,12 +17,20 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.util.ClientStateListener;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Test;
@@ -32,13 +40,17 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClientRegressionWithRealNetworkTest extends HazelcastTestSupport {
+public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
 
     @After
     public void cleanUp() {
@@ -90,5 +102,85 @@ public class ClientRegressionWithRealNetworkTest extends HazelcastTestSupport {
         });
 
         assertOpenEventually(clientLatch);
+    }
+
+    @Test
+    public void testConnectWithDNSHostnames() throws InterruptedException {
+        Config config = new Config();
+        config.getNetworkConfig().setPublicAddress("localhost");
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("localhost").setConnectionAttemptLimit(Integer.MAX_VALUE);
+        ClientStateListener clientStateListener = new ClientStateListener(clientConfig);
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        final ClientConnectionManager connectionManager = clientInstanceImpl.getConnectionManager();
+
+        Hazelcast.newHazelcastInstance(config);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(2, connectionManager.getActiveConnections().size());
+            }
+        });
+
+        hazelcastInstance.shutdown();
+
+        assertTrue(clientStateListener.awaitConnected(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS));
+
+        assertEquals(1, connectionManager.getActiveConnections().size());
+    }
+
+    @Test
+    public void testListenersWhenDNSHostnamesAreUsed() {
+        Config config = new Config();
+        int heartBeatSeconds = 5;
+        config.getNetworkConfig().setPublicAddress("localhost");
+        config.setProperty(GroupProperty.CLIENT_HEARTBEAT_TIMEOUT_SECONDS.getName(), Integer.toString(heartBeatSeconds));
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+        networkConfig.addAddress("localhost");
+        networkConfig.setConnectionAttemptLimit(Integer.MAX_VALUE);
+        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        final IMap<Integer, Integer> map = client.getMap("test");
+
+        final AtomicInteger eventCount = new AtomicInteger(0);
+
+        map.addEntryListener(new EntryAddedListener() {
+            @Override
+            public void entryAdded(EntryEvent event) {
+                eventCount.incrementAndGet();
+            }
+        }, false);
+
+        Hazelcast.newHazelcastInstance(config);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+                int size = clientInstanceImpl.getConnectionManager().getActiveConnections().size();
+                assertEquals(2, size);
+
+            }
+        });
+
+        hazelcastInstance.shutdown();
+
+        sleepAtLeastSeconds(2 * heartBeatSeconds);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                map.put(1, 2);
+                assertNotEquals(0, eventCount.get());
+            }
+        });
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -362,8 +362,7 @@ public class ClientServiceTest extends ClientTestSupport {
             map.put(randomString(), randomString());
         }
         HazelcastClientInstanceImpl clientInstanceImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
-        InetSocketAddress socketAddress = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
-        Address address = new Address(socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+        Address address = hazelcastInstance.getCluster().getLocalMember().getAddress();
         ClientConnectionManager connectionManager = clientInstanceImpl.getConnectionManager();
         final ClientConnection connection = (ClientConnection) connectionManager.getActiveConnection(address);
         assertTrueEventually(new AssertTask() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.nio.Address;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -124,10 +125,10 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     private void configureDummyClientConnection(HazelcastInstance instance) throws UnknownHostException {
-        InetSocketAddress socketAddress = getAddress(instance).getInetSocketAddress();
+        Address memberAddress = getAddress(instance);
         dummyClientConfig.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         ClientNetworkConfig networkConfig = dummyClientConfig.getNetworkConfig();
-        networkConfig.addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+        networkConfig.addAddress(memberAddress.getHost() + ":" + memberAddress.getPort());
     }
 
     private List<HazelcastInstance> createNodes(int numberOfLiteNodes, int numberOfDataNodes) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -97,8 +97,12 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
 
     private class TestAddressProvider implements AddressProvider {
         @Override
-        public Collection<InetSocketAddress> loadAddresses() {
-            return Collections.singletonList(new InetSocketAddress("127.0.0.1", 5701));
+        public Collection<Address> loadAddresses() {
+            try {
+                return Collections.singletonList(new Address("127.0.0.1", 5701));
+            } catch (UnknownHostException e) {
+                return null;
+            }
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -33,7 +33,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -104,14 +103,14 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
         return new AddressProvider() {
             @Override
-            public Collection<InetSocketAddress> loadAddresses() {
-                Collection<InetSocketAddress> inetAddresses = new ArrayList<InetSocketAddress>();
+            public Collection<Address> loadAddresses() {
+                Collection<Address> possibleAddresses = new ArrayList<Address>();
                 for (Address address : getKnownAddresses()) {
-                    Collection<InetSocketAddress> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
+                    Collection<Address> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
                             address.getHost(), 1);
-                    inetAddresses.addAll(addresses);
+                    possibleAddresses.addAll(addresses);
                 }
-                return inetAddresses;
+                return possibleAddresses;
             }
         };
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/UnisocketClientDriverFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/UnisocketClientDriverFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.test.bounce;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
 
 import java.net.InetSocketAddress;
 
@@ -46,10 +47,9 @@ public class UnisocketClientDriverFactory extends AbstractClientDriverFactory {
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         config.getNetworkConfig().setSmartRouting(false);
 
-        InetSocketAddress socketAddress = member.getCluster().getLocalMember().getSocketAddress();
+        Address address = member.getCluster().getLocalMember().getAddress();
 
-        config.getNetworkConfig().
-                addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+        config.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
 
         return config;
     }


### PR DESCRIPTION
Make sure that the provided address string is used in the activeConnectionsMap. This fixes the domain name to ip address conversion problem and duplicate connection initiation problem to the same member one with ip address and one with domain name. 

We made the assumption that the user will have to use the same host name or ip in the client config if the member is configured with a public ip address.

fixes #11116 
fixes #11264