### PR TITLE
Query cache destroy fix

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -762,8 +762,7 @@ public class ClientConfig {
     }
 
     /**
-     *
-     * @param mapName The name of the map for which the query cache config is to be returned.
+     * @param mapName   The name of the map for which the query cache config is to be returned.
      * @param cacheName The name of the query cache.
      * @return The query cache config. If the config does not exist, it is created.
      */
@@ -786,12 +785,11 @@ public class ClientConfig {
     }
 
     /**
-     *
-     * @param mapName The name of the map for which the query cache config is to be returned.
-     * @param queryCacheName The name of the query cache config.
+     * @param mapName   The name of the map for which the query cache config is to be returned.
+     * @param cacheName The name of the query cache.
      * @return The query cache config. If no such config exist null is returned.
      */
-    public QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String queryCacheName) {
+    public QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String cacheName) {
         if (queryCacheConfigs == null) {
             return null;
         }
@@ -801,6 +799,6 @@ public class ClientConfig {
             return null;
         }
 
-        return lookupByPattern(queryCacheConfigsForMap, queryCacheName);
+        return lookupByPattern(queryCacheConfigsForMap, cacheName);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheMemoryLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheMemoryLeakTest.java
@@ -21,10 +21,23 @@ import com.hazelcast.client.proxy.ClientMapProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.querycache.QueryCacheContext;
+import com.hazelcast.map.impl.querycache.accumulator.DefaultAccumulatorInfoSupplier;
+import com.hazelcast.map.impl.querycache.publisher.MapListenerRegistry;
+import com.hazelcast.map.impl.querycache.publisher.MapPublisherRegistry;
+import com.hazelcast.map.impl.querycache.publisher.PartitionAccumulatorRegistry;
+import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
+import com.hazelcast.map.impl.querycache.publisher.PublisherRegistry;
+import com.hazelcast.map.impl.querycache.publisher.QueryCacheListenerRegistry;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheFactory;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -34,13 +47,25 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientQueryCacheMemoryLeakTest extends HazelcastTestSupport {
 
     private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
 
     @Test
     public void removes_internal_query_caches_upon_map_destroy() throws Exception {
@@ -49,6 +74,8 @@ public class ClientQueryCacheMemoryLeakTest extends HazelcastTestSupport {
 
         String mapName = "test";
         IMap<Integer, Integer> map = client.getMap(mapName);
+
+        populateMap(map);
 
         for (int j = 0; j < 10; j++) {
             map.getQueryCache(j + "-test-QC", TruePredicate.INSTANCE, true);
@@ -65,8 +92,102 @@ public class ClientQueryCacheMemoryLeakTest extends HazelcastTestSupport {
         assertEquals(0, queryCacheFactory.getQueryCacheCount());
     }
 
-    @After
-    public void tearDown() throws Exception {
-        factory.shutdownAll();
+    @Test
+    public void no_query_cache_left_after_creating_and_destroying_same_map_concurrently() throws Exception {
+        final HazelcastInstance node = factory.newHazelcastInstance();
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final String mapName = "test";
+
+        ExecutorService pool = Executors.newFixedThreadPool(5);
+
+        for (int i = 0; i < 1000; i++) {
+            Runnable runnable = new Runnable() {
+                public void run() {
+                    IMap<Integer, Integer> map = client.getMap(mapName);
+                    ;
+                    try {
+                        populateMap(map);
+                        for (int j = 0; j < 10; j++) {
+                            map.getQueryCache(j + "-test-QC", TruePredicate.INSTANCE, true);
+                        }
+                    } finally {
+                        map.destroy();
+                    }
+
+                }
+            };
+            pool.submit(runnable);
+        }
+
+        pool.shutdown();
+        pool.awaitTermination(60, TimeUnit.SECONDS);
+
+        SubscriberContext subscriberContext = getSubscriberContext(client, mapName);
+        QueryCacheEndToEndProvider provider = subscriberContext.getEndToEndQueryCacheProvider();
+        QueryCacheFactory queryCacheFactory = subscriberContext.getQueryCacheFactory();
+
+        assertEquals(0, provider.getQueryCacheCount(mapName));
+        assertEquals(0, queryCacheFactory.getQueryCacheCount());
+
+        assertNoListenerLeftOnEventService(node);
+        assertNoRegisteredListenerLeft(node, mapName);
+        assertNoAccumulatorInfoSupplierLeft(node, mapName);
+        assertNoPartitionAccumulatorRegistryLeft(node, mapName);
+    }
+
+    private static void assertNoAccumulatorInfoSupplierLeft(HazelcastInstance node, String mapName) {
+        PublisherContext publisherContext = getPublisherContext(node);
+        DefaultAccumulatorInfoSupplier accumulatorInfoSupplier
+                = (DefaultAccumulatorInfoSupplier) publisherContext.getAccumulatorInfoSupplier();
+        int accumulatorInfoCountOfMap = accumulatorInfoSupplier.accumulatorInfoCountOfMap(mapName);
+        assertEquals(0, accumulatorInfoCountOfMap);
+    }
+
+    private static void assertNoRegisteredListenerLeft(HazelcastInstance node, String mapName) {
+        PublisherContext publisherContext = getPublisherContext(node);
+        MapListenerRegistry mapListenerRegistry = publisherContext.getMapListenerRegistry();
+        QueryCacheListenerRegistry registry = mapListenerRegistry.getOrNull(mapName);
+        if (registry != null) {
+            Map<String, String> registeredListeners = registry.getAll();
+            assertTrue(registeredListeners.isEmpty());
+        }
+    }
+
+    private static void assertNoPartitionAccumulatorRegistryLeft(HazelcastInstance node, String mapName) {
+        PublisherContext publisherContext = getPublisherContext(node);
+        MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
+        PublisherRegistry registry = mapPublisherRegistry.getOrCreate(mapName);
+        if(registry == null) {
+            return;
+        }
+
+        Map<String, PartitionAccumulatorRegistry> accumulatorRegistryMap = registry.getAll();
+        assertTrue(accumulatorRegistryMap.isEmpty());
+    }
+
+    private static void assertNoListenerLeftOnEventService(HazelcastInstance node) {
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(node);
+        EventServiceImpl eventService = ((EventServiceImpl) nodeEngineImpl.getEventService());
+        EventServiceSegment segment = eventService.getSegment(MapService.SERVICE_NAME, false);
+        ConcurrentMap registrationIdMap = segment.getRegistrationIdMap();
+        assertEquals(registrationIdMap.toString(), 0, registrationIdMap.size());
+    }
+
+    private static void populateMap(IMap<Integer, Integer> map) {
+        for (int i = 0; i < 10; i++) {
+            map.put(i, i);
+        }
+    }
+
+    private static SubscriberContext getSubscriberContext(HazelcastInstance client, String mapName) {
+        final IMap<Integer, Integer> map = client.getMap(mapName);
+        return ((ClientMapProxy) map).getQueryCacheContext().getSubscriberContext();
+    }
+
+    private static PublisherContext getPublisherContext(HazelcastInstance node) {
+        MapService mapService = getNodeEngineImpl(node).getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
+        return queryCacheContext.getPublisherContext();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -44,7 +44,6 @@ import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.Target;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
-import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
 import com.hazelcast.map.impl.querycache.subscriber.NodeQueryCacheEndToEndConstructor;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
@@ -74,7 +73,6 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.CollectionUtil;
-import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.executor.DelegatingFuture;
@@ -1039,12 +1037,11 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     private QueryCache<K, V> createQueryCache(QueryCacheRequest request) {
-        ConstructorFunction<String, InternalQueryCache> constructorFunction = new NodeQueryCacheEndToEndConstructor(request);
         QueryCacheContext queryCacheContext = request.getContext();
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
         return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getCacheName(),
-                constructorFunction);
+                new NodeQueryCacheEndToEndConstructor(request));
     }
 
     private void handleHazelcastInstanceAwareParams(Object... objects) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1182,7 +1182,7 @@ abstract class MapProxySupport<K, V>
             QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
             SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
             QueryCacheEndToEndProvider provider = subscriberContext.getEndToEndQueryCacheProvider();
-            provider.removeQueryCachesOfMap(name);
+            provider.destroyAllQueryCaches(name);
         } finally {
             super.preDestroy();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
@@ -168,20 +168,20 @@ public class NodeQueryCacheContext implements QueryCacheContext {
         return mapServiceContext.toObject(obj);
     }
 
-    private String registerLocalIMapListener(String mapName) {
+    private String registerLocalIMapListener(String name) {
         return mapServiceContext.addLocalListenerAdapter(new ListenerAdapter<IMapEvent>() {
             @Override
             public void onEvent(IMapEvent event) {
                 // NOP
             }
-        }, mapName);
+        }, name);
     }
 
     @SerializableByConvention
     private class RegisterMapListenerFunction implements IFunction<String, String> {
         @Override
-        public String apply(String mapName) {
-            return registerLocalIMapListener(mapName);
+        public String apply(String name) {
+            return registerLocalIMapListener(name);
         }
     };
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
@@ -49,6 +49,10 @@ public class DefaultAccumulatorInfoSupplier implements AccumulatorInfoSupplier {
     @Override
     public AccumulatorInfo getAccumulatorInfoOrNull(String mapName, String cacheId) {
         ConcurrentMap<String, AccumulatorInfo> cacheToInfoMap = cacheInfoPerMap.get(mapName);
+        if (cacheToInfoMap == null) {
+            return null;
+        }
+
         return cacheToInfoMap.get(cacheId);
     }
 
@@ -64,6 +68,17 @@ public class DefaultAccumulatorInfoSupplier implements AccumulatorInfoSupplier {
         if (cacheToInfoMap == null) {
             return;
         }
+
         cacheToInfoMap.remove(cacheId);
+    }
+
+    // only for testing
+    public int accumulatorInfoCountOfMap(String mapName) {
+        ConcurrentMap<String, AccumulatorInfo> accumulatorInfo = cacheInfoPerMap.get(mapName);
+        if (accumulatorInfo == null) {
+            return 0;
+        } else {
+            return accumulatorInfo.size();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
  * If all incoming events are in the correct sequence order, this accumulator applies those events to
  * {@link com.hazelcast.map.QueryCache QueryCache}.
  * Otherwise, it informs registered callback if there is any.
- *
+ * <p>
  * This class can be accessed by multiple-threads at a time.
  */
 public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData> {
@@ -154,9 +154,12 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
 
         if (!isNextSequence) {
             if (logger.isWarningEnabled()) {
-                logger.warning(format("Event lost detected for partitionId=%d, expectedSequence=%d "
-                                + "but foundSequence=%d, cacheSize=%d",
-                        partitionId, expectedSequence, foundSequence, getQueryCache().size()));
+                InternalQueryCache queryCache = getQueryCache();
+                if (queryCache != null) {
+                    logger.warning(format("Event lost detected for partitionId=%d, expectedSequence=%d "
+                                    + "but foundSequence=%d, cacheSize=%d",
+                            partitionId, expectedSequence, foundSequence, queryCache.size()));
+                }
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
@@ -84,7 +84,7 @@ public class DestroyQueryCacheOperation extends MapOperation {
             return;
         }
         String listenerId = listenerRegistry.remove(cacheId);
-        mapService.getMapServiceContext().removeEventListener(name, listenerId);
+        mapService.getMapServiceContext().removeEventListener(cacheId, listenerId);
     }
 
     private void removeAccumulatorInfo() {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMemoryLeakTest.java
@@ -20,10 +20,20 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.querycache.accumulator.DefaultAccumulatorInfoSupplier;
+import com.hazelcast.map.impl.querycache.publisher.MapListenerRegistry;
+import com.hazelcast.map.impl.querycache.publisher.MapPublisherRegistry;
+import com.hazelcast.map.impl.querycache.publisher.PartitionAccumulatorRegistry;
+import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
+import com.hazelcast.map.impl.querycache.publisher.PublisherRegistry;
+import com.hazelcast.map.impl.querycache.publisher.QueryCacheListenerRegistry;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheFactory;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -32,7 +42,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -44,6 +61,7 @@ public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
 
         String mapName = "test";
         IMap<Integer, Integer> map = node.getMap(mapName);
+        populateMap(map);
 
         for (int j = 0; j < 10; j++) {
             map.getQueryCache(j + "-test-QC", TruePredicate.INSTANCE, true);
@@ -59,10 +77,103 @@ public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
         assertEquals(0, queryCacheFactory.getQueryCacheCount());
     }
 
-    private SubscriberContext getSubscriberContext(HazelcastInstance node) {
+    @Test
+    public void no_query_cache_left_after_creating_and_destroying_same_map_concurrently() throws Exception {
+        final HazelcastInstance node = createHazelcastInstance();
+        final String mapName = "test";
+
+        ExecutorService pool = Executors.newFixedThreadPool(5);
+
+        for (int i = 0; i < 1000; i++) {
+            Runnable runnable = new Runnable() {
+                public void run() {
+                    IMap<Integer, Integer> map = node.getMap(mapName);
+                    ;
+                    try {
+                        populateMap(map);
+                        for (int j = 0; j < 10; j++) {
+                            map.getQueryCache(j + "-test-QC", TruePredicate.INSTANCE, true);
+                        }
+                    } finally {
+                        map.destroy();
+                    }
+
+                }
+            };
+            pool.submit(runnable);
+        }
+
+        pool.shutdown();
+        pool.awaitTermination(60, TimeUnit.SECONDS);
+
+        SubscriberContext subscriberContext = getSubscriberContext(node);
+        QueryCacheEndToEndProvider provider = subscriberContext.getEndToEndQueryCacheProvider();
+        QueryCacheFactory queryCacheFactory = subscriberContext.getQueryCacheFactory();
+
+        assertEquals(0, provider.getQueryCacheCount(mapName));
+        assertEquals(0, queryCacheFactory.getQueryCacheCount());
+
+        assertNoListenerLeftOnEventService(node);
+        assertNoRegisteredListenerLeft(node, mapName);
+        assertNoAccumulatorInfoSupplierLeft(node, mapName);
+        assertNoPartitionAccumulatorRegistryLeft(node, mapName);
+    }
+
+    private static void assertNoAccumulatorInfoSupplierLeft(HazelcastInstance node, String mapName) {
+        PublisherContext publisherContext = getPublisherContext(node);
+        DefaultAccumulatorInfoSupplier accumulatorInfoSupplier
+                = (DefaultAccumulatorInfoSupplier) publisherContext.getAccumulatorInfoSupplier();
+        int accumulatorInfoCountOfMap = accumulatorInfoSupplier.accumulatorInfoCountOfMap(mapName);
+        assertEquals(0, accumulatorInfoCountOfMap);
+    }
+
+    private static void assertNoRegisteredListenerLeft(HazelcastInstance node, String mapName) {
+        PublisherContext publisherContext = getPublisherContext(node);
+        MapListenerRegistry mapListenerRegistry = publisherContext.getMapListenerRegistry();
+        QueryCacheListenerRegistry registry = mapListenerRegistry.getOrNull(mapName);
+        if (registry != null) {
+            Map<String, String> registeredListeners = registry.getAll();
+            assertTrue(registeredListeners.isEmpty());
+        }
+    }
+
+    private static void assertNoPartitionAccumulatorRegistryLeft(HazelcastInstance node, String mapName) {
+        PublisherContext publisherContext = getPublisherContext(node);
+        MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
+        PublisherRegistry registry = mapPublisherRegistry.getOrCreate(mapName);
+        if(registry == null) {
+            return;
+        }
+
+        Map<String, PartitionAccumulatorRegistry> accumulatorRegistryMap = registry.getAll();
+        assertTrue(accumulatorRegistryMap.isEmpty());
+    }
+
+    private static void assertNoListenerLeftOnEventService(HazelcastInstance node) {
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(node);
+        EventServiceImpl eventService = ((EventServiceImpl) nodeEngineImpl.getEventService());
+        EventServiceSegment segment = eventService.getSegment(MapService.SERVICE_NAME, false);
+        ConcurrentMap registrationIdMap = segment.getRegistrationIdMap();
+        assertEquals(registrationIdMap.toString(), 0, registrationIdMap.size());
+    }
+
+    private static void populateMap(IMap<Integer, Integer> map) {
+        for (int i = 0; i < 10; i++) {
+            map.put(i, i);
+        }
+    }
+
+    private static SubscriberContext getSubscriberContext(HazelcastInstance node) {
         MapService mapService = getNodeEngineImpl(node).getService(MapService.SERVICE_NAME);
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
         return queryCacheContext.getSubscriberContext();
+    }
+
+    private static PublisherContext getPublisherContext(HazelcastInstance node) {
+        MapService mapService = getNodeEngineImpl(node).getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
+        return queryCacheContext.getPublisherContext();
     }
 }


### PR DESCRIPTION
depends on https://github.com/hazelcast/hazelcast/pull/11222

closes https://github.com/hazelcast/hazelcast/issues/11185

__Fix:__
Synchronized query cache create and destroy methods