### PR TITLE
reverted previous fix and updated test-coverage's surefire plugin

### DIFF
--- a/hazelcast-all/src/test/java/com/hazelcast/it/CheckAllDependenciesIT.java
+++ b/hazelcast-all/src/test/java/com/hazelcast/it/CheckAllDependenciesIT.java
@@ -6,6 +6,6 @@ public class CheckAllDependenciesIT extends CheckDependenciesIT {
 
     @Override
     protected boolean isMatching(String urlString) {
-        return urlString.contains("hazelcast/hazelcast/") && !urlString.contains("test");
+        return urlString.contains("hazelcast-all-") && urlString.contains("target");
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/osgi/ClientCheckDependenciesIT.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/osgi/ClientCheckDependenciesIT.java
@@ -6,6 +6,6 @@ public class ClientCheckDependenciesIT extends CheckDependenciesIT {
 
     @Override
     protected boolean isMatching(String urlString) {
-        return urlString.contains("hazelcast-client/target/classes/META-INF/MANIFEST.MF");
+        return urlString.contains("hazelcast-client-") && urlString.contains("target");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -8,7 +8,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.felix.utils.manifest.Clause;
 import org.apache.felix.utils.manifest.Parser;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -23,8 +22,9 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-@Ignore
 public class CheckDependenciesIT extends HazelcastTestSupport {
+
+
     private static final String MANIFEST_PATH = "META-INF/MANIFEST.MF";
     private static final String[] WHITELIST_PREFIXES = new String[]{
 
@@ -117,6 +117,6 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
     }
 
     protected boolean isMatching(String urlString) {
-        return urlString.contains("hazelcast/target/classes/META-INF/MANIFEST.MF");
+        return urlString.contains("hazelcast-3.") && urlString.contains("target");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -591,6 +591,9 @@
                             <includes>
                                 <include>**/*.java</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/**IT.java</exclude>
+                            </excludes>
                             <groups>
                                 com.hazelcast.test.annotation.QuickTest,
                                 com.hazelcast.test.annotation.SlowTest
@@ -987,6 +990,7 @@
                                 <include>**/**.java</include>
                             </includes>
                             <excludes>
+                                <exclude>**/**IT.java</exclude>
                                 <exclude>**/jsr/**.java</exclude>
                             </excludes>
                             <groups>


### PR DESCRIPTION
this PR is reverted version of https://github.com/hazelcast/hazelcast/pull/11215. 

After https://github.com/hazelcast/hazelcast/pull/11215 is merged, our nightly and deploy builds started to fail. When I run these tests at my local, they passed with `surefire-plugin` but with `fail-safe plugin` they failed. --> `mvn failsafe:integration-test ` , so i have reverted `urlString`s to old version.

This PR excludes integration tests from `test-coverage---surefire-plugin`, in this way sonar build runs IT tests only with `fail-safe-plugin`.

fixes #11093
