### PR TITLE
Adding debug info for failing QueryCacheTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheInMemoryFormatTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheInMemoryFormatTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.map.impl.querycache.AbstractQueryCacheTestSupport.getMap;
 import static org.junit.Assert.assertEquals;
 
@@ -52,7 +53,7 @@ public class QueryCacheInMemoryFormatTest extends HazelcastTestSupport {
     @Test
     public void testBinaryFormat_deserializeMoreTime() {
         int expectedDeserializationCount = 10;
-        testInMemoryFormat(InMemoryFormat.BINARY, expectedDeserializationCount);
+        testInMemoryFormat(BINARY, expectedDeserializationCount);
     }
 
     private void testInMemoryFormat(InMemoryFormat inMemoryFormat, int expectedDeserializationCount) {
@@ -75,11 +76,14 @@ public class QueryCacheInMemoryFormatTest extends HazelcastTestSupport {
         IMap<Integer, SerializableObject> map = getMap(node, mapName);
 
         map.put(1, new SerializableObject());
+        assertEquals(0, SerializableObject.deserializationCount.get());
 
         QueryCache<Integer, SerializableObject> cache = map.getQueryCache(cacheName);
 
         for (int i = 0; i < 10; i++) {
             cache.get(1);
+            int expectedInitialCountInLoop = inMemoryFormat == BINARY ? i + 1 : 1;
+            assertEquals("Error on iteration " + i, expectedInitialCountInLoop, SerializableObject.deserializationCount.get());
         }
 
         assertEquals(expectedDeserializationCount, SerializableObject.deserializationCount.get());
@@ -91,6 +95,7 @@ public class QueryCacheInMemoryFormatTest extends HazelcastTestSupport {
 
         private void readObject(java.io.ObjectInputStream stream) throws IOException, ClassNotFoundException {
             deserializationCount.incrementAndGet();
+            Thread.dumpStack();
         }
     }
 }


### PR DESCRIPTION
Add some debug info for #10627.
The test mail fail anyway, for example when the put operation gets invoked more than once which is perfectly possible. So the test may fail and that may be a correct result.
We will know at what stage the deserialization was invoked and we will see the frame.