### PR TITLE
Client fails to reconnect when domain names are used in member list

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
@@ -16,17 +16,20 @@
 
 package com.hazelcast.client.connection;
 
-import java.net.InetSocketAddress;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import java.util.Collection;
 
 /**
  * Provides initial addresses for client to find and connect to a node
  */
+@PrivateApi
 public interface AddressProvider {
 
     /**
-     * @return Collection of InetSocketAddress
+     * @return The possible member addresses to connect to.
      */
-    Collection<InetSocketAddress> loadAddresses();
+    Collection<Address> loadAddresses();
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
@@ -22,8 +22,8 @@ import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,10 +45,10 @@ public class AwsAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         updateLookupTable();
         final Map<String, String> lookupTable = getLookupTable();
-        final Collection<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(lookupTable.size());
+        final Collection<Address> addresses = new ArrayList<Address>(lookupTable.size());
 
         for (String privateAddress : lookupTable.keySet()) {
             addresses.addAll(AddressHelper.getSocketAddresses(privateAddress));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -19,8 +19,8 @@ package com.hazelcast.client.spi.impl;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
+import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -41,16 +41,16 @@ public class DefaultAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         final List<String> addresses = networkConfig.getAddresses();
         if (addresses.isEmpty() && noOtherAddressProviderExist) {
-            addresses.add("localhost");
+            addresses.add("127.0.0.1");
         }
-        final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
+        final List<Address> possibleAddresses = new LinkedList<Address>();
 
         for (String address : addresses) {
-            socketAddresses.addAll(AddressHelper.getSocketAddresses(address));
+            possibleAddresses.addAll(AddressHelper.getSocketAddresses(address));
         }
-        return socketAddresses;
+        return possibleAddresses;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -23,8 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -42,18 +40,13 @@ public class DiscoveryAddressProvider
     }
 
     @Override
-    public Collection<InetSocketAddress> loadAddresses() {
+    public Collection<Address> loadAddresses() {
         Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
                 "Discovered nodes cannot be null!");
 
-        Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
+        Collection<Address> possibleMembers = new ArrayList<Address>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {
-            Address discoveredAddress = discoveryNode.getPrivateAddress();
-            try {
-                possibleMembers.add(discoveredAddress.getInetSocketAddress());
-            } catch (UnknownHostException e) {
-                logger.warning("Unresolvable host exception", e);
-            }
+            possibleMembers.add(discoveryNode.getPrivateAddress());
         }
         return possibleMembers;
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -124,12 +123,12 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         config.getNetworkConfig().setSmartRouting(false);
 
-        InetSocketAddress socketAddress1 = server1.getCluster().getLocalMember().getSocketAddress();
-        InetSocketAddress socketAddress2 = server2.getCluster().getLocalMember().getSocketAddress();
+        Address address1 = server1.getCluster().getLocalMember().getAddress();
+        Address address2 = server2.getCluster().getLocalMember().getAddress();
 
         config.getNetworkConfig().
-                addAddress(socketAddress1.getHostName() + ":" + socketAddress1.getPort()).
-                addAddress(socketAddress2.getHostName() + ":" + socketAddress2.getPort());
+                addAddress(address1.getHost() + ":" + address1.getPort()).
+                addAddress(address2.getHost() + ":" + address2.getPort());
 
         hazelcastFactory.newHazelcastClient(config);
 
@@ -151,7 +150,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
         connectionManager.addConnectionListener(listener);
 
-        final Address serverAddress = new Address(server.getCluster().getLocalMember().getSocketAddress());
+        final Address serverAddress = server.getCluster().getLocalMember().getAddress();
         final Connection connectionToServer = connectionManager.getConnection(serverAddress);
 
         final CountDownLatch isConnected = new CountDownLatch(1);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -362,8 +362,7 @@ public class ClientServiceTest extends ClientTestSupport {
             map.put(randomString(), randomString());
         }
         HazelcastClientInstanceImpl clientInstanceImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
-        InetSocketAddress socketAddress = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
-        Address address = new Address(socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+        Address address = hazelcastInstance.getCluster().getLocalMember().getAddress();
         ClientConnectionManager connectionManager = clientInstanceImpl.getConnectionManager();
         final ClientConnection connection = (ClientConnection) connectionManager.getConnection(address);
         assertTrueEventually(new AssertTask() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.nio.Address;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -33,7 +34,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
@@ -124,10 +124,10 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     private void configureDummyClientConnection(HazelcastInstance instance) throws UnknownHostException {
-        InetSocketAddress socketAddress = getAddress(instance).getInetSocketAddress();
+        Address memberAddress = getAddress(instance);
         dummyClientConfig.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         ClientNetworkConfig networkConfig = dummyClientConfig.getNetworkConfig();
-        networkConfig.addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+        networkConfig.addAddress(memberAddress.getHost() + ":" + memberAddress.getPort());
     }
 
     private List<HazelcastInstance> createNodes(int numberOfLiteNodes, int numberOfDataNodes) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -33,7 +33,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -104,14 +103,14 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
         return new AddressProvider() {
             @Override
-            public Collection<InetSocketAddress> loadAddresses() {
-                Collection<InetSocketAddress> inetAddresses = new ArrayList<InetSocketAddress>();
+            public Collection<Address> loadAddresses() {
+                Collection<Address> possibleAddresses = new ArrayList<Address>();
                 for (Address address : getKnownAddresses()) {
-                    Collection<InetSocketAddress> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
+                    Collection<Address> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
                             address.getHost(), 1);
-                    inetAddresses.addAll(addresses);
+                    possibleAddresses.addAll(addresses);
                 }
-                return inetAddresses;
+                return possibleAddresses;
             }
         };
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -300,7 +300,7 @@ class DefaultAddressPicker implements AddressPicker {
         if (address != null) {
             address = address.trim();
             if ("127.0.0.1".equals(address) || "localhost".equals(address)) {
-                return pickLoopbackAddress(defaultPort);
+                return pickLoopbackAddress(address, defaultPort);
             } else {
                 // allow port to be defined in same string in the form of <host>:<port>, e.g. 10.0.0.0:1234
                 AddressUtil.AddressHolder holder = AddressUtil.getAddressHolder(address, defaultPort);
@@ -314,9 +314,9 @@ class DefaultAddressPicker implements AddressPicker {
         return new AddressDefinition(InetAddress.getByName("127.0.0.1"));
     }
 
-    private AddressDefinition pickLoopbackAddress(int defaultPort) throws UnknownHostException {
-        InetAddress adddress = InetAddress.getByName("127.0.0.1");
-        return new AddressDefinition(adddress.getHostAddress(), defaultPort, adddress);
+    private AddressDefinition pickLoopbackAddress(String host, int defaultPort) throws UnknownHostException {
+        InetAddress adddress = InetAddress.getByName(host);
+        return new AddressDefinition(host, defaultPort, adddress);
     }
 
     private AddressDefinition pickMatchingAddress(Collection<InterfaceDefinition> interfaces) throws SocketException {

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -40,7 +40,7 @@ public class DefaultNodeContext implements NodeContext {
 
     @Override
     public AddressPicker createAddressPicker(Node node) {
-        return new DefaultAddressPicker(node);
+        return new DefaultAddressPicker(node.getConfig(), node.getProperties(), node.getLogger(AddressPicker.class));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultAddressPickerTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class DefaultAddressPickerTest {
+
+    private static final String PUBLIC_HOST = "www.hazelcast.org";
+    private static final String HAZELCAST_LOCAL_ADDRESS_PROP = "hazelcast.local.localAddress";
+
+    private ILogger logger = Logger.getLogger(AddressPicker.class);
+    private Config config = new Config();
+    private HazelcastProperties properties;
+    private AddressPicker addressPicker;
+
+    private InetAddress loopback;
+    private String localAddressValue;
+
+    @Before
+    public void setup() throws UnknownHostException {
+        properties = new HazelcastProperties(config);
+
+        InetAddress publicAddress = null;
+        try {
+            loopback = InetAddress.getByName("127.0.0.1");
+            publicAddress = InetAddress.getByName(PUBLIC_HOST);
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        assumeNotNull(loopback, publicAddress);
+
+        localAddressValue = System.getProperty(HAZELCAST_LOCAL_ADDRESS_PROP);
+        System.clearProperty(HAZELCAST_LOCAL_ADDRESS_PROP);
+    }
+
+    @After
+    public void tearDown() {
+        if (addressPicker != null) {
+            IOUtil.closeResource(addressPicker.getServerSocketChannel());
+        }
+        if (localAddressValue != null) {
+            System.setProperty(HAZELCAST_LOCAL_ADDRESS_PROP, localAddressValue);
+        }
+    }
+
+    @Test
+    public void testBindAddress_withDefaultPortAndLoopbackAddress() throws Exception {
+        config.setProperty(HAZELCAST_LOCAL_ADDRESS_PROP, loopback.getHostAddress());
+        testBindAddress(loopback);
+    }
+
+    @Test
+    public void testBindAddress_withCustomPortAndLoopbackAddress() throws Exception {
+        config.setProperty(HAZELCAST_LOCAL_ADDRESS_PROP, loopback.getHostAddress());
+        int port = 6789;
+        config.getNetworkConfig().setPort(port);
+        testBindAddress(loopback);
+    }
+
+    @Test
+    public void testBindAddress_withNonLoopbackAddressViaInterfaces() throws Exception {
+        InetAddress address = findIPv4NonLoopbackInterface();
+        assumeNotNull(address);
+
+        config.getNetworkConfig().getInterfaces().setEnabled(true)
+                .clear().addInterface(address.getHostAddress());
+
+        testBindAddress(address);
+    }
+
+    @Test
+    public void testBindAddress_withNonLoopbackAddressViaTCPMembers() throws Exception {
+        InetAddress address = findIPv4NonLoopbackInterface();
+        assumeNotNull(address);
+
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true)
+                .clear().addMember(address.getHostAddress());
+
+        testBindAddress(address);
+    }
+
+    @Test
+    public void testBindAddress_withNonLoopbackAddressViaSystemProperty() throws Exception {
+        InetAddress address = findIPv4NonLoopbackInterface();
+        assumeNotNull(address);
+
+        config.setProperty(HAZELCAST_LOCAL_ADDRESS_PROP, address.getHostAddress());
+
+        testBindAddress(address);
+    }
+
+    private void testBindAddress(InetAddress address) throws Exception {
+        addressPicker = new DefaultAddressPicker(config, properties, logger);
+        addressPicker.pickAddress();
+
+        int port = config.getNetworkConfig().getPort();
+        assertEquals(new Address(address, port), addressPicker.getBindAddress());
+        assertEquals(addressPicker.getBindAddress(), addressPicker.getPublicAddress());
+    }
+
+    @Test
+    public void testBindAddress_whenAddressAlreadyInUse() throws Exception {
+        int port = 6789;
+        config.getNetworkConfig().setPort(port);
+        config.getNetworkConfig().setPortAutoIncrement(false);
+
+        addressPicker = new DefaultAddressPicker(config, properties, logger);
+        addressPicker.pickAddress();
+
+        try {
+            new DefaultAddressPicker(config, properties, logger).pickAddress();
+            fail("Should fail with 'java.net.BindException: Address already in use'");
+        } catch (Exception expected) {
+        }
+    }
+
+    @Test
+    public void testBindAddress_whenAddressAlreadyInUse_WithPortAutoIncrement() throws Exception {
+        int port = 6789;
+        config.getNetworkConfig().setPort(port);
+        config.getNetworkConfig().setPortAutoIncrement(true);
+
+        addressPicker = new DefaultAddressPicker(config, properties, logger);
+        addressPicker.pickAddress();
+
+        new DefaultAddressPicker(config, properties, logger).pickAddress();
+    }
+
+    @Test
+    public void testPublicAddress_withDefaultPortAndLoopbackAddress() throws Exception {
+        testPublicAddress("127.0.0.1", -1);
+    }
+
+    @Test
+    public void testPublicAddress_withDefaultPortAndLocalhost() throws Exception {
+        testPublicAddress("localhost", -1);
+    }
+
+    @Test
+    public void testPublicAddress_withSpecifiedHost() throws Exception {
+        testPublicAddress(PUBLIC_HOST, -1);
+    }
+
+    @Test
+    public void testPublicAddress_withSpecifiedHostAndPort() throws Exception {
+        testPublicAddress(PUBLIC_HOST, 6789);
+    }
+
+    private void testPublicAddress(String host, int port) throws Exception {
+        config.getNetworkConfig().setPublicAddress(port < 0 ? host : (host + ":" + port));
+        addressPicker = new DefaultAddressPicker(config, properties, logger);
+        addressPicker.pickAddress();
+
+        if (port < 0) {
+            port = config.getNetworkConfig().getPort();
+        }
+
+        assertEquals(new Address(host, port), addressPicker.getPublicAddress());
+    }
+
+    @Test
+    public void testPublicAddress_withSpecifiedHostAndPortViaProperty() throws Exception {
+        String host = PUBLIC_HOST;
+        int port = 6789;
+        config.setProperty("hazelcast.local.publicAddress", host + ":" + port);
+
+        addressPicker = new DefaultAddressPicker(config, properties, logger);
+        addressPicker.pickAddress();
+
+        assertEquals(new Address(host, port), addressPicker.getPublicAddress());
+    }
+
+    @Test(expected = UnknownHostException.class)
+    public void testPublicAddress_withInvalidAddress() throws Exception {
+        config.getNetworkConfig().setPublicAddress("invalid");
+
+        addressPicker = new DefaultAddressPicker(config, properties, logger);
+        addressPicker.pickAddress();
+    }
+
+    private static InetAddress findIPv4NonLoopbackInterface() {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface ni = interfaces.nextElement();
+                Enumeration<InetAddress> addresses = ni.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress address = addresses.nextElement();
+                    if (address.isLoopbackAddress()) {
+                        continue;
+                    }
+                    if (address instanceof Inet6Address) {
+                        continue;
+                    }
+                    return address;
+                }
+            }
+
+        } catch (SocketException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Make sure that the provided address string is used in the activeConnectionsMap. This fixes the domain name to ip address conversion problem and duplicate connection initiation problem to the same member one with ip address and one with domain name.

We made the assumption that the user will have to use the same host name or ip in the client config if the member is configured with a public ip address.

fixes #11116
fixes #11264
back-port of #11226