### PR TITLE
Fix BounceMemberRule driver type ambiguity

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -41,6 +41,7 @@ import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
 import static com.hazelcast.test.HazelcastTestSupport.spawn;
 import static com.hazelcast.test.bounce.BounceTestConfiguration.DriverType.ALWAYS_UP_MEMBER;
 import static com.hazelcast.test.bounce.BounceTestConfiguration.DriverType.CLIENT;
+import static com.hazelcast.test.bounce.BounceTestConfiguration.DriverType.MEMBER;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.lang.System.currentTimeMillis;
 
@@ -396,15 +397,22 @@ public class BounceMemberRule implements TestRule {
         }
 
         public BounceMemberRule build() {
+
             if (testDriverType == null) {
                 // guess driver: if HazelcastTestFactory class is available, then use the client driver,
-                // otherwise default to always-up member as test driver
+                // otherwise use member driver as default
                 if (isClassAvailable(null, "com.hazelcast.client.test.TestHazelcastFactory")) {
                     testDriverType = CLIENT;
                 } else {
-                    testDriverType = ALWAYS_UP_MEMBER;
+                    testDriverType = MEMBER;
                 }
             }
+
+            if (testDriverType == ALWAYS_UP_MEMBER) {
+                assert driversCount == 1
+                        : "Driver count can only be 1 when driver type is ALWAYS_UP_MEMBER but found " + driversCount;
+            }
+
             if (driverFactory == null) {
                 // choose a default driver factory
                 switch (testDriverType) {


### PR DESCRIPTION
- Changed default driver type from ALWAYS_UP_MEMBER to MEMBER
- Added assertion to point driver count cannot be > 1 when driver type is ALWAYS_UP_MEMBER