### PR TITLE
Introduce synchronous hook for member list changes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -287,6 +287,10 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void onMemberListChange() {
+    }
+
+    @Override
     public void onClusterVersionChange(Version newVersion) {
         systemLogger.info("Cluster version set to " + newVersion);
         ServiceManager serviceManager = node.getNodeEngine().getServiceManager();

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -194,9 +194,14 @@ public interface NodeExtension {
     void onClusterStateChange(ClusterState newState, boolean isTransient);
 
     /**
-     * Called when partition state (partition assignments, version etc) changes
+     * Called synchronously when partition state (partition assignments, version etc) changes
      */
     void onPartitionStateChange();
+
+    /**
+     * Called synchronously when member list changes
+     */
+    void onMemberListChange();
 
     /**
      * Called after cluster version is changed.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -581,32 +581,23 @@ public class MembershipManager {
     }
 
     void onMemberRemove(MemberImpl deadMember) {
-        // sync call
+        // sync calls
         node.getPartitionService().memberRemoved(deadMember);
-        // sync call
         nodeEngine.onMemberLeft(deadMember);
+        node.getNodeExtension().onMemberListChange();
     }
 
     void sendMembershipEvents(Collection<MemberImpl> currentMembers, Collection<MemberImpl> newMembers) {
         Set<Member> eventMembers = new LinkedHashSet<Member>(currentMembers);
         if (!newMembers.isEmpty()) {
-            if (newMembers.size() == 1) {
-                MemberImpl newMember = newMembers.iterator().next();
-                // sync call
+            for (MemberImpl newMember : newMembers) {
+                // sync calls
                 node.getPartitionService().memberAdded(newMember);
+                node.getNodeExtension().onMemberListChange();
 
                 // async events
                 eventMembers.add(newMember);
-                sendMembershipEventNotifications(newMember, unmodifiableSet(eventMembers), true);
-            } else {
-                for (MemberImpl newMember : newMembers) {
-                    // sync call
-                    node.getPartitionService().memberAdded(newMember);
-
-                    // async events
-                    eventMembers.add(newMember);
-                    sendMembershipEventNotifications(newMember, unmodifiableSet(new LinkedHashSet<Member>(eventMembers)), true);
-                }
+                sendMembershipEventNotifications(newMember, unmodifiableSet(new LinkedHashSet<Member>(eventMembers)), true);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -165,6 +165,11 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void onMemberListChange() {
+        nodeExtension.onMemberListChange();
+    }
+
+    @Override
     public void onClusterVersionChange(Version newVersion) {
         nodeExtension.onClusterVersionChange(newVersion);
     }


### PR DESCRIPTION
Similar to partition table updates, a synchronous hook is needed in
NodeExtension for hot restart.

Required for https://github.com/hazelcast/hazelcast-enterprise/issues/1577