### PR TITLE
Proper handling of HazelcastInstanceAware. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.cluster.Versions;
@@ -35,7 +36,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.map.impl.iterator.MapPartitionIterator;
 import com.hazelcast.map.impl.iterator.MapQueryPartitionIterator;
-import com.hazelcast.map.journal.EventJournalMapEvent;
 import com.hazelcast.map.impl.journal.MapEventJournalReadOperation;
 import com.hazelcast.map.impl.journal.MapEventJournalSubscribeOperation;
 import com.hazelcast.map.impl.query.AggregationResult;
@@ -49,6 +49,7 @@ import com.hazelcast.map.impl.querycache.subscriber.NodeQueryCacheEndToEndConstr
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
+import com.hazelcast.map.journal.EventJournalMapEvent;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.mapreduce.Collator;
@@ -224,6 +225,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public void removeAll(Predicate<K, V> predicate) {
         checkNotNull(predicate, "predicate cannot be null");
+        handleHazelcastInstanceAwareParams(predicate);
 
         removeAllInternal(predicate);
     }
@@ -394,6 +396,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addInterceptor(MapInterceptor interceptor) {
         checkNotNull(interceptor, "Interceptor should not be null!");
+        handleHazelcastInstanceAwareParams(interceptor);
 
         return addMapInterceptorInternal(interceptor);
     }
@@ -408,12 +411,16 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addLocalEntryListener(MapListener listener) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
+
         return addLocalEntryListenerInternal(listener);
     }
 
     @Override
     public String addLocalEntryListener(EntryListener listener) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
+
         return addLocalEntryListenerInternal(listener);
     }
 
@@ -421,6 +428,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addLocalEntryListenerInternal(listener, predicate, null, includeValue);
     }
@@ -429,6 +437,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addLocalEntryListener(EntryListener listener, Predicate<K, V> predicate, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addLocalEntryListenerInternal(listener, predicate, null, includeValue);
     }
@@ -437,6 +446,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addLocalEntryListenerInternal(listener, predicate, toDataWithStrategy(key), includeValue);
     }
@@ -445,6 +455,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addLocalEntryListener(EntryListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addLocalEntryListenerInternal(listener, predicate, toDataWithStrategy(key), includeValue);
     }
@@ -452,6 +463,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addEntryListener(MapListener listener, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
 
         return addEntryListenerInternal(listener, null, includeValue);
     }
@@ -459,6 +471,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addEntryListener(EntryListener listener, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
 
         return addEntryListenerInternal(listener, null, includeValue);
     }
@@ -467,6 +480,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addEntryListener(MapListener listener, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
 
         return addEntryListenerInternal(listener, toDataWithStrategy(key), includeValue);
     }
@@ -475,6 +489,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addEntryListener(EntryListener listener, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
 
         return addEntryListenerInternal(listener, toDataWithStrategy(key), includeValue);
     }
@@ -483,6 +498,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addEntryListener(MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addEntryListenerInternal(listener, predicate, toDataWithStrategy(key), includeValue);
     }
@@ -491,6 +507,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addEntryListener(EntryListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addEntryListenerInternal(listener, predicate, toDataWithStrategy(key), includeValue);
     }
@@ -499,6 +516,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addEntryListenerInternal(listener, predicate, null, includeValue);
     }
@@ -507,6 +525,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public String addEntryListener(EntryListener listener, Predicate<K, V> predicate, boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return addEntryListenerInternal(listener, predicate, null, includeValue);
     }
@@ -521,6 +540,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addPartitionLostListener(MapPartitionLostListener listener) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(listener);
 
         return addPartitionLostListenerInternal(listener);
     }
@@ -609,6 +629,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     @SuppressWarnings("unchecked")
     public Set<K> keySet(Predicate predicate) {
+        handleHazelcastInstanceAwareParams(predicate);
         return executePredicate(predicate, IterationType.KEY, true);
     }
 
@@ -619,6 +640,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public Set<Map.Entry<K, V>> entrySet(Predicate predicate) {
+        handleHazelcastInstanceAwareParams(predicate);
         return executePredicate(predicate, IterationType.ENTRY, true);
     }
 
@@ -630,6 +652,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     @SuppressWarnings("unchecked")
     public Collection<V> values(Predicate predicate) {
+        handleHazelcastInstanceAwareParams(predicate);
         return executePredicate(predicate, IterationType.VALUE, false);
     }
 
