### PR TITLE
The test should use the correct member address in the client config

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/ClientDriverFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/ClientDriverFactory.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.test.bounce.BounceTestConfiguration;
 import com.hazelcast.test.bounce.DriverFactory;
@@ -60,10 +61,9 @@ public class ClientDriverFactory implements DriverFactory {
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
         config.getNetworkConfig().setSmartRouting(false);
 
-        InetSocketAddress socketAddress = member.getCluster().getLocalMember().getSocketAddress();
+        Address serverAddress = member.getCluster().getLocalMember().getAddress();
 
-        config.getNetworkConfig().
-                addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+        config.getNetworkConfig().addAddress(serverAddress.getHost() + ":" + serverAddress.getPort());
 
         return config;
     }


### PR DESCRIPTION
The client test should be using the member configured address after the fix at PR https://github.com/hazelcast/hazelcast/pull/11368

The reason for failure: Member starts at 127.0.0.1 but when the client config is generated at ClientDriverFactory.getClientConfig, it adds the address as localhost. Hence, after the PR https://github.com/hazelcast/hazelcast/pull/11368, the client configuration and member configuration should use the exactly the same configuration. If you use ip number in member and dns name for the client, then client can not communicate with the server. This was the fix at the related PR.

fixes partially https://github.com/hazelcast/hazelcast/issues/10107
fixes partially https://github.com/hazelcast/hazelcast/issues/9870