### PR TITLE
Make cache remove all operations namespace aware

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -25,6 +25,8 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
@@ -38,7 +40,7 @@ import java.util.Set;
  */
 public class CacheRemoveAllBackupOperation
         extends AbstractNamedOperation
-        implements BackupOperation, IdentifiedDataSerializable, MutatingOperation {
+        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable, MutatingOperation {
 
     private Set<Data> keys;
 
@@ -89,6 +91,16 @@ public class CacheRemoveAllBackupOperation
                 cache.removeRecord(key);
             }
         }
+    }
+
+    @Override
+    public ObjectNamespace getServiceNamespace() {
+        ICacheRecordStore recordStore = cache;
+        if (recordStore == null) {
+            ICacheService service = getService();
+            recordStore = service.getOrCreateRecordStore(name, getPartitionId());
+        }
+        return recordStore.getObjectNamespace();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
@@ -18,13 +18,16 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheClearResponse;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.partition.IPartitionService;
 
@@ -40,7 +43,7 @@ import static com.hazelcast.cache.impl.CacheEventContextUtil.createCacheComplete
  */
 public class CacheRemoveAllOperation
         extends PartitionWideCacheOperation
-        implements BackupAwareOperation, MutatingOperation {
+        implements BackupAwareOperation, MutatingOperation, ServiceNamespaceAware {
 
     private Set<Data> keys;
     private int completionId;
@@ -117,6 +120,11 @@ public class CacheRemoveAllOperation
     @Override
     public Operation getBackupOperation() {
         return new CacheRemoveAllBackupOperation(name, filteredKeys);
+    }
+
+    @Override
+    public ObjectNamespace getServiceNamespace() {
+        return cache != null ? cache.getObjectNamespace() : CacheService.getObjectNamespace(name);
     }
 
     @Override


### PR DESCRIPTION
See : 
https://hazelcast-l337.ci.cloudbees.com/job/new-lab-fast-pr/10741/testReport/junit/com.hazelcast.client.quorum.cache/ClientCacheWriteQuorumTest/testRemoveAllOperationSuccessfulWhenQuorumSizeMet/

`com.hazelcast.client.quorum.cache.ClientCacheWriteQuorumTest.testRemoveAllOperationSuccessfulWhenQuorumSizeMet`

```
com.hazelcast.core.HazelcastException: java.lang.AssertionError: CacheService[hz:impl:cacheService] is instance of FragmentedMigrationAwareService, com.hazelcast.cache.impl.operation.CacheRemoveAllOperation{serviceName='hz:impl:cacheService', identityHash=662590027, partitionId=31, replicaIndex=0, callId=158, invocationTime=1505386624623 (2017-09-14 10:57:04.623), waitTimeout=-1, callTimeout=60000, name=/hz/cacheQuorum2921314d-859e-4b8e-8bc9-d48bc8c64230} should implement ServiceNamespaceAware!
	at com.hazelcast.util.ExceptionUtil.peel(ExceptionUtil.java:94)
	at com.hazelcast.util.ExceptionUtil.peel(ExceptionUtil.java:56)
	at com.hazelcast.util.ExceptionUtil.peel(ExceptionUtil.java:52)
	at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.sendClientMessage(AbstractMessageTask.java:221)
	at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.handleProcessingFailure(AbstractMessageTask.java:162)
	at com.hazelcast.client.impl.protocol.task.AbstractMessageTask.run(AbstractMessageTask.java:107)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
	at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:64)
	at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:80)
	at ------ submitted from ------.(Unknown Source)
	at com.hazelcast.client.spi.impl.ClientInvocationFuture.resolveAndThrowIfException(ClientInvocationFuture.java:96)
	at com.hazelcast.client.spi.impl.ClientInvocationFuture.resolveAndThrowIfException(ClientInvocationFuture.java:33)
	at com.hazelcast.spi.impl.AbstractInvocationFuture.get(AbstractInvocationFuture.java:155)
	at com.hazelcast.client.cache.impl.AbstractClientCacheProxyBase.invoke(AbstractClientCacheProxyBase.java:208)
	at com.hazelcast.client.cache.impl.AbstractClientInternalCacheProxy.removeAllInternal(AbstractClientInternalCacheProxy.java:540)
	at com.hazelcast.client.cache.impl.ClientCacheProxy.removeAll(ClientCacheProxy.java:284)
```