@@ -667,6 +690,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @SuppressWarnings("unchecked")
     public Set<K> localKeySet(Predicate predicate) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(predicate);
 
         MapQueryEngine queryEngine = getMapQueryEngine();
         Query query = Query.of()
@@ -681,6 +705,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(entryProcessor);
 
         Data result = executeOnKeyInternal(key, entryProcessor);
         return toObject(result);
@@ -689,6 +714,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public Map<K, Object> executeOnKeys(Set<K> keys, EntryProcessor entryProcessor) {
         checkNotNull(keys, NULL_KEYS_ARE_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(entryProcessor);
 
         if (keys.isEmpty()) {
             return emptyMap();
@@ -700,6 +726,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public void submitToKey(K key, EntryProcessor entryProcessor, ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(entryProcessor, callback);
 
         executeOnKeyInternal(key, entryProcessor, callback);
     }
@@ -707,6 +734,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public ICompletableFuture submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(entryProcessor);
 
         InternalCompletableFuture future = executeOnKeyInternal(key, entryProcessor, null);
         return new DelegatingFuture(future, serializationService);
@@ -719,6 +747,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate) {
+        handleHazelcastInstanceAwareParams(entryProcessor, predicate);
         List<Data> result = new ArrayList<Data>();
 
         executeOnEntriesInternal(entryProcessor, predicate, result);
@@ -742,6 +771,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(aggregator, NULL_AGGREGATOR_IS_NOT_ALLOWED);
 
         MapQueryEngine queryEngine = getMapQueryEngine();
+        // HazelcastInstanceAware handled by cloning
         aggregator = serializationService.toObject(serializationService.toData(aggregator));
 
         Query query = Query.of()
@@ -758,7 +788,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public <R> R aggregate(Aggregator<Map.Entry<K, V>, R> aggregator, Predicate<K, V> predicate) {
         checkNotNull(aggregator, NULL_AGGREGATOR_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(predicate);
 
+        // HazelcastInstanceAware handled by cloning
         aggregator = serializationService.toObject(serializationService.toData(aggregator));
         MapQueryEngine queryEngine = getMapQueryEngine();
         if (predicate instanceof PagingPredicate) {
@@ -780,6 +812,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(projection, NULL_PROJECTION_IS_NOT_ALLOWED);
 
         MapQueryEngine queryEngine = getMapQueryEngine();
+        // HazelcastInstanceAware handled by cloning
         projection = serializationService.toObject(serializationService.toData(projection));
 
         Query query = Query.of()
@@ -796,7 +829,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public <R> Collection<R> project(Projection<Map.Entry<K, V>, R> projection, Predicate<K, V> predicate) {
         checkNotNull(projection, NULL_PROJECTION_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        handleHazelcastInstanceAwareParams(predicate);
 
+        // HazelcastInstanceAware handled by cloning
         projection = serializationService.toObject(serializationService.toData(projection));
         MapQueryEngine queryEngine = getMapQueryEngine();
 
@@ -925,6 +960,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         }
         checkNotNull(projection, NULL_PROJECTION_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
+        // HazelcastInstanceAware handled by cloning
+        projection = serializationService.toObject(serializationService.toData(projection));
+        handleHazelcastInstanceAwareParams(predicate);
         return new MapQueryPartitionIterator<K, V, R>(this, fetchSize, partitionId, predicate, projection);
     }
 
@@ -943,6 +981,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
             int partitionId,
             com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
             Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        handleHazelcastInstanceAwareParams(predicate);
+        // HazelcastInstanceAware handled by cloning
+        projection = serializationService.toObject(serializationService.toData(projection));
         final MapEventJournalReadOperation<K, V, T> op = new MapEventJournalReadOperation<K, V, T>(
                 name, startSequence, minSize, maxSize, predicate, projection);
         op.setPartitionId(partitionId);
@@ -966,6 +1007,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(name, "name cannot be null");
         checkNotNull(predicate, "predicate cannot be null");
         checkNotInstanceOf(PagingPredicate.class, predicate, "predicate");
+        handleHazelcastInstanceAwareParams(predicate);
 
         return getQueryCacheInternal(name, null, predicate, includeValue, this);
     }
@@ -975,6 +1017,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         checkNotNull(name, "name cannot be null");
         checkNotNull(predicate, "predicate cannot be null");
         checkNotInstanceOf(PagingPredicate.class, predicate, "predicate");
+        handleHazelcastInstanceAwareParams(listener, predicate);
 
         return getQueryCacheInternal(name, listener, predicate, includeValue, this);
     }
@@ -1002,5 +1045,13 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
         return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getUserGivenCacheName(),
                 constructorFunction);
+    }
+
+    private void handleHazelcastInstanceAwareParams(Object... objects) {
+        for (Object object : objects) {
+            if (object instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) object).setHazelcastInstance(getNodeEngine().getHazelcastInstance());
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -977,9 +977,6 @@ abstract class MapProxySupport<K, V>
 
     public String addMapInterceptorInternal(MapInterceptor interceptor) {
         NodeEngine nodeEngine = getNodeEngine();
-        if (interceptor instanceof HazelcastInstanceAware) {
-            ((HazelcastInstanceAware) interceptor).setHazelcastInstance(nodeEngine.getHazelcastInstance());
-        }
         String id = mapServiceContext.generateInterceptorId(name, interceptor);
         Collection<Member> members = nodeEngine.getClusterService().getMembers();
         for (Member member : members) {

--- a/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
@@ -16,81 +16,149 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
-import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.query.SqlPredicate;
-import org.junit.Ignore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * A simple test that performs random puts, updates & removes on a map and counts the number of entries
- * and exits (with regards to the value space defined by the predicate) as performed by the map randomizer
- * and as observed on the listener side.
- */
-@Ignore("Not a JUnit test")
-public class MapListenerTest {
+import static org.junit.Assert.assertEquals;
 
-    private static final AtomicInteger ENTRIES, EXITS, ENTRIES_OBSERVED, EXITS_OBSERVED;
-    private static final Logger LOGGER = LoggerFactory.getLogger(MapListenerTest.class);
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapListenerTest extends HazelcastTestSupport {
+
     private static final int AGE_THRESHOLD = 50;
 
     static {
         System.setProperty("hazelcast.map.entry.filtering.natural.event.types", "true");
-        ENTRIES = new AtomicInteger();
-        EXITS = new AtomicInteger();
-        ENTRIES_OBSERVED = new AtomicInteger();
-        EXITS_OBSERVED = new AtomicInteger();
     }
 
-    static class AllListener implements EntryAddedListener<String, Person>, EntryRemovedListener<String, Person>,
-            EntryUpdatedListener<String, Person> {
+    @Test
+    public void testListener_eventCountsCorrect() throws Exception {
+        // GIVEN
+        HazelcastInstance hz = createHazelcastInstance();
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(AllListener.class);
+        // GIVEN MAP & LISTENER
+        IMap<String, Person> map = hz.getMap("map");
+        AllListener listener = new AllListener();
+        map.addEntryListener(listener, new SqlPredicate("age > " + AGE_THRESHOLD), true);
+
+        // GIVEN MAP EVENTS
+        generateMapEvents(map, listener);
+
+        // THEN
+        assertEquals(listener.entries.get(), listener.entriesObserved.get());
+        assertEquals(listener.exits.get(), listener.exitsObserved.get());
+    }
+
+    @Test
+    public void testListener_hazelcastAwareHandled() throws Exception {
+        // GIVEN
+        HazelcastInstance[] instances = createHazelcastInstanceFactory(2).newInstances();
+
+        // GIVEN MAP & LISTENER
+        IMap<String, Person> map = instances[0].getMap("map");
+        MyEntryListener listener = new MyEntryListener();
+        map.addEntryListener(listener, new SqlPredicate("age > " + AGE_THRESHOLD), true);
+
+        // GIVEN MAP EVENTS
+        generateMapEvents(map, null);
+
+        // THEN
+        assertEquals("HazelcastInstance not injected properly to listener", 0, listener.nulls.get());
+    }
+
+    private void generateMapEvents(IMap<String, Person> map, AllListener listener) throws InterruptedException, ExecutionException {
+        MapRandomizer mapRandomizer = new MapRandomizer(map, listener);
+        Future future = spawn(mapRandomizer);
+        sleepAtLeastSeconds(2);
+        mapRandomizer.setRunning(false);
+        future.get();
+    }
+
+    static class MyEntryListener implements EntryAddedListener<String, Person>, EntryRemovedListener<String, Person>,
+            EntryUpdatedListener<String, Person>, HazelcastInstanceAware {
+
+        private HazelcastInstance hazelcastInstance;
+        public AtomicInteger nulls = new AtomicInteger(0);
 
         @Override
         public void entryAdded(EntryEvent<String, Person> event) {
-            ENTRIES_OBSERVED.incrementAndGet();
+            trackNullInstance();
+        }
+
+        @Override
+        public void entryUpdated(EntryEvent<String, Person> event) {
+            trackNullInstance();
         }
 
         @Override
         public void entryRemoved(EntryEvent<String, Person> event) {
-            if (event.getValue() != null && event.getOldValue() != null) {
-                dumpEvent("exit from removed", event);
+            trackNullInstance();
+        }
+
+        private void trackNullInstance() {
+            if (hazelcastInstance == null) {
+                nulls.incrementAndGet();
             }
-            EXITS_OBSERVED.incrementAndGet();
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+        }
+    }
+
+    class AllListener implements EntryAddedListener<String, Person>, EntryRemovedListener<String, Person>,
+            EntryUpdatedListener<String, Person> {
+
+        public final AtomicInteger entries, exits, entriesObserved, exitsObserved;
+
+        public AllListener() {
+            entries = new AtomicInteger();
+            exits = new AtomicInteger();
+            entriesObserved = new AtomicInteger();
+            exitsObserved = new AtomicInteger();
+        }
+
+        @Override
+        public void entryAdded(EntryEvent<String, Person> event) {
+            entriesObserved.incrementAndGet();
+        }
+
+        @Override
+        public void entryRemoved(EntryEvent<String, Person> event) {
+            exitsObserved.incrementAndGet();
         }
 
         @Override
         public void entryUpdated(EntryEvent<String, Person> event) {
             if (event.getOldValue().getAge() > AGE_THRESHOLD &&
                     event.getValue().getAge() <= AGE_THRESHOLD) {
-                EXITS_OBSERVED.incrementAndGet();
-                dumpEvent("exit", event);
+                exitsObserved.incrementAndGet();
             } else if (event.getOldValue().getAge() <= AGE_THRESHOLD &&
                     event.getValue().getAge() > AGE_THRESHOLD) {
-                ENTRIES_OBSERVED.incrementAndGet();
-                dumpEvent("entry", event);
+                entriesObserved.incrementAndGet();
             }
-        }
-
-        private static void dumpEvent(String qualifier, EntryEvent event) {
-            LOGGER.info(qualifier + " " + event);
         }
     }
 
@@ -141,12 +209,14 @@ public class MapListenerTest {
 
         final Random random = new Random();
         final IMap<String, Person> map;
+        final AllListener listener;
 
         volatile boolean running;
 
-        MapRandomizer(IMap<String, Person> map) {
+        MapRandomizer(IMap<String, Person> map, AllListener listener) {
             this.map = map;
             this.running = true;
+            this.listener = listener;
         }
 
         private void act() {
@@ -168,8 +238,10 @@ public class MapListenerTest {
         private void addPerson() {
             Person p = new Person(random.nextInt(100), UUID.randomUUID().toString());
             map.put(p.getName(), p);
-            if (p.getAge() > AGE_THRESHOLD) {
-                ENTRIES.incrementAndGet();
+            if (listener != null) {
+                if (p.getAge() > AGE_THRESHOLD) {
+                    listener.entries.incrementAndGet();
+                }
             }
         }
 
@@ -180,12 +252,12 @@ public class MapListenerTest {
                 Person p = map.get(key);
                 int oldAge = p.getAge();
                 p.setAge(p.getAge() + random.nextInt(10) * ((int) Math.pow(-1, random.nextInt(2))));
-                if (oldAge > AGE_THRESHOLD && p.getAge() <= AGE_THRESHOLD) {
-                    EXITS.incrementAndGet();
-                    LOGGER.info("updatePersonAge exit from " + oldAge + " to " + p.getAge());
-                } else if (oldAge <= AGE_THRESHOLD && p.getAge() > AGE_THRESHOLD) {
-                    ENTRIES.incrementAndGet();
-                    LOGGER.info("updatePersonAge entry from " + oldAge + " to " + p.getAge());
+                if (listener != null) {
+                    if (oldAge > AGE_THRESHOLD && p.getAge() <= AGE_THRESHOLD) {
+                        listener.exits.incrementAndGet();
+                    } else if (oldAge <= AGE_THRESHOLD && p.getAge() > AGE_THRESHOLD) {
+                        listener.entries.incrementAndGet();
+                    }
                 }
                 map.put(key, p);
             }
@@ -195,8 +267,10 @@ public class MapListenerTest {
             if (map.size() > 0) {
                 Collection<String> allKeys = map.keySet();
                 String key = allKeys.toArray(new String[0])[random.nextInt(map.size())];
-                if (map.get(key).getAge() > AGE_THRESHOLD) {
-                    EXITS.incrementAndGet();
+                if (listener != null) {
+                    if (map.get(key).getAge() > AGE_THRESHOLD) {
+                        listener.exits.incrementAndGet();
+                    }
                 }
                 map.remove(key);
             }
@@ -214,46 +288,4 @@ public class MapListenerTest {
         }
     }
 
-    public static void main(String[] args) throws InterruptedException {
-        // create Hazelcast instance
-        Config config = new Config();
-        config.setInstanceName("hz-maplistener");
-        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        config.getNetworkConfig().getInterfaces().setInterfaces(Arrays.asList(new String[]{"127.0.0.1"}));
-        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
-
-        IMap<String, Person> map = hz.getMap("map");
-        MapListener listener = new AllListener();
-        map.addEntryListener(listener, new SqlPredicate("age > " + AGE_THRESHOLD), true);
-
-        MapRandomizer mapRandomizer = new MapRandomizer(map);
-        Thread t = new Thread(mapRandomizer);
-        t.start();
-
-        // let it run for 1 minute
-        Thread.sleep(60000);
-        mapRandomizer.setRunning(false);
-
-        // assertions
-        assertCount(ENTRIES, ENTRIES_OBSERVED, "entries");
-        assertCount(EXITS, EXITS_OBSERVED, "exits");
-
-        // dumpMap(map);
-        hz.shutdown();
-    }
-
-    private static void assertCount(AtomicInteger expected, AtomicInteger observed, String unit) {
-        if (expected.get() != observed.get()) {
-            LOGGER.error("Actually performed " + expected.get() + " " + unit + ", but observed " + observed.get());
-        } else {
-            LOGGER.info("Correctly observed " + expected.get() + " " + unit);
-        }
-    }
-
-    private static void dumpMap(IMap<String, Person> map) {
-        LOGGER.info("Map dump follows");
-        for (Map.Entry<String, Person> e : map.entrySet()) {
-            LOGGER.info(e.getKey() + " > " + e.getValue());
-        }
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/PredicateHzAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/PredicateHzAwareTest.java
@@ -1,0 +1,81 @@
+package com.hazelcast.query.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IMap;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+public class PredicateHzAwareTest extends HazelcastTestSupport {
+    @Parameterized.Parameters(name = "instanceCount:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {1},
+                {3}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public int instanceCount;
+
+    @Test
+    public void testHzAware() throws Exception {
+        final HazelcastInstance[] instances = createHazelcastInstanceFactory(instanceCount).newInstances();
+        final IMap<String, Integer> m = instances[0].getMap("mappy");
+        m.put("a", 1);
+        m.put("b", 2);
+
+        final Collection<Integer> result = m.project(new SimpleProjection(), new SimplePredicate());
+
+        assertTrue(result.size() == 1);
+        assertEquals(2, (int) result.iterator().next());
+    }
+
+    private static class SimpleProjection extends Projection<Map.Entry<String, Integer>, Integer>
+            implements HazelcastInstanceAware, Serializable {
+
+        private transient HazelcastInstance instance;
+
+        @Override
+        public Integer transform(Map.Entry<String, Integer> input) {
+            assertNotNull(instance);
+            return input.getValue();
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+
+    private static class SimplePredicate implements Predicate<String, Integer>, Serializable, HazelcastInstanceAware {
+        private transient HazelcastInstance instance;
+
+        @Override
+        public boolean apply(Map.Entry<String, Integer> mapEntry) {
+            assertNotNull(instance);
+            return mapEntry.getValue() % 2 == 0;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/10620

No need for fixes on the client side, since all objects that are serialized will be handled properly anyway.

It's a matter of taste where to put this handling. I chose the proxy to be sure we have the instance injected as early as possible - so just after the null validation phase.