### PR TITLE
[WIP] passing DiscoveryMode to the DiscoveryStrategy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.discovery;
 
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.util.StringUtil;
 
@@ -37,6 +38,7 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
 
     private final ILogger logger;
     private final Map<String, Comparable> properties;
+    private DiscoveryMode discoveryMode;
 
     public AbstractDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
         this.logger = logger;
@@ -207,5 +209,13 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
             sb.append('.');
         }
         return sb.append(property.key()).toString();
+    }
+
+    public DiscoveryMode getDiscoveryMode() {
+        return discoveryMode;
+    }
+
+    public void setDiscoveryMode(DiscoveryMode discoveryMode) {
+        this.discoveryMode = discoveryMode;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.discovery.multicast.impl.MulticastDiscoveryReceiver;
 import com.hazelcast.spi.discovery.multicast.impl.MulticastDiscoverySender;
 import com.hazelcast.spi.discovery.multicast.impl.MulticastMemberInfo;
@@ -79,9 +80,7 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             multicastSocket.joinGroup(InetAddress.getByName(group));
             multicastDiscoverySender = new MulticastDiscoverySender(discoveryNode, multicastSocket, logger, group, port);
             multicastDiscoveryReceiver = new MulticastDiscoveryReceiver(multicastSocket, logger);
-            if (discoveryNode != null) {
-                isClient = false;
-            }
+            isClient = getDiscoveryMode() == DiscoveryMode.Client;
         } catch (Exception e) {
             logger.finest(e.getMessage());
             rethrow(e);


### PR DESCRIPTION
introducing `getDiscoveryMode` is one way to offer `DiscoveryMode` feature of Discovery SPI to Implementors while without breaking binary compatibility.

fixes #10089 