### PR TITLE
[wip] Backport PR #11226

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
@@ -16,7 +16,8 @@
 
 package com.hazelcast.client.connection;
 
-import java.net.InetSocketAddress;
+import com.hazelcast.nio.Address;
+
 import java.util.Collection;
 
 /**
@@ -25,8 +26,8 @@ import java.util.Collection;
 public interface AddressProvider {
 
     /**
-     * @return Collection of InetSocketAddress
+     * @return The possible member addresses to connect to.
      */
-    Collection<InetSocketAddress> loadAddresses();
+    Collection<Address> loadAddresses();
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
@@ -22,8 +22,8 @@ import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,10 +45,10 @@ public class AwsAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         updateLookupTable();
         final Map<String, String> lookupTable = getLookupTable();
-        final Collection<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(lookupTable.size());
+        final Collection<Address> addresses = new ArrayList<Address>(lookupTable.size());
 
         for (String privateAddress : lookupTable.keySet()) {
             addresses.addAll(AddressHelper.getSocketAddresses(privateAddress));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -19,8 +19,8 @@ package com.hazelcast.client.spi.impl;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
+import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,16 +41,16 @@ public class DefaultAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         final List<String> addresses = networkConfig.getAddresses();
         if (addresses.isEmpty() && noOtherAddressProviderExist) {
-            addresses.add("localhost");
+            addresses.add("127.0.0.1");
         }
-        final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
+        final List<Address> possibleAddresses = new LinkedList<Address>();
 
         for (String address : addresses) {
-            socketAddresses.addAll(AddressHelper.getSocketAddresses(address));
+            possibleAddresses.addAll(AddressHelper.getSocketAddresses(address));
         }
-        return socketAddresses;
+        return possibleAddresses;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -23,8 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -42,18 +40,13 @@ public class DiscoveryAddressProvider
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
                 "Discovered nodes cannot be null!");
 
-        Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
+        Collection<Address> possibleMembers = new ArrayList<Address>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {
-            Address discoveredAddress = discoveryNode.getPrivateAddress();
-            try {
-                possibleMembers.add(discoveredAddress.getInetSocketAddress());
-            } catch (UnknownHostException e) {
-                logger.warning("Unresolvable host exception", e);
-            }
+            possibleMembers.add(discoveryNode.getPrivateAddress());
         }
         return possibleMembers;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.util;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_CONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Helper class for the user to track the lifecycle state of the client.
