### PR TITLE
CallIdSequenceWithBackpressure.waitForSpace related fixes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -141,6 +141,7 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
 import com.hazelcast.spi.impl.sequence.CallIdSequenceWithBackpressure;
+import com.hazelcast.spi.impl.sequence.CallIdSequenceWithBackpressureFailFast;
 import com.hazelcast.spi.impl.sequence.CallIdSequenceWithoutBackpressure;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -247,6 +248,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         long backofftimeoutMs = properties.getLong(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS);
         if (maxAllowedConcurrentInvocations == Integer.MAX_VALUE) {
             callIdSequence = new CallIdSequenceWithoutBackpressure();
+        } else if (backofftimeoutMs <= 0) {
+            callIdSequence = new CallIdSequenceWithBackpressureFailFast(maxAllowedConcurrentInvocations);
         } else {
             callIdSequence = new CallIdSequenceWithBackpressure(maxAllowedConcurrentInvocations, backofftimeoutMs);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -244,9 +244,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
         int maxAllowedConcurrentInvocations = properties.getInteger(MAX_CONCURRENT_INVOCATIONS);
         long backofftimeoutMs = properties.getLong(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS);
-        boolean isBackPressureDisabled = maxAllowedConcurrentInvocations == Integer.MAX_VALUE;
+        boolean isBackPressureEnabled = maxAllowedConcurrentInvocations != Integer.MAX_VALUE;
         callIdSequence = CallIdFactory
-                .newCallIdSequence(isBackPressureDisabled, maxAllowedConcurrentInvocations, backofftimeoutMs);
+                .newCallIdSequence(isBackPressureEnabled, maxAllowedConcurrentInvocations, backofftimeoutMs);
 
         invocationService = initInvocationService();
         listenerService = initListenerService();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 /**
@@ -124,11 +123,7 @@ public class ClientInvocation implements Runnable {
 
     public ClientInvocationFuture invoke() {
         assert (clientMessage != null);
-        try {
-            clientMessage.setCorrelationId(callIdSequence.next());
-        } catch (TimeoutException e) {
-            throw new HazelcastOverloadException("Timed out trying to acquire another call ID.", e);
-        }
+        clientMessage.setCorrelationId(callIdSequence.next());
         invokeOnSelection();
         return clientInvocationFuture;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
@@ -20,9 +20,8 @@ import com.hazelcast.internal.util.ThreadLocalRandomProvider;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
+import com.hazelcast.spi.impl.sequence.CallIdFactory;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
-import com.hazelcast.spi.impl.sequence.CallIdSequenceWithBackpressure;
-import com.hazelcast.spi.impl.sequence.CallIdSequenceWithoutBackpressure;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.Random;
@@ -153,11 +152,7 @@ class BackpressureRegulator {
     }
 
     CallIdSequence newCallIdSequence() {
-        if (enabled) {
-            return new CallIdSequenceWithBackpressure(maxConcurrentInvocations, backoffTimeoutMs);
-        } else {
-            return new CallIdSequenceWithoutBackpressure();
-        }
+        return CallIdFactory.newCallIdSequence(enabled, maxConcurrentInvocations, backoffTimeoutMs);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
 import com.hazelcast.internal.metrics.MetricsProvider;
@@ -30,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.OperationAccessor.deactivate;
@@ -110,12 +108,8 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
      */
     public boolean register(Invocation invocation) {
         final long callId;
-        try {
-            boolean force = invocation.op.isUrgent() || invocation.isRetryCandidate();
-            callId = force ? callIdSequence.forceNext() : callIdSequence.next();
-        } catch (TimeoutException e) {
-            throw new HazelcastOverloadException("Failed to start invocation due to overload: " + invocation, e);
-        }
+        boolean force = invocation.op.isUrgent() || invocation.isRetryCandidate();
+        callId = force ? callIdSequence.forceNext() : callIdSequence.next();
         try {
             // fails with IllegalStateException if the operation is already active
             setCallId(invocation.op, callId);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
@@ -51,6 +51,16 @@ public abstract class AbstractCallIdSequence implements CallIdSequence {
     }
 
     @Override
+    public long next() {
+        if (!hasSpace()) {
+            handleNoSpaceLeft();
+        }
+        return forceNext();
+    }
+
+    protected abstract void handleNoSpaceLeft();
+
+    @Override
     public long getLastCallId() {
         return longs.get(INDEX_HEAD);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
 
 import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+import static com.hazelcast.util.Preconditions.checkPositive;
 
 /**
  * A {@link CallIdSequence} that provides backpressure by taking
@@ -43,6 +44,9 @@ public abstract class AbstractCallIdSequence implements CallIdSequence {
     private final int maxConcurrentInvocations;
 
     public AbstractCallIdSequence(int maxConcurrentInvocations) {
+        checkPositive(maxConcurrentInvocations,
+                "maxConcurrentInvocations should be a positive number. maxConcurrentInvocations=" + maxConcurrentInvocations);
+
         this.maxConcurrentInvocations = maxConcurrentInvocations;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.sequence;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+
+import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+
+/**
+ * A {@link CallIdSequence} that provides backpressure by taking
+ * the number of in-flight operations into account when before creating a new call-id.
+ * <p>
+ * It is possible to temporarily create more concurrent invocations than the declared capacity due to:
+ * <ul>
+ *     <li>system operations</li>
+ *     <li>the racy nature of checking if space is available and getting the next sequence. </li>
+ * </ul>
+ * The latter cause is not a problem since the capacity is exceeded temporarily and it isn't sustainable.
+ * So perhaps there are a few threads that at the same time see that the there is space and do a next.
+ */
+public abstract class AbstractCallIdSequence implements CallIdSequence {
+    private static final int INDEX_HEAD = 7;
+    private static final int INDEX_TAIL = 15;
+
+    // instead of using 2 AtomicLongs, we use an array if width of 3 cache lines to prevent any false sharing.
+    private final AtomicLongArray longs = new AtomicLongArray(3 * CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES);
+
+    private final int maxConcurrentInvocations;
+
+    public AbstractCallIdSequence(int maxConcurrentInvocations) {
+        this.maxConcurrentInvocations = maxConcurrentInvocations;
+    }
+
+    @Override
+    public long getLastCallId() {
+        return longs.get(INDEX_HEAD);
+    }
+
+    @Override
+    public int getMaxConcurrentInvocations() {
+        return maxConcurrentInvocations;
+    }
+
+    @Override
+    public void complete() {
+        long newTail = longs.incrementAndGet(INDEX_TAIL);
+        assert newTail <= longs.get(INDEX_HEAD);
+    }
+
+    public long forceNext() {
+        return longs.incrementAndGet(INDEX_HEAD);
+    }
+
+    long getTail() {
+        return longs.get(INDEX_TAIL);
+    }
+
+    protected boolean hasSpace() {
+        return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.sequence;
+
+public final class CallIdFactory {
+    private CallIdFactory() {
+    }
+
+    public static CallIdSequence newCallIdSequence(boolean isBackPressureDisabled, int maxAllowedConcurrentInvocations,
+                                                   long backofftimeoutMs) {
+        if (isBackPressureDisabled) {
+            return new CallIdSequenceWithoutBackpressure();
+        } else if (backofftimeoutMs <= 0) {
+            return new FailFastCallIdSequence(maxAllowedConcurrentInvocations);
+        } else {
+            return new CallIdSequenceWithBackpressure(maxAllowedConcurrentInvocations, backofftimeoutMs);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdFactory.java
@@ -20,9 +20,9 @@ public final class CallIdFactory {
     private CallIdFactory() {
     }
 
-    public static CallIdSequence newCallIdSequence(boolean isBackPressureDisabled, int maxAllowedConcurrentInvocations,
+    public static CallIdSequence newCallIdSequence(boolean isBackPressureEnabled, int maxAllowedConcurrentInvocations,
                                                    long backofftimeoutMs) {
-        if (isBackPressureDisabled) {
+        if (!isBackPressureEnabled) {
             return new CallIdSequenceWithoutBackpressure();
         } else if (backofftimeoutMs <= 0) {
             return new FailFastCallIdSequence(maxAllowedConcurrentInvocations);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
@@ -17,7 +17,7 @@
 package com.hazelcast.spi.impl.sequence;
 
 
-import java.util.concurrent.TimeoutException;
+import com.hazelcast.core.HazelcastOverloadException;
 
 /**
  * Responsible for generating invocation callIds.
@@ -53,13 +53,12 @@ public interface CallIdSequence {
     /**
      * Generates the next unique call ID. When the implementation
      * supports backpressure, it will not return unless the number of outstanding invocations is within the
-     * configured limit. Instead it will block until the condition is met and eventually throw a timeout exception.
+     * configured limit. Instead it will block until the condition is met and eventually throw HazelcastOverloadException.
      *
      * @return the generated call ID
-     * @throws TimeoutException if the outstanding invocation count hasn't dropped below the configured limit
-     * within the configured timeout
+     * @throws HazelcastOverloadException if the outstanding invocation count hasn't dropped below the configured limit
      */
-    long next() throws TimeoutException;
+    long next();
 
     /**
      * Generates the next unique call ID.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
@@ -103,11 +103,11 @@ public final class CallIdSequenceWithBackpressure implements CallIdSequence {
 
         long start = System.nanoTime();
         for (long idleCount = 0; ; idleCount++) {
-            long now = System.nanoTime();
-            if (now - start > backoffTimeoutNanos) {
+            long elapsedNanos = System.nanoTime() - start;
+            if (elapsedNanos > backoffTimeoutNanos) {
                 throw new HazelcastOverloadException(String.format("Timed out trying to acquire another call ID."
-                        + " maxConcurrentInvocations = %d, backoffTimeout = %d msecs, now:%d, start:%d", maxConcurrentInvocations,
-                        NANOSECONDS.toMillis(backoffTimeoutNanos), now, start));
+                        + " maxConcurrentInvocations = %d, backoffTimeout = %d msecs, elapsed:%d msecs", maxConcurrentInvocations,
+                        NANOSECONDS.toMillis(backoffTimeoutNanos), NANOSECONDS.toMillis(elapsedNanos)));
             }
             IDLER.idle(idleCount);
             if (hasSpace()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
@@ -37,7 +37,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * So perhaps there are a few threads that at the same time see that the there is space and do a next.
  * But any following invocation needs to wait till there is is capacity.
  */
-public final class CallIdSequenceWithBackpressure extends FailFastCallIdSequence {
+public final class CallIdSequenceWithBackpressure extends AbstractCallIdSequence {
     static final int MAX_DELAY_MS = 500;
     private static final IdleStrategy IDLER = new BackoffIdleStrategy(
             0, 0, MILLISECONDS.toNanos(1), MILLISECONDS.toNanos(MAX_DELAY_MS));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
@@ -47,8 +47,6 @@ public final class CallIdSequenceWithBackpressure extends AbstractCallIdSequence
     public CallIdSequenceWithBackpressure(int maxConcurrentInvocations, long backoffTimeoutMs) {
         super(maxConcurrentInvocations);
 
-        checkPositive(maxConcurrentInvocations,
-                "maxConcurrentInvocations should be a positive number. maxConcurrentInvocations=" + maxConcurrentInvocations);
         checkPositive(backoffTimeoutMs, "backoffTimeoutMs should be a positive number. backoffTimeoutMs=" + backoffTimeoutMs);
 
         this.backoffTimeoutNanos = MILLISECONDS.toNanos(backoffTimeoutMs);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
@@ -53,14 +53,7 @@ public final class CallIdSequenceWithBackpressure extends AbstractCallIdSequence
     }
 
     @Override
-    public long next() {
-        if (!hasSpace()) {
-            waitForSpace();
-        }
-        return forceNext();
-    }
-
-    private void waitForSpace() {
+    protected void handleNoSpaceLeft() {
         long start = System.nanoTime();
         for (long idleCount = 0; ; idleCount++) {
             long elapsedNanos = System.nanoTime() - start;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
@@ -36,11 +36,8 @@ public class FailFastCallIdSequence extends AbstractCallIdSequence {
     }
 
     @Override
-    public long next() {
-        if (!hasSpace()) {
-            throw new HazelcastOverloadException(
-                    "Maximum invocation count is reached. maxConcurrentInvocations = " + getMaxConcurrentInvocations());
-        }
-        return forceNext();
+    protected void handleNoSpaceLeft() {
+        throw new HazelcastOverloadException(
+                "Maximum invocation count is reached. maxConcurrentInvocations = " + getMaxConcurrentInvocations());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
@@ -35,7 +35,7 @@ import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
  * The latter cause is not a problem since the capacity is exceeded temporarily and it isn't sustainable.
  * So perhaps there are a few threads that at the same time see that the there is space and do a next.
  */
-public final class CallIdSequenceWithBackpressureFailFast implements CallIdSequence {
+public class FailFastCallIdSequence implements CallIdSequence {
     private static final int INDEX_HEAD = 7;
     private static final int INDEX_TAIL = 15;
 
@@ -44,7 +44,7 @@ public final class CallIdSequenceWithBackpressureFailFast implements CallIdSeque
 
     private final int maxConcurrentInvocations;
 
-    public CallIdSequenceWithBackpressureFailFast(int maxConcurrentInvocations) {
+    public FailFastCallIdSequence(int maxConcurrentInvocations) {
         this.maxConcurrentInvocations = maxConcurrentInvocations;
     }
 
@@ -81,7 +81,7 @@ public final class CallIdSequenceWithBackpressureFailFast implements CallIdSeque
         return longs.get(INDEX_TAIL);
     }
 
-    private boolean hasSpace() {
+    protected boolean hasSpace() {
         return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressureTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.sequence;
 
+import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.DummyBackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
@@ -30,7 +31,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static org.junit.Assert.assertEquals;
@@ -103,7 +103,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
         try {
             sequence.next();
             fail();
-        } catch (TimeoutException e) {
+        } catch (HazelcastOverloadException e) {
             // expected
         }
 
@@ -145,10 +145,6 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
     }
 
     static long nextCallId(CallIdSequence seq, boolean isUrgent) {
-        try {
-            return isUrgent ? seq.forceNext() : seq.next();
-        } catch (TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+        return isUrgent ? seq.forceNext() : seq.next();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequenceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.sequence;
+
+import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.DummyBackupAwareOperation;
+import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
+import com.hazelcast.spi.impl.operationservice.impl.DummyPriorityOperation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.spi.OperationAccessor.setCallId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FailFastCallIdSequenceTest extends HazelcastTestSupport {
+
+    FailFastCallIdSequence sequence = new FailFastCallIdSequence(100);
+
+    @Test
+    public void test() {
+        assertEquals(0, sequence.getLastCallId());
+        assertEquals(100, sequence.getMaxConcurrentInvocations());
+    }
+
+    @Test
+    public void whenNext_thenSequenceIncrements() {
+        // regular operation
+        testNext(new DummyOperation());
+
+        // backup-aware operation
+        testNext(new DummyBackupAwareOperation());
+
+        // urgent operation
+        testNext(new DummyPriorityOperation());
+    }
+
+    private void testNext(Operation operation) {
+        long oldSequence = sequence.getLastCallId();
+        long result = nextCallId(sequence, operation.isUrgent());
+        assertEquals(oldSequence + 1, result);
+        assertEquals(oldSequence + 1, sequence.getLastCallId());
+    }
+
+    @Test (expected = HazelcastOverloadException.class)
+    public void next_whenNoCapacity_thenThrowException() throws InterruptedException {
+        sequence = new FailFastCallIdSequence(1);
+        final long oldLastCallId = sequence.getLastCallId();
+
+        final CountDownLatch nextCalledLatch = new CountDownLatch(1);
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                DummyBackupAwareOperation op = new DummyBackupAwareOperation();
+                long callId = nextCallId(sequence, op.isUrgent());
+                setCallId(op, callId);
+                nextCalledLatch.countDown();
+                sleepSeconds(3);
+                sequence.complete();
+            }
+        });
+
+        nextCalledLatch.await();
+
+        nextCallId(sequence, false);
+    }
+
+    @Test
+    public void next_whenNoCapacity_thenBlockTillTimeout() {
+        sequence = new FailFastCallIdSequence(1);
+
+        // first invocation consumes the available call ID
+        nextCallId(sequence, false);
+
+        long oldLastCallId = sequence.getLastCallId();
+        try {
+            sequence.next();
+            fail();
+        } catch (HazelcastOverloadException e) {
+            // expected
+        }
+
+        assertEquals(oldLastCallId, sequence.getLastCallId());
+    }
+
+    @Test
+    public void when_overCapacityButPriorityItem_then_noBackpressure() {
+        final FailFastCallIdSequence sequence = new FailFastCallIdSequence(1);
+
+        // occupy the single call ID slot
+        nextCallId(sequence, true);
+
+        long oldLastCallId = sequence.getLastCallId();
+
+        long result = nextCallId(sequence, true);
+        assertEquals(oldLastCallId + 1, result);
+        assertEquals(oldLastCallId + 1, sequence.getLastCallId());
+    }
+
+    @Test
+    public void whenComplete_thenTailIncrements() {
+        nextCallId(sequence, false);
+
+        long oldSequence = sequence.getLastCallId();
+        long oldTail = sequence.getTail();
+        sequence.complete();
+
+        assertEquals(oldSequence, sequence.getLastCallId());
+        assertEquals(oldTail + 1, sequence.getTail());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void complete_whenNoMatchingNext() {
+        nextCallId(sequence, false);
+        sequence.complete();
+        sequence.complete();
+    }
+
+    static long nextCallId(CallIdSequence seq, boolean isUrgent) {
+        return isUrgent ? seq.forceNext() : seq.next();
+    }
+}


### PR DESCRIPTION
CallIdSequenceWithBackpressure.waitForSpace should not do anything if backoffTimeoutNanos is not a positive number, I changed it this way.

 Changed the next method to throw HazelcastOverloadException rather than TimeoutException since practically at all the places this method is called we do an extra catch and convert TimeoutException to HazelcastOverloadException.

According to javadoc of System.nanoTime(), we should rely on the differences but not the absolute time values (and it says that it may even be a negative number). Hence, I changed it to use diff as suggested when deciding on deadline expiry in CallIdSequenceWithBackpressure.

    /**
     * Returns the current value of the most precise available system
     * timer, in nanoseconds.
     *
     * <p>This method can only be used to measure elapsed time and is
     * not related to any other notion of system or wall-clock time.
     * The value returned represents nanoseconds since some fixed but
     * arbitrary time (perhaps in the future, so values may be
     * negative).  This method provides nanosecond precision, but not
     * necessarily nanosecond accuracy. No guarantees are made about
     * how frequently values change. Differences in successive calls
     * that span greater than approximately 292 years (2<sup>63</sup>
     * nanoseconds) will not accurately compute elapsed time due to
     * numerical overflow.
     *
     * <p> For example, to measure how long some code takes to execute:
     * <pre>
     *   long startTime = System.nanoTime();
     *   // ... the code being measured ...
     *   long estimatedTime = System.nanoTime() - startTime;
     * </pre>
     *
     * @return The current value of the system timer, in nanoseconds.
     * @since 1.5
     */
    public static native long nanoTime();