### PR TITLE
Optimized isEquals() method of RecordFactory implementations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
@@ -65,16 +65,15 @@ public class DataRecordFactory implements RecordFactory<Data> {
 
     @Override
     public boolean isEquals(Object value1, Object value2) {
-        if (value1 == null && value2 == null) {
+        if (value1 == value2) {
             return true;
         }
-        if (value1 == null) {
+        if (value1 == null || value2 == null) {
             return false;
         }
-        if (value2 == null) {
-            return false;
-        }
-
-        return serializationService.toData(value1).equals(serializationService.toData(value2));
+        // the PartitioningStrategy is not needed here, since `Data.equals()` only checks the payload, not the partitionHash
+        Data data1 = serializationService.toData(value1);
+        Data data2 = serializationService.toData(value2);
+        return data1.equals(data2);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
@@ -51,17 +51,14 @@ public class ObjectRecordFactory implements RecordFactory<Object> {
 
     @Override
     public boolean isEquals(Object value1, Object value2) {
-        Object v1 = value1 instanceof Data ? serializationService.toObject(value1) : value1;
-        Object v2 = value2 instanceof Data ? serializationService.toObject(value2) : value2;
-        if (v1 == null && v2 == null) {
+        if (value1 == value2) {
             return true;
         }
-        if (v1 == null) {
+        if (value1 == null || value2 == null) {
             return false;
         }
-        if (v2 == null) {
-            return false;
-        }
-        return v1.equals(v2);
+        Object v1 = value1 instanceof Data ? serializationService.toObject(value1) : value1;
+        Object v2 = value2 instanceof Data ? serializationService.toObject(value2) : value2;
+        return v1 != null ? v1.equals(v2) : v2 == null;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordFactoryTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.record;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractRecordFactoryTest<T> extends HazelcastTestSupport {
+
+    SerializationService serializationService;
+    PartitioningStrategy partitioningStrategy;
+    RecordFactory<T> factory;
+
+    Person object1;
+    Person object2;
+
+    Data data1;
+    Data data2;
+    Data nullData;
+
+    Record<T> record;
+
+    @Before
+    public final void init() {
+        serializationService = createSerializationService();
+        partitioningStrategy = new DefaultPartitioningStrategy();
+
+        object1 = new Person("Alice");
+        object2 = new Person("Bob");
+
+        data1 = serializationService.toData(object1);
+        data2 = serializationService.toData(object2);
+        nullData = new HeapData(new byte[0]);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsDisabledAndCacheDeserializedValuesIsALWAYS() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getCachedRecordClass(), record);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsDisabledAndCacheDeserializedValuesIsNEVER() {
+        newRecordFactory(false, CacheDeserializedValues.NEVER);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getRecordClass(), record);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsEnabledAndCacheDeserializedValuesIsALWAYS() {
+        newRecordFactory(true, CacheDeserializedValues.ALWAYS);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getCachedRecordWithStatsClass(), record);
+    }
+
+    @Test
+    public void testNewRecord_withStatisticsEnabledAndCacheDeserializedValuesIsNEVER() {
+        newRecordFactory(true, CacheDeserializedValues.NEVER);
+        record = newRecord(factory, data1, object1);
+
+        assertInstanceOf(getRecordWithStatsClass(), record);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testNewRecord_withNullValue() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+
+        newRecord(factory, data1, null);
+    }
+
+    @Test
+    public void testSetValue() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = factory.newRecord(object1);
+
+        factory.setValue(record, object2);
+
+        assertEquals(getValue(data2, object2), record.getValue());
+    }
+
+    @Test
+    public void testSetValue_withData() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = factory.newRecord(object1);
+
+        factory.setValue(record, data2);
+
+        assertEquals(getValue(data2, object2), record.getValue());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testSetValue_withNull() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+        record = factory.newRecord(object1);
+
+        factory.setValue(record, null);
+    }
+
+    @Test
+    public void testIsEquals() {
+        newRecordFactory(false, CacheDeserializedValues.ALWAYS);
+
+        assertTrue(factory.isEquals(null, null));
+        assertTrue(factory.isEquals(object1, object1));
+        assertTrue(factory.isEquals(object1, data1));
+        assertTrue(factory.isEquals(data1, data1));
+        assertTrue(factory.isEquals(data1, object1));
+        assertTrue(factory.isEquals(nullData, nullData));
+
+        assertFalse(factory.isEquals(null, object1));
+        assertFalse(factory.isEquals(null, data1));
+        assertFalse(factory.isEquals(null, nullData));
+        assertFalse(factory.isEquals(object1, null));
+        assertFalse(factory.isEquals(object1, nullData));
+        assertFalse(factory.isEquals(object1, object2));
+        assertFalse(factory.isEquals(object1, data2));
+        assertFalse(factory.isEquals(data1, null));
+        assertFalse(factory.isEquals(data1, nullData));
+        assertFalse(factory.isEquals(data1, object2));
+        assertFalse(factory.isEquals(data1, data2));
+        assertFalse(factory.isEquals(nullData, null));
+        assertFalse(factory.isEquals(nullData, object1));
+        assertFalse(factory.isEquals(nullData, data1));
+    }
+
+    @Test
+    public void testIsEquals_withCustomPartitioningStrategy() {
+        partitioningStrategy = new PersonPartitioningStrategy();
+
+        data1 = serializationService.toData(object1, partitioningStrategy);
+        data2 = serializationService.toData(object2, partitioningStrategy);
+
+        testIsEquals();
+    }
+
+    abstract void newRecordFactory(boolean isStatisticsEnabled, CacheDeserializedValues cacheDeserializedValues);
+
+    abstract Class<?> getRecordClass();
+
+    abstract Class<?> getRecordWithStatsClass();
+
+    abstract Class<?> getCachedRecordClass();
+
+    abstract Class<?> getCachedRecordWithStatsClass();
+
+    abstract Object getValue(Data dataValue, Object objectValue);
+
+    InternalSerializationService createSerializationService() {
+        return new DefaultSerializationServiceBuilder().build();
+    }
+
+    Record<T> newRecord(RecordFactory<T> factory, Data key, Object value) {
+        Record<T> record = factory.newRecord(value);
+        ((AbstractRecord) record).setKey(key);
+        return record;
+    }
+
+    static class Person implements Serializable {
+
+        private final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Person)) {
+                return false;
+            }
+
+            Person person = (Person) o;
+            return name != null ? name.equals(person.name) : person.name == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return name != null ? name.hashCode() : 0;
+        }
+    }
+
+    static class PersonPartitioningStrategy implements PartitioningStrategy<Person> {
+
+        @Override
+        public Object getPartitionKey(Person key) {
+            return key.name;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordFactoryTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class DataRecordFactoryTest extends AbstractRecordFactoryTest<Data> {
+public class ObjectRecordFactoryTest extends AbstractRecordFactoryTest<Object> {
 
     @Override
     void newRecordFactory(boolean isStatisticsEnabled, CacheDeserializedValues cacheDeserializedValues) {
@@ -35,31 +35,31 @@ public class DataRecordFactoryTest extends AbstractRecordFactoryTest<Data> {
                 .setStatisticsEnabled(isStatisticsEnabled)
                 .setCacheDeserializedValues(cacheDeserializedValues);
 
-        factory = new DataRecordFactory(mapConfig, serializationService, partitioningStrategy);
+        factory = new ObjectRecordFactory(mapConfig, serializationService);
     }
 
     @Override
     Class<?> getRecordClass() {
-        return DataRecord.class;
+        return ObjectRecord.class;
     }
 
     @Override
     Class<?> getRecordWithStatsClass() {
-        return DataRecordWithStats.class;
+        return ObjectRecordWithStats.class;
     }
 
     @Override
     Class<?> getCachedRecordClass() {
-        return CachedDataRecord.class;
+        return ObjectRecord.class;
     }
 
     @Override
     Class<?> getCachedRecordWithStatsClass() {
-        return CachedDataRecordWithStats.class;
+        return ObjectRecordWithStats.class;
     }
 
     @Override
     Object getValue(Data dataValue, Object objectValue) {
-        return dataValue;
+        return objectValue;
     }
 }


### PR DESCRIPTION
After adding some tests I'm quite sure that the `PartitioningStrategy` is not relevant in the `DataRecordFactroy.isEquals()` method. The key is used to calculate the `partitionHash` of a `Data` instance, but that once is not used in the `Data.isEqual()` method. We just compare the payload and its size there.