+ * The user will instantiate this listener and it will be registered to the client configuration.
+ * If the provided client config is not used while instantiating the client, this helper class
+ * will not be useful. It is the user's responsibility to instantiate the client with the same
+ * ClientConfig which was used to instantiate this helper.
+ */
+public class ClientStateListener
+        implements LifecycleListener {
+    private LifecycleEvent.LifecycleState currentState = STARTING;
+
+    private final Lock lock = new ReentrantLock();
+    private final Condition connectedCondition = lock.newCondition();
+    private final Condition disconnectedCondition = lock.newCondition();
+
+    /**
+     * Registers this instance with the provided client configuration
+     *
+     * @param clientConfig The client configuration to which this listener will be registered
+     */
+    public ClientStateListener(ClientConfig clientConfig) {
+        clientConfig.addListenerConfig(new ListenerConfig(this));
+    }
+
+    @Override
+    public void stateChanged(LifecycleEvent event) {
+        lock.lock();
+        try {
+            currentState = event.getState();
+            if (currentState.equals(CLIENT_CONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                connectedCondition.signalAll();
+            } else if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState
+                    .equals(SHUTDOWN)) {
+                disconnectedCondition.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits until the client is connected to cluster or the timeout expires.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the time unit of the {@code timeout} argument
+     * @return true if the client is connected to the cluster. On returning false,
+     * you can check if timeout occured or the client is shutdown using {@code isShutdown} {@code getCurrentState}
+     * @throws InterruptedException
+     */
+    public boolean awaitConnected(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        lock.lock();
+        try {
+            if (currentState.equals(CLIENT_CONNECTED)) {
+                return true;
+            }
+
+            if (currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                return false;
+            }
+
+            long duration = unit.toNanos(timeout);
+            while (duration > 0) {
+                duration = connectedCondition.awaitNanos(duration);
+
+                if (currentState.equals(CLIENT_CONNECTED)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits until the client is connected to cluster.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @return returns whatever {@code awaitConnected(long timeout, TimeUnit unit)} returns.
+     * @throws InterruptedException
+     */
+    public boolean awaitConnected()
+            throws InterruptedException {
+        return awaitConnected(Long.MAX_VALUE, MILLISECONDS);
+    }
+
+    /**
+     * Waits until the client is disconnected from the cluster or the timeout expires.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the time unit of the {@code timeout} argument
+     * @return true if the client is disconnected to the cluster. On returning false,
+     * you can check if timeout occured or the client is shutdown using {@code isShutdown} {@code getCurrentState}
+     * @throws InterruptedException
+     */
+    public boolean awaitDisconnected(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        lock.lock();
+        try {
+            if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState.equals(SHUTDOWN)) {
+                return true;
+            }
+
+            long duration = unit.toNanos(timeout);
+            while (duration > 0) {
+                duration = disconnectedCondition.awaitNanos(duration);
+
+                if (currentState.equals(CLIENT_DISCONNECTED) || currentState.equals(SHUTTING_DOWN) || currentState
+                        .equals(SHUTDOWN)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Waits until the client is disconnected from the cluster.
+     * Does not wait if the client is already shutting down or shutdown.
+     *
+     * @return returns whatever {@code awaitDisconnected(long timeout, TimeUnit unit)} returns.
+     * @throws InterruptedException
+     */
+    public boolean awaitDisconnected()
+            throws InterruptedException {
+        return awaitDisconnected(Long.MAX_VALUE, MILLISECONDS);
+    }
+
+    /**
+     * @return true if the client is connected.
+     */
+    public boolean isConnected() {
+        lock.lock();
+        try {
+            return currentState.equals(CLIENT_CONNECTED);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @return true if the client is shutdown.
+     */
+    public boolean isShutdown() {
+        lock.lock();
+        try {
+            return currentState.equals(SHUTDOWN);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @return true if the client is started.
+     */
+    public boolean isStarted() {
+        lock.lock();
+        try {
+            return currentState.equals(STARTED) || currentState.equals(CLIENT_CONNECTED) || currentState
+                    .equals(CLIENT_DISCONNECTED);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @return The current lifecycle state of the client.
+     */
+    public LifecycleEvent.LifecycleState getCurrentState() {
+        lock.lock();
+        try {
+            return currentState;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -106,12 +106,12 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         config.getNetworkConfig().setSmartRouting(false);
 
-        InetSocketAddress socketAddress1 = server1.getCluster().getLocalMember().getSocketAddress();
-        InetSocketAddress socketAddress2 = server2.getCluster().getLocalMember().getSocketAddress();
+        Address address1 = server1.getCluster().getLocalMember().getAddress();
+        Address address2 = server2.getCluster().getLocalMember().getAddress();
 
         config.getNetworkConfig().
-                addAddress(socketAddress1.getHostName() + ":" + socketAddress1.getPort()).
-                addAddress(socketAddress2.getHostName() + ":" + socketAddress2.getPort());
+                addAddress(address1.getHost() + ":" + address1.getPort()).
+                addAddress(address2.getHost() + ":" + address2.getPort());
 
         hazelcastFactory.newHazelcastClient(config);
 
@@ -133,7 +133,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
         connectionManager.addConnectionListener(listener);
 
-        final Address serverAddress = new Address(server.getCluster().getLocalMember().getSocketAddress());
+        final Address serverAddress = server.getCluster().getLocalMember().getAddress();
         final Connection connectionToServer = connectionManager.getConnection(serverAddress);
 
         final CountDownLatch isConnected = new CountDownLatch(1);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -362,8 +362,7 @@ public class ClientServiceTest extends ClientTestSupport {
             map.put(randomString(), randomString());
         }
         HazelcastClientInstanceImpl clientInstanceImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
-        InetSocketAddress socketAddress = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
-        Address address = new Address(socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+        Address address = hazelcastInstance.getCluster().getLocalMember().getAddress();
         ClientConnectionManager connectionManager = clientInstanceImpl.getConnectionManager();
         final ClientConnection connection = (ClientConnection) connectionManager.getConnection(address);
         assertTrueEventually(new AssertTask() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.nio.Address;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -33,7 +34,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
@@ -124,10 +124,10 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     private void configureDummyClientConnection(HazelcastInstance instance) throws UnknownHostException {
-        InetSocketAddress socketAddress = getAddress(instance).getInetSocketAddress();
+        Address memberAddress = getAddress(instance);
         dummyClientConfig.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         ClientNetworkConfig networkConfig = dummyClientConfig.getNetworkConfig();
-        networkConfig.addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+        networkConfig.addAddress(memberAddress.getHost() + ":" + memberAddress.getPort());
     }
 
     private List<HazelcastInstance> createNodes(int numberOfLiteNodes, int numberOfDataNodes) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -33,7 +33,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -104,14 +103,14 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
         return new AddressProvider() {
             @Override
-            public Collection<InetSocketAddress> loadAddresses() {
-                Collection<InetSocketAddress> inetAddresses = new ArrayList<InetSocketAddress>();
+            public Collection<Address> loadAddresses() {
+                Collection<Address> possibleAddresses = new ArrayList<Address>();
                 for (Address address : getKnownAddresses()) {
-                    Collection<InetSocketAddress> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
+                    Collection<Address> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
                             address.getHost(), 1);
-                    inetAddresses.addAll(addresses);
+                    possibleAddresses.addAll(addresses);
                 }
-                return inetAddresses;
+                return possibleAddresses;
             }
         };
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -282,12 +282,8 @@ class DefaultAddressPicker implements AddressPicker {
         String address = config.getProperty("hazelcast.local.localAddress");
         if (address != null) {
             address = address.trim();
-            if ("127.0.0.1".equals(address) || "localhost".equals(address)) {
-                return pickLoopbackAddress();
-            } else {
-                logger.info("Picking address configured by property 'hazelcast.local.localAddress'");
-                return new AddressDefinition(address, InetAddress.getByName(address));
-            }
+            logger.info("Picking address configured by property 'hazelcast.local.localAddress'");
+            return new AddressDefinition(address, InetAddress.getByName(address));
         }
         return null;
     }
@@ -300,7 +296,7 @@ class DefaultAddressPicker implements AddressPicker {
         if (address != null) {
             address = address.trim();
             if ("127.0.0.1".equals(address) || "localhost".equals(address)) {
-                return pickLoopbackAddress(defaultPort);
+                return pickLoopbackAddress(address, defaultPort);
             } else {
                 // allow port to be defined in same string in the form of <host>:<port>, e.g. 10.0.0.0:1234
                 AddressUtil.AddressHolder holder = AddressUtil.getAddressHolder(address, defaultPort);
@@ -314,9 +310,9 @@ class DefaultAddressPicker implements AddressPicker {
         return new AddressDefinition(InetAddress.getByName("127.0.0.1"));
     }
 
-    private AddressDefinition pickLoopbackAddress(int defaultPort) throws UnknownHostException {
-        InetAddress adddress = InetAddress.getByName("127.0.0.1");
-        return new AddressDefinition(adddress.getHostAddress(), defaultPort, adddress);
+    private AddressDefinition pickLoopbackAddress(String host, int defaultPort) throws UnknownHostException {
+        InetAddress adddress = InetAddress.getByName(host);
+        return new AddressDefinition(host, defaultPort, adddress);
     }
 
     private AddressDefinition pickMatchingAddress(Collection<InterfaceDefinition> interfaces) throws SocketException {


### PR DESCRIPTION
Fixes the cluster connection to use the user provided address without changing. The user should always provide address that is compatible with the server configuration if client is configured with addresses. E.g. if server uses dns host name, the client should also use the same name.

fixes #11116
fixes #11264