### PR TITLE
Fix invocation member left notification for crash-recover

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -646,7 +646,7 @@ public class ClusterJoinManager {
                 PartitionRuntimeState partitionRuntimeState = node.getPartitionService().createPartitionState();
 
                 Operation op = new FinalizeJoinOp(member.getUuid(),
-                        clusterService.getMembershipManager().createMembersView(), preJoinOp, postJoinOp,
+                        clusterService.getMembershipManager().getMembersView(), preJoinOp, postJoinOp,
                         clusterClock.getClusterTime(), clusterService.getClusterId(),
                         clusterClock.getClusterStartTime(), clusterStateManager.getState(),
                         clusterService.getClusterVersion(), partitionRuntimeState, false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -366,6 +366,9 @@ public class ClusterStateManager {
 
         } catch (Throwable e) {
             tx.rollback();
+            if (e instanceof TargetNotMemberException || e.getCause() instanceof MemberLeftException) {
+                throw new IllegalStateException("Cluster members changed during state change!", e);
+            }
             throw ExceptionUtil.rethrow(e);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -159,11 +159,8 @@ public class MembershipManager {
         return memberMapRef.get();
     }
 
+    // used in Jet, must be public
     public MembersView getMembersView() {
-        return getMemberMap().toMembersView();
-    }
-
-    MembersView createMembersView() {
         return memberMapRef.get().toMembersView();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.AssertTask;
@@ -148,7 +147,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
             }
         });
 
-        exception.expect(TargetNotMemberException.class);
+        exception.expect(IllegalStateException.class);
         hz.getCluster().changeClusterState(ClusterState.PASSIVE, options);
     }
 
@@ -324,7 +323,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         try {
             hz.getCluster().changeClusterState(ClusterState.FROZEN, options);
             fail("A member is terminated. Cannot commit the transaction!");
-        } catch (TargetNotMemberException ignored) {
+        } catch (IllegalStateException ignored) {
         }
 
         assertClusterStateEventually(ClusterState.ACTIVE, instances[2], instances[1]);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -554,7 +554,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         MemberInfo newMemberInfo = new MemberInfo(new Address("127.0.0.1", 6000), newUnsecureUuidString(),
                 Collections.<String, Object>emptyMap(), node.getVersion());
         MembersView membersView =
-                MembersView.cloneAdding(membershipManager.createMembersView(), singleton(newMemberInfo));
+                MembersView.cloneAdding(membershipManager.getMembersView(), singleton(newMemberInfo));
 
         Operation memberUpdate = new MembersUpdateOp(membershipManager.getMember(getAddress(hz3)).getUuid(),
                 membersView, clusterService.getClusterTime(), null, true);
@@ -592,7 +592,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, hz1, hz4);
         assertClusterSize(4, hz2);
 
-        hz3 = newHazelcastInstance(config, "test-instance", new StaticMemberNodeContext(member3));
+        hz3 = newHazelcastInstance(config, "test-instance", new StaticMemberNodeContext(factory, member3));
 
         assertClusterSizeEventually(4, hz1, hz4);
 
@@ -692,11 +692,11 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         return clusterService.getMembershipManager().getMemberMap();
     }
 
