### PR TITLE
fix retry count of the async reconnect test

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -179,12 +179,9 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-
-        assertTrue(client.getLifecycleService().isRunning());
-
-        hazelcastInstance.shutdown();
 
         client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
             @Override
@@ -195,8 +192,11 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
             }
         });
 
+        hazelcastInstance.shutdown();
+
         hazelcastFactory.newHazelcastInstance();
 
+        assertTrue(client.getLifecycleService().isRunning());
         assertOpenEventually(reconnectedLatch);
 
         client.getMap(randomMapName());


### PR DESCRIPTION
The retry count was the default value 2 which quickly used and client shutdowns before the member  restart. So we should increase the ConnectionAttemptLimit to max. 

fixes #10810 