### PR TITLE
Enable / disable IndeterminateOperationStateException per invocation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -17,8 +17,12 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.IndeterminateOperationStateException;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.nio.Address;
+
+import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
+import static com.hazelcast.util.Preconditions.checkFalse;
 
 /**
  * The InvocationBuilder is responsible for building an invocation of an operation and invoking it.
@@ -65,6 +69,7 @@ public abstract class InvocationBuilder {
     protected int tryCount = DEFAULT_TRY_COUNT;
     protected long tryPauseMillis = DEFAULT_TRY_PAUSE_MILLIS;
     protected boolean resultDeserialized = DEFAULT_DESERIALIZE_RESULT;
+    protected boolean failOnIndeterminateOperationState;
 
     /**
      * Creates an InvocationBuilder
@@ -130,6 +135,29 @@ public abstract class InvocationBuilder {
      */
     public InvocationBuilder setTryCount(int tryCount) {
         this.tryCount = tryCount;
+        return this;
+    }
+
+    /**
+     * Returns true if {@link IndeterminateOperationStateException} is enabled for this invocation
+     *
+     * @return true if {@link IndeterminateOperationStateException} is enabled for this invocation
+     */
+    public boolean shouldFailOnIndeterminateOperationState() {
+        return failOnIndeterminateOperationState;
+    }
+
+    /**
+     * Enables / disables throwing {@link IndeterminateOperationStateException} for this invocation.
+     * Can be used only for partition invocations
+     * @see IndeterminateOperationStateException
+     *
+     * @return the InvocationBuilder
+     */
+    public InvocationBuilder setFailOnIndeterminateOperationState(boolean failOnIndeterminateOperationState) {
+        checkFalse((failOnIndeterminateOperationState && partitionId == GENERIC_PARTITION_ID),
+                "failOnIndeterminateOperationState can be used with only partition invocations");
+        this.failOnIndeterminateOperationState = failOnIndeterminateOperationState;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -781,7 +781,6 @@ public abstract class Invocation implements OperationResponseHandler {
         final ConnectionManager connectionManager;
         final InternalExecutionService executionService;
         final long defaultCallTimeoutMillis;
-        final boolean failOnIndeterminateOperationState;
         final InvocationRegistry invocationRegistry;
         final InvocationMonitor invocationMonitor;
         final ILogger logger;
@@ -802,7 +801,6 @@ public abstract class Invocation implements OperationResponseHandler {
                 ConnectionManager connectionManager,
                 InternalExecutionService executionService,
                 long defaultCallTimeoutMillis,
-                boolean failOnIndeterminateOperationState,
                 InvocationRegistry invocationRegistry,
                 InvocationMonitor invocationMonitor,
                 ILogger logger,
@@ -821,7 +819,6 @@ public abstract class Invocation implements OperationResponseHandler {
             this.connectionManager = connectionManager;
             this.executionService = executionService;
             this.defaultCallTimeoutMillis = defaultCallTimeoutMillis;
-            this.failOnIndeterminateOperationState = failOnIndeterminateOperationState;
             this.invocationRegistry = invocationRegistry;
             this.invocationMonitor = invocationMonitor;
             this.logger = logger;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -50,7 +50,8 @@ class InvocationBuilderImpl extends InvocationBuilder {
         if (target == null) {
             op.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
             invocation = new PartitionInvocation(
-                    context, op, doneCallback, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                    context, op, doneCallback, tryCount, tryPauseMillis, callTimeout, resultDeserialized,
+                    failOnIndeterminateOperationState);
         } else {
             invocation = new TargetInvocation(
                     context, op, target, doneCallback, tryCount, tryPauseMillis, callTimeout, resultDeserialized);

--- a/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
@@ -14,10 +14,10 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.Before;
@@ -38,8 +38,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class IndeterminateOperationStateExceptionTest extends HazelcastTestSupport {
 
     private HazelcastInstance instance1;
@@ -48,9 +48,16 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
 
     @Before
     public void init() {
+        SilentOperation.executionStarted = false;
+        DummyReadOperation.lastInvocationAddress = null;
+    }
+
+    private void setup(boolean enableFailOnIndeterminateOperationState) {
         Config config = new Config();
-        config.setProperty(OPERATION_BACKUP_TIMEOUT_MILLIS.getName(), String.valueOf(1000));
-        config.setProperty(FAIL_ON_INDETERMINATE_OPERATION_STATE.getName(), String.valueOf(true));
+        config.setProperty(OPERATION_BACKUP_TIMEOUT_MILLIS.getName(), String.valueOf(3000));
+        if (enableFailOnIndeterminateOperationState) {
+            config.setProperty(FAIL_ON_INDETERMINATE_OPERATION_STATE.getName(), String.valueOf(true));
+        }
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         instance1 = factory.newHazelcastInstance(config);
@@ -59,7 +66,9 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
     }
 
     @Test
-    public void partitionInvocation_shouldFail_whenBackupTimeoutOccurs() throws InterruptedException, TimeoutException {
+    public void partitionInvocation_shouldFailOnBackupTimeout_whenConfigurationEnabledGlobally() throws InterruptedException, TimeoutException {
+        setup(true);
+
         dropOperationsBetween(instance1, instance2, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
         int partitionId = getPartitionId(instance1);
 
@@ -75,11 +84,42 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
     }
 
     @Test
+    public void partitionInvocation_shouldFailOnBackupTimeout_whenConfigurationEnabledForInvocation() throws InterruptedException, TimeoutException {
+        setup(false);
+
+        dropOperationsBetween(instance1, instance2, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
+        int partitionId = getPartitionId(instance1);
+
+        InternalOperationService operationService = getNodeEngineImpl(instance1).getOperationService();
+        InternalCompletableFuture<Object> future = operationService
+                .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new PrimaryOperation(), partitionId)
+                .setFailOnIndeterminateOperationState(true)
+                .invoke();
+        try {
+            future.get(2, TimeUnit.MINUTES);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IndeterminateOperationStateException);
+        }
+    }
+
+    @Test
     public void partitionInvocation_shouldFail_whenPartitionPrimaryLeaves() throws InterruptedException, TimeoutException {
+        setup(true);
+
         int partitionId = getPartitionId(instance2);
         InternalOperationService operationService = getNodeEngineImpl(instance1).getOperationService();
         InternalCompletableFuture<Object> future = operationService
                 .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new SilentOperation(), partitionId).invoke();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(SilentOperation.executionStarted);
+            }
+        });
+
         spawn(new Runnable() {
             @Override
             public void run() {
@@ -97,6 +137,8 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
     @Test
     public void readOnlyPartitionInvocation_shouldSucceed_whenPartitionPrimaryLeaves()
             throws InterruptedException, TimeoutException, ExecutionException {
+        setup(true);
+
         dropOperationsBetween(instance2, instance1, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.NORMAL_RESPONSE));
 
         int partitionId = getPartitionId(instance2);
@@ -116,6 +158,8 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
 
     @Test
     public void transaction_shouldFail_whenBackupTimeoutOccurs() throws InterruptedException, TimeoutException {
+        setup(true);
+
         dropOperationsBetween(instance1, instance2, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
         dropOperationsBetween(instance2, instance1, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.BACKUP));
 
@@ -144,10 +188,20 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
 
     @Test(expected = MemberLeftException.class)
     public void targetInvocation_shouldFailWithMemberLeftException_onTargetMemberLeave() throws Exception {
+        setup(true);
+
         InternalOperationService operationService = getNodeEngineImpl(instance1).getOperationService();
         Address target = getAddress(instance2);
         InternalCompletableFuture<Object> future = operationService
                 .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new SilentOperation(), target).invoke();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(SilentOperation.executionStarted);
+            }
+        });
 
         spawn(new Runnable() {
             @Override
@@ -203,8 +257,11 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
 
     public static class SilentOperation extends Operation {
 
+        static volatile boolean executionStarted;
+
         @Override
         public void run() throws Exception {
+            executionStarted = true;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
@@ -69,7 +69,7 @@ public class InboundResponseHandler_NotifyTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         Invocation.Context context = operationService.invocationContext;
-        Invocation invocation = new PartitionInvocation(context, op, 0, 0, 0, false);
+        Invocation invocation = new PartitionInvocation(context, op, 0, 0, 0, false, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -59,8 +59,8 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         Invocation.Context context = new Context(null, null, null, null, null,
-                1000, false, invocationRegistry, null, logger, null, null, null, null, null, null, null, null, null);
-        return new PartitionInvocation(context, op, 0, 0, 0, false);
+                1000, invocationRegistry, null, logger, null, null, null, null, null, null, null, null, null);
+        return new PartitionInvocation(context, op, 0, 0, 0, false, false);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NotifyCallTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NotifyCallTimeoutTest.java
@@ -58,7 +58,7 @@ public class Invocation_NotifyCallTimeoutTest extends HazelcastTestSupport {
         op.setPartitionId(0).setWaitTimeout(-1);
 
         Invocation invocation = new PartitionInvocation(
-                operationService.invocationContext, op, 10, MINUTES.toSeconds(2), MINUTES.toSeconds(2), false);
+                operationService.invocationContext, op, 10, MINUTES.toSeconds(2), MINUTES.toSeconds(2), false, false);
 
         OperationAccessor.setInvocationTime(op, node.getClusterService().getClusterClock().getClusterTime());
 
@@ -75,7 +75,7 @@ public class Invocation_NotifyCallTimeoutTest extends HazelcastTestSupport {
         op.setPartitionId(0).setWaitTimeout(SECONDS.toMillis(2));
 
         Invocation invocation = new PartitionInvocation(
-                operationService.invocationContext, op, 10, MINUTES.toSeconds(2), MINUTES.toSeconds(2), false);
+                operationService.invocationContext, op, 10, MINUTES.toSeconds(2), MINUTES.toSeconds(2), false, false);
 
         OperationAccessor.setInvocationTime(op, node.getClusterService().getClusterClock().getClusterTime());
 
@@ -94,7 +94,7 @@ public class Invocation_NotifyCallTimeoutTest extends HazelcastTestSupport {
         op.setPartitionId(0).setWaitTimeout(SECONDS.toMillis(60));
 
         Invocation invocation = new PartitionInvocation(
-                operationService.invocationContext, op, 10, MINUTES.toSeconds(2), MINUTES.toSeconds(2), false);
+                operationService.invocationContext, op, 10, MINUTES.toSeconds(2), MINUTES.toSeconds(2), false, false);
 
         OperationAccessor.setInvocationTime(op, node.getClusterService().getClusterClock().getClusterTime());
 


### PR DESCRIPTION
Use the global IndeterminateOperationStateException configuration by default. When a partition invocation is built with InvocationBuilder, IndeterminateOperationStateException can be also configured individually. It means even if the global configuration is disabled, it can be used for some invocations, and vice versa.