### PR TITLE
Minor event journal improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -163,11 +163,12 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
 
     @Override
     public RingbufferConfig toRingbufferConfig(EventJournalConfig config) {
+        final int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         return new RingbufferConfig()
                 .setAsyncBackupCount(0)
                 .setBackupCount(0)
                 .setInMemoryFormat(InMemoryFormat.OBJECT)
-                .setCapacity(config.getCapacity())
+                .setCapacity(config.getCapacity() / partitionCount)
                 .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
@@ -64,7 +64,7 @@ public class CacheEventJournalReadTask<K, V, T>
     protected Operation prepareOperation() {
         if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
             throw new UnsupportedOperationException(
-                    "Event journal actions are not available when cluster version is 3.9 or higher");
+                    "Event journal actions are available when cluster version is 3.9 or higher");
         }
         final Projection<? super EventJournalCacheEvent<K, V>, T> projection
                 = serializationService.toObject(parameters.projection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalSubscribeTask.java
@@ -51,7 +51,7 @@ public class CacheEventJournalSubscribeTask
     protected Operation prepareOperation() {
         if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
             throw new UnsupportedOperationException(
-                    "Event journal actions are not available when cluster version is 3.9 or higher");
+                    "Event journal actions are available when cluster version is 3.9 or higher");
         }
         return new CacheEventJournalSubscribeOperation(parameters.name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
@@ -62,7 +62,7 @@ public class MapEventJournalReadTask<K, V, T>
     protected Operation prepareOperation() {
         if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
             throw new UnsupportedOperationException(
-                    "Event journal actions are not available when cluster version is 3.9 or higher");
+                    "Event journal actions are available when cluster version is 3.9 or higher");
         }
         final Projection<? super EventJournalMapEvent<K, V>, T> projection = serializationService.toObject(parameters.projection);
         final Predicate<? super EventJournalMapEvent<K, V>> predicate = serializationService.toObject(parameters.predicate);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
