### PR TITLE
Disable event journal when cluster version is less than 3.9

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
@@ -18,6 +18,7 @@ package com.hazelcast.journal;
 
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.spi.ObjectNamespace;
@@ -151,7 +152,29 @@ public interface EventJournal<E> {
      */
     boolean hasEventJournal(ObjectNamespace namespace);
 
+    /**
+     * Returns the event journal configuration or {@code null} if there is none or the journal is disabled
+     * for the given {@code namespace}.
+     * <p>
+     * <b>NOTE</b>
+     * If the {@link ClusterService#getClusterVersion()} is less
+     * than {@link com.hazelcast.internal.cluster.Versions#V3_9},
+     * this method will return {@code null}, regardless of whether
+     * the journal is actually enabled by the configuration. This
+     * is because some members might not know how to save journal
+     * events and respond to subscribe/read operations.
+     *
+     * @param namespace the object namespace of the specific distributed object
+     * @return the journal configuration or {@code null} if the journal is not enabled or available
+     */
     EventJournalConfig getEventJournalConfig(ObjectNamespace namespace);
 
+    /**
+     * Creates a new {@link RingbufferConfig} for a ringbuffer that will keep
+     * event journal events for a single partition.
+     *
+     * @param config the event journal config
+     * @return the ringbuffer config for a single partition of the event journal
+     */
     RingbufferConfig toRingbufferConfig(EventJournalConfig config);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
@@ -130,7 +131,11 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
 
     @Override
     public EventJournalConfig getEventJournalConfig(ObjectNamespace namespace) {
-        return nodeEngine.getConfig().findMapEventJournalConfig(namespace.getObjectName());
+        // when the cluster version is less than 3.9 we act as if the journal is disabled
+        // this is because some members might not know how to save journal events
+        return nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)
+                ? null
+                : nodeEngine.getConfig().findMapEventJournalConfig(namespace.getObjectName());
     }
 
     @Override


### PR DESCRIPTION
Even though the event journal is configured as enabled, we decide to
ignore this setting as there might be some pre-3.9 members in the
cluster which don't know how to handle event journal data. One option
is to keep the journal data on 3.9 members and lose the data once
that partition is migrated to 3.8 members but this is more confusing.
Since we don't allow subscribing to or reading from the event journal
when the cluster version is not 3.9 or higher, not saving to it is
completely fine.

The EE PR has compatibility tests : https://github.com/hazelcast/hazelcast-enterprise/pull/1714