### PR TITLE
Fix ConfiguredBehaviourTests

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -73,8 +73,10 @@ public final class ClientContext {
             return newRepairingTask(serviceName);
         }
     };
+    private final String name;
 
     public ClientContext(HazelcastClientInstanceImpl client) {
+        this.name = client.getName();
         this.serializationService = client.getSerializationService();
         this.clusterService = client.getClientClusterService();
         this.partitionService = client.getClientPartitionService();
@@ -126,6 +128,10 @@ public final class ClientContext {
         }
 
         throw new IllegalArgumentException(format("%s is not a known service-name to fetch metadata for", serviceName));
+    }
+
+    public String getName() {
+        return name;
     }
 
     /**


### PR DESCRIPTION
Tests were not waiting for clients to disconnect. It could be the
case that, client did not get disconnections when servers are closed.
In that case tests can fail.

When I add the waits for shutdown/disconnect, I realized that the thread
doing the shutdown (cluster executor thread), waiting itself to shutdown
and timing out with warning. We had an external thread spawn for these
cases before, it  seems that in new development of ClientConnectionStrategy
it is missed. I added that back.

fixes #10810