### PR TITLE
Handled near cache compatibility for versions smaller than 3.8

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.spi;
 
+import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
@@ -27,13 +29,15 @@ import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.util.Collection;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.instance.BuildInfo.UNKNOWN_HAZELCAST_VERSION;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * Base class for client proxies.
- *
+ * <p>
  * Allows the client to proxy operations through member nodes.
  */
 public abstract class ClientProxy implements DistributedObject {
@@ -99,6 +103,17 @@ public abstract class ClientProxy implements DistributedObject {
 
     protected final HazelcastClientInstanceImpl getClient() {
         return (HazelcastClientInstanceImpl) getContext().getHazelcastInstance();
+    }
+
+    protected final int getConnectedServerVersion() {
+        HazelcastClientInstanceImpl client = getClient();
+        ClientConnectionManager connectionManager = client.getConnectionManager();
+        Collection<ClientConnection> activeConnections = connectionManager.getActiveConnections();
+        for (ClientConnection connection : activeConnections) {
+            return connection.getConnectedServerVersion();
+        }
+
+        return UNKNOWN_HAZELCAST_VERSION;
     }
 
     @Deprecated

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingHandler.java
@@ -41,14 +41,14 @@ import static java.lang.String.format;
  */
 public final class RepairingHandler {
 
+    private final int partitionCount;
+    private final boolean serializeKeys;
     private final ILogger logger;
     private final String localUuid;
     private final String name;
     private final NearCache nearCache;
-    private final boolean serializeKeys;
     private final SerializationService serializationService;
     private final MinimalPartitionService partitionService;
-    private final int partitionCount;
     private final MetaDataContainer[] metaDataContainers;
 
     public RepairingHandler(ILogger logger, String localUuid, String name, NearCache nearCache,


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/11343

A latest [fix](https://github.com/hazelcast/hazelcast/pull/11003) was caused this regression. The near cache invalidation listener has 2 modes: one for the versions < 3.8 and one for the versions >= 3.8. 
In this PR, after getting version of connected server, we provide only one mode can work and other one stays untouched and doesn't try to work unnecessarily. 

As a result, we shouldn't see any noise in the logs due to the operation retries of an incompatible mode.




