### PR TITLE
[BACKPORT] Fix ScheduledFutureProxy partition & member listener leak (#11274)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
@@ -63,10 +63,10 @@ public class ClientScheduledFutureProxy<V>
 
     private ScheduledTaskHandler handler;
 
-    public ClientScheduledFutureProxy(ScheduledTaskHandler handler, ClientContext context) {
+    ClientScheduledFutureProxy(ScheduledTaskHandler handler, ClientContext context) {
         super(DistributedScheduledExecutorService.SERVICE_NAME, handler.getSchedulerName());
-        setContext(context);
         this.handler = handler;
+        setContext(context);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionLostListenerTest.java
@@ -76,8 +76,8 @@ public class ClientPartitionLostListenerTest {
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         client.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-
-        assertRegistrationsSizeEventually(instance, 1);
+        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 2);
     }
 
     @Test
@@ -86,10 +86,12 @@ public class ClientPartitionLostListenerTest {
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         final String registrationId = client.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        assertRegistrationsSizeEventually(instance, 1);
+        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 2);
 
         client.getPartitionService().removePartitionLostListener(registrationId);
-        assertRegistrationsSizeEventually(instance, 0);
+        // Expected = 1 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 1);
     }
 
     @Test
@@ -101,8 +103,8 @@ public class ClientPartitionLostListenerTest {
         final EventCollectingPartitionLostListener listener = new EventCollectingPartitionLostListener();
 
         client.getPartitionService().addPartitionLostListener(listener);
-
-        assertRegistrationsSizeEventually(instance, 1);
+        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 2);
 
         final InternalPartitionServiceImpl partitionService = getNode(instance).getNodeEngine().getService(SERVICE_NAME);
         final int partitionId = 5;
@@ -127,9 +129,10 @@ public class ClientPartitionLostListenerTest {
 
         final EventCollectingPartitionLostListener listener = new EventCollectingPartitionLostListener();
         client.getPartitionService().addPartitionLostListener(listener);
-
-        assertRegistrationsSizeEventually(instance1, 1);
-        assertRegistrationsSizeEventually(instance2, 1);
+        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // * instances
+        assertRegistrationsSizeEventually(instance1, 3);
+        assertRegistrationsSizeEventually(instance2, 3);
 
         final InternalPartitionServiceImpl partitionService = getNode(other).getNodeEngine().getService(SERVICE_NAME);
         final int partitionId = 5;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
@@ -25,8 +25,12 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -50,5 +54,18 @@ public class ClientScheduledExecutorServiceBasicTest extends ScheduledExecutorSe
     @Override
     public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
         return factory.newHazelcastClient().getScheduledExecutorService(name);
+    }
+
+    @Override
+    @Test()
+    @Ignore("Never supported feature")
+    public void schedule_testPartitionLostEvent() {
+    }
+
+    @Override
+    @Test
+    @Ignore("Never supported feature")
+    public void scheduleOnMember_testMemberLostEvent()
+            throws ExecutionException, InterruptedException {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledFuture.java
@@ -78,4 +78,5 @@ public interface IScheduledFuture<V>
      * {@code true
      */
     boolean cancel(boolean mayInterruptIfRunning);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
@@ -63,7 +63,6 @@ public class ScheduledExecutorServiceProxy
         extends AbstractDistributedObject<DistributedScheduledExecutorService>
         implements IScheduledExecutorService {
 
-    private static final int GET_ALL_SCHEDULED_TIMEOUT = 10;
     private static final int SHUTDOWN_TIMEOUT = 10;
 
     private static final FutureUtil.ExceptionHandler WHILE_SHUTDOWN_EXCEPTION_HANDLER =
@@ -283,7 +282,7 @@ public class ScheduledExecutorServiceProxy
     public IScheduledFuture<?> getScheduledFuture(ScheduledTaskHandler handler) {
         checkNotNull(handler, "Handler is null");
 
-        ScheduledFutureProxy proxy = new ScheduledFutureProxy(handler);
+        ScheduledFutureProxy proxy = new ScheduledFutureProxy(handler, this);
         attachHazelcastInstance(proxy);
         return proxy;
     }
@@ -357,7 +356,7 @@ public class ScheduledExecutorServiceProxy
             List<IScheduledFuture<V>> futures = new ArrayList<IScheduledFuture<V>>();
 
             for (ScheduledTaskHandler handler : handlers) {
-                IScheduledFuture future = new ScheduledFutureProxy(handler);
+                IScheduledFuture future = new ScheduledFutureProxy(handler, this);
                 attachHazelcastInstance(future);
                 futures.add(future);
             }
@@ -379,14 +378,14 @@ public class ScheduledExecutorServiceProxy
 
     private <V> IScheduledFuture<V> createFutureProxy(int partitionId, String taskName) {
         ScheduledFutureProxy proxy = new ScheduledFutureProxy(
-                ScheduledTaskHandlerImpl.of(partitionId, getName(), taskName));
+                ScheduledTaskHandlerImpl.of(partitionId, getName(), taskName), this);
         proxy.setHazelcastInstance(getNodeEngine().getHazelcastInstance());
         return proxy;
     }
 
     private <V> IScheduledFuture<V> createFutureProxy(Address address, String taskName) {
         ScheduledFutureProxy proxy = new ScheduledFutureProxy(
-                ScheduledTaskHandlerImpl.of(address, getName(), taskName));
+                ScheduledTaskHandlerImpl.of(address, getName(), taskName), this);
         proxy.setHazelcastInstance(getNodeEngine().getHazelcastInstance());
         return proxy;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -386,15 +386,18 @@ public class BasicClusterStateTest
     }
 
     @Test
-    public void test_listener_registration_whenClusterState_PASSIVE() {
+    public void
+    test_listener_registration_whenClusterState_PASSIVE() {
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance master = factory.newHazelcastInstance();
         final HazelcastInstance other = factory.newHazelcastInstance();
 
         changeClusterStateEventually(master, ClusterState.PASSIVE);
         master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 1);
-        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 1);
+        // Expected = 2 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // * instances
+        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
+        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
     }
 
     @Test
@@ -404,14 +407,16 @@ public class BasicClusterStateTest
         final HazelcastInstance other = factory.newHazelcastInstance();
 
         final String registrationId = master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 1);
