### PR TITLE
Fix attempt QuorumTest for clients

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/QuorumTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/QuorumTestUtil.java
@@ -31,6 +31,7 @@ public class QuorumTestUtil {
         ClientConfig clientConfig = new ClientConfig();
         Address address = getNode(instance).address;
         clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getNetworkConfig().setSmartRouting(false);
         clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
         return clientConfig;
     }


### PR DESCRIPTION
Make sure a client uses a single connection to the cluster. So it is aligned
with blocked connections.

Fixes #10383