### PR TITLE
Assert that Jsr(Client)TestUtil is not used in ParallelTest classes

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearSystemProperties;
 import static com.hazelcast.cache.jsr.JsrTestUtil.setSystemProperties;
+import static com.hazelcast.test.HazelcastTestSupport.assertThatIsNoParallelTest;
 
 /**
  * Utility class responsible for setup/cleanup of client JSR tests.
@@ -34,10 +35,12 @@ public final class JsrClientTestUtil {
     }
 
     public static void setup() {
+        assertThatIsNoParallelTest();
         setSystemProperties("client");
     }
 
     public static void setupWithHazelcastInstance() {
+        assertThatIsNoParallelTest();
         setSystemProperties("client");
 
         Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertThatIsNoParallelTest;
 import static java.lang.String.format;
 import static org.junit.Assert.fail;
 
@@ -48,6 +49,7 @@ public final class JsrTestUtil {
     }
 
     public static void setup() {
+        assertThatIsNoParallelTest();
         setSystemProperties("server");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -49,19 +49,21 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.jitter.JitterRule;
 import org.junit.After;
 import org.junit.ComparisonFailure;
 import org.junit.Rule;
+import org.junit.experimental.categories.Category;
 
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +88,7 @@ import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -854,7 +857,7 @@ public abstract class HazelcastTestSupport {
             actual.add(object);
         }
 
-        List expected = Arrays.asList(values);
+        List expected = asList(values);
 
         assertEquals("size should match", expected.size(), actual.size());
         assertEquals(expected, actual);
@@ -1187,6 +1190,10 @@ public abstract class HazelcastTestSupport {
         return (OperationParkerImpl) getNodeEngineImpl(instance).getOperationParker();
     }
 
+    public static void assertThatIsNoParallelTest() {
+        assertFalse("Test cannot be a ParallelTest", hasTestCategory(ParallelTest.class));
+    }
+
     // ###################################
     // ########## reflection utils #######
     // ###################################
@@ -1203,6 +1210,46 @@ public abstract class HazelcastTestSupport {
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         }
+    }
+
+    /**
+     * Checks if the calling test has a given {@link Category}.
+     *
+     * @see #getTestCategories() getTestCategories() for limitations of this method
+     */
+    public static boolean hasTestCategory(Class<?> testCategory) {
+        for (Class<?> category : getTestCategories()) {
+            if (category.isAssignableFrom(testCategory)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the value of the {@link Category} annotation of the calling test class.
+     * <p>
+     * This method doesn't cover {@link Category} annotations on a test method.
+     * It may also fail on test class hierarchies (the annotated class has to be in the stack trace).
+     */
+    public static HashSet<Class<?>> getTestCategories() {
+        HashSet<Class<?>> testCategories = new HashSet<Class<?>>();
+        for (StackTraceElement stackTraceElement : new Exception().getStackTrace()) {
+            String className = stackTraceElement.getClassName();
+            try {
+                Class<?> clazz = Class.forName(className);
+                Category annotation = clazz.getAnnotation(Category.class);
+                if (annotation != null) {
+                    List<Class<?>> categoryList = asList(annotation.value());
+                    testCategories.addAll(categoryList);
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        if (testCategories.isEmpty()) {
+            fail("Could not find any classes with a @Category annotation in the stack trace");
+        }
+        return testCategories;
     }
 
     // ###################################

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withParallelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withParallelTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TestCategoriesTest_withParallelTest extends HazelcastTestSupport {
+
+    @Test
+    public void testGetTestCategories() {
+        HashSet<Class<?>> testCategories = getTestCategories();
+        assertEquals("Expected a two test categories", 2, testCategories.size());
+        assertTrue("Expected to find a QuickTest category", testCategories.contains(QuickTest.class));
+        assertTrue("Expected to find a ParallelTest category", testCategories.contains(ParallelTest.class));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAssertThatIsNoParallelTest() {
+        assertThatIsNoParallelTest();
+        throw new RuntimeException("Expected an AssertionError on this ParallelTest");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withSerialTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withSerialTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class TestCategoriesTest_withSerialTest extends HazelcastTestSupport {
+
+    @Test
+    public void testGetTestCategories() {
+        HashSet<Class<?>> testCategories = getTestCategories();
+        assertEquals("Expected a single test category", 1, testCategories.size());
+        assertTrue("Expected to find a QuickTest category", testCategories.contains(QuickTest.class));
+    }
+
+    @Test
+    public void testAssertThatIsNoParallelTest() {
+        try {
+            assertThatIsNoParallelTest();
+        } catch (AssertionError e) {
+            fail("Expected no exception on this non ParallelTest");
+        }
+    }
+}


### PR DESCRIPTION
We have tests, which are not allowed to be a `ParallelTest`, because they use real network or play around with static states (e.g. from JSR classes, which is external code, so we cannot fix this). This new assertion method can be used in the setup phase to ensure, that the tests are not accidentally annotated with `ParallelTest`.