### PR TITLE
Fix for ClientScheduledExecutorServiceBasicTest.getErroneous_durable …

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.scheduledexecutor;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -60,7 +61,9 @@ public class ClientScheduledExecutorServiceBasicTest extends ScheduledExecutorSe
 
     @Override
     public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
-        return factory.newHazelcastClient().getScheduledExecutorService(name);
+        ClientConfig config = new ClientConfig();
+        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        return factory.newHazelcastClient(config).getScheduledExecutorService(name);
     }
 
     @Override


### PR DESCRIPTION
…test

Make sure client is able to connect back to cluster via setting
connection attempt limit to Integer.MAX

fixes #11387