### PR TITLE
Fixed and improved MapLoader tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/CountingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/CountingMapLoader.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.mapstore;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -96,7 +95,7 @@ class CountingMapLoader extends SimpleMapLoader {
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
             loadAllKeysClosed.set(true);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/LoadAllTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 public class LoadAllTest extends AbstractMapStoreTest {
 
     @Test(expected = NullPointerException.class)
-    public void load_givenKeys_null() throws Exception {
+    public void load_givenKeys_null() {
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
         final HazelcastInstance node = createHazelcastInstance(config);
@@ -58,7 +58,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void load_givenKeys_withEmptySet() throws Exception {
+    public void load_givenKeys_withEmptySet() {
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
         final HazelcastInstance node = createHazelcastInstance(config);
@@ -69,7 +69,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void load_givenKeys() throws Exception {
+    public void load_givenKeys() {
         // SETUP
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
@@ -91,7 +91,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void load_allKeys() throws Exception {
+    public void load_allKeys() {
         // SETUP
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
@@ -112,7 +112,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void testAllItemsLoaded_whenLoadingAllOnMultipleInstances() throws Exception {
+    public void testAllItemsLoaded_whenLoadingAllOnMultipleInstances() {
         String mapName = randomMapName();
         Config config = createNewConfig(mapName);
 
@@ -129,7 +129,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void testItemsNotOverwritten_whenLoadingWithoutReplacing() throws Exception {
+    public void testItemsNotOverwritten_whenLoadingWithoutReplacing() {
         String mapName = randomMapName();
         Config config = createNewConfig(mapName);
 
@@ -149,7 +149,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void load_allKeys_preserveExistingKeys_firesEvent() throws Exception {
+    public void load_allKeys_preserveExistingKeys_firesEvent() {
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
 
@@ -170,7 +170,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void load_allKeys_firesEvent() throws Exception {
+    public void load_allKeys_firesEvent() {
         final int itemCount = 1000;
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
@@ -189,7 +189,7 @@ public class LoadAllTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void load_givenKeys_withBackupNodes() throws Exception {
+    public void load_givenKeys_withBackupNodes() {
         final int itemCount = 10000;
         final int rangeStart = 1000;
         // select an ordinary value

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapClassLoaderTest.java
@@ -50,7 +50,7 @@ public class MapClassLoaderTest extends HazelcastTestSupport {
 
     // https://github.com/hazelcast/hazelcast/issues/2721
     @Test
-    public void testIssue2721() throws InterruptedException {
+    public void testIssue2721() {
         final Config config = new Config();
 
         // get map config
@@ -88,10 +88,8 @@ public class MapClassLoaderTest extends HazelcastTestSupport {
 
     private class InMemoryMapStore implements MapStore<String, String> {
 
-        private final ConcurrentHashMap<String, String> store =
-                new ConcurrentHashMap<String, String>();
-        private final ConcurrentHashMap<String, Boolean> contextClassLoaders =
-                new ConcurrentHashMap<String, Boolean>();
+        private final ConcurrentHashMap<String, String> store = new ConcurrentHashMap<String, String>();
+        private final ConcurrentHashMap<String, Boolean> contextClassLoaders = new ConcurrentHashMap<String, Boolean>();
 
         public TreeMap<String, Boolean> getContextClassLoaders() {
             return new TreeMap<String, Boolean>(contextClassLoaders);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapCreationDelayWithMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapCreationDelayWithMapStoreTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
 public class MapCreationDelayWithMapStoreTest extends HazelcastTestSupport {
 
     @Test(timeout = 120000)
-    public void testMapCreation__notAffectedByUnresponsiveLoader() throws Exception {
+    public void testMapCreation__notAffectedByUnresponsiveLoader() {
         final UnresponsiveLoader<Integer, Integer> unresponsiveLoader = new UnresponsiveLoader<Integer, Integer>();
         final IMap<Integer, Integer> map = TestMapUsingMapStoreBuilder.<Integer, Integer>create()
                 .withMapStore(unresponsiveLoader)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -52,13 +52,13 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     private CountingMapLoader mapLoader;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         nodeFactory = createHazelcastInstanceFactory(NODE_COUNT + 2);
         mapLoader = new CountingMapLoader(MAP_STORE_ENTRY_COUNT);
     }
 
     @Test(timeout = MINUTE)
-    public void testDoesntLoadAgain_whenLoaderNodeGoesDown() throws Exception {
+    public void testDoesntLoadAgain_whenLoaderNodeGoesDown() {
         Config cfg = newConfig("default", LAZY);
         HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
         HazelcastInstance hz3 = nodes[2];
@@ -77,7 +77,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = MINUTE)
-    public void testLoads_whenInitialLoaderNodeRemoved() throws Exception {
+    public void testLoads_whenInitialLoaderNodeRemoved() {
         Config cfg = newConfig("default", LAZY);
         HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
         HazelcastInstance hz3 = nodes[2];
@@ -95,7 +95,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
 
     @Test(timeout = MINUTE)
     // FIXES https://github.com/hazelcast/hazelcast/issues/6056
-    public void testLoadsAll_whenInitialLoaderNodeRemovedAfterLoading() throws Exception {
+    public void testLoadsAll_whenInitialLoaderNodeRemovedAfterLoading() {
         Config cfg = newConfig("default", LAZY);
         HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
         HazelcastInstance hz3 = nodes[2];
@@ -144,7 +144,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
 
     @Test(timeout = MINUTE)
     // FIXES https://github.com/hazelcast/hazelcast/issues/7959
-    public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups() throws Exception {
+    public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups() {
         PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
 
         Config cfg = newConfig("default", LAZY, 0, pausingLoader);
@@ -179,16 +179,19 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     }
 
     private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode, int backups, MapLoader loader) {
-        Config cfg = new Config();
-        cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
-        cfg.setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE.getName(), Integer.toString(BATCH_SIZE));
-        cfg.setProperty(GroupProperty.PARTITION_COUNT.getName(), "13");
+        Config config = new Config()
+                .setGroupConfig(new GroupConfig(getClass().getSimpleName()))
+                .setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE.getName(), Integer.toString(BATCH_SIZE))
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "13");
 
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
-                .setImplementation(loader).setInitialLoadMode(loadMode);
+                .setInitialLoadMode(loadMode)
+                .setImplementation(loader);
 
-        cfg.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig).setBackupCount(backups);
+        config.getMapConfig(mapName)
+                .setBackupCount(backups)
+                .setMapStoreConfig(mapStoreConfig);
 
-        return cfg;
+        return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderLifecycleTest.java
@@ -50,7 +50,7 @@ public class MapLoaderLifecycleTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testInitCalled_whenMapCreated() throws Exception {
+    public void testInitCalled_whenMapCreated() {
 
         HazelcastInstance hz = createHazelcastInstance(config);
 
@@ -62,7 +62,7 @@ public class MapLoaderLifecycleTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testDestroyCalled_whenNodeShutdown() throws Exception {
+    public void testDestroyCalled_whenNodeShutdown() {
 
         HazelcastInstance hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreAdapterTest.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.map.impl.mapstore;
 
-
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
@@ -205,7 +205,7 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
                     node1FinishedLoading.countDown();
                     assertTrueEventually(new AssertTask() {
                         @Override
-                        public void run() throws Exception {
+                        public void run() {
                             assertEquals(PRELOAD_SIZE, map.size());
                         }
                     }, 5);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -202,7 +202,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
             final int index = i;
             assertTrueEventually(new AssertTask() {
                 @Override
-                public void run() throws Exception {
+                public void run() {
                     final Integer valueInMap = map.get(index);
                     final Integer valueInStore = (Integer) store.getStore().get(index);
 
@@ -266,7 +266,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testInitialLoadModeEagerWhileStoppigOneNode() throws InterruptedException {
+    public void testInitialLoadModeEagerWhileStoppigOneNode() {
         final int instanceCount = 2;
         final int size = 10000;
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(instanceCount);
@@ -302,7 +302,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 240000)
-    public void testMapInitialLoad() throws InterruptedException {
+    public void testMapInitialLoad() {
         int size = 10000;
         String mapName = randomMapName();
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
@@ -454,7 +454,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberFlush() throws Exception {
+    public void testOneMemberFlush() {
         TestMapStore testMapStore = new TestMapStore(1, 1, 1);
         testMapStore.setLoadAllKeys(false);
         int size = 100;
@@ -485,7 +485,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberFlushOnShutdown() throws Exception {
+    public void testOneMemberFlushOnShutdown() {
         TestMapStore testMapStore = new TestMapStore(1, 1, 1);
         testMapStore.setLoadAllKeys(false);
         Config config = newConfig(testMapStore, 200);
@@ -504,7 +504,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testGetAllKeys() throws Exception {
+    public void testGetAllKeys() {
         EventBasedMapStore<Integer, String> testMapStore = new EventBasedMapStore<Integer, String>();
         Map<Integer, String> store = testMapStore.getStore();
         int size = 1000;
@@ -554,7 +554,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
      * Test for Issue 572
     */
     @Test(timeout = 120000)
-    public void testMapstoreDeleteOnClear() throws Exception {
+    public void testMapstoreDeleteOnClear() {
         Config config = getConfig();
         SimpleMapStore store = new SimpleMapStore();
         config.getMapConfig("testMapstoreDeleteOnClear").setMapStoreConfig(new MapStoreConfig().setEnabled(true).setImplementation(store));
@@ -645,7 +645,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testIssue1019() throws InterruptedException {
+    public void testIssue1019() {
         final String keyWithNullValue = "keyWithNullValue";
 
         EventBasedMapStore<String, Integer> testMapStore = new EventBasedMapStore<String, Integer>() {
@@ -685,7 +685,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testIssue1115EnablingMapstoreMutatingValue() throws InterruptedException {
+    public void testIssue1115EnablingMapstoreMutatingValue() {
         Config config = getConfig();
         String mapName = "testIssue1115";
         MapStore mapStore = new ProcessingStore();
@@ -751,7 +751,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
      * Test for issue https://github.com/hazelcast/hazelcast/issues/1110
      */
     @Test(timeout = 300000)
-    public void testMapLoader_withMapLoadChunkSize() throws InterruptedException {
+    public void testMapLoader_withMapLoadChunkSize() {
         final int chunkSize = 5;
         final int numberOfEntriesToLoad = 100;
         final String mapName = randomString();
@@ -845,7 +845,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testReadingConfiguration() throws Exception {
+    public void testReadingConfiguration() {
         String mapName = "mapstore-test";
         InputStream is = getClass().getResourceAsStream("/com/hazelcast/config/hazelcast-mapstore-config.xml");
         XmlConfigBuilder builder = new XmlConfigBuilder(is);
@@ -883,7 +883,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testMapStoreNotCalledFromEntryProcessorBackup() throws Exception {
+    public void testMapStoreNotCalledFromEntryProcessorBackup() {
         final String mapName = "testMapStoreNotCalledFromEntryProcessorBackup_" + randomString();
         final int instanceCount = 2;
         Config config = getConfig();
@@ -928,14 +928,14 @@ public class MapStoreTest extends AbstractMapStoreTest {
         assertWriteBehindQueuesEmpty(mapName, singletonList(hzInstance));
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, store.store.size());
             }
         });
     }
 
     @Test
-    public void testEntryProcessor_calls_load_only_one_time_per_key() throws Exception {
+    public void testEntryProcessor_calls_load_only_one_time_per_key() {
         Config config = getConfig();
         // configure map with one backup and dummy map store
         MapConfig mapConfig = config.getMapConfig("default");
@@ -987,7 +987,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
         // expect oldValue equals 1
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 Integer value = oldValue.get();
                 assertNotNull(value);
                 assertEquals(1, value.intValue());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWithPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWithPredicateTest.java
@@ -54,7 +54,7 @@ public class MapStoreWithPredicateTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 Set expected = map.keySet(Predicates.greaterThan("value", 1));
                 assertEquals(3, expected.size());
                 assertContains(expected, "key1");
@@ -80,7 +80,7 @@ public class MapStoreWithPredicateTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 final Collection values = map.values(Predicates.greaterThan("value", 1));
                 assertEquals(3, values.size());
                 assertContains(values, 17);
@@ -91,7 +91,7 @@ public class MapStoreWithPredicateTest extends AbstractMapStoreTest {
     }
 
     @Test
-    public void testEntrySetWithPredicate_checksMapStoreLoad() throws InterruptedException {
+    public void testEntrySetWithPredicate_checksMapStoreLoad() {
         EventBasedMapStore<String, Integer> testMapStore = new EventBasedMapStore<String, Integer>();
 
         Map<String, Integer> mapForStore = new HashMap<String, Integer>();
@@ -106,7 +106,7 @@ public class MapStoreWithPredicateTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 final Set<Map.Entry<String, Integer>> entrySet = map.entrySet(Predicates.greaterThan("value", 1));
                 assertEquals(3, entrySet.size());
             }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteBehindTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteBehindTest.java
@@ -75,7 +75,7 @@ import static org.junit.Assert.fail;
 public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
     @Test(timeout = 120000)
-    public void testOneMemberWriteBehindWithMaxIdle() throws Exception {
+    public void testOneMemberWriteBehindWithMaxIdle() {
         final EventBasedMapStore testMapStore = new EventBasedMapStore();
         Config config = newConfig(testMapStore, 5, InitialLoadMode.EAGER);
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "1");
@@ -86,7 +86,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
         final int total = 10;
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(EventBasedMapStore.STORE_EVENTS.LOAD_ALL_KEYS, testMapStore.getEvents().poll());
             }
         });
@@ -98,7 +98,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
         sleepSeconds(11);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, map.size());
             }
         });
@@ -127,7 +127,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
         assertOpenEventually(testMapStore.storeLatch);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, writeBehindQueueSize(instance, mapName));
             }
         });
@@ -235,14 +235,14 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
         map.put("key", "value2");
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals("value2", testMapStore.getStore().get("key"));
             }
         });
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberWriteBehindFlush() throws Exception {
+    public void testOneMemberWriteBehindFlush() {
         TestMapStore testMapStore = new TestMapStore(1, 1, 1);
         testMapStore.setLoadAllKeys(false);
         int writeDelaySeconds = 2;
@@ -276,7 +276,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberWriteBehind2() throws Exception {
+    public void testOneMemberWriteBehind2() {
         final EventBasedMapStore testMapStore = new EventBasedMapStore();
         testMapStore.setLoadAllKeys(false);
         Config config = newConfig(testMapStore, 1, InitialLoadMode.EAGER);
@@ -285,7 +285,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 Object event = testMapStore.getEvents().poll();
                 assertEquals(EventBasedMapStore.STORE_EVENTS.LOAD_ALL_KEYS, event);
             }
@@ -295,14 +295,14 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(EventBasedMapStore.STORE_EVENTS.LOAD, testMapStore.getEvents().poll());
             }
         });
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(EventBasedMapStore.STORE_EVENTS.STORE, testMapStore.getEvents().poll());
             }
         });
@@ -311,7 +311,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(EventBasedMapStore.STORE_EVENTS.DELETE, testMapStore.getEvents().poll());
             }
         });
@@ -320,7 +320,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     @Test(timeout = 120000)
     @Category(NightlyTest.class)
     // issue #2747: when MapStore configured with write behind, distributed objects' destroy method does not work
-    public void testWriteBehindDestroy() throws InterruptedException {
+    public void testWriteBehindDestroy() {
         final int writeDelaySeconds = 5;
         String mapName = randomMapName();
 
@@ -340,7 +340,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testKeysWithPredicateShouldLoadMapStore() throws InterruptedException {
+    public void testKeysWithPredicateShouldLoadMapStore() {
         EventBasedMapStore<String, Integer> testMapStore = new EventBasedMapStore<String, Integer>()
                 .insert("key1", 17)
                 .insert("key2", 23)
@@ -351,7 +351,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 Set result = map.keySet();
                 assertContains(result, "key1");
                 assertContains(result, "key2");
@@ -361,7 +361,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testIssue1085WriteBehindBackup() throws InterruptedException {
+    public void testIssue1085WriteBehindBackup() {
         Config config = getConfig();
         String name = "testIssue1085WriteBehindBackup";
         MapConfig writeBehindBackup = config.getMapConfig(name);
@@ -383,7 +383,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testIssue1085WriteBehindBackupWithLongRunnigMapStore() throws InterruptedException {
+    public void testIssue1085WriteBehindBackupWithLongRunnigMapStore() {
         final String name = randomMapName("testIssue1085WriteBehindBackup");
         final int expectedStoreCount = 3;
         final int nodeCount = 3;
@@ -416,7 +416,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
         // we should see at least expected store count.
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 int storeOperationCount = mapStore.count.intValue();
                 assertTrue("expected: " + expectedStoreCount
                         + ", actual: " + storeOperationCount, expectedStoreCount <= storeOperationCount);
@@ -426,7 +426,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
 
     @Test(timeout = 120000)
-    public void testMapDelete_whenLoadFails() throws Exception {
+    public void testMapDelete_whenLoadFails() {
         final FailingLoadMapStore mapStore = new FailingLoadMapStore();
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
@@ -442,7 +442,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000, expected = IllegalStateException.class)
-    public void testMapRemove_whenMapStoreLoadFails() throws Exception {
+    public void testMapRemove_whenMapStoreLoadFails() {
         final FailingLoadMapStore mapStore = new FailingLoadMapStore();
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
@@ -454,7 +454,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testIssue1085WriteBehindBackupTransactional() throws InterruptedException {
+    public void testIssue1085WriteBehindBackupTransactional() {
         final String name = randomMapName();
         final int size = 1000;
         MapStoreTest.MapStoreWithStoreCount mapStore = new MapStoreTest.MapStoreWithStoreCount(size, 120);
@@ -476,7 +476,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testWriteBehindSameSecondSameKey() throws Exception {
+    public void testWriteBehindSameSecondSameKey() {
         final TestMapStore testMapStore = new TestMapStore(100, 0, 0); // In some cases 2 store operation may happened
         testMapStore.setLoadAllKeys(false);
         Config config = newConfig(testMapStore, 2);
@@ -494,20 +494,20 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals("value" + (size1 - 1), testMapStore.getStore().get("key"));
             }
         });
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals("value" + (size2 - 1), testMapStore.getStore().get("key" + (size2 - 1)));
             }
         });
     }
 
     @Test(timeout = 120000)
-    public void testWriteBehindWriteRemoveOrderOfSameKey() throws Exception {
+    public void testWriteBehindWriteRemoveOrderOfSameKey() {
         final String mapName = randomMapName("_testWriteBehindWriteRemoveOrderOfSameKey_");
         final int iterationCount = 5;
         final int delaySeconds = 1;
@@ -534,7 +534,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(expectedStoreSizeEventually, store.getStore().size());
             }
         });
@@ -542,7 +542,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void mapStore_setOnIMapDoesNotRemoveKeyFromWriteBehindDeleteQueue() throws Exception {
+    public void mapStore_setOnIMapDoesNotRemoveKeyFromWriteBehindDeleteQueue() {
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setImplementation(new SimpleMapStore<String, String>())
@@ -561,7 +561,7 @@ public class MapStoreWriteBehindTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testDelete_thenPutIfAbsent_withWriteBehindEnabled() throws Exception {
+    public void testDelete_thenPutIfAbsent_withWriteBehindEnabled() {
         TestMapStore testMapStore = new TestMapStore(1, 1, 1);
         Config config = newConfig(testMapStore, 100);
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
@@ -83,7 +83,7 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberWriteThroughWithLRU() throws Exception {
+    public void testOneMemberWriteThroughWithLRU() {
         final int size = 10000;
         TestMapStore testMapStore = new TestMapStore(size * 2, 1, 1);
         testMapStore.setLoadAllKeys(false);
@@ -108,7 +108,7 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
         }, false);
 
         for (int i = 0; i < size * 2; i++) {
-            // trigger eviction.
+            // trigger eviction
             if (i == (size * 2) - 1 || i == size) {
                 sleepMillis(1001);
             }
@@ -236,7 +236,7 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberWriteThroughFailingStore() throws Exception {
+    public void testOneMemberWriteThroughFailingStore() {
         FailAwareMapStore testMapStore = new FailAwareMapStore();
         testMapStore.setFail(true, true);
         Config config = newConfig(testMapStore, 0);
@@ -269,7 +269,7 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
     }
 
     @Test(timeout = 120000)
-    public void testOneMemberWriteThroughFailingStore2() throws Exception {
+    public void testOneMemberWriteThroughFailingStore2() {
         FailAwareMapStore testMapStore = new FailAwareMapStore();
         testMapStore.setFail(true, false);
         Config config = newConfig(testMapStore, 0);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/PausingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/PausingMapLoader.java
@@ -18,12 +18,13 @@ package com.hazelcast.map.impl.mapstore;
 
 import com.hazelcast.core.IFunction;
 import com.hazelcast.core.MapLoader;
-import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.IterableUtil;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * MapLoader that pauses once while loading keys until resumed using {@link #resume()}
@@ -72,7 +73,7 @@ class PausingMapLoader<K, V> implements MapLoader<K, V> {
             pauseLatch.countDown();
             resumeLatch.await();
         } catch (InterruptedException e) {
-            ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -80,7 +81,7 @@ class PausingMapLoader<K, V> implements MapLoader<K, V> {
         try {
             pauseLatch.await();
         } catch (InterruptedException e) {
-            ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 


### PR DESCRIPTION
* fixed wrong usage of `ExpectedException` (must be last statement)
* fixed wrong asserts, which were not executed before
* removed superfluous `throws Exception`
* ignored `testNullKey_loadAll()`, which is known to be racy

The failures from https://github.com/hazelcast/hazelcast/issues/11244 are still there and occur regularly in my local runs. Nevertheless some other asserts of that test are fixed.