### PR TITLE
Add partition ID to RingbufferWaitNotifyKey

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -118,7 +118,7 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
 
     @Override
     public WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
-        return new RingbufferWaitNotifyKey(namespace);
+        return new RingbufferWaitNotifyKey(namespace, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -108,7 +108,7 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
 
     @Override
     public WaitNotifyKey getWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
-        return new RingbufferWaitNotifyKey(namespace);
+        return new RingbufferWaitNotifyKey(namespace, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -88,15 +88,15 @@ public class RingbufferContainer<T> implements IdentifiedDataSerializable, Notif
      *
      * @param namespace the namespace of the ring buffer container
      */
-    public RingbufferContainer(ObjectNamespace namespace) {
+    public RingbufferContainer(ObjectNamespace namespace, int partitionId) {
         this.namespace = namespace;
-        this.emptyRingWaitNotifyKey = new RingbufferWaitNotifyKey(namespace);
+        this.emptyRingWaitNotifyKey = new RingbufferWaitNotifyKey(namespace, partitionId);
     }
 
     public RingbufferContainer(ObjectNamespace namespace, RingbufferConfig config,
                                SerializationService serializationService,
-                               ClassLoader configClassLoader) {
-        this(namespace);
+                               ClassLoader configClassLoader, int partitionId) {
+        this(namespace, partitionId);
 
         this.inMemoryFormat = config.getInMemoryFormat();
         this.ringbuffer = new ArrayRingbuffer(config.getCapacity());

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -166,7 +166,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
                 namespace,
                 config,
                 nodeEngine.getSerializationService(),
-                nodeEngine.getConfigClassLoader());
+                nodeEngine.getConfigClassLoader(), partitionId);
         ringbuffer.getStore().instrument(nodeEngine);
         partitionContainers.put(namespace, ringbuffer);
         return ringbuffer;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
@@ -22,15 +22,20 @@ import com.hazelcast.spi.WaitNotifyKey;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * A {@link com.hazelcast.spi.AbstractWaitNotifyKey} to make it possible to wait for an item to be published in the ringbuffer.
+ * A {@link com.hazelcast.spi.AbstractWaitNotifyKey} to make it possible to wait
+ * for an item to be published in the ringbuffer.
+ * The exact ringbuffer is specified by the partition ID and namespace as those
+ * two parameters uniquely identify a single ringbuffer inside the ringbuffer service.
  */
 public class RingbufferWaitNotifyKey implements WaitNotifyKey {
 
     private final ObjectNamespace namespace;
+    private final int partitionId;
 
-    public RingbufferWaitNotifyKey(ObjectNamespace namespace) {
+    public RingbufferWaitNotifyKey(ObjectNamespace namespace, int partitionId) {
         checkNotNull(namespace);
         this.namespace = namespace;
+        this.partitionId = partitionId;
     }
 
     @Override
@@ -44,12 +49,22 @@ public class RingbufferWaitNotifyKey implements WaitNotifyKey {
 
         RingbufferWaitNotifyKey that = (RingbufferWaitNotifyKey) o;
 
-        return namespace.equals(that.namespace);
+        return partitionId == that.partitionId && namespace.equals(that.namespace);
     }
 
     @Override
     public int hashCode() {
-        return namespace.hashCode();
+        int result = namespace.hashCode();
+        result = 31 * result + partitionId;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RingbufferWaitNotifyKey{"
+                + "namespace=" + namespace
+                + ", partitionId=" + partitionId
+                + '}';
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
@@ -122,7 +122,7 @@ public class ReplicationOperation extends Operation implements IdentifiedDataSer
             final ObjectNamespace namespace = isGreaterOrEqualV39(in)
                     ? (ObjectNamespace) in.readObject()
                     : RingbufferService.getRingbufferNamespace(in.readUTF());
-            final RingbufferContainer container = new RingbufferContainer(namespace);
+            final RingbufferContainer container = new RingbufferContainer(namespace, getPartitionId());
             container.readData(in);
             migrationData.put(namespace, container);
         }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
@@ -121,9 +121,11 @@ public class RingbufferContainerSerializationTest extends HazelcastTestSupport {
     }
 
     private RingbufferContainer getRingbufferContainer(RingbufferConfig config) {
+        // partitionId is irrelevant for this test
         return new RingbufferContainer(
                 RingbufferService.getRingbufferNamespace(config.getName()), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader(),
+                0);
     }
 
     private void testSerialization(RingbufferContainer original) {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
@@ -104,9 +104,11 @@ public class RingbufferContainerTest extends HazelcastTestSupport {
     }
 
     private RingbufferContainer getRingbufferContainer(RingbufferConfig config) {
+        // partitionId is irrelevant for this test
         return new RingbufferContainer(
                 RingbufferService.getRingbufferNamespace(config.getName()), config,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader(),
+                0);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
@@ -34,27 +34,35 @@ public class RingbufferWaitNotifyKeyTest {
 
     @Test
     public void test_equals() {
-        test_equals(
-                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
-                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), true);
-        test_equals(
-                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
-                waitNotifyKey(RingbufferService.SERVICE_NAME, "talip"), false);
-        test_equals(
-                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
-                waitNotifyKey(MapService.SERVICE_NAME, "peter"), false);
-        test_equals(
-                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"),
-                waitNotifyKey(MapService.SERVICE_NAME, "talip"), false);
-        test_equals(waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), "", false);
-        test_equals(waitNotifyKey(RingbufferService.SERVICE_NAME, "peter"), null, false);
+        test_equals(waitNotifyKey("peter"), waitNotifyKey("peter"), true);
+        test_equals(waitNotifyKey("peter"), waitNotifyKey("talip"), false);
+        test_equals(waitNotifyKey("peter"), waitNotifyKey(MapService.SERVICE_NAME, "peter"), false);
+        test_equals(waitNotifyKey("peter"), waitNotifyKey(MapService.SERVICE_NAME, "talip"), false);
+        test_equals(waitNotifyKey("peter"), "", false);
+        test_equals(waitNotifyKey("peter"), null, false);
 
-        RingbufferWaitNotifyKey key = waitNotifyKey(RingbufferService.SERVICE_NAME, "peter");
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter", 1),
+                waitNotifyKey(MapService.SERVICE_NAME, "peter", 1), false);
+
+        test_equals(
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter", 1),
+                waitNotifyKey(RingbufferService.SERVICE_NAME, "peter", 2), false);
+
+        final RingbufferWaitNotifyKey key = waitNotifyKey("peter");
         test_equals(key, key, true);
     }
 
+    private RingbufferWaitNotifyKey waitNotifyKey(String object) {
+        return waitNotifyKey(RingbufferService.SERVICE_NAME, object);
+    }
+
     private RingbufferWaitNotifyKey waitNotifyKey(String service, String object) {
-        return new RingbufferWaitNotifyKey(new DistributedObjectNamespace(service, object));
+        return waitNotifyKey(service, object, 0);
+    }
+
+    private RingbufferWaitNotifyKey waitNotifyKey(String service, String object, int partitionId) {
+        return new RingbufferWaitNotifyKey(new DistributedObjectNamespace(service, object), partitionId);
     }
 
     public void test_equals(Object key1, Object key2, boolean equals) {


### PR DESCRIPTION
This makes the operation wait/notify key more fine grained.
Previously the key was for all partitions. This meant that for an
read operation for a specific partition to be notified, all other
read operations before it in the wait queue needed to be notified and
processed first.

This causes a form of head-of-line blocking - if a read operation
returns true from shouldWait, other operations in the queue that
might get processed don't get a chance.