### PR TITLE
Fixed JSR tests which fail on the default MBeanServer being created

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -62,9 +62,7 @@ public final class JsrTestUtil {
     }
 
     /**
-     * Sets the System properties for JSR related tests.
-     * <p>
-     * Uses plain strings to avoid triggering any classloading of JSR classes with static code initializations.
+     * Sets the System properties for JSR related tests including the JCache provider type.
      *
      * @param providerType "server" or "client" according to your test type
      */
@@ -78,6 +76,14 @@ public final class JsrTestUtil {
          */
         setSystemProperty("hazelcast.jcache.provider.type", providerType);
 
+        setSystemProperties();
+    }
+
+    /**
+     * Sets the System properties for JSR related tests.
+     */
+    public static void setSystemProperties() {
+        // uses plain strings to avoid triggering any classloading of JSR classes with static code initializations
         setSystemProperty("javax.management.builder.initial", "com.hazelcast.cache.impl.TCKMBeanServerBuilder");
         setSystemProperty("CacheManagerImpl", "com.hazelcast.cache.HazelcastCacheManager");
         setSystemProperty("javax.cache.Cache", "com.hazelcast.cache.ICache");

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.test;
 
+import com.hazelcast.cache.jsr.JsrTestUtil;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
@@ -113,6 +114,11 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
 
     // initialize environment, logging and attach a final-modifier removing agent if required
     private static void initialize() {
+        // we set the JSR System properties globally, since some tests trigger the MBeanServer
+        // initialization, which will not create the correct one without these System properties
+        // (this was done via the pom.xml before for most test profiles, so this does no harm)
+        JsrTestUtil.setSystemProperties();
+
         if (isRunningCompatibilityTest()) {
             attachFinalRemovalAgent();
             System.out.println("Running compatibility tests.");


### PR DESCRIPTION
Some tests trigger the `MBeanServer` initialization, which will not create the correct one for some JSR tests. The solution is to set the JSR System properties globally. This was done via the `pom.xml` before in our test profiles, so this does no harm.

I will not do a cleanup of the System properties in the Hazelcast runner. So all tests will set the properties and just the JSR tests will clean them up (together with their custom `JCache` provider type and a cleanup of the CachingProvider registry). This should be race free, since the JSR tests are already isolated. It's just some other test running before in the same JVM, which left the wrong `MBeanServer` in the static `mBeanServerList` of `MBeanServerFactory`. I tried to clean this list as well, but this seems to be the much simpler solution.

Fixes https://github.com/hazelcast/hazelcast/issues/11404