### PR TITLE
[BACKPORT] Fixed JSR tests which fail on the default MBeanServer being created

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -62,9 +62,7 @@ public final class JsrTestUtil {
     }
 
     /**
-     * Sets the System properties for JSR related tests.
-     * <p>
-     * Uses plain strings to avoid triggering any classloading of JSR classes with static code initializations.
+     * Sets the System properties for JSR related tests including the JCache provider type.
      *
      * @param providerType "server" or "client" according to your test type
      */
@@ -78,6 +76,14 @@ public final class JsrTestUtil {
          */
         setSystemProperty("hazelcast.jcache.provider.type", providerType);
 
+        setSystemProperties();
+    }
+
+    /**
+     * Sets the System properties for JSR related tests.
+     */
+    public static void setSystemProperties() {
+        // uses plain strings to avoid triggering any classloading of JSR classes with static code initializations
         setSystemProperty("javax.management.builder.initial", "com.hazelcast.cache.impl.TCKMBeanServerBuilder");
         setSystemProperty("CacheManagerImpl", "com.hazelcast.cache.HazelcastCacheManager");
         setSystemProperty("javax.cache.Cache", "com.hazelcast.cache.ICache");

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.test;
 
+import com.hazelcast.cache.jsr.JsrTestUtil;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
@@ -64,6 +65,11 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     private static final boolean THREAD_CONTENTION_INFO_AVAILABLE;
 
     static {
+        // we set the JSR System properties globally, since some tests trigger the MBeanServer
+        // initialization, which will not create the correct one without these System properties
+        // (this was done via the pom.xml before for most test profiles, so this does no harm)
+        JsrTestUtil.setSystemProperties();
+
         TestLoggingUtils.initializeLogging();
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");


### PR DESCRIPTION
Some tests trigger the MBeanServer initialization, which will not create
the correct one for some JSR tests. The solution is to set the JSR
System properties globally. This was done via the pom.xml before for
most test profiles, so this does no harm.

(cherry picked from commit c97bf7b)

The `AbstractHazelcastClassRunner` in `maintenance` has no `initialize()` method yet, so I put the `JsrTestUtil.setSystemProperties()` call at the beginning of the `static` initializer.

Backport of https://github.com/hazelcast/hazelcast/pull/11405