### PR TITLE
Add test checking how many instances of Discovery Strategies were created

### DIFF
--- a/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,2 +1,3 @@
 com.hazelcast.spi.discovery.DiscoverySpiTest$TestDiscoveryStrategyFactory
 com.hazelcast.spi.discovery.DiscoverySpiTest$MetadataProvidingDiscoveryStrategyFactory
+com.hazelcast.spi.discovery.DiscoverySpiTest$ParametrizedDiscoveryStrategyFactory


### PR DESCRIPTION
There was a bug when a discovery strategy factory was auto-registered via
META-INF/service/* and the same strategy factory was  also explicitly
configured then Hazelcast would have created 2 instances of the same strategy.

This bug was fixed as a side-effect of https://github.com/hazelcast/hazelcast/pull/11121
This PR is just adding an explicit test