### PR TITLE
connection-attempt-limit's default value is updated for async client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -40,7 +40,7 @@ public class ClientNetworkConfig {
     private boolean smartRouting = true;
     private boolean redoOperation;
     private int connectionTimeout = CONNECTION_TIMEOUT;
-    private int connectionAttemptLimit = 2;
+    private int connectionAttemptLimit = -1;
     private int connectionAttemptPeriod = CONNECTION_ATTEMPT_PERIOD;
     private SocketInterceptorConfig socketInterceptorConfig;
     private SocketOptions socketOptions = new SocketOptions();
@@ -151,6 +151,7 @@ public class ClientNetworkConfig {
      *
      * @param connectionAttemptLimit number of times to attempt to connect
      *                               A zero value means try forever.
+     *                               A negative value means default value
      * @return configured {@link com.hazelcast.client.config.ClientNetworkConfig} for chaining
      */
     public ClientNetworkConfig setConnectionAttemptLimit(int connectionAttemptLimit) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -74,8 +74,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         Address memberAddress = hazelcastFactory.nextAddress();
 
         // trying 8.8.8.8 address will delay the initial connection since no such server exist
-        clientConfig.getNetworkConfig().addAddress("8.8.8.8", memberAddress.getHost() + ":" + memberAddress.getPort())
-                .setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getNetworkConfig().addAddress("8.8.8.8", memberAddress.getHost() + ":" + memberAddress.getPort());
         clientConfig.addListenerConfig(new ListenerConfig(new LifecycleListener() {
             @Override
             public void stateChanged(LifecycleEvent event) {
@@ -210,7 +209,6 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 


### PR DESCRIPTION
Connection attempt limit's default values is 2. But for the new async starting client and async reconnection behaviour we set this value as 20.