### PR TITLE
Fix for map-loader put in case of size-base eviction NPE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -40,14 +40,20 @@ public interface MapLoader<K, V> {
      * to obtain the value. Implementation can use any means of loading the given key;
      * such as an O/R mapping tool, simple SQL or reading a file etc.
      *
-     * @param key
-     * @return value of the key
+     * @param key, cannot be null
+     * @return value of the key, value cannot be null
      */
     V load(K key);
 
     /**
      * Loads given keys. This is batch load operation so that implementation can
      * optimize the multiple loads.
+     *
+     * For any key in the input keys, there should be a single mapping in the resulting map. Also the resulting
+     * map should not have any keys that are not part of the input keys.
+     *
+     * The given collection should not contain any <code>null</code> keys.
+     * The returned Map should not contain any <code>null</code> keys or values.
      *
      * @param keys keys of the values entries to load
      * @return map of loaded key-value pairs.
@@ -60,7 +66,9 @@ public interface MapLoader<K, V> {
      * {@link Closeable} interface in which case it will be closed once iteration is over.
      * This is intended for releasing resources such as closing a JDBC result set.
      *
-     * @return all the keys
+     * The returned Iterable should not contain any <code>null</code> keys.
+     *
+     * @return all the keys. Keys inside the Iterable cannot be null.
      */
     Iterable<K> loadAllKeys();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -31,6 +31,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 
 public final class MapKeyLoaderUtil {
@@ -110,6 +111,8 @@ public final class MapKeyLoaderUtil {
         return new IFunction<Data, Entry<Integer, Data>>() {
             @Override
             public Entry<Integer, Data> apply(Data input) {
+                // Null-pointer here, in case of null key loaded by MapLoader
+                checkNotNull(input, "Key loaded by a MapLoader cannot be null.");
                 Integer partition = partitionService.getPartitionId(input);
                 return new MapEntrySimple<Integer, Data>(partition, input);
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -60,6 +60,10 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
             final Data value = keyValueSequence.get(i + 1);
             final Object object = mapServiceContext.toObject(value);
             recordStore.putFromLoadBackup(key, object);
+            if (!recordStore.existInMemory(key)) {
+                continue;
+            }
+
             publishWanReplicationEvent(key, value, recordStore.getRecord(key));
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -60,6 +60,8 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
             final Data value = keyValueSequence.get(i + 1);
             final Object object = mapServiceContext.toObject(value);
             recordStore.putFromLoadBackup(key, object);
+            // the following check is for the case when the putFromLoad does not put the data due to various reasons
+            // one of the reasons may be size eviction threshold has been reached
             if (!recordStore.existInMemory(key)) {
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -72,6 +72,9 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
             // here object conversion is for interceptors.
             Object value = hasInterceptor ? mapServiceContext.toObject(dataValue) : dataValue;
             Object previousValue = recordStore.putFromLoad(key, value);
+            if (!recordStore.existInMemory(key)) {
+                continue;
+            }
 
             // do not run interceptors in case the put was skipped due to null value
             if (value != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -72,7 +72,9 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
             // here object conversion is for interceptors.
             Object value = hasInterceptor ? mapServiceContext.toObject(dataValue) : dataValue;
             Object previousValue = recordStore.putFromLoad(key, value);
-            if (!recordStore.existInMemory(key)) {
+            // the following check is for the case when the putFromLoad does not put the data due to various reasons
+            // one of the reasons may be size eviction threshold has been reached
+            if (value != null && !recordStore.existInMemory(key)) {
                 continue;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -735,6 +735,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
+    public boolean existInMemory(Data key) {
+        return storage.containsKey(key);
+    }
+
+    @Override
     public boolean containsKey(Data key) {
         checkIfLoaded();
         final long now = getNow();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -105,6 +105,11 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
 
     MapEntries getAll(Set<Data> keySet);
 
+    /**
+     * Checks if the key exist in memory without trying to load data from map-loader
+     */
+    boolean existInMemory(Data key);
+
     boolean containsKey(Data dataKey);
 
     int getLockedEntryCount();


### PR DESCRIPTION
Fix for map-loader put in case of size-based eviction NPE
Also backports map-loader key&value validation 

EE side: https://github.com/hazelcast/hazelcast-enterprise/pull/1662

Test-case is called: `testMapLoaderHittingEvictionOnInitialLoad()`