### PR TITLE
Inject dependencies in Cache resources

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -27,7 +27,7 @@ import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 
@@ -100,9 +100,8 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
     }
 
     protected void injectDependencies(Object obj) {
-        if (obj instanceof HazelcastInstanceAware) {
-            ((HazelcastInstanceAware) obj).setHazelcastInstance(getClient());
-        }
+        ManagedContext managedContext = getSerializationService().getManagedContext();
+        managedContext.initialize(obj);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -390,7 +390,7 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V>
             throw new NullPointerException("CacheEntryListenerConfiguration can't be null");
         }
         CacheEventListenerAdaptor<K, V> adaptor = new CacheEventListenerAdaptor<K, V>(this, cacheEntryListenerConfiguration,
-                getSerializationService(), getClient());
+                getSerializationService());
         EventHandler handler = createHandler(adaptor);
         String regId = getContext().getListenerService().registerListener(createCacheEntryListenerCodec(), handler);
         if (regId != null) {

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryListenerException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheCacheEntryListener implements CacheEntryCreatedListener, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheCacheEntryListener INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheCacheEntryListener() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public void onCreated(Iterable iterable)
+            throws CacheEntryListenerException {
+
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListenerFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListenerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.cache.impl.CacheCreateUseDestroyTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.configuration.Factory;
+import javax.cache.event.CacheEntryListener;
+import javax.cache.integration.CacheLoaderException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheCacheEntryListenerFactory implements Factory<CacheEntryListener>,
+                                                        HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheCacheEntryListenerFactory INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheCacheEntryListenerFactory() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public CacheEntryListener create() {
+        return new JCacheCacheEntryListener();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoader.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheCacheLoader
+        implements CacheLoader, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheCacheLoader INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheCacheLoader() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public Object load(Object key)
+            throws CacheLoaderException {
+        return key.toString();
+    }
+
+    @Override
+    public Map loadAll(Iterable keys)
+            throws CacheLoaderException {
+        return new HashMap();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoaderFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoaderFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheLoader;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheCacheLoaderFactory
+        implements Factory<CacheLoader>, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheCacheLoaderFactory INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheCacheLoaderFactory() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public CacheLoader create() {
+        return new JCacheCacheLoader();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerDITest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerDITest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.annotation.Resource;
+import javax.cache.Cache;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"jCacheCacheManager-applicationContext-DI.xml"})
+@Category(QuickTest.class)
+public class JCacheCacheManagerDITest {
+
+    @Resource(name = "cacheManager")
+    private JCacheCacheManager springCacheManager;
+
+    @BeforeClass
+    public static void start() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testCacheWithCacheLoaderFactory_dependenciesInjected() {
+        Cache cacheWithLoader = springCacheManager.getCacheManager().getCache("cacheWithLoader");
+        // use cacheloader at least once to ensure it's instantiated
+        cacheWithLoader.get(1);
+
+        // ensure CacheLoaderFactory & CacheLoader dependencies have been injected
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheCacheLoaderFactory.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheCacheLoaderFactory.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheCacheLoaderFactory.INSTANCE.getDummyBean());
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheCacheLoader.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheCacheLoader.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheCacheLoader.INSTANCE.getDummyBean());
+    }
+
+    @Test
+    public void testCacheWithCacheWriterFactory_dependenciesInjected() {
+        Cache cacheWithWriter = springCacheManager.getCacheManager().getCache("cacheWithWriter");
+        // use cacheloader at least once to ensure it's instantiated
+        cacheWithWriter.put(1, "1");
+
+        // ensure CacheLoaderFactory & CacheLoader dependencies have been injected
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheCacheWriterFactory.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheCacheWriterFactory.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheCacheWriterFactory.INSTANCE.getDummyBean());
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheCacheWriter.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheCacheWriter.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheCacheWriter.INSTANCE.getDummyBean());
+    }
+
+    @Test
+    public void testCacheWithExpiryPolicyFactory_dependenciesInjected() {
+        Cache cacheWithExpiryPolicy = springCacheManager.getCacheManager().getCache("cacheWithExpiryPolicy");
+        // use cacheloader at least once to ensure it's instantiated
+        cacheWithExpiryPolicy.put(1, "1");
+
+        // ensure CacheLoaderFactory & CacheLoader dependencies have been injected
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheExpiryPolicyFactory.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheExpiryPolicyFactory.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheExpiryPolicyFactory.INSTANCE.getDummyBean());
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheExpiryPolicy.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheExpiryPolicy.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheExpiryPolicy.INSTANCE.getDummyBean());
+    }
+
+    @Test
+    public void testCacheWithListeners_dependenciesInjected() {
+        Cache cacheWithPartitionLostListener = springCacheManager.getCacheManager()
+                                                                 .getCache("cacheWithListeners");
+
+        cacheWithPartitionLostListener.get(1);
+
+        // ensure partition lost listener got its dependencies injected
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCachePartitionLostListener.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCachePartitionLostListener.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCachePartitionLostListener.INSTANCE.getDummyBean());
+        // ensure CacheEntryListenerFactory & CacheEntryListener dependencies have been injected
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheCacheEntryListenerFactory.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheCacheEntryListenerFactory.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheCacheEntryListenerFactory.INSTANCE.getDummyBean());
+        assertTrue("HazelcastInstance not injected to HazelcastInstanceAware object",
+                JCacheCacheEntryListener.HAZELCAST_INSTANCE_INJECTED.get());
+        assertTrue("Node not injected to NodeAware object",
+                JCacheCacheEntryListener.NODE_INJECTED.get());
+        assertNotNull("Spring bean not injected to @SpringAware object",
+                JCacheCacheEntryListener.INSTANCE.getDummyBean());
+    }
+
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriter.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheCacheWriter
+        implements CacheWriter, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheCacheWriter INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheCacheWriter() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public void write(Cache.Entry entry)
+            throws CacheWriterException {
+
+    }
+
+    @Override
+    public void writeAll(Collection collection)
+            throws CacheWriterException {
+
+    }
+
+    @Override
+    public void delete(Object key)
+            throws CacheWriterException {
+
+    }
+
+    @Override
+    public void deleteAll(Collection keys)
+            throws CacheWriterException {
+
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriterFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriterFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheWriter;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheCacheWriterFactory
+        implements Factory<CacheWriter>, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheCacheWriterFactory INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheCacheWriterFactory() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public CacheWriter create() {
+        return new JCacheCacheWriter();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicy.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ExpiryPolicy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheExpiryPolicy implements ExpiryPolicy, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheExpiryPolicy INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheExpiryPolicy() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public Duration getExpiryForCreation() {
+        return Duration.ETERNAL;
+    }
+
+    @Override
+    public Duration getExpiryForAccess() {
+        return Duration.ETERNAL;
+    }
+
+    @Override
+    public Duration getExpiryForUpdate() {
+        return Duration.ETERNAL;
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicyFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicyFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import javax.cache.configuration.Factory;
+import javax.cache.expiry.ExpiryPolicy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCacheExpiryPolicyFactory implements Factory<ExpiryPolicy>, HazelcastInstanceAware, NodeAware {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCacheExpiryPolicyFactory INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCacheExpiryPolicyFactory() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public ExpiryPolicy create() {
+        return new JCacheExpiryPolicy();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCachePartitionLostListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCachePartitionLostListener.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import com.hazelcast.cache.impl.event.CachePartitionLostEvent;
+import com.hazelcast.cache.impl.event.CachePartitionLostListener;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spring.context.SpringAware;
+
+import javax.annotation.Resource;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringAware
+public class JCachePartitionLostListener implements HazelcastInstanceAware, NodeAware, CachePartitionLostListener {
+
+    public static final AtomicBoolean HAZELCAST_INSTANCE_INJECTED = new AtomicBoolean();
+    public static final AtomicBoolean NODE_INJECTED = new AtomicBoolean();
+
+    public static JCachePartitionLostListener INSTANCE;
+
+    @Resource(name = "dummy")
+    private IJCacheDummyBean dummyBean;
+
+    public JCachePartitionLostListener() {
+        INSTANCE = this;
+    }
+
+    @Override
+    public void partitionLost(CachePartitionLostEvent event) {
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        HAZELCAST_INSTANCE_INJECTED.set(true);
+    }
+
+    @Override
+    public void setNode(Node node) {
+        NODE_INJECTED.set(true);
+    }
+
+    public IJCacheDummyBean getDummyBean() {
+        return dummyBean;
+    }
+
+    public void setDummyBean(IJCacheDummyBean dummyBean) {
+        this.dummyBean = dummyBean;
+    }
+}

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xmlns:cache="http://www.springframework.org/schema/cache"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/cache
+		http://www.springframework.org/schema/cache/spring-cache.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.9.xsd">
+
+    <cache:annotation-driven cache-manager="cacheManager"/>
+
+    <hz:hazelcast id="instance">
+        <hz:config>
+            <hz:spring-aware />
+            <hz:instance-name>named-spring-hz-instance</hz:instance-name>
+            <hz:group name="dev" password="dev-pass"/>
+            <hz:network port="5701" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="true"/>
+                    <hz:tcp-ip enabled="false">
+                        <hz:interface>127.0.0.1:5701</hz:interface>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="true">
+                    <hz:interface>127.0.0.1</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+            <hz:cache name="cacheWithLoader" read-through="true"
+                      cache-loader-factory="com.hazelcast.spring.cache.JCacheCacheLoaderFactory">
+            </hz:cache>
+            <hz:cache name="cacheWithWriter" write-through="true"
+                      cache-writer-factory="com.hazelcast.spring.cache.JCacheCacheWriterFactory">
+            </hz:cache>
+            <hz:cache name="cacheWithExpiryPolicy" expiry-policy-factory="com.hazelcast.spring.cache.JCacheExpiryPolicyFactory">
+            </hz:cache>
+            <hz:cache name="cacheWithListeners">
+                <hz:cache-entry-listeners>
+                    <hz:cache-entry-listener
+                            cache-entry-listener-factory="com.hazelcast.spring.cache.JCacheCacheEntryListenerFactory" />
+                </hz:cache-entry-listeners>
+                <hz:partition-lost-listeners>
+                    <hz:partition-lost-listener class-name="com.hazelcast.spring.cache.JCachePartitionLostListener"/>
+                </hz:partition-lost-listeners>
+            </hz:cache>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:cache-manager id="hazelcastJCacheCacheManager" instance-ref="instance" name="hazelcastJCacheCacheManager"/>
+
+    <bean id="cacheManager" class="org.springframework.cache.jcache.JCacheCacheManager">
+        <constructor-arg ref="hazelcastJCacheCacheManager"/>
+    </bean>
+
+    <bean id="dummy" class="com.hazelcast.spring.cache.JCacheCacheManagerTest.DummyBean"/>
+</beans>

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
@@ -91,9 +91,8 @@ abstract class AbstractCacheProxyBase<K, V>
     }
 
     void injectDependencies(Object obj) {
-        if (obj instanceof HazelcastInstanceAware) {
-            ((HazelcastInstanceAware) obj).setHazelcastInstance(nodeEngine.getHazelcastInstance());
-        }
+        ManagedContext managedContext = serializationService.getManagedContext();
+        managedContext.initialize(obj);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -25,7 +25,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionConfig.MaxSizePolicy;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
 import com.hazelcast.internal.eviction.EvictionChecker;
 import com.hazelcast.internal.eviction.EvictionListener;
@@ -181,9 +181,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     private void injectDependencies(Object obj) {
-        if (obj instanceof HazelcastInstanceAware) {
-            ((HazelcastInstanceAware) obj).setHazelcastInstance(nodeEngine.getHazelcastInstance());
-        }
+        ManagedContext managedContext = nodeEngine.getSerializationService().getManagedContext();
+        managedContext.initialize(obj);
     }
 
     private void registerResourceIfItIsClosable(Object resource) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -428,12 +428,13 @@ abstract class AbstractInternalCacheProxy<K, V>
             listener = (T) listenerConfig.getImplementation();
         } else if (listenerConfig.getClassName() != null) {
             try {
-                return ClassLoaderUtil.newInstance(getNodeEngine().getConfigClassLoader(),
+                listener = ClassLoaderUtil.newInstance(getNodeEngine().getConfigClassLoader(),
                         listenerConfig.getClassName());
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e);
             }
         }
+        injectDependencies(listener);
         return listener;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -296,8 +296,7 @@ public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> implements EventJ
 
         CacheEventListenerAdaptor<K, V> entryListener = new CacheEventListenerAdaptor<K, V>(this,
                 cacheEntryListenerConfiguration,
-                getNodeEngine().getSerializationService(),
-                getNodeEngine().getHazelcastInstance());
+                getNodeEngine().getSerializationService());
         String regId = getService().registerListener(getDistributedObjectName(), entryListener, entryListener, false);
         if (regId != null) {
             if (addToConfig) {


### PR DESCRIPTION
`NodeAware` and `@SpringAware` `Cache` resources need to have dependencies injected by the managed context.

See individual commits' comments.

Fixes #11384 