@@ -50,7 +50,7 @@ public class MapEventJournalSubscribeTask
     protected Operation prepareOperation() {
         if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
             throw new UnsupportedOperationException(
-                    "Event journal actions are not available when cluster version is 3.9 or higher");
+                    "Event journal actions are available when cluster version is 3.9 or higher");
         }
         return new MapEventJournalSubscribeOperation(parameters.name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
@@ -74,9 +74,16 @@ public class EventJournalConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Gets the capacity of the event journal.
-     * The capacity is the total number of items that the event journal can hold at any moment.
-     * The actual number of items contained in the journal can be lower.
+     * Gets the capacity of the event journal. The capacity is the total number of items
+     * that the event journal can hold at any moment. The actual number of items
+     * contained in the journal can be lower.
+     * <p>
+     * <b>NOTE</b>
+     * The capacity is shared equally between all partitions.
+     * This is done by assigning each partition {@code getCapacity() / partitionCount}
+     * available slots in the event journal. Because of this, the effective total
+     * capacity may be somewhat lower and you must take into account that the
+     * configured capacity is at least greater than the partition count.
      *
      * @return the capacity.
      */
@@ -85,7 +92,16 @@ public class EventJournalConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Sets the capacity of the event journal.
+     * Sets the capacity of the event journal. The capacity is the total number of items
+     * that the event journal can hold at any moment. The actual number of items
+     * contained in the journal can be lower.
+     * <p>
+     * <b>NOTE</b>
+     * The capacity is shared equally between all partitions.
+     * This is done by assigning each partition {@code getCapacity() / partitionCount}
+     * available slots in the event journal. Because of this, the effective total
+     * capacity may be somewhat lower and you must take into account that the
+     * configured capacity is at least greater than the partition count.
      *
      * @param capacity the capacity.
      * @return the updated config.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -135,11 +135,12 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
 
     @Override
     public RingbufferConfig toRingbufferConfig(EventJournalConfig config) {
+        final int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         return new RingbufferConfig()
                 .setAsyncBackupCount(0)
                 .setBackupCount(0)
                 .setInMemoryFormat(InMemoryFormat.OBJECT)
-                .setCapacity(config.getCapacity())
+                .setCapacity(config.getCapacity() / partitionCount)
                 .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -3183,10 +3183,13 @@
             <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        Number of items in the event journal. If no time-to-live-seconds
-                        is set, the size will always be equal to capacity after the event
-                        journal has been filled. This is because no items are getting retired.
-                        The default value is 10000.
+                        The capacity of the event journal. The capacity is the total number of items that the event journal
+                        can hold at any moment. The actual number of items contained in the journal can be lower.
+                        Its default value is 10000. The capacity is shared equally between all partitions.
+                        This is done by assigning each partition {@code getCapacity() / partitionCount}
+                        available slots in the event journal. Because of this, the effective total
+                        capacity may be somewhat lower and you must take into account that the
+                        configured capacity is at least greater than the partition count.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1240,16 +1240,20 @@ It has the following sub-elements:
     	event journal config as enabled then all caches which don't have specific event journal
     	will be also enabled.
     * <capacity>:
-    * Gets the capacity of the event journal.
-    * The capacity is the total number of items that the event journal can hold at any moment.
-    * The actual number of items contained in the journal can be lower. Its default value is 10000.
+    	The capacity of the event journal. The capacity is the total number of items that the event journal
+    	can hold at any moment. The actual number of items contained in the journal can be lower. Its default value is 10000.
+    	The capacity is shared equally between all partitions.
+    	This is done by assigning each partition {@code getCapacity() / partitionCount}
+    	available slots in the event journal. Because of this, the effective total
+    	capacity may be somewhat lower and you must take into account that the
+    	configured capacity is at least greater than the partition count.
     * <time-to-live-seconds>:
-    * Sets the time to live in seconds.
-    * Time to live is the time the event journal retains items before removing them from the journal.
-    * The events are removed on journal read and write actions, not while the journal is idle.
-    * Time to live can be disabled by setting timeToLiveSeconds to 0. This means that the
-    * events never expire but they can be overwritten when the capacity of the journal is exceeed.
-    * Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Its default value is 0.
+    	Sets the time to live in seconds.
+    	Time to live is the time the event journal retains items before removing them from the journal.
+    	The events are removed on journal read and write actions, not while the journal is idle.
+    	Time to live can be disabled by setting timeToLiveSeconds to 0. This means that the
+    	events never expire but they can be overwritten when the capacity of the journal is exceeed.
+    	Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Its default value is 0.
 -->
 
     <event-journal enabled="false">

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -100,7 +101,9 @@ public class BasicCacheJournalTest extends HazelcastTestSupport {
     @Override
     protected Config getConfig() {
         final Config config = super.getConfig();
-        config.addEventJournalConfig(new EventJournalConfig().setCacheName("default").setEnabled(true));
+        final int defaultPartitionCount = Integer.parseInt(GroupProperty.PARTITION_COUNT.getDefaultValue());
+        config.addEventJournalConfig(new EventJournalConfig().setCapacity(200 * defaultPartitionCount)
+                                                             .setCacheName("default").setEnabled(true));
         final CacheSimpleConfig nonEvictingCache = new CacheSimpleConfig().setName("cache");
         nonEvictingCache.getEvictionConfig().setSize(Integer.MAX_VALUE);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -109,7 +110,9 @@ public class BasicMapJournalTest extends HazelcastTestSupport {
     @Override
     protected Config getConfig() {
         final Config config = super.getConfig();
-        config.addEventJournalConfig(new EventJournalConfig().setMapName("default").setEnabled(true));
+        final int defaultPartitionCount = Integer.parseInt(GroupProperty.PARTITION_COUNT.getDefaultValue());
+        config.addEventJournalConfig(new EventJournalConfig().setCapacity(500 * defaultPartitionCount)
+                                                             .setMapName("default").setEnabled(true));
 
         final MapConfig mapConfig = new MapConfig("mappy");
         final MapConfig expiringMap = new MapConfig("expiring").setTimeToLiveSeconds(1);


### PR DESCRIPTION
- fixes some error messages when the cluster does not support event
journal operations due to the cluster version
- the event journal capacity is shared between all partition-specific
ringbuffers. It seems this is more commonly expected and it leads to
a more sensible usage of heap space. Updated documentation to explain
this.

Fixes : https://github.com/hazelcast/hazelcast/issues/11220