### PR TITLE
Raised memorystats probe level from info to mandatory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryStats.java
@@ -18,6 +18,8 @@ package com.hazelcast.memory;
 
 import com.hazelcast.internal.metrics.Probe;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+
 /**
  * Memory statistics for the JVM which current HazelcastInstance belongs to.
  * <p/>
@@ -86,7 +88,7 @@ public interface MemoryStats {
      *
      * @return the maximum amount of native memory in bytes.
      */
-    @Probe
+    @Probe(level = MANDATORY)
     long getMaxNative();
 
     /**
@@ -95,7 +97,7 @@ public interface MemoryStats {
      *
      * @return the amount of committed native memory in bytes.
      */
-    @Probe
+    @Probe(level = MANDATORY)
     long getCommittedNative();
 
     /**
@@ -103,7 +105,7 @@ public interface MemoryStats {
      *
      * @return the amount of used native memory in bytes
      */
-    @Probe
+    @Probe(level = MANDATORY)
     long getUsedNative();
 
     /**
@@ -111,20 +113,20 @@ public interface MemoryStats {
      *
      * @return the amount of free native memory in bytes
      */
-    @Probe
+    @Probe(level = MANDATORY)
     long getFreeNative();
 
     /**
      * Returns the amount of native memory reserved for metadata. This memory
      * is separate and not accounted for by the {@code ...NativeMemory} statistics.
      */
-    @Probe
+    @Probe(level = MANDATORY)
     long getMaxMetadata();
 
     /**
      * @return amount of used metadata memory
      */
-    @Probe
+    @Probe(level = MANDATORY)
     long getUsedMetadata();
 
     /**


### PR DESCRIPTION
These probes are too important to be under info. So we
always want to see them and that happens with mandatory probe level.