### PR TITLE
Client heartbeat monitor should only apply for owner connections

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientOwnershipTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientOwnershipTest.java
@@ -146,9 +146,9 @@ public class ClientOwnershipTest extends HazelcastTestSupport {
         assertEquals(1, endpoints.size());
         ClientEndpoint endpoint = endpoints.iterator().next();
         if (asOwner) {
-            assertTrue(endpoint.isFirstConnection());
+            assertTrue(endpoint.isOwnerConnection());
         } else {
-            assertTrue(!endpoint.isFirstConnection());
+            assertTrue(!endpoint.isOwnerConnection());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -75,7 +75,11 @@ public interface ClientEndpoint extends Client {
 
     void removeTransactionContext(String txnId);
 
-    boolean isFirstConnection();
+    /**
+     * Indicates whether this endpoint is the owner connection for that client.
+     * @return {@code true} when this endpoint is the owner connection for the client
+     */
+    boolean isOwnerConnection();
 
     Subject getSubject();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -56,7 +56,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     private LoginContext loginContext;
     private ClientPrincipal principal;
-    private boolean firstConnection;
+    private boolean ownerConnection;
     private Credentials credentials;
     private volatile boolean authenticated;
     private int clientVersion;
@@ -104,15 +104,15 @@ public final class ClientEndpointImpl implements ClientEndpoint {
         return loginContext != null ? loginContext.getSubject() : null;
     }
 
-    public boolean isFirstConnection() {
-        return firstConnection;
+    public boolean isOwnerConnection() {
+        return ownerConnection;
     }
 
     @Override
     public void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection,
                               String clientVersion, long authCorrelationId) {
         this.principal = principal;
-        this.firstConnection = firstConnection;
+        this.ownerConnection = firstConnection;
         this.credentials = credentials;
         this.authenticated = true;
         this.authenticationCorrelationId = authCorrelationId;
@@ -279,7 +279,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
         return "ClientEndpoint{"
                 + "connection=" + connection
                 + ", principal='" + principal
-                + ", firstConnection=" + firstConnection
+                + ", ownerConnection=" + ownerConnection
                 + ", authenticated=" + authenticated
                 + ", clientVersion=" + clientVersionString
                 + ", creationTime=" + creationTime

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -467,7 +467,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
                     endpoint.getClientType());
             sendClientEvent(event);
 
-            if (!endpoint.isFirstConnection()) {
+            if (!endpoint.isOwnerConnection()) {
                 logger.finest("connectionRemoved: Not the owner conn:" + connection + " for endpoint " + endpoint);
                 return;
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -98,7 +98,9 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     private void monitor(String memberUuid, ClientEndpoint clientEndpoint) {
-        if (clientEndpoint.isOwnerConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())) {
+        // C++ client sends heartbeat over its non-owner connections
+        // For other client types, disregard non-owner connections for heartbeat monitoring purposes
+        if (clientEndpoint.isOwnerConnection() == ClientType.CPP.equals(clientEndpoint.getClientType())) {
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -98,7 +98,7 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     private void monitor(String memberUuid, ClientEndpoint clientEndpoint) {
-        if (clientEndpoint.isFirstConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())) {
+        if (clientEndpoint.isOwnerConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())) {
             return;
         }
 


### PR DESCRIPTION
Reasoning: the existing condition in client heartbeat monitor was
already checking whether this memberUUID is owner of the given
clientUUID, assuming that there exists a single connection between
a member and a client. However sometimes multiple connections may
exist leading the client heartbeat monitor to close a non-owner connection.