-        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 1);
+        // Expected = 3 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // * instances
+        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
+        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
 
         changeClusterStateEventually(master, ClusterState.PASSIVE);
         master.getPartitionService().removePartitionLostListener(registrationId);
-
-        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 0);
-        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 0);
+        // Expected = 2 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService} * instances
+        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 2);
+        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 2);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerRegistrationTest.java
@@ -59,7 +59,8 @@ public class PartitionLostListenerRegistrationTest
         final String id = instance.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
         assertNotNull(id);
 
-        assertRegistrationsSizeEventually(instance, 1);
+        // Expected = 2 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 2);
     }
 
     @Test
@@ -68,7 +69,8 @@ public class PartitionLostListenerRegistrationTest
         config.addListenerConfig(new ListenerConfig(mock(PartitionLostListener.class)));
 
         final HazelcastInstance instance = createHazelcastInstance(config);
-        assertRegistrationsSizeEventually(instance, 1);
+        // Expected = 2 -> 1 from config + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 2);
     }
 
     private void assertRegistrationsSizeEventually(final HazelcastInstance instance, final int expectedSize) {
@@ -99,7 +101,8 @@ public class PartitionLostListenerRegistrationTest
         final String id2 = partitionService.addPartitionLostListener(listener);
 
         assertNotEquals(id1, id2);
-        assertRegistrationsSizeEventually(instance, 2);
+        // Expected = 3 -> 2 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 3);
     }
 
     @Test
@@ -113,7 +116,8 @@ public class PartitionLostListenerRegistrationTest
         final boolean result = partitionService.removePartitionLostListener(id1);
 
         assertTrue(result);
