### PR TITLE
SSL Made key/trust-store type configurable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactorySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactorySupport.java
@@ -43,25 +43,37 @@ public abstract class SSLEngineFactorySupport {
     protected void load(Properties properties) throws Exception {
         String keyStorePassword = getProperty(properties, "keyStorePassword");
         String keyStore = getProperty(properties, "keyStore");
+        String keyManagerAlgorithm = getProperty(properties, "keyManagerAlgorithm", KeyManagerFactory.getDefaultAlgorithm());
+        String keyStoreType = getProperty(properties, "keyStoreType", "JKS");
+
         String trustStore = getProperty(properties, "trustStore", keyStore);
         String trustStorePassword = getProperty(properties, "trustStorePassword", keyStorePassword);
-        String keyManagerAlgorithm = properties.getProperty("keyManagerAlgorithm", KeyManagerFactory.getDefaultAlgorithm());
-        String trustManagerAlgorithm = properties.getProperty("trustManagerAlgorithm", TrustManagerFactory.getDefaultAlgorithm());
-        this.protocol = properties.getProperty("protocol", "TLS");
-        this.kmf = loadKeyManagerFactory(keyStorePassword, keyStore, keyManagerAlgorithm);
-        this.tmf = loadTrustManagerFactory(trustStorePassword, trustStore, trustManagerAlgorithm);
+        String trustManagerAlgorithm
+                = getProperty(properties, "trustManagerAlgorithm", TrustManagerFactory.getDefaultAlgorithm());
+        String trustStoreType = getProperty(properties, "trustStoreType", "JKS");
+
+        this.protocol = getProperty(properties, "protocol", "TLS");
+        this.kmf = loadKeyManagerFactory(keyStorePassword, keyStore, keyManagerAlgorithm, keyStoreType);
+        this.tmf = loadTrustManagerFactory(trustStorePassword, trustStore, trustManagerAlgorithm, trustStoreType);
     }
 
     public static TrustManagerFactory loadTrustManagerFactory(String trustStorePassword,
                                                               String trustStore,
                                                               String trustManagerAlgorithm) throws Exception {
+        return loadTrustManagerFactory(trustStorePassword, trustStore, trustManagerAlgorithm, "JKS");
+    }
+
+    public static TrustManagerFactory loadTrustManagerFactory(String trustStorePassword,
+                                                              String trustStore,
+                                                              String trustManagerAlgorithm,
+                                                              String trustStoreType) throws Exception {
         if (trustStore == null) {
             return null;
         }
 
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(trustManagerAlgorithm);
         char[] passPhrase = trustStorePassword == null ? null : trustStorePassword.toCharArray();
-        KeyStore ts = KeyStore.getInstance("JKS");
+        KeyStore ts = KeyStore.getInstance(trustStoreType);
         loadKeyStore(ts, passPhrase, trustStore);
         tmf.init(ts);
         return tmf;
@@ -70,13 +82,20 @@ public abstract class SSLEngineFactorySupport {
     public static KeyManagerFactory loadKeyManagerFactory(String keyStorePassword,
                                                           String keyStore,
                                                           String keyManagerAlgorithm) throws Exception {
+        return loadKeyManagerFactory(keyStorePassword, keyStore, keyManagerAlgorithm, "JKS");
+    }
+
+    public static KeyManagerFactory loadKeyManagerFactory(String keyStorePassword,
+                                                          String keyStore,
+                                                          String keyManagerAlgorithm,
+                                                          String keyStoreType) throws Exception {
         if (keyStore == null) {
             return null;
         }
 
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(keyManagerAlgorithm);
         char[] passPhrase = keyStorePassword == null ? null : keyStorePassword.toCharArray();
-        KeyStore ks = KeyStore.getInstance("JKS");
+        KeyStore ks = KeyStore.getInstance(keyStoreType);
         loadKeyStore(ks, passPhrase, keyStore);
         kmf.init(ks, passPhrase);
         return kmf;

--- a/hazelcast/src/test/java/com/hazelcast/nio/ssl/BasicSSLContextFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ssl/BasicSSLContextFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.security.KeyStoreException;
 import java.util.Properties;
 
 import static com.hazelcast.nio.ssl.TestKeyStoreUtil.JAVAX_NET_SSL_KEY_STORE;
@@ -42,6 +43,16 @@ public class BasicSSLContextFactoryTest {
         assertSSLContext();
     }
 
+    @Test(expected = KeyStoreException.class)
+    public void testInit_withUnknownKeyStoreType() throws Exception {
+        Properties properties = createSslProperties();
+        properties.put(SSLEngineFactorySupport.JAVA_NET_SSL_PREFIX + "keyStoreType", "unknown");
+
+        factory.init(properties);
+
+        assertSSLContext();
+    }
+
     @Test
     public void testInit_withWrongKeyStore() throws Exception {
         Properties properties = createSslProperties();
@@ -58,6 +69,16 @@ public class BasicSSLContextFactoryTest {
         properties.setProperty(JAVAX_NET_SSL_KEY_STORE, getMalformedKeyStoreFilePath());
 
         factory.init(properties);
+    }
+
+    @Test(expected = KeyStoreException.class)
+    public void testInit_withUnknownTrustStoreType() throws Exception {
+        Properties properties = createSslProperties();
+        properties.put(SSLEngineFactorySupport.JAVA_NET_SSL_PREFIX + "trustStoreType", "unknown");
+
+        factory.init(properties);
+
+        assertSSLContext();
     }
 
     private void assertSSLContext() {


### PR DESCRIPTION
Instead of hardcoded JKS

The original loadTrustManagerFactory/loadKeyManagerFactories methods are overloaded
so we don't cause any compatibility problems since SSLEngineFactorySupport is
a public class.

Fix https://github.com/hazelcast/hazelcast-enterprise/issues/1731

This PR also fixes a bug where the following properties are not loaded from system properties if set:
- keyManagerAlgorithm
- trustManagerAlgorithm
- protocol