### PR TITLE
[BACKPORT] Fix cluster merge deadlock when core size is 1

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.spi.ClientExecutionService;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -54,7 +55,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
         }
         int executorPoolSize = poolSize;
         if (executorPoolSize <= 0) {
-            executorPoolSize = Runtime.getRuntime().availableProcessors();
+            executorPoolSize = RuntimeAvailableProcessors.get();
         }
         logger = loggingService.getLogger(ClientExecutionService.class);
         internalExecutor = new LoggingScheduledExecutor(logger, internalPoolSize,

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -42,6 +42,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -155,7 +156,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
     private Executor newClientExecutor() {
         final ExecutionService executionService = nodeEngine.getExecutionService();
-        int coreSize = Runtime.getRuntime().availableProcessors();
+        int coreSize = RuntimeAvailableProcessors.get();
 
         int threadCount = node.getProperties().getInteger(GroupProperty.CLIENT_ENGINE_THREAD_COUNT);
         if (threadCount <= 0) {
@@ -170,7 +171,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
     private Executor newClientQueryExecutor() {
         final ExecutionService executionService = nodeEngine.getExecutionService();
-        int coreSize = Runtime.getRuntime().availableProcessors();
+        int coreSize = RuntimeAvailableProcessors.get();
 
         int threadCount = node.getProperties().getInteger(GroupProperty.CLIENT_ENGINE_QUERY_THREAD_COUNT);
         if (threadCount <= 0) {

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.mapreduce.TopologyChangedStrategy;
 
 /**
@@ -26,7 +27,7 @@ public class JobTrackerConfig {
     /**
      * Default size of thread.
      */
-    public static final int DEFAULT_MAX_THREAD_SIZE = Runtime.getRuntime().availableProcessors();
+    public static final int DEFAULT_MAX_THREAD_SIZE = RuntimeAvailableProcessors.get();
     /**
      * Default value of retry counter.
      */

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -39,6 +39,7 @@ import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -516,7 +517,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         println("Memory max: " + BYTES.toMegaBytes(max) + "MB");
         println("Memory free: " + BYTES.toMegaBytes(free) + "MB " + (int) (free * ONE_HUNDRED / max) + "%");
         println("Used Memory:" + BYTES.toMegaBytes(total - free) + "MB");
-        println("# procs: " + Runtime.getRuntime().availableProcessors());
+        println("# procs: " + RuntimeAvailableProcessors.get());
         println("OS info: " + ManagementFactory.getOperatingSystemMXBean().getArch()
                 + " " + ManagementFactory.getOperatingSystemMXBean().getName()
                 + " " + ManagementFactory.getOperatingSystemMXBean().getVersion());

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeoutException;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGE_FAILED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGING;
-import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
@@ -47,6 +46,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 class ClusterMergeTask implements Runnable {
 
     private static final long MIN_WAIT_ON_FUTURE_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10);
+    private static final String MERGE_TASKS_EXECUTOR = "hz:cluster-merge";
 
     private final Node node;
 
@@ -128,7 +128,7 @@ class ClusterMergeTask implements Runnable {
         // execute merge tasks
         Collection<Future> futures = new LinkedList<Future>();
         for (Runnable task : tasks) {
-            Future f = node.nodeEngine.getExecutionService().submit(SYSTEM_EXECUTOR, task);
+            Future f = node.nodeEngine.getExecutionService().submit(MERGE_TASKS_EXECUTOR, task);
             futures.add(f);
         }
         long callTimeoutMillis = node.getProperties().getMillis(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS);

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/RuntimeAvailableProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/RuntimeAvailableProcessors.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+/**
+ * Utility to access {@link Runtime#availableProcessors()} and optionally override its return value.
+ */
+public final class RuntimeAvailableProcessors {
+
+    private static volatile int availableProcessors = Runtime.getRuntime().availableProcessors();
+
+    private RuntimeAvailableProcessors() {
+    }
+
+    public static int get() {
+        return availableProcessors;
+    }
+
+    public static void override(int availableProcessors) {
+        RuntimeAvailableProcessors.availableProcessors = availableProcessors;
+    }
+
+    public static void resetOverride() {
+        RuntimeAvailableProcessors.availableProcessors = Runtime.getRuntime().availableProcessors();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/NodeJobTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/NodeJobTracker.java
@@ -17,6 +17,7 @@
 package com.hazelcast.mapreduce.impl;
 
 import com.hazelcast.config.JobTrackerConfig;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.mapreduce.Job;
 import com.hazelcast.mapreduce.KeyValueSource;
@@ -44,7 +45,7 @@ class NodeJobTracker
         IPartitionService ps = nodeEngine.getPartitionService();
         int maxThreadSize = jobTrackerConfig.getMaxThreadSize();
         if (maxThreadSize <= 0) {
-            maxThreadSize = Runtime.getRuntime().availableProcessors();
+            maxThreadSize = RuntimeAvailableProcessors.get();
         }
         int queueSize = jobTrackerConfig.getQueueSize();
         if (queueSize <= 0) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.TaskScheduler;
@@ -142,7 +143,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         this.scheduledExecutorService = new LoggingScheduledExecutor(logger, 1, singleExecutorThreadFactory);
         enableRemoveOnCancelIfAvailable();
 
-        int coreSize = Runtime.getRuntime().availableProcessors();
+        int coreSize = RuntimeAvailableProcessors.get();
         // default executors
         register(SYSTEM_EXECUTOR, coreSize, Integer.MAX_VALUE, ExecutorType.CACHED);
         register(SCHEDULED_EXECUTOR, coreSize * POOL_MULTIPLIER, coreSize * QUEUE_MULTIPLIER, ExecutorType.CACHED);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.internal.util.concurrent.MPSCQueue;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
@@ -126,7 +127,7 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
         int threadCount = properties.getInteger(GENERIC_OPERATION_THREAD_COUNT);
         if (threadCount <= 0) {
             // default generic operation thread count
-            int coreSize = Runtime.getRuntime().availableProcessors();
+            int coreSize = RuntimeAvailableProcessors.get();
             threadCount = Math.max(2, coreSize / 2);
         }
 
@@ -144,7 +145,7 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
         int threadCount = properties.getInteger(PARTITION_OPERATION_THREAD_COUNT);
         if (threadCount <= 0) {
             // default partition operation thread count
-            int coreSize = Runtime.getRuntime().availableProcessors();
+            int coreSize = RuntimeAvailableProcessors.get();
             threadCount = Math.max(2, coreSize);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.ILogger;
 
 import java.util.Iterator;
@@ -70,7 +71,7 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
         this.logger = logger;
         this.callIdSequence = callIdSequence;
 
-        int coreSize = Runtime.getRuntime().availableProcessors();
+        int coreSize = RuntimeAvailableProcessors.get();
         boolean reallyMultiCore = coreSize >= CORE_SIZE_CHECK;
         int concurrencyLevel = reallyMultiCore ? coreSize * CORE_SIZE_FACTOR : CONCURRENCY_LEVEL;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.logging.ILogger;
@@ -447,8 +448,8 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     private void initInvocationContext() {
         ManagedExecutorService asyncExecutor = nodeEngine.getExecutionService().register(
-                    ExecutionService.ASYNC_EXECUTOR, Runtime.getRuntime().availableProcessors(),
-                    ASYNC_QUEUE_CAPACITY, ExecutorType.CONCRETE);
+                ExecutionService.ASYNC_EXECUTOR, RuntimeAvailableProcessors.get(),
+                ASYNC_QUEUE_CAPACITY, ExecutorType.CONCRETE);
 
         this.invocationContext = new Invocation.Context(
                 asyncExecutor,

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.instance.DefaultNodeContext;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.NodeIOService;
@@ -221,6 +222,16 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     @Test
     public void testTcpIp_MergeAfterSplitBrain() throws InterruptedException {
         testMergeAfterSplitBrain(false);
+    }
+
+    @Test
+    public void test_MergeAfterSplitBrain_withSingleCore() throws InterruptedException {
+        RuntimeAvailableProcessors.override(1);
+        try {
+            testMergeAfterSplitBrain(false);
+        } finally {
+            RuntimeAvailableProcessors.resetOverride();
+        }
     }
 
     private void testMergeAfterSplitBrain(boolean multicast) throws InterruptedException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/RuntimeAvailableProcessorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/RuntimeAvailableProcessorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertUtilityConstructor;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class RuntimeAvailableProcessorsTest {
+
+    @Test
+    public void getAvailableProcessors_withoutOverride() throws Exception {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        assertEquals(availableProcessors, RuntimeAvailableProcessors.get());
+    }
+
+    @Test
+    public void getAvailableProcessors_withOverride() throws Exception {
+        int customAvailableProcessors = 1234;
+        RuntimeAvailableProcessors.override(customAvailableProcessors);
+        try {
+            assertEquals(customAvailableProcessors, RuntimeAvailableProcessors.get());
+        } finally {
+            RuntimeAvailableProcessors.resetOverride();
+        }
+    }
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(RuntimeAvailableProcessors.class);
+    }
+
+}


### PR DESCRIPTION
- Added ability to override runtime available processors
- Added a test to verify cluster split-merge works with
single core.

Fixes https://github.com/hazelcast/hazelcast/issues/11403

Backport of https://github.com/hazelcast/hazelcast/pull/11437