### PR TITLE
Removing a race between loading futures and checkIfLoaded. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -131,15 +131,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
 
         logger.info("Starting to load all keys for map " + name + " on partitionId=" + partitionId);
-        Future<?> loadingKeysFuture = keyLoader.startLoading(mapStoreContext, replaceExistingValues);
-        loadingFutures.add(loadingKeysFuture);
+        loadingFutures.add(keyLoader.startLoading(mapStoreContext, replaceExistingValues));
     }
 
     @Override
     public void loadAllFromStore(List<Data> keys, boolean replaceExistingValues) {
         if (!keys.isEmpty()) {
-            Future f = recordStoreLoader.loadValues(keys, replaceExistingValues);
-            loadingFutures.add(f);
+            loadingFutures.add(recordStoreLoader.loadValues(keys, replaceExistingValues));
         }
 
         // We should not track key loading here. IT's not key loading but values loading.


### PR DESCRIPTION
Fixes #11244.
The race is pretty self-explanatory. 
The future are check here: https://github.com/tombujok/hazelcast/blob/8594c190de04ce5584deaf58915ca0c919157e1f/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java#L182-L182