### PR TITLE
[BACKPORT] Assert that Jsr(Client)TestUtil is not used in ParallelTest classes

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearSystemProperties;
 import static com.hazelcast.cache.jsr.JsrTestUtil.setSystemProperties;
+import static com.hazelcast.test.HazelcastTestSupport.assertThatIsNoParallelTest;
 
 /**
  * utility class responsible for setup/cleanup client jsr tests
@@ -31,10 +32,12 @@ import static com.hazelcast.cache.jsr.JsrTestUtil.setSystemProperties;
 public class JsrClientTestUtil {
 
     public static void setup() {
+        assertThatIsNoParallelTest();
         setSystemProperties("client");
     }
 
     public static void setupWithHazelcastInstance() {
+        assertThatIsNoParallelTest();
         setSystemProperties("client");
 
         Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertThatIsNoParallelTest;
 import static java.lang.String.format;
 import static org.junit.Assert.fail;
 
@@ -48,6 +49,7 @@ public final class JsrTestUtil {
     }
 
     public static void setup() {
+        assertThatIsNoParallelTest();
         setSystemProperties("server");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withParallelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withParallelTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TestCategoriesTest_withParallelTest extends HazelcastTestSupport {
+
+    @Test
+    public void testGetTestCategories() {
+        HashSet<Class<?>> testCategories = getTestCategories();
+        assertEquals("Expected a two test categories", 2, testCategories.size());
+        assertTrue("Expected to find a QuickTest category", testCategories.contains(QuickTest.class));
+        assertTrue("Expected to find a ParallelTest category", testCategories.contains(ParallelTest.class));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAssertThatIsNoParallelTest() {
+        assertThatIsNoParallelTest();
+        throw new RuntimeException("Expected an AssertionError on this ParallelTest");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withSerialTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withSerialTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class TestCategoriesTest_withSerialTest extends HazelcastTestSupport {
+
+    @Test
+    public void testGetTestCategories() {
+        HashSet<Class<?>> testCategories = getTestCategories();
+        assertEquals("Expected a single test category", 1, testCategories.size());
+        assertTrue("Expected to find a QuickTest category", testCategories.contains(QuickTest.class));
+    }
+
+    @Test
+    public void testAssertThatIsNoParallelTest() {
+        try {
+            assertThatIsNoParallelTest();
+        } catch (AssertionError e) {
+            fail("Expected no exception on this non ParallelTest");
+        }
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/11295

(cherry picked from commit 703f658)