### PR TITLE
Adding smart listener opens connections to all members synchronously

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -49,7 +49,7 @@ import static com.hazelcast.client.spi.properties.ClientProperty.INVOCATION_TIME
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.onOutOfMemory;
 import static com.hazelcast.spi.impl.operationservice.impl.AsyncInboundResponseHandler.getIdleStrategy;
 
-abstract class ClientInvocationServiceSupport implements ClientInvocationService {
+public abstract class ClientInvocationServiceSupport implements ClientInvocationService {
 
     private static final HazelcastProperty IDLE_STRATEGY
             = new HazelcastProperty("hazelcast.client.responsequeue.idlestrategy", "block");

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientListener;
 import com.hazelcast.core.ClientService;
 import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
@@ -46,7 +47,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -534,5 +534,21 @@ public class ClientServiceTest extends ClientTestSupport {
                 assertEquals(1, atomicInteger.get());
             }
         }, 4);
+    }
+
+    @Test
+    public void testAddingListenersOpenConnectionsToAllCluster() {
+        int memberCount = 4;
+        for (int i = 0; i < memberCount; i++) {
+            hazelcastFactory.newHazelcastInstance();
+        }
+
+        HazelcastClientInstanceImpl client = getHazelcastClientInstanceImpl(hazelcastFactory.newHazelcastClient());
+        ClientConnectionManager connectionManager = client.getConnectionManager();
+        IMap<Object, Object> map = client.getMap("test");
+        map.addEntryListener(mock(EntryListener.class), false);
+
+        assertEquals(memberCount, connectionManager.getActiveConnections().size());
+
     }
 }


### PR DESCRIPTION
To prevent event miss in case registering listeners in tests that
members are already opened, adding smart listeners also opens
connections to all members proactively.

fixes #11386 
fixes #6654 
fixes #11436  