-        assertRegistrationsSizeEventually(instance, 0);
+        // Expected = 1 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        assertRegistrationsSizeEventually(instance, 1);
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -572,13 +572,18 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
         executorService.schedule(new PlainCallableTask(), delay, SECONDS);
     }
     @Test()
-    public void schedule_whenPartitionLost()
+    public void schedule_testPartitionLostEvent()
             throws ExecutionException, InterruptedException {
         int delay = 1;
 
-        HazelcastInstance[] instances = createClusterWithCount(2);
+        HazelcastInstance[] instances = createClusterWithCount(1);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         final IScheduledFuture future = executorService.schedule(new PlainCallableTask(), delay, SECONDS);
+
+        // Used to make sure both futures (on the same handler) get the event. Catching possible equal/hashcode issues in the Map
+        final IScheduledFuture futureCopeInstance = (IScheduledFuture) ((List) executorService.getAllScheduledFutures()
+                                                                                              .values().toArray()[0]).get(0);
+
         ScheduledTaskHandler handler = future.getHandler();
 
         int partitionOwner = handler.getPartitionId();
@@ -591,8 +596,46 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
                     throws Exception {
                 try {
                     future.get();
+                    fail();
                 } catch (IllegalStateException ex) {
-                    assertEquals("Partition holding this Scheduled task was lost along with all backups.",
+                    try {
+                        futureCopeInstance.get();
+                        fail();
+                    } catch (IllegalStateException ex2) {
+                        assertEquals("Partition holding this Scheduled task was lost along with all backups.",
+                                ex.getMessage());
+                        assertEquals("Partition holding this Scheduled task was lost along with all backups.",
+                                ex2.getMessage());
+                    }
+
+                }
+            }
+        });
+    }
+
+    @Test()
+    public void scheduleOnMember_testMemberLostEvent()
+            throws ExecutionException, InterruptedException {
+        int delay = 1;
+
+        HazelcastInstance[] instances = createClusterWithCount(2);
+        Member member = instances[1].getCluster().getLocalMember();
+
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        final IScheduledFuture future = executorService.scheduleOnMember(new PlainCallableTask(),
+                member, delay, SECONDS);
+
+        instances[1].getLifecycleService().terminate();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                try {
+                    future.get();
+                    fail();
+                } catch (IllegalStateException ex) {
+                    assertEquals("Member holding this Scheduled task was removed from the cluster.",
                             ex.getMessage());
                 }
             }
@@ -820,7 +863,7 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
         ScheduledTaskHandler handler = first.getHandler();
         IScheduledFuture<Double> copy = executorService.getScheduledFuture(handler);
 
-        assertEquals(first, copy);
+        assertEquals(first.getHandler(), copy.getHandler());
     }
 
     @Test
@@ -914,6 +957,13 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
         expected.expect(ExecutionException.class);
         expected.expectCause(new RootCauseMatcher(IllegalStateException.class, "Erroneous task"));
         Object result = future.get();
+    }
+
+    @Test
+    public void managedContext_whenLocalExecution() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IScheduledExecutorService s = instance.getScheduledExecutorService("s");
+        s.schedule(new PlainCallableTask(), 0, SECONDS);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -378,4 +378,5 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
             }
         }
     }
+
 }


### PR DESCRIPTION
When creating a ScheduledFutureProxy it listens for partition & member loss events.
These listeners only get unregistered when the Future at hand, is disposed. However,
lots of use-cases demonstrate that the original Future is ignored. Instead, calls to
scheduler.getAllScheduled() are utilized to fetch all running tasks, and dispose the
finished ones. This, creates even more proxy objects, all following the same practise,
registering themselves as listeners, therefore they can't be garbage collected.

This patch, introduces a middle-man who acts as the sole & universal listener for those
events, the service itself, and all FutureProxy objects, are weakly referred from within
this class.

The contract of the ScheduledFutureProxy has changed to reflect j.u.c.FutureTask which
uses reference-equality. This also allows the weak reference collection to work as designed.

Note: This change makes the ScheduledExecutorService listener on partition & member loss
events. This is regardless if its in use or not.
(cherry picked from commit 5b8632553391543693d7a87c5d29cdea51293447)