### PR TITLE
Handle legacy WAN URIs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -22,27 +22,37 @@ import com.hazelcast.internal.ascii.TextCommandService;
 public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcessor<T> {
     public static final String URI_MAPS = "/hazelcast/rest/maps/";
     public static final String URI_QUEUES = "/hazelcast/rest/queues/";
+    public static final String URI_MANCENTER_BASE_URL = "/hazelcast/rest/mancenter";
+    public static final String URI_MANCENTER_CHANGE_URL = URI_MANCENTER_BASE_URL + "/changeurl";
+    public static final String URI_UPDATE_PERMISSIONS = URI_MANCENTER_BASE_URL + "/security/permissions";
+    public static final String URI_HEALTH_URL = "/hazelcast/health";
+
+    // Cluster
     public static final String URI_CLUSTER = "/hazelcast/rest/cluster";
     public static final String URI_CLUSTER_MANAGEMENT_BASE_URL = "/hazelcast/rest/management/cluster";
-    public static final String URI_MANCENTER_BASE_URL = "/hazelcast/rest/mancenter";
     public static final String URI_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/state";
     public static final String URI_CHANGE_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeState";
     public static final String URI_CLUSTER_VERSION_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/version";
     public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/clusterShutdown";
+    public static final String URI_SHUTDOWN_NODE_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
+    public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
+
+    // Hot restart
     public static final String URI_FORCESTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/forceStart";
     public static final String URI_PARTIALSTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/partialStart";
     public static final String URI_HOT_RESTART_BACKUP_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/hotBackup";
     public static final String URI_HOT_RESTART_BACKUP_INTERRUPT_CLUSTER_URL
             = URI_CLUSTER_MANAGEMENT_BASE_URL + "/hotBackupInterrupt";
-    public static final String URI_SHUTDOWN_NODE_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
-    public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
-    public static final String URI_MANCENTER_CHANGE_URL = URI_MANCENTER_BASE_URL + "/changeurl";
+
+    // WAN
     public static final String URI_WAN_SYNC_MAP = URI_MANCENTER_BASE_URL + "/wan/sync/map";
     public static final String URI_WAN_SYNC_ALL_MAPS = URI_MANCENTER_BASE_URL + "/wan/sync/allmaps";
     public static final String URI_MANCENTER_WAN_CLEAR_QUEUES = URI_MANCENTER_BASE_URL + "/wan/clearWanQueues";
     public static final String URI_ADD_WAN_CONFIG = URI_MANCENTER_BASE_URL + "/wan/addWanConfig";
-    public static final String URI_UPDATE_PERMISSIONS = URI_MANCENTER_BASE_URL + "/security/permissions";
-    public static final String URI_HEALTH_URL = "/hazelcast/health";
+    public static final String LEGACY_URI_WAN_SYNC_MAP = "/hazelcast/rest/wan/sync/map";
+    public static final String LEGACY_URI_WAN_SYNC_ALL_MAPS = "/hazelcast/rest/wan/sync/allmaps";
+    public static final String LEGACY_URI_MANCENTER_WAN_CLEAR_QUEUES = "/hazelcast/rest/mancenter/clearWanQueues";
+    public static final String LEGACY_URI_ADD_WAN_CONFIG = "/hazelcast/rest/wan/addWanConfig";
 
     protected HttpCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -88,6 +88,15 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));
     }
 
+    /**
+     * Sets the HTTP response to a string containing basic cluster information:
+     * <ul>
+     *     <li>Member list</li>
+     *     <li>Client connection count</li>
+     *     <li>Connection count</li>
+     * </ul>
+     * @param command the HTTP request
+     */
     private void handleCluster(HttpGetCommand command) {
         Node node = textCommandService.getNode();
         StringBuilder res = new StringBuilder(node.getClusterService().getMemberListString());

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -89,13 +89,13 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 handleListNodes(command);
             } else if (uri.startsWith(URI_SHUTDOWN_NODE_CLUSTER_URL)) {
                 handleShutdownNode(command);
-            } else if (uri.startsWith(URI_WAN_SYNC_MAP)) {
+            } else if (uri.startsWith(URI_WAN_SYNC_MAP) || uri.startsWith(LEGACY_URI_WAN_SYNC_MAP)) {
                 handleWanSyncMap(command);
-            } else if (uri.startsWith(URI_WAN_SYNC_ALL_MAPS)) {
+            } else if (uri.startsWith(URI_WAN_SYNC_ALL_MAPS) || uri.startsWith(LEGACY_URI_WAN_SYNC_ALL_MAPS)) {
                 handleWanSyncAllMaps(command);
-            } else if (uri.startsWith(URI_MANCENTER_WAN_CLEAR_QUEUES)) {
+            } else if (uri.startsWith(URI_MANCENTER_WAN_CLEAR_QUEUES) || uri.startsWith(LEGACY_URI_MANCENTER_WAN_CLEAR_QUEUES)) {
                 handleWanClearQueues(command);
-            } else if (uri.startsWith(URI_ADD_WAN_CONFIG)) {
+            } else if (uri.startsWith(URI_ADD_WAN_CONFIG) || uri.startsWith(LEGACY_URI_ADD_WAN_CONFIG)) {
                 handleAddWanConfig(command);
             } else if (uri.startsWith(URI_UPDATE_PERMISSIONS)) {
                 handleUpdatePermissions(command);
@@ -369,13 +369,20 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         command.send200();
     }
 
