### PR TITLE
QueryEngine tweaks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.Versions;
@@ -158,7 +159,10 @@ public abstract class AbstractMapQueryMessageTask<P, QueryResult extends Result,
                         .invoke();
                 futures.add(future);
             } catch (Throwable t) {
-                if (t.getCause() instanceof QueryResultSizeExceededException) {
+                if (!(t instanceof HazelcastException)) {
+                    // these are programmatic errors that needs to be visible
+                    throw rethrow(t);
+                } else if (t.getCause() instanceof QueryResultSizeExceededException) {
                     throw rethrow(t);
                 } else {
                     // log failure to invoke query on member at fine level

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -304,8 +304,8 @@ public abstract class AbstractMapQueryMessageTask<P, QueryResult extends Result,
                     missedPartitionsCount++;
                 }
             }
-            throw rethrow(new QueryException("Query aborted. Could not execute query for all partitions. Missed "
-                    + missedPartitionsCount + " partitions"));
+            throw new QueryException("Query aborted. Could not execute query for all partitions. Missed "
+                    + missedPartitionsCount + " partitions");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -162,6 +162,10 @@ public abstract class MapOperation extends AbstractNamedOperation implements Ide
     }
 
     protected boolean isNativeInMemoryFormat() {
+        if (mapContainer == null) {
+            // operation won't get executed in this context anyway.
+            return false;
+        }
         return mapContainer.getMapConfig().getInMemoryFormat().equals(NATIVE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -34,7 +34,6 @@ import com.hazelcast.spi.impl.AbstractNamedOperation;
 
 import java.util.List;
 
-import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.util.CollectionUtil.isEmpty;
 
 public abstract class MapOperation extends AbstractNamedOperation implements IdentifiedDataSerializable, ServiceNamespaceAware {
@@ -159,14 +158,6 @@ public abstract class MapOperation extends AbstractNamedOperation implements Ide
         } else {
             return partitionContainer.getExistingRecordStore(name);
         }
-    }
-
-    protected boolean isNativeInMemoryFormat() {
-        if (mapContainer == null) {
-            // operation won't get executed in this context anyway.
-            return false;
-        }
-        return mapContainer.getMapConfig().getInMemoryFormat().equals(NATIVE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.QueryException;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
@@ -114,6 +115,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         if (isResultFromAnyPartitionMissing(mutablePartitionIds)) {
             doRunQueryOnPartitionThreads(query, mutablePartitionIds, result);
         }
+        assertAllPartitionsQueried(mutablePartitionIds);
 
         return result;
     }
@@ -126,6 +128,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         if (isResultFromAnyPartitionMissing(mutablePartitionIds)) {
             doRunQueryOnPartitionThreads(query, mutablePartitionIds, result);
         }
+        assertAllPartitionsQueried(mutablePartitionIds);
 
         return result;
     }
@@ -150,12 +153,9 @@ public class MapQueryEngineImpl implements MapQueryEngine {
     private void dispatchQueryOnQueryThreads(Query query, Target target, Collection<Integer> partitionIds, Result result) {
         try {
             List<Future<Result>> futures = queryDispatcher.dispatchFullQueryOnQueryThread(query, target);
-            addResultsOfPredicate(futures, result, partitionIds);
+            addResultsOfPredicate(futures, result, partitionIds, false);
         } catch (Throwable t) {
-            if (t.getCause() instanceof QueryResultSizeExceededException) {
-                throw rethrow(t);
-            }
-            logger.fine("Could not get results", t);
+            throw rethrow(t);
         }
     }
 
@@ -163,7 +163,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         try {
             List<Future<Result>> futures = queryDispatcher.dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
                     query, partitionIds);
-            addResultsOfPredicate(futures, result, partitionIds);
+            addResultsOfPredicate(futures, result, partitionIds, true);
         } catch (Throwable t) {
             throw rethrow(t);
         }
@@ -172,23 +172,38 @@ public class MapQueryEngineImpl implements MapQueryEngine {
     @SuppressWarnings("unchecked")
     // modifies partitionIds list! Optimization not to allocate an extra collection with collected partitionIds
     private void addResultsOfPredicate(List<Future<Result>> futures, Result result,
-                                       Collection<Integer> partitionIds) throws ExecutionException, InterruptedException {
+                                       Collection<Integer> partitionIds, boolean rethrowAll)
+            throws ExecutionException, InterruptedException {
         for (Future<Result> future : futures) {
-            Result queryResult = future.get();
-            if (queryResult == null) {
-                continue;
-            }
-            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
-            if (queriedPartitionIds != null) {
-                if (!partitionIds.containsAll(queriedPartitionIds)) {
-                    // do not take into account results that contain partition IDs already removed from partitionIds
-                    // collection as this means that we will count results from a single partition twice
-                    // see also https://github.com/hazelcast/hazelcast/issues/6471
+            try {
+                Result queryResult = future.get();
+                if (queryResult == null) {
                     continue;
                 }
-                partitionIds.removeAll(queriedPartitionIds);
-                result.combine(queryResult);
+                Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
+                if (queriedPartitionIds != null) {
+                    if (!partitionIds.containsAll(queriedPartitionIds)) {
+                        // do not take into account results that contain partition IDs already removed from partitionIds
+                        // collection as this means that we will count results from a single partition twice
+                        // see also https://github.com/hazelcast/hazelcast/issues/6471
+                        continue;
+                    }
+                    partitionIds.removeAll(queriedPartitionIds);
+                    result.combine(queryResult);
+                }
+            } catch (Throwable t) {
+                if (t.getCause() instanceof QueryResultSizeExceededException || rethrowAll) {
+                    throw rethrow(t);
+                }
+                logger.fine("Could not get query results", t);
             }
+        }
+    }
+
+    private void assertAllPartitionsQueried(Collection<Integer> mutablePartitionIds) {
+        if (isResultFromAnyPartitionMissing(mutablePartitionIds)) {
+            throw new QueryException("Query aborted. Could not execute query for all partitions. Missed "
+                    + mutablePartitionIds.size() + " partitions");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -63,7 +63,6 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
         } else {
             result = queryRunner.runIndexOrPartitionScanQueryOnOwnedPartitions(query);
         }
-
     }
 
     private void runAsyncPartitionThreadScanForNative(QueryRunner queryRunner) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
 
@@ -145,6 +146,11 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
             return null;
         }
         return result;
+    }
+
+    private boolean isNativeInMemoryFormat() {
+        // the mapContainer may be null if the failure happens before the beforeRun of an operation (e.g. on quorum failure)
+        return mapContainer != null && mapContainer.getMapConfig().getInMemoryFormat().equals(NATIVE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -25,6 +25,8 @@ import com.hazelcast.spi.ReadonlyOperation;
 
 import java.io.IOException;
 
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+
 public class QueryPartitionOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private Query query;
@@ -41,10 +43,11 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
     @Override
     public void run() throws Exception {
         QueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
+        boolean isNativeMemoryFormat = mapContainer.getMapConfig().getInMemoryFormat().equals(NATIVE);
         // Native handling only for RU compatibility purposes, can be deleted in 3.10 master
         // An old member may send a QueryOperation (and not HDQueryOperation) to an HD member.
         // In this case we want to handle it in the most efficient way.
-        if (isNativeInMemoryFormat()) {
+        if (isNativeMemoryFormat) {
             // partition-index scan or partition-scan
             result = queryRunner.runPartitionIndexOrPartitionScanQueryOnGivenOwnedPartition(query, getPartitionId());
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -217,12 +217,11 @@ public class QueryRunner {
                                                                      Collection<Integer> partitions, int migrationStamp)
             throws InterruptedException, ExecutionException {
 
-        Collection<QueryableEntry> entries;
         if (!validateMigrationStamp(migrationStamp)) {
             return null;
         }
 
-        entries = partitionScanExecutor.execute(name, predicate, partitions);
+        Collection<QueryableEntry> entries = partitionScanExecutor.execute(name, predicate, partitions);
 
         // If a migration is in progress or migration ownership changes, this means migrations were executed and we may
         // return stale data, so we should rather return null.


### PR DESCRIPTION
Fixes #10776 (or at least attempts to get more info in case of another failure).
The failure might have been only observed if any QueryOperation or a QueryPartitionOperation has been silently ignored. 
I've added a validation if there are any partitions missing at the end of the query invocation. If so  we will know the root cause on another failure.

The commit contains:

- Do not discard all query results in case of one operation failure. 
- Checks if the query completed for all partitions, if not an exception is thrown.