### PR TITLE
Trigger Hot Restart partition replica sync during cluster shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -228,11 +228,13 @@ public interface Cluster {
      * All the node join / leave rules described in {@link ClusterState#PASSIVE} state also applies here.
      * <p>
      * Any node can start the shutdown process. A shutdown command is sent to other nodes periodically until
-     * either all other nodes leave the cluster or a configurable timeout occurs. If some of the nodes do not
+     * either all other nodes leave the cluster or a configurable timeout occurs
+     * (see {@link GroupProperty#CLUSTER_SHUTDOWN_TIMEOUT_SECONDS}). If some of the nodes do not
      * shutdown before the timeout duration, shutdown can be also invoked on them.
      *
      * @throws IllegalStateException if member-list changes during the transaction
      *                               or there are ongoing/pending migration operations
+     *                               or shutdown process times out
      * @throws TransactionException  if there's already an ongoing transaction
      *                               or this transaction fails
      *                               or this transaction timeouts
@@ -251,12 +253,14 @@ public interface Cluster {
      * All the node join / leave rules described in {@link ClusterState#PASSIVE} state also applies here.
      * <p>
      * Any node can start the shutdown process. A shutdown command is sent to other nodes periodically until
-     * either all other nodes leave the cluster or a configurable timeout occurs. If some of the nodes do not
+     * either all other nodes leave the cluster or a configurable timeout occurs
+     * (see {@link GroupProperty#CLUSTER_SHUTDOWN_TIMEOUT_SECONDS}). If some of the nodes do not
      * shutdown before the timeout duration, shutdown can be also invoked on them.
      *
      * @param transactionOptions transaction options
      * @throws IllegalStateException if member-list changes during the transaction
      *                               or there are ongoing/pending migration operations
+     *                               or shutdown process times out
      * @throws TransactionException  if there's already an ongoing transaction
      *                               or this transaction fails
      *                               or this transaction timeouts

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/InternalHotRestartService.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.nio.Address;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Internal service for interacting with hot restart related functionalities (e.g. force and partial start)
@@ -86,4 +87,13 @@ public interface InternalHotRestartService {
      * it is excluded in cluster start.
      */
     void resetHotRestartData();
+
+    /**
+     * Waits until partition replicas (primaries and backups) get in sync.
+     *
+     * @param timeout timeout
+     * @param unit time unit
+     * @throws IllegalStateException when timeout happens or a member leaves the cluster while waiting
+     */
+    void waitPartitionReplicaSyncOnCluster(long timeout, TimeUnit unit);
 }

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/NoopInternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/NoopInternalHotRestartService.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.Address;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Empty implementation of InternalHotRestartService to avoid null checks. This will provide default behaviour when hot restart
@@ -63,5 +64,9 @@ public class NoopInternalHotRestartService implements InternalHotRestartService 
 
     @Override
     public void resetHotRestartData() {
+    }
+
+    @Override
+    public void waitPartitionReplicaSyncOnCluster(long timeout, TimeUnit unit) {
     }
 }


### PR DESCRIPTION
During cluster shutdown, partition primaries and backups may be out of sync.
When Hot Restart enabled, partition data is restored back but backup inconsistency
with primary cannot be detected, because restarted nodes don't restore replica versions.

To fix this, we force partition replica synchronization while shutting down
the cluster after changing state to PASSIVE.

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1737