### PR TITLE
fix hazelcast api delegating class loader  for user code deployment tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -110,6 +110,7 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
 
     /**
      * Attempts to locate a class' bytes as a resource in parent classpath, then loads the class in this classloader.
+     *
      * @return
      */
     private Class<?> findClassInParentURLs(final String name) {
@@ -132,9 +133,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
 
     // delegate to parent if class is not under com.hazelcast package or if class is ProxyInvocationHandler itself.
     private boolean shouldDelegate(String name) {
-//        if (name.startsWith("usercodedeployment")) {
-//            return false;
-//        }
+        if (name.startsWith("usercodedeployment")) {
+            return false;
+        }
 
         if (!name.startsWith("com.hazelcast")) {
             return true;
@@ -148,10 +149,6 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
     }
 
     private boolean isHazelcastTestClass(String name) {
-        if (name.startsWith("usercodedeployment")) {
-            return true;
-        }
-
         if (!name.startsWith("com.hazelcast")) {
             return false;
         }


### PR DESCRIPTION
Classes like 
usercodeDeployment.IncrementingEntrprocessor
usercodeDeployment.WhitelistedEP etc
should not be delegated and loaded with same class loader of interface EntryProcessor from current codebase. 

A test build to verify the fix before merge
https://hazelcast-l337.ci.cloudbees.com/job/sancar-test-build/
fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1639