### PR TITLE
Fix for non smart listeners

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -91,10 +91,6 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
         eventHandlerMap.remove(callId);
     }
 
-    protected EventHandler getEventHandler(long callId) {
-        return eventHandlerMap.get(callId);
-    }
-
     public void handleClientMessage(ClientMessage clientMessage, Connection connection) {
         try {
             eventExecutor.execute(new ClientEventProcessor(clientMessage, (ClientConnection) connection));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -479,8 +479,9 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
                     NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance);
                     EventServiceImpl eventService = (EventServiceImpl) nodeEngineImpl.getEventService();
                     EventServiceSegment serviceSegment = eventService.getSegment(getServiceName(), false);
-                    assertNotNull(serviceSegment);
-                    assertEquals(1, serviceSegment.getRegistrationIdMap().size());
+                    Member member = instance.getCluster().getLocalMember();
+                    assertNotNull(member.toString(), serviceSegment);
+                    assertEquals(member.toString(), 1, serviceSegment.getRegistrationIdMap().size());
                 }
             }
         });


### PR DESCRIPTION
When a connection is removed listeners resources are cleaned immediately
on both server and client.
On the client side, when connection is removed,
if clean up is scheduled to happen after new registartions, then we were
falsely removing the event handlers of new registrations.

To fix the order problem between `connection added` and `connection removed`
the task of `connection removed` is moved to `connection added`. Cleaning
up event handlers will be done when a new regitration done for same listener
registration.

getActiveRegistrations method used in tests are also modified to be able
return empty list when connection is removed.

fixes the failure seen in
https://github.com/hazelcast/hazelcast/issues/10235#issuecomment-325973662
related to #10235