### PR TITLE
make HazelcastOSGiIntegrationTest's url suitable for windows env

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
@@ -61,6 +61,8 @@ public class HazelcastOSGiIntegrationTest {
         System.setProperty(MAVEN_REPOSITORIES_PROP, MAVEN_REPOSITORIES);
 
         String url = "reference:file:" + PathUtils.getBaseDir() + "/target/classes";
+        // modify url for Windows environment
+        url = url.replace("\\", "/");
         UrlProvisionOption hzBundle = bundle(url);
         CompositeOption junitBundles = junitBundles();
         return options(hzBundle, junitBundles);


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/9892 . I have tested this fix on our windows lab machine and it passed.

main cause of the [failure](https://github.com/hazelcast/hazelcast/issues/9892) was url path is not read correctly by osgi.bundle method `C:UsershasanIdeaProjectshazelcasthazelcast/target/classes`:
```
Auto-properties install: reference:file:C:UsershasanIdeaProjectshazelcasthazelcast/target/classes(org.osgi.framework.BundleException: Unable to cache bundle: reference:file:C:UsershasanIdeaProjectshazelcasthazelcast/target/classes - java.io.IOException: Referenced file does not exist: C:UsershasanIdeaProjectshazelcasthazelcast\target\classes)
org.osgi.framework.BundleException: Unable to cache bundle: reference:file:C:UsershasanIdeaProjectshazelcasthazelcast/target/classes
	at org.apache.felix.framework.Felix.installBundle(Felix.java:2878)
	at org.apache.felix.framework.BundleContextImpl.installBundle(BundleContextImpl.java:165)
	at org.apache.felix.main.AutoProcessor.processAutoProperties(AutoProcessor.java:296)
	at org.apache.felix.main.AutoProcessor.process(AutoProcessor.java:79)
	at org.apache.felix.main.Main.main(Main.java:292)
Caused by: java.io.IOException: Referenced file does not exist: C:UsershasanIdeaProjectshazelcasthazelcast\target\classes
	at org.apache.felix.framework.cache.BundleArchive.createRevisionFromLocation(BundleArchive.java:852)
	at org.apache.felix.framework.cache.BundleArchive.reviseInternal(BundleArchive.java:550)
	at org.apache.felix.framework.cache.BundleArchive.<init>(BundleArchive.java:153)
	at org.apache.felix.framework.cache.BundleCache.create(BundleCache.java:277)
	at org.apache.felix.framework.Felix.installBundle(Felix.java:2874)
```

I have made changes based on this doc --> https://access.redhat.com/documentation/en-US/Fuse_ESB/4.4.1/html-single/Deploying_into_the_OSGi_Container/index.html#UrlHandlers-File . 