-    private class StaticMemberNodeContext implements NodeContext {
+    public static class StaticMemberNodeContext implements NodeContext {
         final NodeContext delegate;
-        private final MemberImpl member;
+        final MemberImpl member;
 
-        StaticMemberNodeContext(MemberImpl member) {
+        public StaticMemberNodeContext(TestHazelcastInstanceFactory factory, MemberImpl member) {
             this.member = member;
             delegate = factory.getRegistry().createNodeContext(member.getAddress());
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnMemberLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnMemberLeftTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.cluster.impl.MembershipUpdateTest.StaticMemberNodeContext;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Invocation_OnMemberLeftTest extends HazelcastTestSupport {
+
+    private OperationServiceImpl localOperationService;
+    private InvocationMonitor localInvocationMonitor;
+    private HazelcastInstance remote;
+    private MemberImpl remoteMember;
+    private TestHazelcastInstanceFactory instanceFactory;
+
+    @Before
+    public void setup() {
+        instanceFactory = createHazelcastInstanceFactory();
+        Config config = new Config();
+        config.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+
+        HazelcastInstance[] cluster = instanceFactory.newInstances(config, 2);
+
+        localOperationService = getOperationServiceImpl(cluster[0]);
+        localInvocationMonitor = localOperationService.getInvocationMonitor();
+
+        remote = cluster[1];
+        remoteMember = (MemberImpl) remote.getCluster().getLocalMember();
+    }
+
+    @Test
+    public void whenMemberLeaves() throws Exception {
+        Future<Object> future =
+                localOperationService.invokeOnTarget(null, new UnresponsiveTargetOperation(), remoteMember.getAddress());
+
+        remote.getLifecycleService().terminate();
+
+        try {
+            future.get();
+            fail("Invocation should have failed with MemberLeftException!");
+        } catch (MemberLeftException e) {
+            ignore(e);
+        }
+    }
+
+    @Test
+    public void whenMemberRestarts_withSameAddress() throws Exception {
+       whenMemberRestarts(new Runnable() {
+           @Override
+           public void run() {
+               remote = instanceFactory.newHazelcastInstance(remoteMember.getAddress());
+           }
+       });
+    }
+
+    @Test
+    public void whenMemberRestarts_withSameIdentity() throws Exception {
+        whenMemberRestarts(new Runnable() {
+            @Override
+            public void run() {
+                StaticMemberNodeContext nodeContext = new StaticMemberNodeContext(instanceFactory, remoteMember);
+                remote = newHazelcastInstance(new Config(), remoteMember.toString(), nodeContext);
+            }
+        });
+    }
+
+    private void whenMemberRestarts(Runnable restartAction) throws Exception {
+        Future<Object> futureBeforeShutdown =
+                localOperationService.invokeOnTarget(null, new UnresponsiveTargetOperation(), remoteMember.getAddress());
+
+        final CountDownLatch blockMonitorLatch = new CountDownLatch(1);
+        final CountDownLatch resumeMonitorLatch = new CountDownLatch(1);
+
+        localInvocationMonitor.execute(new Runnable() {
+            @Override
+            public void run() {
+                blockMonitorLatch.countDown();
+                assertOpenEventually(resumeMonitorLatch);
+            }
+        });
+        assertOpenEventually(blockMonitorLatch);
+
+        remote.getLifecycleService().terminate();
+        restartAction.run();
+
+        Future<Object> futureAfterRestart =
+                localOperationService.invokeOnTarget(null, new UnresponsiveTargetOperation(), remoteMember.getAddress());
+
+        resumeMonitorLatch.countDown();
+
+        try {
+            futureBeforeShutdown.get();
+            fail("Invocation should have failed with MemberLeftException!");
+        } catch (MemberLeftException e) {
+            ignore(e);
+        }
+
+        try {
+            futureAfterRestart.get(1, TimeUnit.SECONDS);
+            fail("future.get() should have failed with TimeoutException!");
+        } catch (TimeoutException e) {
+            ignore(e);
+        }
+    }
+
+    private static class UnresponsiveTargetOperation extends Operation {
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
While determining which invocations to notify during a member left event,
comparison of invocation's target and left member is done using member uuid.
Normally Hazelcast does not support crash-recover, a left member cannot rejoin
with the same uuid. Hence uuid comparison is enough.

But Hot-Restart breaks this limitation and when Hot-Restart is enabled a member
can restore its uuid and it's allowed to rejoin when cluster state is FROZEN or PASSIVE.

That's why another ordering property is needed. Invocation keeps member-list-version before
operation is submitted to the target. If a member restarts with the same identity (uuid),
by comparing member-list-version during member removal with the invocation's member-list-version
we can determine whether invocation is submitted before member left or after restart.

Before change in https://github.com/hazelcast/hazelcast/pull/11201, we were not notifying invocations when a member left in FROZEN or PASSIVE states. 

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1222