### PR TITLE
Increase hazelcast.wait.seconds.before.join in a test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -23,20 +23,27 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.InputStream;
 
+import static com.hazelcast.test.OverridePropertyRule.set;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
 
     private Config config;
+
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = set("hazelcast.wait.seconds.before.join", "10");
 
     @Before
     public void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRule.java
@@ -1,0 +1,67 @@
+package com.hazelcast.test;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+
+/**
+ * Set or clear a property before running a test. The property will be restored once the test is finished.
+ *
+ */
+public final class OverridePropertyRule implements TestRule {
+    private final String propertyName;
+    private final String value;
+
+    private OverridePropertyRule(String propertyName, String value) {
+        this.propertyName = propertyName;
+        this.value = value;
+    }
+
+    /**
+     * Clears the property.
+     *
+     * @param propertyName system property to clear
+     * @return instance of the rule
+     */
+    public static OverridePropertyRule clear(String propertyName) {
+        return new OverridePropertyRule(propertyName, null);
+    }
+
+
+    /**
+     * Set the property to a newValue
+     *
+     * @param propertyName system property to set
+     * @param newValue value to set
+     * @return instance of the rule
+     */
+    public static OverridePropertyRule set(String propertyName, String newValue) {
+        return new OverridePropertyRule(propertyName, newValue);
+    }
+
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                String oldValue = System.getProperty(propertyName);
+                setOrClearProperty(propertyName, value);
+                try {
+                    base.evaluate();
+                } finally {
+                    setOrClearProperty(propertyName, oldValue);
+                }
+            }
+        };
+    }
+
+    private static void setOrClearProperty(String propertyName, String value) {
+        if (value == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, value);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #11085

The hazelcast.wait.seconds.before.join is set to 1s in our tests by default.
This is insufficient to the MulticastDiscovery strategy as the 2nd member may
start before receiving the multicast message from the 1st member.