### PR TITLE
NPE on operation sendResponse if no response handler is set

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -342,7 +342,16 @@ public abstract class Operation implements DataSerializable {
 
     public final void sendResponse(Object value) {
         OperationResponseHandler responseHandler = getOperationResponseHandler();
-        responseHandler.sendResponse(this, value);
+        if (responseHandler == null) {
+            if (value instanceof Throwable) {
+                // in case of a throwable, we want the stacktrace.
+                getLogger().warning("Missing responseHandler for " + toString(), (Throwable) value);
+            } else {
+                getLogger().warning("Missing responseHandler for " + toString() + " value[" + value + "]");
+            }
+        } else {
+            responseHandler.sendResponse(this, value);
+        }
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationTest.java
@@ -1,0 +1,28 @@
+package com.hazelcast.spi;
+
+import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationTest {
+
+    // test for https://github.com/hazelcast/hazelcast/issues/11375
+    @Test
+    public void sendResponse_whenResponseHandlerIsNull_andThrowableValue_thenNoNPE(){
+        Operation op = new DummyOperation();
+        op.sendResponse(new Exception());
+    }
+
+    // test for https://github.com/hazelcast/hazelcast/issues/11375
+    @Test
+    public void sendResponse_whenResponseHandlerIsNull_andNoThrowableValue_thenNoNPE(){
+        Operation op = new DummyOperation();
+        op.sendResponse("foo");
+    }
+}


### PR DESCRIPTION
The problem is fixed by adding a check if the response handler is set.

If it isn't set a warning is printed so we don't loose the exception/response.

fix https://github.com/hazelcast/hazelcast/issues/11375