### PR TITLE
JavaDoc IAtomicLong & MapLoader.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -40,12 +40,11 @@ package com.hazelcast.core;
  * </pre>
  * </p>
  *
- * During a network partition event it is possible for the register to exist in each of the partitioned clusters or to
- * not exist at all. Under these circumstances the values held in the register may diverge.  Once the network partition
- * heals, Hazelcast will use the value held in the largest cluster, in this case updates made to the register in the
- * smaller clusterswill be lost. Starting from Hazelcast 3.10 a merge callback will allow the user to make their own
- * choices as to which value is used.  To prevent updates to the {@link IAtomicLong} in the smaller clusters a
- * <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-quorum">quorun</a> may be
+ * During a network partition event it is possible for the {@link IAtomicLong} to exist in each of the partitioned
+ * clusters or to not exist at all. Under these circumstances the values held in the {@link IAtomicLong} may diverge.
+ * Once the network partition heals, Hazelcast will use the value held in the largest cluster, in this case updates
+ * made to the register in the smaller clusters will be lost. To prevent updates to the {@link IAtomicLong} in the
+ * smaller clusters a <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-quorum">quorum</a> may be
  * configured, even so there is still a time window between the split brain and its detection in which updates may still
  * occur.
  *

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -40,6 +40,15 @@ package com.hazelcast.core;
  * </pre>
  * </p>
  *
+ * During a network partition event it is possible for the register to exist in each of the partitioned clusters or to
+ * not exist at all. Under these circumstances the values held in the register may diverge.  Once the network partition
+ * heals, Hazelcast will use the value held in the largest cluster, in this case updates made to the register in the
+ * smaller clusterswill be lost. Starting from Hazelcast 3.10 a merge callback will allow the user to make their own
+ * choices as to which value is used.  To prevent updates to the {@link IAtomicLong} in the smaller clusters a
+ * <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-quorum">quorun</a> may be
+ * configured, even so there is still a time window between the split brain and its detection in which updates may still
+ * occur.
+ *
  * @see IAtomicReference
  */
 public interface IAtomicLong extends DistributedObject {

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -44,9 +44,9 @@ package com.hazelcast.core;
  * clusters or to not exist at all. Under these circumstances the values held in the {@link IAtomicLong} may diverge.
  * Once the network partition heals, Hazelcast will use the value held in the largest cluster, in this case updates
  * made to the {@link IAtomicLong} in the smaller clusters will be lost. To prevent updates to the {@link IAtomicLong} in the
- * smaller clusters a <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-quorum">quorum</a> may be
- * configured, even so there is still a time window between the split brain and its detection in which updates may still
- * occur.
+ * smaller clusters a <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-quorum">quorum</a>
+ * may be configured, even so there is still a time window between the split brain and its detection in which updates
+ * may still occur.
  *
  * @see IAtomicReference
  */

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -43,7 +43,7 @@ package com.hazelcast.core;
  * During a network partition event it is possible for the {@link IAtomicLong} to exist in each of the partitioned
  * clusters or to not exist at all. Under these circumstances the values held in the {@link IAtomicLong} may diverge.
  * Once the network partition heals, Hazelcast will use the value held in the largest cluster, in this case updates
- * made to the register in the smaller clusters will be lost. To prevent updates to the {@link IAtomicLong} in the
+ * made to the {@link IAtomicLong} in the smaller clusters will be lost. To prevent updates to the {@link IAtomicLong} in the
  * smaller clusters a <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#configuring-quorum">quorum</a> may be
  * configured, even so there is still a time window between the split brain and its detection in which updates may still
  * occur.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -37,8 +37,8 @@ import java.util.Map;
  * never return, the partition thread does not time out the operation.  Whilst the partition thread is
  * executing the MapLoader it is unable to respond to requests for data on any other structure that
  * may reside in the same partition, or to respond to other partitions mapped to the same partition thread. For example
- * a very slow MapLoader for one map could block a request for data on another map, or even a queue. It is 
- * therefore strongly recommended not to use MapLoader to call across a WAN or to a system which will take 
+ * a very slow MapLoader for one map could block a request for data on another map, or even a queue. It is
+ * therefore strongly recommended not to use MapLoader to call across a WAN or to a system which will take
  * on average longer than a few milliseconds to respond.
  * <p/>
  * MapLoaders should not be used to perform cascading operations on other data structures via a


### PR DESCRIPTION
Improved JavaDoc addressing...

1. Network Partitions for IAtomicLong.
2. Partition Thread hogging on MapLoader.
3. Accessing other Partitions from within a MapLoader. 