### PR TITLE
Minor cache improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -110,10 +110,10 @@ public class CacheEventHandler {
                 eventData, cacheEventContext.getOrderKey());
     }
 
-    void publishEvent(String cacheName, CacheEventSet eventSet, int orderKey) {
+    void publishEvent(String cacheNameWithPrefix, CacheEventSet eventSet, int orderKey) {
         final EventService eventService = nodeEngine.getEventService();
         final Collection<EventRegistration> candidates =
-                eventService.getRegistrations(SERVICE_NAME, cacheName);
+                eventService.getRegistrations(SERVICE_NAME, cacheNameWithPrefix);
         if (candidates.isEmpty()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -64,9 +64,9 @@ public class CacheRecordStore
     protected SerializationService serializationService;
     protected CacheRecordFactory cacheRecordFactory;
 
-    public CacheRecordStore(String name, int partitionId, NodeEngine nodeEngine,
+    public CacheRecordStore(String cacheNameWithPrefix, int partitionId, NodeEngine nodeEngine,
                             AbstractCacheService cacheService) {
-        super(name, partitionId, nodeEngine, cacheService);
+        super(cacheNameWithPrefix, partitionId, nodeEngine, cacheService);
         this.serializationService = nodeEngine.getSerializationService();
         this.cacheRecordFactory = createCacheRecordFactory();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -65,8 +65,8 @@ public class CacheService extends AbstractCacheService {
     }
 
     @Override
-    protected ICacheRecordStore createNewRecordStore(String name, int partitionId) {
-        CacheRecordStore recordStore = new CacheRecordStore(name, partitionId, nodeEngine, this);
+    protected ICacheRecordStore createNewRecordStore(String cacheNameWithPrefix, int partitionId) {
+        CacheRecordStore recordStore = new CacheRecordStore(cacheNameWithPrefix, partitionId, nodeEngine, this);
         recordStore.instrument(nodeEngine);
         return recordStore;
     }
@@ -148,7 +148,7 @@ public class CacheService extends AbstractCacheService {
     }
 
     @Override
-    public boolean isWanReplicationEnabled(String cacheName) {
+    public boolean isWanReplicationEnabled(String cacheNameWithPrefix) {
         return false;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -33,53 +33,54 @@ import java.util.Collection;
 
 public interface ICacheService
         extends ManagedService, RemoteService, FragmentedMigrationAwareService,
-                EventPublishingService<Object, CacheEventListener> {
+        EventPublishingService<Object, CacheEventListener> {
 
     String CACHE_SUPPORT_NOT_AVAILABLE_ERROR_MESSAGE =
             "There is no valid JCache API library at classpath. "
-            + "Please be sure that there is a JCache API library in your classpath "
-            + "and it is newer than `0.x` and `1.0.0-PFD` versions!";
+                    + "Please be sure that there is a JCache API library in your classpath "
+                    + "and it is newer than `0.x` and `1.0.0-PFD` versions!";
 
     String SERVICE_NAME = "hz:impl:cacheService";
 
     /**
-     * Gets or creates a cache record store with the prefixed {@code name}
+     * Gets or creates a cache record store with the prefixed {@code cacheNameWithPrefix}
      * and partition ID.
      *
-     * @param name        the full cache name containing the prefix
-     * @param partitionId the record store partition ID
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     * @param partitionId         the record store partition ID
      * @return the cache partition record store
      */
-    ICacheRecordStore getOrCreateRecordStore(String name, int partitionId);
+    ICacheRecordStore getOrCreateRecordStore(String cacheNameWithPrefix, int partitionId);
 
     /**
-     * Gets a cache record store with the prefixed {@code name} and partition ID.
+     * Returns a cache record store with the prefixed {@code cacheNameWithPrefix} and partition ID
+     * or {@code null} if one doesn't exist.
      *
-     * @param name        the full cache name containing the prefix
-     * @param partitionId the record store partition ID
-     * @return the cache partition record store
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     * @param partitionId         the record store partition ID
+     * @return the cache partition record store or {@code null} if it doesn't exist
      */
-    ICacheRecordStore getRecordStore(String name, int partitionId);
+    ICacheRecordStore getRecordStore(String cacheNameWithPrefix, int partitionId);
 
     CachePartitionSegment getSegment(int partitionId);
 
     CacheConfig putCacheConfigIfAbsent(CacheConfig config);
 
-    CacheConfig getCacheConfig(String name);
+    CacheConfig getCacheConfig(String cacheNameWithPrefix);
 
     CacheConfig findCacheConfig(String simpleName);
 
     Collection<CacheConfig> getCacheConfigs();
 
-    CacheConfig deleteCacheConfig(String name);
+    CacheConfig deleteCacheConfig(String cacheNameWithPrefix);
 
-    CacheStatisticsImpl createCacheStatIfAbsent(String name);
+    CacheStatisticsImpl createCacheStatIfAbsent(String cacheNameWithPrefix);
 
-    CacheContext getOrCreateCacheContext(String name);
+    CacheContext getOrCreateCacheContext(String cacheNameWithPrefix);
 
-    void deleteCache(String name, String callerUuid, boolean destroy);
+    void deleteCache(String cacheNameWithPrefix, String callerUuid, boolean destroy);
 
-    void deleteCacheStat(String name);
+    void deleteCacheStat(String cacheNameWithPrefix);
 
     void setStatisticsEnabled(CacheConfig cacheConfig, String cacheNameWithPrefix, boolean enabled);
 
@@ -87,32 +88,44 @@ public interface ICacheService
 
     void publishEvent(CacheEventContext cacheEventContext);
 
-    void publishEvent(String cacheName, CacheEventSet eventSet, int orderKey);
+    void publishEvent(String cacheNameWithPrefix, CacheEventSet eventSet, int orderKey);
 
     NodeEngine getNodeEngine();
 
-    String registerListener(String name, CacheEventListener listener, boolean isLocal);
+    String registerListener(String cacheNameWithPrefix, CacheEventListener listener, boolean isLocal);
 
-    String registerListener(String name, CacheEventListener listener, EventFilter eventFilter, boolean isLocal);
+    String registerListener(String cacheNameWithPrefix, CacheEventListener listener, EventFilter eventFilter, boolean isLocal);
 
-    boolean deregisterListener(String name, String registrationId);
+    boolean deregisterListener(String cacheNameWithPrefix, String registrationId);
 
-    void deregisterAllListener(String name);
+    void deregisterAllListener(String cacheNameWithPrefix);
 
-    CacheStatistics getStatistics(String name);
+    CacheStatistics getStatistics(String cacheNameWithPrefix);
 
     /**
      * Creates cache operations according to the storage-type of the cache
      */
-    CacheOperationProvider getCacheOperationProvider(String nameWithPrefix, InMemoryFormat storageType);
+    CacheOperationProvider getCacheOperationProvider(String cacheNameWithPrefix, InMemoryFormat storageType);
 
-    String addInvalidationListener(String name, CacheEventListener listener, boolean localOnly);
+    String addInvalidationListener(String cacheNameWithPrefix, CacheEventListener listener, boolean localOnly);
 
-    void sendInvalidationEvent(String name, Data key, String sourceUuid);
+    void sendInvalidationEvent(String cacheNameWithPrefix, Data key, String sourceUuid);
 
-    boolean isWanReplicationEnabled(String cacheName);
+    /**
+     * Returns {@code true} if WAN replication is enabled for the cache named {@code cacheNameWithPrefix}.
+     *
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     */
+    boolean isWanReplicationEnabled(String cacheNameWithPrefix);
 
+    /**
+     * Returns the WAN event publisher responsible for publishing
+     * primary and backup WAN events for caches.
+     */
     CacheWanEventPublisher getCacheWanEventPublisher();
 
+    /**
+     * Returns an interface for interacting with the cache event journals.
+     */
     CacheEventJournal getEventJournal();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CacheWanEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CacheWanEventPublisher.java
@@ -23,47 +23,56 @@ import com.hazelcast.spi.Operation;
 /**
  * This interface provides methods to publish wan replication events
  * from cache operations.
- *
- * Methods of this class should be called within the partition thread to wan keep event order.
+ * <p>
+ * Methods of this class should be called from within the partition thread
+ * to keep event order for keys belonging to a single partition.
  */
 public interface CacheWanEventPublisher {
 
     /**
      * This method will create a wrapper object using the given {@link CacheEntryView}
      * and place it to wan replication queues.
-     *
+     * <p>
      * Updating cache operations should call this method in their {@link Operation#afterRun()} method.
      *
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     * @param entryView           the updated cache entry
      * @see com.hazelcast.cache.impl.operation.CachePutOperation
      * @see com.hazelcast.cache.impl.operation.CacheGetAndReplaceOperation
      */
-    void publishWanReplicationUpdate(String cacheName, CacheEntryView<Data, Data> entryView);
+    void publishWanReplicationUpdate(String cacheNameWithPrefix, CacheEntryView<Data, Data> entryView);
 
     /**
      * This method will create a wrapper object using the given {@link CacheEntryView}
      * and place it to wan replication queues.
-     *
+     * <p>
      * Cache operations which removes data from cache should call this method in their
      * {@link Operation#afterRun()} method.
      *
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     * @param key                 the key of the removed entry
      * @see com.hazelcast.cache.impl.operation.CacheRemoveOperation
      */
-    void publishWanReplicationRemove(String cacheName, Data key);
+    void publishWanReplicationRemove(String cacheNameWithPrefix, Data key);
 
     /**
      * Backup operations of operations that call {@link this#publishWanReplicationUpdate(String, CacheEntryView)}
      * should call this method to provide wan event backups
      *
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     * @param entryView           the updated cache entry
      * @see com.hazelcast.cache.impl.operation.CachePutBackupOperation
      */
-    void publishWanReplicationUpdateBackup(String cacheName, CacheEntryView<Data, Data> entryView);
+    void publishWanReplicationUpdateBackup(String cacheNameWithPrefix, CacheEntryView<Data, Data> entryView);
 
     /**
      * Backup operations of operations that call {@link this#publishWanReplicationRemove(String, Data)}
      * should call this method to provide wan event backups
      *
+     * @param cacheNameWithPrefix the full name of the {@link com.hazelcast.cache.ICache}, including the manager scope prefix
+     * @param key                 the key of the removed entry
      * @see com.hazelcast.cache.impl.operation.CacheRemoveBackupOperation
      */
-    void publishWanReplicationRemoveBackup(String cacheName, Data key);
+    void publishWanReplicationRemoveBackup(String cacheNameWithPrefix, Data key);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheBackupEntryProcessorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheBackupEntryProcessorOperation.java
@@ -48,9 +48,9 @@ public class CacheBackupEntryProcessorOperation
     public CacheBackupEntryProcessorOperation() {
     }
 
-    public CacheBackupEntryProcessorOperation(String name, Data key, EntryProcessor entryProcessor,
+    public CacheBackupEntryProcessorOperation(String cacheNameWithPrefix, Data key, EntryProcessor entryProcessor,
                                               Object... arguments) {
-        super(name, key);
+        super(cacheNameWithPrefix, key);
         this.entryProcessor = entryProcessor;
         this.arguments = arguments;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryProcessorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryProcessorOperation.java
@@ -47,9 +47,9 @@ public class CacheEntryProcessorOperation
     public CacheEntryProcessorOperation() {
     }
 
-    public CacheEntryProcessorOperation(String name, Data key, int completionId,
+    public CacheEntryProcessorOperation(String cacheNameWithPrefix, Data key, int completionId,
                                         javax.cache.processor.EntryProcessor entryProcessor, Object... arguments) {
-        super(name, key, completionId);
+        super(cacheNameWithPrefix, key, completionId);
         this.entryProcessor = entryProcessor;
         this.arguments = arguments;
         this.completionId = completionId;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
@@ -41,8 +41,9 @@ public class CacheGetAndReplaceOperation
     public CacheGetAndReplaceOperation() {
     }
 
-    public CacheGetAndReplaceOperation(String name, Data key, Data value, ExpiryPolicy expiryPolicy, int completionId) {
-        super(name, key, completionId);
+    public CacheGetAndReplaceOperation(String cacheNameWithPrefix, Data key, Data value,
+                                       ExpiryPolicy expiryPolicy, int completionId) {
+        super(cacheNameWithPrefix, key, completionId);
         this.value = value;
         this.expiryPolicy = expiryPolicy;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetOperation.java
@@ -39,8 +39,8 @@ public class CacheGetOperation
     public CacheGetOperation() {
     }
 
-    public CacheGetOperation(String name, Data key, ExpiryPolicy expiryPolicy) {
-        super(name, key);
+    public CacheGetOperation(String cacheNameWithPrefix, Data key, ExpiryPolicy expiryPolicy) {
+        super(cacheNameWithPrefix, key);
         this.expiryPolicy = expiryPolicy;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -53,8 +53,8 @@ public class CachePutAllBackupOperation
     public CachePutAllBackupOperation() {
     }
 
-    public CachePutAllBackupOperation(String name, Map<Data, CacheRecord> cacheRecords) {
-        super(name);
+    public CachePutAllBackupOperation(String cacheNameWithPrefix, Map<Data, CacheRecord> cacheRecords) {
+        super(cacheNameWithPrefix);
         this.cacheRecords = cacheRecords;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
@@ -57,9 +57,9 @@ public class CachePutAllOperation
     public CachePutAllOperation() {
     }
 
-    public CachePutAllOperation(String name, List<Map.Entry<Data, Data>> entries,
+    public CachePutAllOperation(String cacheNameWithPrefix, List<Map.Entry<Data, Data>> entries,
                                 ExpiryPolicy expiryPolicy, int completionId) {
-        super(name);
+        super(cacheNameWithPrefix);
         this.entries = entries;
         this.expiryPolicy = expiryPolicy;
         this.completionId = completionId;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
@@ -42,8 +42,9 @@ public class CachePutIfAbsentOperation
     public CachePutIfAbsentOperation() {
     }
 
-    public CachePutIfAbsentOperation(String name, Data key, Data value, ExpiryPolicy expiryPolicy, int completionId) {
-        super(name, key, completionId);
+    public CachePutIfAbsentOperation(String cacheNameWithPrefix, Data key, Data value,
+                                     ExpiryPolicy expiryPolicy, int completionId) {
+        super(cacheNameWithPrefix, key, completionId);
         this.value = value;
         this.expiryPolicy = expiryPolicy;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
@@ -46,8 +46,9 @@ public class CachePutOperation
     public CachePutOperation() {
     }
 
-    public CachePutOperation(String name, Data key, Data value, ExpiryPolicy expiryPolicy, boolean get, int completionId) {
-        super(name, key, completionId);
+    public CachePutOperation(String cacheNameWithPrefix, Data key, Data value,
+                             ExpiryPolicy expiryPolicy, boolean get, int completionId) {
+        super(cacheNameWithPrefix, key, completionId);
         this.value = value;
         this.expiryPolicy = expiryPolicy;
         this.get = get;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
@@ -38,8 +38,8 @@ public class CacheRemoveOperation
     public CacheRemoveOperation() {
     }
 
-    public CacheRemoveOperation(String name, Data key, Data oldValue, int completionId) {
-        super(name, key, completionId);
+    public CacheRemoveOperation(String cacheNameWithPrefix, Data key, Data oldValue, int completionId) {
+        super(cacheNameWithPrefix, key, completionId);
         this.oldValue = oldValue;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
@@ -43,9 +43,9 @@ public class CacheReplaceOperation
     public CacheReplaceOperation() {
     }
 
-    public CacheReplaceOperation(String name, Data key, Data oldValue, Data newValue, ExpiryPolicy expiryPolicy,
+    public CacheReplaceOperation(String cacheNameWithPrefix, Data key, Data oldValue, Data newValue, ExpiryPolicy expiryPolicy,
                                  int completionId) {
-        super(name, key, completionId);
+        super(cacheNameWithPrefix, key, completionId);
         this.newValue = newValue;
         this.oldValue = oldValue;
         this.expiryPolicy = expiryPolicy;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -639,6 +639,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
                 + ", inMemoryFormat=" + inMemoryFormat
                 + ", backupCount=" + backupCount
                 + ", hotRestart=" + hotRestartConfig
+                + ", wanReplicationRef=" + wanReplicationRef
                 + '}';
     }
 }


### PR DESCRIPTION
- improved the toString method of the CacheConfig with WAN replication
info
- changed some method parameter names to reflect the fact that they
require the prefixed cache name. Some methods have previously
included this and this causes confusion as one cannot be sure if the
cacheName then includes the prefix or not