+    /**
+     * Initiates a WAN sync for a single map and the wan replication name and target group defined
+     * by the command parameters.
+     *
+     * @param command the HTTP command
+     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
+     *                                      named character encoding is not supported
+     */
     private void handleWanSyncMap(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
-        byte[] data = command.getData();
-        String[] strList = bytesToString(data).split("&");
-        String wanRepName = URLDecoder.decode(strList[0], "UTF-8");
-        String targetGroup = URLDecoder.decode(strList[1], "UTF-8");
-        String mapName = URLDecoder.decode(strList[2], "UTF-8");
+        final String[] params = decodeParams(command, 3);
+        final String wanRepName = params[0];
+        final String targetGroup = params[1];
+        final String mapName = params[2];
         try {
             textCommandService.getNode().getNodeEngine().getWanReplicationService().syncMap(wanRepName, targetGroup, mapName);
             res = response(ResponseType.SUCCESS, "message", "Sync initiated");
@@ -386,12 +393,19 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         sendResponse(command, res);
     }
 
+    /**
+     * Initiates WAN sync for all maps and the wan replication name and target group defined
+     * by the command parameters.
+     *
+     * @param command the HTTP command
+     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
+     *                                      named character encoding is not supported
+     */
     private void handleWanSyncAllMaps(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
-        byte[] data = command.getData();
-        String[] strList = bytesToString(data).split("&");
-        String wanRepName = URLDecoder.decode(strList[0], "UTF-8");
-        String targetGroup = URLDecoder.decode(strList[1], "UTF-8");
+        final String[] params = decodeParams(command, 2);
+        final String wanRepName = params[0];
+        final String targetGroup = params[1];
         try {
             textCommandService.getNode().getNodeEngine().getWanReplicationService().syncAllMaps(wanRepName, targetGroup);
             res = response(ResponseType.SUCCESS, "message", "Sync initiated");
@@ -402,12 +416,19 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         sendResponse(command, res);
     }
 
+    /**
+     * Clears the WAN queues for the wan replication name and target group defined
+     * by the command parameters.
+     *
+     * @param command the HTTP command
+     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
+     *                                      named character encoding is not supported
+     */
     private void handleWanClearQueues(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
-        byte[] data = command.getData();
-        String[] strList = bytesToString(data).split("&");
-        String wanRepName = URLDecoder.decode(strList[0], "UTF-8");
-        String targetGroup = URLDecoder.decode(strList[1], "UTF-8");
+        final String[] params = decodeParams(command, 2);
+        final String wanRepName = params[0];
+        final String targetGroup = params[1];
         try {
             textCommandService.getNode().getNodeEngine().getWanReplicationService().clearQueues(wanRepName, targetGroup);
             res = response(ResponseType.SUCCESS, "message", "WAN replication queues are cleared.");
@@ -418,11 +439,18 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         sendResponse(command, res);
     }
 
+    /**
+     * Broadcasts a new {@link WanReplicationConfig} to all members. The config is defined
+     * by an encoded JSON as a first parameter of the HTTP command.
+     *
+     * @param command the HTTP command
+     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
+     *                                      named character encoding is not supported
+     */
     private void handleAddWanConfig(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
-        byte[] data = command.getData();
-        String[] strList = bytesToString(data).split("&");
-        String wanConfigJson = URLDecoder.decode(strList[0], "UTF-8");
+        final String[] params = decodeParams(command, 1);
+        final String wanConfigJson = params[0];
         try {
             OperationService opService = textCommandService.getNode().getNodeEngine().getOperationService();
             final Set<Member> members = textCommandService.getNode().getClusterService().getMembers();
@@ -513,6 +541,26 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         public String toString() {
             return super.toString().toLowerCase();
         }
+    }
+
+    /**
+     * Decodes HTTP post params contained in {@link HttpPostCommand#getData()}. The data
+     * should be encoded in UTF-8 and joined together with an ampersand (&).
+     *
+     * @param command    the HTTP post command
+     * @param paramCount the number of parameters expected in the command
+     * @return the decoded params
+     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
+     *                                      named character encoding is not supported
+     */
+    private static String[] decodeParams(HttpPostCommand command, int paramCount) throws UnsupportedEncodingException {
+        final byte[] data = command.getData();
+        final String[] encoded = bytesToString(data).split("&");
+        final String[] decoded = new String[encoded.length];
+        for (int i = 0; i < paramCount; i++) {
+            decoded[i] = URLDecoder.decode(encoded[i], "UTF-8");
+        }
+        return decoded;
     }
 
     private boolean checkCredentials(HttpPostCommand command) throws UnsupportedEncodingException {


### PR DESCRIPTION
Handles pre-3.8 HZ public URIs and delegates to the same code as the
new URIs. Also refactored the parameter decoding in the command
processor and added some javadoc.

Fixes : https://github.com/hazelcast/hazelcast-enterprise/issues/1548