### PR TITLE
Add methods on MapService and CacheService to get object namespace

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -35,7 +35,6 @@ import com.hazelcast.internal.eviction.impl.strategy.sampling.SamplingEvictionSt
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
@@ -151,7 +150,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         evictionChecker = createCacheEvictionChecker(evictionConfig.getSize(), evictionConfig.getMaximumSizePolicy());
         evictionPolicyEvaluator = createEvictionPolicyEvaluator(evictionConfig);
         evictionStrategy = createEvictionStrategy(evictionConfig);
-        objectNamespace = new DistributedObjectNamespace(ICacheService.SERVICE_NAME, name);
+        objectNamespace = CacheService.getObjectNamespace(name);
 
         injectDependencies(evictionPolicyEvaluator.getEvictionPolicyComparator());
         registerResourceIfItIsClosable(cacheWriter);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.impl.event.CacheWanEventPublisher;
 import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
+import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
@@ -154,5 +155,9 @@ public class CacheService extends AbstractCacheService {
     @Override
     public CacheWanEventPublisher getCacheWanEventPublisher() {
         throw new UnsupportedOperationException("Wan replication is not supported");
+    }
+
+    public static ObjectNamespace getObjectNamespace(String cacheName) {
+        return new DistributedObjectNamespace(SERVICE_NAME, cacheName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
@@ -22,7 +22,7 @@ import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
@@ -39,7 +39,7 @@ public class CacheEventJournalSubscribeOperation
         extends AbstractNamedOperation
         implements PartitionAwareOperation, IdentifiedDataSerializable, ReadonlyOperation {
     private EventJournalInitialSubscriberState response;
-    private DistributedObjectNamespace namespace;
+    private ObjectNamespace namespace;
 
     public CacheEventJournalSubscribeOperation() {
     }
@@ -58,7 +58,7 @@ public class CacheEventJournalSubscribeOperation
                     "Event journal actions are not available when cluster version is " + clusterVersion);
         }
 
-        namespace = new DistributedObjectNamespace(CacheService.SERVICE_NAME, name);
+        namespace = CacheService.getObjectNamespace(name);
         final CacheService service = getService();
         if (!service.getEventJournal().hasEventJournal(namespace)) {
             throw new UnsupportedOperationException(

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapForceUnlockMessageTask.java
@@ -26,7 +26,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
@@ -75,7 +74,7 @@ public class MapForceUnlockMessageTask
     }
 
     private ObjectNamespace getNamespace() {
-        return new DistributedObjectNamespace(MapService.SERVICE_NAME, parameters.name);
+        return MapService.getObjectNamespace(parameters.name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsLockedMessageTask.java
@@ -26,7 +26,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
@@ -85,6 +84,6 @@ public class MapIsLockedMessageTask
     }
 
     private ObjectNamespace getNamespace() {
-        return new DistributedObjectNamespace(MapService.SERVICE_NAME, parameters.name);
+        return MapService.getObjectNamespace(parameters.name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLockMessageTask.java
@@ -26,7 +26,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
@@ -72,7 +71,7 @@ public class MapLockMessageTask
     }
 
     private ObjectNamespace getNamespace() {
-        return new DistributedObjectNamespace(MapService.SERVICE_NAME, parameters.name);
+        return MapService.getObjectNamespace(parameters.name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryLockMessageTask.java
@@ -26,7 +26,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
@@ -72,7 +71,7 @@ public class MapTryLockMessageTask
     }
 
     private ObjectNamespace getNamespace() {
-        return new DistributedObjectNamespace(MapService.SERVICE_NAME, parameters.name);
+        return MapService.getObjectNamespace(parameters.name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapUnlockMessageTask.java
@@ -26,7 +26,6 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
@@ -75,7 +74,7 @@ public class MapUnlockMessageTask
     }
 
     private ObjectNamespace getNamespace() {
-        return new DistributedObjectNamespace(MapService.SERVICE_NAME, parameters.name);
+        return MapService.getObjectNamespace(parameters.name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -41,7 +41,6 @@ import com.hazelcast.query.impl.IndexInfo;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -126,7 +125,7 @@ public class MapContainer {
         this.serializationService = nodeEngine.getSerializationService();
         this.recordFactoryConstructor = createRecordFactoryConstructor(serializationService);
         this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues());
-        this.objectNamespace = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
+        this.objectNamespace = MapService.getObjectNamespace(name);
         initWanReplication(nodeEngine);
         this.extractors = new Extractors(mapConfig.getMapAttributeConfigs(), config.getClassLoader());
         if (shouldUseGlobalIndex(mapConfig)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.cluster.ClusterVersionListener;
 import com.hazelcast.map.impl.event.MapEventPublishingService;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.spi.ClientAwareService;
+import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.EventRegistration;
@@ -30,6 +31,7 @@ import com.hazelcast.spi.FragmentedMigrationAwareService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.NotifiableEventListener;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareService;
 import com.hazelcast.spi.PartitionMigrationEvent;
@@ -256,4 +258,7 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
         mapIndexSynchronizer.onClusterVersionChange(newVersion);
     }
 
+    public static ObjectNamespace getObjectNamespace(String mapName) {
+        return new DistributedObjectNamespace(SERVICE_NAME, mapName);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -23,9 +23,9 @@ import com.hazelcast.map.impl.query.IndexProvider;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -210,7 +210,7 @@ public class PartitionContainer {
         final NodeEngine nodeEngine = mapService.getMapServiceContext().getNodeEngine();
         final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
         if (lockService != null) {
-            final DistributedObjectNamespace namespace = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
+            final ObjectNamespace namespace = MapService.getObjectNamespace(name);
             lockService.clearLockStore(partitionId, namespace);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
@@ -19,9 +19,8 @@ package com.hazelcast.map.impl.journal;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.journal.EventJournalInitialSubscriberState;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MapOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.version.Version;
@@ -35,7 +34,7 @@ import com.hazelcast.version.Version;
  */
 public class MapEventJournalSubscribeOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
     private EventJournalInitialSubscriberState response;
-    private DistributedObjectNamespace namespace;
+    private ObjectNamespace namespace;
 
     public MapEventJournalSubscribeOperation() {
     }
@@ -53,7 +52,7 @@ public class MapEventJournalSubscribeOperation extends MapOperation implements P
             throw new UnsupportedOperationException(
                     "Event journal actions are not available when cluster version is " + clusterVersion);
         }
-        namespace = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
+        namespace = getServiceNamespace();
         if (!mapServiceContext.getEventJournal().hasEventJournal(namespace)) {
             throw new UnsupportedOperationException(
                     "Cannot subscribe to event journal because it is either not configured or disabled for map " + name);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -19,10 +19,8 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
 
 public class ContainsKeyOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
@@ -54,8 +52,7 @@ public class ContainsKeyOperation extends ReadonlyKeyBasedMapOperation implement
 
     @Override
     public WaitNotifyKey getWaitKey() {
-        DistributedObjectNamespace namespace = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
-        return new LockWaitNotifyKey(namespace, dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
@@ -126,7 +125,7 @@ public class EntryOffloadableSetUnlockOperation extends MutatingKeyBasedMapOpera
 
     @Override
     public WaitNotifyKey getNotifiedKey() {
-        return new LockWaitNotifyKey(new DistributedObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -25,13 +25,11 @@ import com.hazelcast.core.ReadOnly;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.BlockingOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
@@ -401,7 +399,7 @@ public class EntryOperation extends MutatingKeyBasedMapOperation implements Back
 
     @Override
     public WaitNotifyKey getWaitKey() {
-        return new LockWaitNotifyKey(new DistributedObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -21,11 +21,9 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
 
 public class GetEntryViewOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
@@ -50,7 +48,7 @@ public class GetEntryViewOperation extends ReadonlyKeyBasedMapOperation implemen
 
     @Override
     public WaitNotifyKey getWaitKey() {
-        return new LockWaitNotifyKey(new DistributedObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 
     public boolean shouldWait() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -19,10 +19,8 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
 
 public final class GetOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
@@ -50,7 +48,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
 
     @Override
     public WaitNotifyKey getWaitKey() {
-        return new LockWaitNotifyKey(new DistributedObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -17,10 +17,8 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
 
 public abstract class LockAwareOperation extends MutatingKeyBasedMapOperation implements BlockingOperation {
@@ -50,6 +48,6 @@ public abstract class LockAwareOperation extends MutatingKeyBasedMapOperation im
 
     @Override
     public final WaitNotifyKey getWaitKey() {
-        return new LockWaitNotifyKey(new DistributedObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -67,7 +67,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.AbstractDistributedObject;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -199,7 +198,7 @@ abstract class MapProxySupport<K, V>
                 mapConfig.getPartitioningStrategyConfig());
         this.localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
         this.partitionService = getNodeEngine().getPartitionService();
-        this.lockSupport = new LockProxySupport(new DistributedObjectNamespace(SERVICE_NAME, name),
+        this.lockSupport = new LockProxySupport(MapService.getObjectNamespace(name),
                 LockServiceImpl.getMaxLeaseTimeInMillis(properties));
         this.operationProvider = mapServiceContext.getMapOperationProvider(mapConfig);
         this.operationService = nodeEngine.getOperationService();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -34,7 +34,6 @@ import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
@@ -180,7 +179,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         if (lockService == null) {
             return null;
         }
-        return lockService.createLockStore(partitionId, new DistributedObjectNamespace(MapService.SERVICE_NAME, name));
+        return lockService.createLockStore(partitionId, MapService.getObjectNamespace(name));
     }
 
     public int getLockedEntryCount() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -42,8 +42,8 @@ import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.CollectionUtil;
@@ -289,8 +289,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
         if (lockService != null) {
-            final DistributedObjectNamespace namespace
-                    = new DistributedObjectNamespace(MapService.SERVICE_NAME, name);
+            final ObjectNamespace namespace = MapService.getObjectNamespace(name);
             lockService.clearLockStore(partitionId, namespace);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -19,13 +19,11 @@ package com.hazelcast.map.impl.tx;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
-import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
@@ -101,7 +99,7 @@ public class TxnRollbackOperation extends MutatingKeyBasedMapOperation implement
 
     @Override
     public WaitNotifyKey getNotifiedKey() {
-        return new LockWaitNotifyKey(new DistributedObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+        return new LockWaitNotifyKey(getServiceNamespace(), dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -281,19 +281,19 @@ final class OperationBackupHandler {
         if (service instanceof FragmentedMigrationAwareService) {
             assert backupAwareOp instanceof ServiceNamespaceAware
                     : service + " is instance of FragmentedMigrationAwareService, "
-                    + backupAwareOp + " should implement ReplicaFragmentAware!";
+                    + backupAwareOp + " should implement ServiceNamespaceAware!";
 
             assert backupOp instanceof ServiceNamespaceAware
                     : service + " is instance of FragmentedMigrationAwareService, "
-                    + backupOp + " should implement ReplicaFragmentAware!";
+                    + backupOp + " should implement ServiceNamespaceAware!";
         } else {
             assert !(backupAwareOp instanceof ServiceNamespaceAware)
                     : service + " is NOT instance of FragmentedMigrationAwareService, "
-                    + backupAwareOp + " should NOT implement ReplicaFragmentAware!";
+                    + backupAwareOp + " should NOT implement ServiceNamespaceAware!";
 
             assert !(backupOp instanceof ServiceNamespaceAware)
                     : service + " is NOT instance of FragmentedMigrationAwareService, "
-                    + backupOp + " should NOT implement ReplicaFragmentAware!";
+                    + backupOp + " should NOT implement ServiceNamespaceAware!";
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl.journal;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.CacheEventType;
 import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -377,11 +378,11 @@ public class BasicCacheJournalTest extends HazelcastTestSupport {
     }
 
     private void assertJournalSize(ICache<?, ?> cache, int size) {
-        assertJournalSize(partitionId, new DistributedObjectNamespace(cache.getServiceName(), cache.getPrefixedName()), size);
+        assertJournalSize(partitionId, CacheService.getObjectNamespace(cache.getPrefixedName()), size);
     }
 
     private void assertJournalSize(int partitionId, ICache<?, ?> cache, int size) {
-        assertJournalSize(partitionId, new DistributedObjectNamespace(cache.getServiceName(), cache.getName()), size);
+        assertJournalSize(partitionId, CacheService.getObjectNamespace(cache.getName()), size);
     }
 
     private void assertJournalSize(int partitionId, ObjectNamespace namespace, int size) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.Node;
 import com.hazelcast.journal.EventJournalInitialSubscriberState;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.journal.EventJournalMapEvent;
 import com.hazelcast.projection.Projection;
@@ -418,11 +419,11 @@ public class BasicMapJournalTest extends HazelcastTestSupport {
     }
 
     private void assertJournalSize(DistributedObject object, int size) {
-        assertJournalSize(partitionId, new DistributedObjectNamespace(object.getServiceName(), object.getName()), size);
+        assertJournalSize(partitionId, MapService.getObjectNamespace(object.getName()), size);
     }
 
     private void assertJournalSize(int partitionId, DistributedObject object, int size) {
-        assertJournalSize(partitionId, new DistributedObjectNamespace(object.getServiceName(), object.getName()), size);
+        assertJournalSize(partitionId, MapService.getObjectNamespace(object.getName()), size);
     }
 
     private void assertJournalSize(int partitionId, ObjectNamespace namespace, int size) {


### PR DESCRIPTION
This is an optimisation to easily get the object namespace from code
paths that either do not have a reference to the MapContainer or
RecordStore or would rather not trigger creating one. The method also
helps in case of refactoring if the type or contents of the namespace
 were to change so the change would be localized.

This is a prerequisite for a WAN EE PR : https://github.com/hazelcast/hazelcast-enterprise/pull/1690