### PR TITLE
Always send response in case of operation error

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
@@ -140,7 +140,7 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
 
         if (invocation == null) {
             responsesMissing.inc();
-            if (nodeEngine.isRunning()) {
+            if (nodeEngine.isRunning() && callId != 0) {
                 logger.warning("No Invocation found for error response with callId: " + callId + " sent from " + sender);
             }
             return;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -352,12 +352,12 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
         if (operation instanceof Backup) {
             failedBackupsCounter.inc();
-        }
-
-        if (!operation.returnsResponse()) {
             return;
         }
 
+        // a response is send regardless of the Operation.returnsResponse method because some operation do want to send
+        // back a response, but they didn't want to send it yet but they ran into some kind of error. If on the receiving
+        // side no invocation is waiting, the response is ignored.
         sendResponseAfterOperationError(operation, e);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_ExceptionTest.java
@@ -1,0 +1,53 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Invocation_ExceptionTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    /**
+     * When an operation indicates it returns no response, it can very well mean that it doesn't have a response yet e.g.
+     * an IExecutorService.submit operation since that will rely on the completion of the task; not the operation. But if
+     * an exception is thrown, then this is the response of that operation since it is very likely that a real response is
+     * going to follow.
+      */
+    @Test
+    public void whenOperationReturnsNoResponse() throws Exception {
+        HazelcastInstance local = createHazelcastInstance();
+        OperationService operationService = getOperationService(local);
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, new OperationsReturnsNoResponse(), 0);
+        assertCompletesEventually(f);
+
+        expected.expect(ExpectedRuntimeException.class);
+        f.join();
+    }
+
+    public class OperationsReturnsNoResponse extends Operation {
+        @Override
+        public void run() throws Exception {
+            throw new ExpectedRuntimeException();
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
There are 2 types of operations that have returnsResponse return false.
- operations that never need to send back a respose; fire and forget operations.
- operations that don't have a response yet while executing; but will have a response in the future e.g. the CallableTaskOperation that initially gets executed on a generic thread, offload the callable in some executor and only when the callable completes, a response is returned.

The problem is with the second category of operations. Imagine that the operation execution fails and the callable doesn't get offloaded on an Executor; then no response will be send to the caller ever because the 'returnsResponse' returns.

This PR changes that by always sending back a response if an operation ran into an Throwable regardless of the returnsResponse state.

If a response is received for a non existing invocation, it will just be discarded.
