### PR TITLE
AddressTranslator fix

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -315,7 +315,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
     @Override
     public Connection getActiveConnection(Address target) {
-        target = addressTranslator.translate(target);
         if (target == null) {
             return null;
         }
@@ -344,7 +343,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         if (!asOwner && getOwnerConnection() == null) {
             throw new IOException("Owner connection is not available!");
         }
-        target = addressTranslator.translate(target);
         if (target == null) {
             throw new IllegalStateException("Address can not be null");
         }
@@ -378,7 +376,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                 if (connection != null) {
                     return connection;
                 }
-                AuthenticationFuture firstCallback = triggerConnect(addressTranslator.translate(address), asOwner);
+                AuthenticationFuture firstCallback = triggerConnect(address, asOwner);
                 connection = (ClientConnection) firstCallback.get(connectionTimeout);
 
                 if (!asOwner) {
@@ -692,8 +690,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     }
 
     private void onAuthenticated(Address target, ClientConnection connection) {
-        ClientConnection oldConnection =
-                activeConnections.put(addressTranslator.translate(connection.getEndPoint()), connection);
+        ClientConnection oldConnection = activeConnections.put(connection.getEndPoint(), connection);
         if (oldConnection == null) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Authentication succeeded for " + connection
@@ -761,7 +758,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             ClientConnection connection = activeConnections.get(target);
             if (connection == null) {
                 try {
-                    connection = createSocketConnection(target);
+                    connection = createSocketConnection(addressTranslator.translate(target));
                 } catch (Exception e) {
                     logger.finest(e);
                     callback.onFailure(e);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Collections;
+
+import static junit.framework.TestCase.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
+
+    private Address privateAddress;
+    private Address publicAddress;
+    private ClientConnectionManagerImpl clientConnectionManager;
+
+    @Before
+    public void setup() throws Exception {
+        Hazelcast.newHazelcastInstance();
+        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        Collection<AddressProvider> list = Collections.<AddressProvider>singletonList(new TestAddressProvider());
+
+        TestAddressTranslator translator = new TestAddressTranslator();
+        clientConnectionManager =
+                new ClientConnectionManagerImpl(getHazelcastClientInstanceImpl(client),
+                        translator, list);
+        clientConnectionManager.start(new ClientContext(getHazelcastClientInstanceImpl(client)));
+        clientConnectionManager.connectToCluster();
+
+        translator.shouldTranslate = true;
+
+        privateAddress = new Address("127.0.0.1", 5701);
+        publicAddress = new Address("192.168.0.1", 5701);
+    }
+
+    @After
+    public void teardown() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+
+    private class TestAddressTranslator implements AddressTranslator {
+
+        volatile boolean shouldTranslate = false;
+
+        @Override
+        public Address translate(Address address) {
+            if (!shouldTranslate) {
+                return address;
+            }
+
+            if (address.equals(privateAddress)) {
+                return publicAddress;
+            }
+            return null;
+        }
+
+        @Override
+        public void refresh() {
+
+        }
+    }
+
+    private class TestAddressProvider implements AddressProvider {
+        @Override
+        public Collection<InetSocketAddress> loadAddresses() {
+            return Collections.singletonList(new InetSocketAddress("127.0.0.1", 5701));
+        }
+    }
+
+    @Test
+    public void testTranslatorNotIsUsedGetActiveConnection() throws Exception {
+        Connection connection = clientConnectionManager.getActiveConnection(privateAddress);
+        assertNotNull(connection);
+    }
+
+    @Test
+    public void testTranslatorIsNotUsedOnTriggerConnect() throws Exception {
+        Connection connection = clientConnectionManager.getOrTriggerConnect(privateAddress);
+        assertNotNull(connection);
+    }
+
+    @Test
+    public void testTranslatorIsNotUsedOnGetConnection() throws Exception {
+        Connection connection = clientConnectionManager.getOrConnect(privateAddress);
+        assertNotNull(connection);
+    }
+
+
+}


### PR DESCRIPTION
Internal maps(active connections & connectionsInProgress) will use
private addresses. Server will send private addresses. Client will
use translation only when trying to create a socket.