### PR TITLE
[WIP] Keep connection in connections map under remote address

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -231,7 +231,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
             return false;
         }
 
-        connection.setEndPoint(remoteEndPoint);
+        //connection.setEndPoint(remoteEndPoint);
         ioService.onSuccessfulConnection(remoteEndPoint);
         if (reply) {
             sendBindRequest(connection, remoteEndPoint, false);
@@ -302,18 +302,18 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
             if (connection instanceof TcpIpConnection) {
                 TcpIpConnection tcpConnection = (TcpIpConnection) connection;
                 Address currentEndPoint = tcpConnection.getEndPoint();
-                if (currentEndPoint != null && !currentEndPoint.equals(remoteEndPoint)) {
-                    throw new IllegalArgumentException(connection + " has already a different endpoint than: "
-                            + remoteEndPoint);
-                }
-                tcpConnection.setEndPoint(remoteEndPoint);
+//                if (currentEndPoint != null && !currentEndPoint.equals(remoteEndPoint)) {
+//                    throw new IllegalArgumentException(connection + " has already a different endpoint than: "
+//                            + remoteEndPoint);
+//                }
+//                tcpConnection.setEndPoint(remoteEndPoint);
 
                 if (!connection.isClient()) {
                     TcpIpConnectionErrorHandler connectionMonitor = getErrorHandler(remoteEndPoint, true);
                     tcpConnection.setErrorHandler(connectionMonitor);
                 }
             }
-            connectionsMap.put(remoteEndPoint, connection);
+            connectionsMap.put(connection.getEndPoint(), connection);
 
             ioService.getEventService().executeEventCallback(new StripedRunnable() {
                 @Override


### PR DESCRIPTION
This occurs if the endpoint is under NAT and it binds to one address
but we connect to an another. We first try connecting to the public
address on the NAT.
If we disable binding checks with
`-Dhazelcast.nio.tcp.spoofing.checks=false`
`-Dhazelcast.socket.client.bind.any=false`
then the connection gets established but the connection will be put
in the connections map under the endpoint bind address (the address
that the endpoint sees behind the NAT), not under the
address to which we requested the connection to be established.

Alternatively, this could be fixed by setting the public address in
the configuration for both sides of the connection but this could
complicate deployment as we don't know the public address in advance
(e.g. AWS).

Fixes : https://github.com/hazelcast/hazelcast/issues/11256