### PR TITLE
Added Near Cache leak tests and fixed NearCacheClientCacheProxy

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -588,7 +588,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
 
         String registrationId = nearCacheMembershipRegistrationId;
         if (registrationId != null) {
-            getContext().getRepairingTask(getServiceName()).deregisterHandler(name);
+            getContext().getRepairingTask(getServiceName()).deregisterHandler(nameWithPrefix);
             getContext().getListenerService().deregisterListener(registrationId);
         }
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheLeakTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.ClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
+import com.hazelcast.internal.nearcache.AbstractNearCacheLeakTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import javax.cache.spi.CachingProvider;
+import java.util.Collection;
+
+import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListener.createInvalidationEventHandler;
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+import static com.hazelcast.config.EvictionPolicy.LRU;
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
+
+/**
+ * Basic Near Cache tests for {@link ICache} on Hazelcast clients.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheNearCacheLeakTest extends AbstractNearCacheLeakTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
+    @Parameter(value = 2)
+    public LocalUpdatePolicy localUpdatePolicy;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameters(name = "format:{0} serializeKeys:{1} localUpdatePolicy:{2}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, true, LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.BINARY, false, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, false, LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, true, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, true, LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, false, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, false, LocalUpdatePolicy.CACHE_ON_UPDATE},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
+                .setInvalidateOnChange(true)
+                .setLocalUpdatePolicy(localUpdatePolicy);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size) {
+        Config config = createConfig();
+        CacheConfig<K, V> cacheConfig = createCacheConfig(nearCacheConfig);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        CachingProvider memberProvider = HazelcastServerCachingProvider.createCachingProvider(member);
+        HazelcastServerCacheManager memberCacheManager = (HazelcastServerCacheManager) memberProvider.getCacheManager();
+        ICache<K, V> memberCache = memberCacheManager.createCache(DEFAULT_NEAR_CACHE_NAME, cacheConfig);
+        ICacheDataStructureAdapter<K, V> dataAdapter = new ICacheDataStructureAdapter<K, V>(memberCache);
+
+        populateDataAdapter(dataAdapter, size);
+
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder(cacheConfig);
+        return builder
+                .setDataInstance(member)
+                .setDataAdapter(dataAdapter)
+                .setMemberCacheManager(memberCacheManager)
+                .build();
+    }
+
+    protected Config createConfig() {
+        return getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), PARTITION_COUNT);
+    }
+
+    protected ClientConfig createClientConfig() {
+        return new ClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K, V> CacheConfig<K, V> createCacheConfig(NearCacheConfig nearCacheConfig) {
+        CacheConfig<K, V> cacheConfig = new CacheConfig<K, V>()
+                .setName(DEFAULT_NEAR_CACHE_NAME)
+                .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
+
+        if (nearCacheConfig.getInMemoryFormat() == NATIVE) {
+            cacheConfig.getEvictionConfig()
+                    .setEvictionPolicy(LRU)
+                    .setMaximumSizePolicy(USED_NATIVE_MEMORY_PERCENTAGE)
+                    .setSize(90);
+        }
+
+        return cacheConfig;
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder(CacheConfig<K, V> cacheConfig) {
+        ClientConfig clientConfig = createClientConfig();
+
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+        CachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
+        HazelcastClientCacheManager cacheManager = (HazelcastClientCacheManager) provider.getCacheManager();
+        ICache<K, V> clientCache = cacheManager.createCache(DEFAULT_NEAR_CACHE_NAME, cacheConfig);
+
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
+        String cacheNameWithPrefix = cacheManager.getCacheNameWithPrefix(DEFAULT_NEAR_CACHE_NAME);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheNameWithPrefix);
+
+        ClientContext clientContext = ((ClientProxy) clientCache).getContext();
+        RepairingTask repairingTask = clientContext.getRepairingTask(CacheService.SERVICE_NAME);
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setNearCacheAdapter(new ICacheDataStructureAdapter<K, V>(clientCache))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setCacheManager(cacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(clientCache))
+                .setRepairingTask(repairingTask);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLeakTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.ClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
+import com.hazelcast.internal.nearcache.AbstractNearCacheLeakTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static com.hazelcast.client.map.impl.nearcache.ClientMapInvalidationListener.createInvalidationEventHandler;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
+
+/**
+ * Basic Near Cache tests for {@link IMap} on Hazelcast clients.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapNearCacheLeakTest extends AbstractNearCacheLeakTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameters(name = "format:{0} serializeKeys:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
+                .setInvalidateOnChange(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size) {
+        Config config = createConfig();
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMapDataStructureAdapter<K, V> dataAdapter = new IMapDataStructureAdapter<K, V>(memberMap);
+
+        // wait until the initial load is done
+        dataAdapter.waitUntilLoaded();
+        populateDataAdapter(dataAdapter, size);
+
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder
+                .setDataInstance(member)
+                .setDataAdapter(dataAdapter)
+                .build();
+    }
+
+    protected Config createConfig() {
+        return getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), PARTITION_COUNT);
+    }
+
+    protected ClientConfig createClientConfig() {
+        return new ClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
+        ClientConfig clientConfig = createClientConfig();
+
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+        IMap<K, V> clientMap = client.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        ClientContext clientContext = ((ClientProxy) clientMap).getContext();
+        RepairingTask repairingTask = clientContext.getRepairingTask(MapService.SERVICE_NAME);
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(clientMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(clientMap))
+                .setRepairingTask(repairingTask);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheLeakTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.replicatedmap.nearcache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.internal.adapter.ReplicatedMapDataStructureAdapter;
+import com.hazelcast.internal.nearcache.AbstractNearCacheLeakTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static com.hazelcast.client.replicatedmap.nearcache.ClientReplicatedMapInvalidationListener.createInvalidationEventHandler;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class ClientReplicatedMapNearCacheLeakTest extends AbstractNearCacheLeakTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, true)
+                .setInvalidateOnChange(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size) {
+        Config config = createConfig();
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        ReplicatedMap<K, V> memberMap = member.getReplicatedMap(DEFAULT_NEAR_CACHE_NAME);
+        ReplicatedMapDataStructureAdapter<K, V> dataAdapter = new ReplicatedMapDataStructureAdapter<K, V>(memberMap);
+
+        populateDataAdapter(dataAdapter, size);
+
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder
+                .setDataInstance(member)
+                .setDataAdapter(dataAdapter)
+                .build();
+    }
+
+    protected Config createConfig() {
+        Config config = getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), PARTITION_COUNT);
+
+        config.getReplicatedMapConfig(DEFAULT_NEAR_CACHE_NAME)
+                .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
+
+        return config;
+    }
+
+    protected ClientConfig createClientConfig() {
+        return new ClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
+        ClientConfig clientConfig = createClientConfig();
+
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+        ReplicatedMap<K, V> clientMap = client.getReplicatedMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setNearCacheAdapter(new ReplicatedMapDataStructureAdapter<K, V>(clientMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(clientMap));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.adapter;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
@@ -306,6 +307,10 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     @MethodNotAvailable
     public void loadAll(Set<? extends K> keys, boolean replaceExistingValues, CompletionListener completionListener) {
         throw new MethodNotAvailableException();
+    }
+
+    public IMap<K, V> getMap() {
+        return hazelcastInstance.getMap(name);
     }
 
     private void begin() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheLeakTest.java
@@ -1,0 +1,91 @@
+package com.hazelcast.internal.nearcache;
+
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.internal.adapter.DataStructureAdapter;
+import com.hazelcast.internal.adapter.ReplicatedMapDataStructureAdapter;
+import com.hazelcast.internal.adapter.TransactionalMapDataStructureAdapter;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractNearCacheLeakTest<NK, NV> extends HazelcastTestSupport {
+
+    /**
+     * The default name used for the data structures which have a Near Cache.
+     */
+    protected static final String DEFAULT_NEAR_CACHE_NAME = "defaultNearCache";
+
+    /**
+     * The partition count to configure in the Hazelcast members.
+     */
+    protected static final String PARTITION_COUNT = "5";
+
+    protected NearCacheConfig nearCacheConfig;
+
+    /**
+     * Creates the {@link NearCacheTestContext} used by the Near Cache tests.
+     *
+     * @param <K>  key type of the created {@link DataStructureAdapter}
+     * @param <V>  value type of the created {@link DataStructureAdapter}
+     * @param size determines the size the backing {@link DataStructureAdapter} should be populated with
+     * @return a {@link NearCacheTestContext} used by the Near Cache tests
+     */
+    protected abstract <K, V> NearCacheTestContext<K, V, NK, NV> createContext(int size);
+
+    @Test
+    public void testNearCacheMemoryLeak() {
+        // invalidations have to be enabled, otherwise no RepairHandler is registered
+        assertTrue(nearCacheConfig.isInvalidateOnChange());
+
+        NearCacheTestContext<Integer, Integer, NK, NV> context = createContext(1000);
+
+        populateNearCache(context, 1000);
+        assertTrue("The Near Cache should be filled (" + context.stats + ")", context.stats.getOwnedEntryCount() > 0);
+
+        assertNearCacheManager(context, 1);
+        assertRepairingTask(context, 1);
+
+        context.nearCacheAdapter.destroy();
+
+        assertNearCacheManager(context, 0);
+        assertRepairingTask(context, 0);
+    }
+
+    protected void assertNearCacheManager(NearCacheTestContext<Integer, Integer, NK, NV> context, int expected) {
+        assertEqualsStringFormat("Expected %d Near Caches in the NearCacheManager, but found %d",
+                expected, context.nearCacheManager.listAllNearCaches().size());
+    }
+
+    protected void assertRepairingTask(NearCacheTestContext<Integer, Integer, NK, NV> context, int expected) {
+        if (context.nearCacheAdapter instanceof ReplicatedMapDataStructureAdapter) {
+            // the ReplicatedMap doesn't support MetaData, so there is are no RepairingHandlers being registered
+            return;
+        }
+        if (context.nearCacheAdapter instanceof TransactionalMapDataStructureAdapter && expected == 0) {
+            // FIXME: the TransactionalMapProxy is missing a postDestroy() method to remove its RepairingHandler
+            return;
+        }
+        assertEqualsStringFormat("Expected %d RepairingHandlers in the RepairingTask, but found %d",
+                expected, context.repairingTask.getHandlers().size());
+    }
+
+    protected void populateNearCache(NearCacheTestContext<Integer, Integer, NK, NV> context, int size) {
+        for (int i = 0; i < size; i++) {
+            context.nearCacheAdapter.get(i);
+            context.nearCacheAdapter.get(i);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static void populateDataAdapter(DataStructureAdapter<?, ?> dataAdapter, int size) {
+        if (size < 1) {
+            return;
+        }
+        DataStructureAdapter<Integer, String> adapter = (DataStructureAdapter<Integer, String>) dataAdapter;
+        for (int i = 0; i < size; i++) {
+            adapter.put(i, "value-" + i);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.adapter.DataStructureLoader;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -100,6 +101,11 @@ public class NearCacheTestContext<K, V, NK, NV> {
      */
     public final NearCacheInvalidationListener invalidationListener;
 
+    /**
+     * The {@link RepairingTask} from the Near Cache instance.
+     */
+    public final RepairingTask repairingTask;
+
     NearCacheTestContext(NearCacheConfig nearCacheConfig,
                          SerializationService serializationService,
                          HazelcastInstance nearCacheInstance,
@@ -112,7 +118,8 @@ public class NearCacheTestContext<K, V, NK, NV> {
                          HazelcastServerCacheManager memberCacheManager,
                          boolean hasLocalData,
                          DataStructureLoader loader,
-                         NearCacheInvalidationListener invalidationListener) {
+                         NearCacheInvalidationListener invalidationListener,
+                         RepairingTask repairingTask) {
         this.nearCacheConfig = nearCacheConfig;
         this.serializationService = serializationService;
 
@@ -130,5 +137,6 @@ public class NearCacheTestContext<K, V, NK, NV> {
         this.hasLocalData = hasLocalData;
         this.loader = loader;
         this.invalidationListener = invalidationListener;
+        this.repairingTask = repairingTask;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.adapter.DataStructureLoader;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastTestSupport;
 
@@ -50,6 +51,8 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> extends HazelcastTestSupp
     private boolean hasLocalData;
     private DataStructureLoader loader;
     private NearCacheInvalidationListener invalidationListener;
+
+    private RepairingTask repairingTask;
 
     public NearCacheTestContextBuilder(NearCacheConfig nearCacheConfig, SerializationService serializationService) {
         this.nearCacheConfig = nearCacheConfig;
@@ -111,6 +114,11 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> extends HazelcastTestSupp
         return this;
     }
 
+    public NearCacheTestContextBuilder<K, V, NK, NV> setRepairingTask(RepairingTask repairingTask) {
+        this.repairingTask = repairingTask;
+        return this;
+    }
+
     public NearCacheTestContext<K, V, NK, NV> build() {
         checkNotNull(serializationService, "serializationService cannot be null!");
 
@@ -130,7 +138,8 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> extends HazelcastTestSupp
                 memberCacheManager,
                 hasLocalData,
                 loader,
-                invalidationListener);
+                invalidationListener,
+                repairingTask);
 
         warmUpPartitions(context.dataInstance, context.nearCacheInstance);
         waitAllForSafeState(context.dataInstance, context.nearCacheInstance);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheLeakTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
+import com.hazelcast.internal.nearcache.AbstractNearCacheLeakTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
+import static java.util.Arrays.asList;
+
+/**
+ * Basic Near Cache tests for {@link IMap} on Hazelcast Lite members.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LiteMemberMapNearCacheLeakTest extends AbstractNearCacheLeakTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+
+    @Parameters(name = "format:{0} serializeKeys:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
+                .setInvalidateOnChange(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size) {
+        Config config = createConfig(false);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMapDataStructureAdapter<K, V> dataAdapter = new IMapDataStructureAdapter<K, V>(memberMap);
+
+        // wait until the initial load is done
+        dataAdapter.waitUntilLoaded();
+        populateDataAdapter(dataAdapter, size);
+
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder
+                .setDataInstance(member)
+                .setDataAdapter(dataAdapter)
+                .build();
+    }
+
+    protected Config createConfig(boolean liteMember) {
+        Config config = getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), PARTITION_COUNT)
+                .setLiteMember(liteMember);
+
+        MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME);
+        if (liteMember) {
+            mapConfig.setNearCacheConfig(nearCacheConfig);
+        }
+
+        return config;
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
+        Config configWithNearCache = createConfig(true);
+
+        HazelcastInstance liteMember = hazelcastFactory.newHazelcastInstance(configWithNearCache);
+        IMap<K, V> liteMemberMap = liteMember.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(liteMember);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        RepairingTask repairingTask = ((MapNearCacheManager) nearCacheManager).getRepairingTask();
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(liteMember))
+                .setNearCacheInstance(liteMember)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(liteMemberMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(liteMemberMap))
+                .setRepairingTask(repairingTask);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheLeakTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
+import com.hazelcast.internal.nearcache.AbstractNearCacheLeakTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
+import static java.util.Arrays.asList;
+
+/**
+ * Basic Near Cache tests for {@link IMap} on Hazelcast members.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({ParallelTest.class, QuickTest.class})
+public class MapNearCacheLeakTest extends AbstractNearCacheLeakTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+
+    @Parameters(name = "format:{0} serializeKeys:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
+                .setInvalidateOnChange(true)
+                .setCacheLocalEntries(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size) {
+        Config config = createConfig(false);
+
+        HazelcastInstance dataInstance = hazelcastFactory.newHazelcastInstance(config);
+        IMap<K, V> dataMap = dataInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMapDataStructureAdapter<K, V> dataAdapter = new IMapDataStructureAdapter<K, V>(dataMap);
+
+        // wait until the initial load is done
+        dataAdapter.waitUntilLoaded();
+        populateDataAdapter(dataAdapter, size);
+
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder
+                .setDataInstance(dataInstance)
+                .setDataAdapter(dataAdapter)
+                .build();
+    }
+
+    protected Config createConfig(boolean withNearCache) {
+        Config config = getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), PARTITION_COUNT);
+
+        MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME);
+        if (withNearCache) {
+            mapConfig.setNearCacheConfig(nearCacheConfig);
+        }
+
+        return config;
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
+        Config configWithNearCache = createConfig(true);
+
+        HazelcastInstance nearCacheInstance = hazelcastFactory.newHazelcastInstance(configWithNearCache);
+        IMap<K, V> nearCacheMap = nearCacheInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheInstance);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        RepairingTask repairingTask = ((MapNearCacheManager) nearCacheManager).getRepairingTask();
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(nearCacheInstance))
+                .setNearCacheInstance(nearCacheInstance)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(nearCacheMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setHasLocalData(true)
+                .setInvalidationListener(createInvalidationEventHandler(nearCacheMap))
+                .setRepairingTask(repairingTask);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheLeakTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.tx;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.adapter.TransactionalMapDataStructureAdapter;
+import com.hazelcast.internal.nearcache.AbstractNearCacheLeakTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
+import static java.util.Arrays.asList;
+
+/**
+ * Basic Near Cache tests for {@link com.hazelcast.core.TransactionalMap} on Hazelcast members.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TxnMapNearCacheLeakTest extends AbstractNearCacheLeakTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+
+    @Parameters(name = "format:{0} serializeKeys:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
+                .setInvalidateOnChange(true)
+                .setCacheLocalEntries(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(int size) {
+        Config config = createConfig(false);
+
+        HazelcastInstance dataInstance = hazelcastFactory.newHazelcastInstance(config);
+        TransactionalMapDataStructureAdapter<K, V> dataAdapter
+                = new TransactionalMapDataStructureAdapter<K, V>(dataInstance, DEFAULT_NEAR_CACHE_NAME);
+
+        populateDataAdapter(dataAdapter, size);
+
+        NearCacheTestContextBuilder<K, V, Data, String> builder = createNearCacheContextBuilder();
+        return builder
+                .setDataInstance(dataInstance)
+                .setDataAdapter(dataAdapter)
+                .build();
+    }
+
+    @Override
+    protected void populateNearCache(NearCacheTestContext<Integer, Integer, Data, String> context, int size) {
+        IMap<Integer, Integer> map = ((TransactionalMapDataStructureAdapter<Integer, Integer>) context.nearCacheAdapter).getMap();
+        for (int i = 0; i < size; i++) {
+            map.get(i);
+            map.get(i);
+        }
+    }
+
+    protected Config createConfig(boolean withNearCache) {
+        Config config = getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), PARTITION_COUNT);
+
+        if (withNearCache) {
+            config.getMapConfig(DEFAULT_NEAR_CACHE_NAME).setNearCacheConfig(nearCacheConfig);
+        }
+        return config;
+    }
+
+    private <K, V> NearCacheTestContextBuilder<K, V, Data, String> createNearCacheContextBuilder() {
+        Config configWithNearCache = createConfig(true);
+
+        HazelcastInstance nearCacheInstance = hazelcastFactory.newHazelcastInstance(configWithNearCache);
+        IMap<K, V> nearCacheMap = nearCacheInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheInstance);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        RepairingTask repairingTask = ((MapNearCacheManager) nearCacheManager).getRepairingTask();
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(nearCacheInstance))
+                .setNearCacheInstance(nearCacheInstance)
+                .setNearCacheAdapter(new TransactionalMapDataStructureAdapter<K, V>(nearCacheInstance, DEFAULT_NEAR_CACHE_NAME))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setInvalidationListener(createInvalidationEventHandler(nearCacheMap))
+                .setRepairingTask(repairingTask);
+    }
+}


### PR DESCRIPTION
This a basic test if the Near Cache is leaking any references in OS.

We seem to have a leak in the `TransactionalMap`, which doesn't remove its `RepairingHandler` on a `destroy()` call. The `RepairingHandler` holds a reference to the Near Cache, which causes a bigger leak than the handler itself.

Fixes https://github.com/hazelcast/hazelcast/issues/11385