### PR TITLE
[BACKPORT] Handle legacy WAN URIs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -22,26 +22,36 @@ import com.hazelcast.internal.ascii.TextCommandService;
 public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcessor<T> {
     public static final String URI_MAPS = "/hazelcast/rest/maps/";
     public static final String URI_QUEUES = "/hazelcast/rest/queues/";
+    public static final String URI_MANCENTER_BASE_URL = "/hazelcast/rest/mancenter";
+    public static final String URI_MANCENTER_CHANGE_URL = URI_MANCENTER_BASE_URL + "/changeurl";
+    public static final String URI_HEALTH_URL = "/hazelcast/health";
+
+    // Cluster
     public static final String URI_CLUSTER = "/hazelcast/rest/cluster";
     public static final String URI_CLUSTER_MANAGEMENT_BASE_URL = "/hazelcast/rest/management/cluster";
-    public static final String URI_MANCENTER_BASE_URL = "/hazelcast/rest/mancenter";
     public static final String URI_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/state";
     public static final String URI_CHANGE_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeState";
     public static final String URI_CLUSTER_VERSION_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/version";
     public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/clusterShutdown";
+    public static final String URI_SHUTDOWN_NODE_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
+    public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
+
+    // Hot restart
     public static final String URI_FORCESTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/forceStart";
     public static final String URI_PARTIALSTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/partialStart";
     public static final String URI_HOT_RESTART_BACKUP_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/hotBackup";
     public static final String URI_HOT_RESTART_BACKUP_INTERRUPT_CLUSTER_URL
             = URI_CLUSTER_MANAGEMENT_BASE_URL + "/hotBackupInterrupt";
-    public static final String URI_SHUTDOWN_NODE_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
-    public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
-    public static final String URI_MANCENTER_CHANGE_URL = URI_MANCENTER_BASE_URL + "/changeurl";
+
+    // WAN
     public static final String URI_WAN_SYNC_MAP = URI_MANCENTER_BASE_URL + "/wan/sync/map";
     public static final String URI_WAN_SYNC_ALL_MAPS = URI_MANCENTER_BASE_URL + "/wan/sync/allmaps";
     public static final String URI_MANCENTER_WAN_CLEAR_QUEUES = URI_MANCENTER_BASE_URL + "/wan/clearWanQueues";
     public static final String URI_ADD_WAN_CONFIG = URI_MANCENTER_BASE_URL + "/wan/addWanConfig";
-    public static final String URI_HEALTH_URL = "/hazelcast/health";
+    public static final String LEGACY_URI_WAN_SYNC_MAP = "/hazelcast/rest/wan/sync/map";
+    public static final String LEGACY_URI_WAN_SYNC_ALL_MAPS = "/hazelcast/rest/wan/sync/allmaps";
+    public static final String LEGACY_URI_MANCENTER_WAN_CLEAR_QUEUES = "/hazelcast/rest/mancenter/clearWanQueues";
+    public static final String LEGACY_URI_ADD_WAN_CONFIG = "/hazelcast/rest/wan/addWanConfig";
 
     protected HttpCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -88,6 +88,15 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));
     }
 
+    /**
+     * Sets the HTTP response to a string containing basic cluster information:
+     * <ul>
+     *     <li>Member list</li>
+     *     <li>Client connection count</li>
+     *     <li>Connection count</li>
+     * </ul>
+     * @param command the HTTP request
+     */
     private void handleCluster(HttpGetCommand command) {
         Node node = textCommandService.getNode();
         StringBuilder res = new StringBuilder(node.getClusterService().membersString());


### PR DESCRIPTION
Handles pre-3.8 HZ public URIs and delegates to the same code as the
new URIs. Also refactored the parameter decoding in the command
processor and added some javadoc.

Fixes : https://github.com/hazelcast/hazelcast-enterprise/issues/1548
Backport of : https://github.com/hazelcast/hazelcast/pull/11262

(cherry picked from commit 673f032)