### PR TITLE
Store record value on a state transition to ACCESS

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryProcessorEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryProcessorEntry.java
@@ -112,7 +112,8 @@ public class CacheEntryProcessorEntry<K, V, R extends CacheRecord>
         }
         if (record != null) {
             state = State.ACCESS;
-            return getRecordValue(record);
+            value = getRecordValue(record);
+            return value;
         }
         if (recordLoaded == null) {
             //LOAD IT


### PR DESCRIPTION
Reasoning:
1. getValue() changes state from NONE to ACCESS.
2. When an entry is not in the NONE state then exists() method
   assumes the value exists if and only if it's already set in the
   value field -> we have to store the value on transition

Fixes #11266