### PR TITLE
Do not fail with IndeterminateOperationStateException for read-only operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.partition.IPartition;
 
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
@@ -53,7 +54,9 @@ final class PartitionInvocation extends Invocation {
 
     @Override
     ExceptionAction onException(Throwable t) {
-        if (shouldFailOnIndeterminateOperationState() && (t instanceof MemberLeftException)) {
+        if (shouldFailOnIndeterminateOperationState()
+                && (t instanceof MemberLeftException)
+                && !(op instanceof ReadonlyOperation)) {
             return THROW_EXCEPTION;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
@@ -106,7 +106,8 @@ public final class PacketFiltersUtil {
 
         final int factory;
 
-        final IntHashSet types = new IntHashSet(1024, 0);
+        // Integer.MIN_VALUE is used for missing value
+        final IntHashSet types = new IntHashSet(1024, Integer.MIN_VALUE);
 
         EndpointAgnosticPacketFilter(InternalSerializationService serializationService, int factory, List<Integer> typeIds) {
             super(serializationService);


### PR DESCRIPTION

IndeterminateOperationStateException applies to operations that mutate a partition.