### PR TITLE
[BACKPORT] Thread leak test and HazelcastTestSupport.assertJoinable() fixes

### DIFF
--- a/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
@@ -25,23 +25,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Set;
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ThreadLeakClientTest extends ThreadLeakTest {
+public class ThreadLeakClientTest extends AbstractThreadLeakTest {
 
     @Test
-    @Override
     public void testThreadLeak() {
-        Set<Thread> threads = Thread.getAllStackTraces().keySet();
-
         HazelcastInstance member = Hazelcast.newHazelcastInstance();
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
 
         client.shutdown();
         member.shutdown();
-
-        assertHazelcastThreadShutdown(threads);
     }
 }

--- a/hazelcast/src/test/java/classloading/AbstractThreadLeakTest.java
+++ b/hazelcast/src/test/java/classloading/AbstractThreadLeakTest.java
@@ -16,21 +16,26 @@
 
 package classloading;
 
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
-public class ThreadLeakTest extends AbstractThreadLeakTest {
+import java.util.Set;
 
-    @Test
-    public void testThreadLeak() {
-        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
-        hz.shutdown();
+import static classloading.ThreadLeakTestUtils.assertHazelcastThreadShutdown;
+import static classloading.ThreadLeakTestUtils.getThreads;
+
+public abstract class AbstractThreadLeakTest extends HazelcastTestSupport {
+
+    private Set<Thread> oldThreads;
+
+    @Before
+    public final void getOldThreads() {
+        oldThreads = getThreads();
+    }
+
+    @After
+    public final void assertThreadLeaks() {
+        assertHazelcastThreadShutdown(oldThreads);
     }
 }

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading;
+
+import com.hazelcast.test.jitter.JitterThread;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertJoinable;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+public final class ThreadLeakTestUtils {
+
+    /**
+     * List of whitelisted classes of threads, which are allowed to be not joinable.
+     * We should not add classes of Hazelcast production code here, just test related classes.
+     */
+    private static final List<Class> THREAD_CLASS_WHITELIST = asList(new Class[]{
+            JitterThread.class
+    });
+
+    public static Set<Thread> getThreads() {
+        return Thread.getAllStackTraces().keySet();
+    }
+
+    public static void assertHazelcastThreadShutdown(Set<Thread> oldThreads) {
+        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+        Thread[] joinableThreads = getJoinableThreads(oldThreads, stackTraces.keySet());
+        if (joinableThreads.length == 0) {
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder("There are still Hazelcast threads running after shutdown!\n");
+        for (Thread thread : joinableThreads) {
+            String stackTrace = Arrays.toString(stackTraces.get(thread));
+            sb.append(format("-> %s (id: %s) (group: %s) (daemon: %b) (alive: %b) (interrupted: %b) (state: %s)%n%s%n%n",
+                    thread.getName(), thread.getId(), getThreadGroupName(thread), thread.isDaemon(), thread.isAlive(),
+                    thread.isInterrupted(), thread.getState(), stackTrace));
+        }
+        System.err.println(sb.toString());
+
+        assertJoinable(joinableThreads);
+    }
+
+    private static Thread[] getJoinableThreads(Set<Thread> oldThreads, Set<Thread> newThreads) {
+        Set<Thread> diff = new HashSet<Thread>(newThreads);
+        diff.removeAll(oldThreads);
+        diff.remove(Thread.currentThread());
+        removeWhitelistedThreadClasses(diff);
+
+        Thread[] joinable = new Thread[diff.size()];
+        diff.toArray(joinable);
+        return joinable;
+    }
+
+    private static void removeWhitelistedThreadClasses(Set<Thread> threads) {
+        Iterator<Thread> iterator = threads.iterator();
+        while (iterator.hasNext()) {
+            Thread thread = iterator.next();
+            if (THREAD_CLASS_WHITELIST.contains(thread.getClass())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static String getThreadGroupName(Thread thread) {
+        ThreadGroup threadGroup = thread.getThreadGroup();
+        return (threadGroup == null) ? "stopped" : threadGroup.getName();
+    }
+}

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -16,6 +16,8 @@
 
 package classloading;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.test.jitter.JitterThread;
 
 import java.util.Arrays;
@@ -30,6 +32,12 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 public final class ThreadLeakTestUtils {
+
+    private static final ILogger LOGGER = Logger.getLogger(ThreadLeakTestUtils.class);
+
+    static {
+        LOGGER.info("Initializing Logger (required for thread leak tests).");
+    }
 
     /**
      * List of whitelisted classes of threads, which are allowed to be not joinable.

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -33,6 +33,8 @@ import static java.util.Arrays.asList;
 
 public final class ThreadLeakTestUtils {
 
+    private static final int ASSERT_TIMEOUT_SECONDS = 300;
+
     private static final ILogger LOGGER = Logger.getLogger(ThreadLeakTestUtils.class);
 
     static {
@@ -67,7 +69,7 @@ public final class ThreadLeakTestUtils {
         }
         System.err.println(sb.toString());
 
-        assertJoinable(joinableThreads);
+        assertJoinable(ASSERT_TIMEOUT_SECONDS, joinableThreads);
     }
 
     private static Thread[] getJoinableThreads(Set<Thread> oldThreads, Set<Thread> newThreads) {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -765,16 +765,16 @@ public abstract class HazelcastTestSupport {
 
     public static void assertJoinable(long timeoutSeconds, Thread... threads) {
         try {
-            long remainingTimeout = TimeUnit.SECONDS.toNanos(timeoutSeconds);
+            long remainingTimeout = TimeUnit.SECONDS.toMillis(timeoutSeconds);
             for (Thread thread : threads) {
-                long start = System.nanoTime();
+                long start = System.currentTimeMillis();
                 thread.join(remainingTimeout);
 
                 if (thread.isAlive()) {
                     fail("Timeout waiting for thread " + thread.getName() + " to terminate");
                 }
 
-                long duration = System.nanoTime() - start;
+                long duration = System.currentTimeMillis() - start;
                 remainingTimeout -= duration;
                 if (remainingTimeout <= 0) {
                     fail("Timeout waiting for thread " + thread.getName() + " to terminate");


### PR DESCRIPTION
* Cleanup of `ThreadLeakTest` to ease thread leak testing in other classes
* `ThreadLeakTestUtils` initializes logger factory
* Fix `HazelcastTestSupport.assertJoinable()`
* Increased timeout to wait for threads to shutdown in thread leak tests

This aligns the thread leak tests with the master branch and also applies a missing fix in `HazelcastTestSupport`.

Fixes: https://github.com/hazelcast/hazelcast/issues/10628