### PR TITLE
Metrics per datastructure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -53,6 +53,16 @@ public class Diagnostics {
     public static final HazelcastProperty METRICS_LEVEL =
             new HazelcastProperty(PREFIX + ".metric.level", ProbeLevel.MANDATORY.name())
                     .setDeprecatedName("hazelcast.performance.metric.level");
+
+    /**
+     * If metrics should be tracked on distributed data-structures like IMap, IQueue etc.
+     *
+     * By default these data-structures are not tracked, but in a future release this will probably be changed to true.
+     */
+    public static final HazelcastProperty METRICS_DISTRIBUTED_DATASTRUCTURES =
+            new HazelcastProperty(PREFIX + ".metric.distributed.datastructures", false);
+
+
     /**
      * Use the {@link Diagnostics} to see internal performance metrics and cluster related information.
      * <p/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.metricsets;
+
+import com.hazelcast.cache.CacheStatistics;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.monitor.LocalInstanceStats;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.spi.impl.servicemanager.ServiceManager;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * A MetricsSet that captures all the {@link StatisticsAwareService} services. In short: it provides the metrics for map,
+ * queue, cache etc.
+ *
+ * It gets access to the metrics by making use of the statistics these data-structures produce. Every x seconds, a task is
+ * executed that obtains all the current {@link StatisticsAwareService} instances and gets all the {@link LocalInstanceStats}.
+ *
+ * Every {@link LocalInstanceStats} that hasn't been registered yet, is registered in the {@link MetricsRegistry}.
+ *
+ * Every {@link LocalInstanceStats} that was seen in the previous round but isn't available any longer, is unregistered from the
+ * {@link MetricsRegistry}.
+ */
+public class StatisticsAwareMetricsSet {
+
+    private static final int SCAN_PERIOD_SECONDS = 10;
+
+    private final ServiceManager serviceManager;
+
+    public StatisticsAwareMetricsSet(ServiceManager serviceManager) {
+        this.serviceManager = serviceManager;
+    }
+
+    public void register(MetricsRegistry metricsRegistry) {
+        metricsRegistry.scheduleAtFixedRate(new Task(metricsRegistry), SCAN_PERIOD_SECONDS, SECONDS);
+    }
+
+    // Periodic task that goes through all StatisticsAwareService asking for stats and registers and if it doesn't exist,
+    // it will register it.
+    private final class Task implements Runnable {
+        private final MetricsRegistry metricsRegistry;
+        private Set<LocalInstanceStats> previousStats = new HashSet<LocalInstanceStats>();
+        private Set<LocalInstanceStats> currentStats = new HashSet<LocalInstanceStats>();
+
+        private Task(MetricsRegistry metricsRegistry) {
+            this.metricsRegistry = metricsRegistry;
+        }
+
+        @Override
+        public void run() {
+            registerAliveStats();
+            purgeDeadStats();
+
+            Set<LocalInstanceStats> tmp = previousStats;
+            previousStats = currentStats;
+            currentStats = tmp;
+            currentStats.clear();
+        }
+
+        private void registerAliveStats() {
+            for (StatisticsAwareService statisticsAwareService : serviceManager.getServices(StatisticsAwareService.class)) {
+                Map<String, LocalInstanceStats> stats = statisticsAwareService.getStats();
+                if (stats == null) {
+                    continue;
+                }
+
+                for (Map.Entry<String, LocalInstanceStats> entry : stats.entrySet()) {
+                    LocalInstanceStats localInstanceStats = entry.getValue();
+
+                    currentStats.add(localInstanceStats);
+
+                    if (previousStats.contains(localInstanceStats)) {
+                        // already registered
+                        continue;
+                    }
+
+                    String name = entry.getKey();
+
+                    NearCacheStats nearCacheStats = getNearCacheStats(localInstanceStats);
+                    if (nearCacheStats != null) {
+                        metricsRegistry.scanAndRegister(nearCacheStats,
+                                localInstanceStats.getClass().getSimpleName() + "[" + name + "].nearcache");
+                    }
+
+                    metricsRegistry.scanAndRegister(localInstanceStats,
+                            localInstanceStats.getClass().getSimpleName() + "[" + name + "]");
+                }
+            }
+        }
+
+        private NearCacheStats getNearCacheStats(LocalInstanceStats localInstanceStats) {
+            if (localInstanceStats instanceof LocalMapStatsImpl) {
+                LocalMapStats localMapStats = (LocalMapStats) localInstanceStats;
+                return localMapStats.getNearCacheStats();
+            } else if (localInstanceStats instanceof CacheStatistics) {
+                CacheStatistics localMapStats = (CacheStatistics) localInstanceStats;
+                return localMapStats.getNearCacheStatistics();
+            } else {
+                return null;
+            }
+        }
+
+        private void purgeDeadStats() {
+            // purge all dead stats; so whatever was there the previous time and can't be found anymore, will be deleted
+            for (LocalInstanceStats localInstanceStats : previousStats) {
+                if (!currentStats.contains(localInstanceStats)) {
+                    metricsRegistry.deregister(localInstanceStats);
+
+                    NearCacheStats nearCacheStats = getNearCacheStats(localInstanceStats);
+                    if (nearCacheStats != null) {
+                        metricsRegistry.deregister(nearCacheStats);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalExecutorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalExecutorStatsImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.util.Clock;
 
@@ -41,11 +42,17 @@ public class LocalExecutorStatsImpl implements LocalExecutorStats {
     private long creationTime;
 
     // These fields are only accessed through the updaters
+    @Probe
     private volatile long pending;
+    @Probe
     private volatile long started;
+    @Probe
     private volatile long completed;
+    @Probe
     private volatile long cancelled;
+    @Probe
     private volatile long totalStartLatency;
+    @Probe
     private volatile long totalExecutionTime;
 
     public LocalExecutorStatsImpl() {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
+import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.util.Clock;
@@ -66,13 +67,21 @@ public class LocalMapStatsImpl implements LocalMapStats {
             newUpdater(LocalMapStatsImpl.class, "maxRemoveLatency");
 
     // These fields are only accessed through the updaters
+    @Probe
     private volatile long lastAccessTime;
+    @Probe
     private volatile long lastUpdateTime;
+    @Probe
     private volatile long hits;
+    @Probe
     private volatile long numberOfOtherOperations;
+    @Probe
     private volatile long numberOfEvents;
+    @Probe
     private volatile long getCount;
+    @Probe
     private volatile long putCount;
+    @Probe
     private volatile long removeCount;
     private volatile long totalGetLatenciesNanos;
     private volatile long totalPutLatenciesNanos;
@@ -81,17 +90,26 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long maxPutLatency;
     private volatile long maxRemoveLatency;
 
+    @Probe
     private volatile long creationTime;
+    @Probe
     private volatile long ownedEntryCount;
+    @Probe
     private volatile long backupEntryCount;
+    @Probe
     private volatile long ownedEntryMemoryCost;
+    @Probe
     private volatile long backupEntryMemoryCost;
     /**
      * Holds total heap cost of map & Near Cache & backups.
      */
+    @Probe
     private volatile long heapCost;
+    @Probe
     private volatile long lockedEntryCount;
+    @Probe
     private volatile long dirtyEntryCount;
+    @Probe
     private volatile int backupCount;
 
     private volatile NearCacheStats nearCacheStats;
@@ -241,31 +259,37 @@ public class LocalMapStatsImpl implements LocalMapStats {
         setMax(this, MAX_REMOVE_LATENCY, latencyNanos);
     }
 
+    @Probe
     @Override
     public long getTotalPutLatency() {
         return NANOSECONDS.toMillis(totalPutLatenciesNanos);
     }
 
+    @Probe
     @Override
     public long getTotalGetLatency() {
         return NANOSECONDS.toMillis(totalGetLatenciesNanos);
     }
 
+    @Probe
     @Override
     public long getTotalRemoveLatency() {
         return NANOSECONDS.toMillis(totalRemoveLatenciesNanos);
     }
 
+    @Probe
     @Override
     public long getMaxPutLatency() {
         return NANOSECONDS.toMillis(maxPutLatency);
     }
 
+    @Probe
     @Override
     public long getMaxGetLatency() {
         return NANOSECONDS.toMillis(maxGetLatency);
     }
 
+    @Probe
     @Override
     public long getMaxRemoveLatency() {
         return NANOSECONDS.toMillis(maxRemoveLatency);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalQueueStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalQueueStatsImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.monitor.LocalQueueStats;
 import com.hazelcast.util.Clock;
 
@@ -41,19 +42,31 @@ public class LocalQueueStatsImpl implements LocalQueueStats {
     private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_EVENTS =
             newUpdater(LocalQueueStatsImpl.class, "numberOfEvents");
 
+    @Probe
     private int ownedItemCount;
+    @Probe
     private int backupItemCount;
+    @Probe
     private long minAge;
+    @Probe
     private long maxAge;
+    @Probe
     private long aveAge;
+    @Probe
     private long creationTime;
 
     // These fields are only accessed through the updater
+    @Probe
     private volatile long numberOfOffers;
+    @Probe
     private volatile long numberOfRejectedOffers;
+    @Probe
     private volatile long numberOfPolls;
+    @Probe
     private volatile long numberOfEmptyPolls;
+    @Probe
     private volatile long numberOfOtherOperations;
+    @Probe
     private volatile long numberOfEvents;
 
     public LocalQueueStatsImpl() {
@@ -110,6 +123,7 @@ public class LocalQueueStatsImpl implements LocalQueueStats {
         return creationTime;
     }
 
+    @Probe
     public long total() {
         return numberOfOffers + numberOfPolls + numberOfOtherOperations;
     }
@@ -163,6 +177,7 @@ public class LocalQueueStatsImpl implements LocalQueueStats {
         NUMBER_OF_EVENTS.incrementAndGet(this);
     }
 
+    @Probe
     @Override
     public long getEventOperationCount() {
         return numberOfEvents;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.monitor.LocalReplicatedMapStats;
 import com.hazelcast.util.Clock;
 
@@ -66,23 +67,40 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     //CHECKSTYLE:ON
 
     // These fields are only accessed through the updaters
+    @Probe
     private volatile long lastAccessTime;
+    @Probe
     private volatile long lastUpdateTime;
+    @Probe
     private volatile long hits;
+    @Probe
     private volatile long numberOfOtherOperations;
+    @Probe
     private volatile long numberOfEvents;
+    @Probe
     private volatile long getCount;
+    @Probe
     private volatile long putCount;
+    @Probe
     private volatile long removeCount;
+    @Probe
     private volatile long totalGetLatencies;
+    @Probe
     private volatile long totalPutLatencies;
+    @Probe
     private volatile long totalRemoveLatencies;
+    @Probe
     private volatile long maxGetLatency;
+    @Probe
     private volatile long maxPutLatency;
+    @Probe
     private volatile long maxRemoveLatency;
 
+    @Probe
     private volatile long creationTime;
+    @Probe
     private volatile long ownedEntryCount;
+    @Probe
     private volatile long ownedEntryMemoryCost;
 
     public LocalReplicatedMapStatsImpl() {
@@ -184,6 +202,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void setDirtyEntryCount(long dirtyEntryCount) {
     }
 
+    @Probe
     @Override
     public long total() {
         return putCount + getCount + removeCount + numberOfOtherOperations;
@@ -270,6 +289,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
         NUMBER_OF_EVENTS.incrementAndGet(this);
     }
 
+    @Probe
     public long getHeapCost() {
         return 0;
     }
@@ -278,6 +298,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void setHeapCost(long heapCost) {
     }
 
+    @Probe
     @Override
     public long getReplicationEventCount() {
         return 0;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.util.Clock;
 
@@ -31,10 +32,13 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
             newUpdater(LocalTopicStatsImpl.class, "totalPublishes");
     private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_RECEIVED_MESSAGES =
             newUpdater(LocalTopicStatsImpl.class, "totalReceivedMessages");
+    @Probe
     private long creationTime;
 
     // These fields are only accessed through the updaters
+    @Probe
     private volatile long totalPublishes;
+    @Probe
     private volatile long totalReceivedMessages;
 
     public LocalTopicStatsImpl() {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.monitor.NearCacheStats;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -46,18 +47,30 @@ public class NearCacheStatsImpl implements NearCacheStats {
     private static final AtomicLongFieldUpdater<NearCacheStatsImpl> PERSISTENCE_COUNT =
             newUpdater(NearCacheStatsImpl.class, "persistenceCount");
 
+    @Probe
     private volatile long creationTime;
+    @Probe
     private volatile long ownedEntryCount;
+    @Probe
     private volatile long ownedEntryMemoryCost;
+    @Probe
     private volatile long hits;
+    @Probe
     private volatile long misses;
+    @Probe
     private volatile long evictions;
+    @Probe
     private volatile long expirations;
 
+    @Probe
     private volatile long persistenceCount;
+    @Probe
     private volatile long lastPersistenceTime;
+    @Probe
     private volatile long lastPersistenceDuration;
+    @Probe
     private volatile long lastPersistenceWrittenBytes;
+    @Probe
     private volatile long lastPersistenceKeyCount;
     private volatile String lastPersistenceFailure = "";
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.diagnostics.BuildInfoPlugin;
 import com.hazelcast.internal.diagnostics.ConfigPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.Diagnostics;
+import com.hazelcast.internal.diagnostics.EventQueuePlugin;
 import com.hazelcast.internal.diagnostics.InvocationPlugin;
 import com.hazelcast.internal.diagnostics.MemberHazelcastInstanceInfoPlugin;
 import com.hazelcast.internal.diagnostics.MemberHeartbeatPlugin;
@@ -32,7 +33,6 @@ import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
 import com.hazelcast.internal.diagnostics.OperationHeartbeatPlugin;
 import com.hazelcast.internal.diagnostics.OverloadedConnectionsPlugin;
-import com.hazelcast.internal.diagnostics.EventQueuePlugin;
 import com.hazelcast.internal.diagnostics.PendingInvocationsPlugin;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
@@ -49,6 +49,7 @@ import com.hazelcast.internal.metrics.metricsets.FileMetricSet;
 import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
 import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
 import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
+import com.hazelcast.internal.metrics.metricsets.StatisticsAwareMetricsSet;
 import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
@@ -92,6 +93,7 @@ import com.hazelcast.wan.WanReplicationService;
 import java.util.Collection;
 import java.util.LinkedList;
 
+import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_DISTRIBUTED_DATASTRUCTURES;
 import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_LEVEL;
 import static java.lang.System.currentTimeMillis;
 
@@ -232,6 +234,9 @@ public class NodeEngineImpl implements NodeEngine {
         ThreadMetricSet.register(metricsRegistry);
         ClassLoadingMetricSet.register(metricsRegistry);
         FileMetricSet.register(metricsRegistry);
+        if (node.getProperties().getBoolean(METRICS_DISTRIBUTED_DATASTRUCTURES)) {
+            new StatisticsAwareMetricsSet(serviceManager).register(metricsRegistry);
+        }
 
         metricsRegistry.collectMetrics(operationService, proxyService, eventService, operationParker);
 


### PR DESCRIPTION
Add metrics for all data-structures. Currently we have zero visibility without mancenter.
    
By default this is disabled.
    
When enabled we get statistics for
map/cache/nearcache/queue/topic/distributedexecutor/replicatedmap/multimap

Can be enabled using:
-Dhazelcast.diagnostics.metric.distributed.datastructures=true

Example output:

```
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].backupCount=1]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].backupEntryCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].backupEntryMemoryCost=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].creationTime=1506497940093]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].dirtyEntryCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].getCount=1]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].heapCost=162]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].hits=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].lastAccessTime=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].lastUpdateTime=1506497940178]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].lockedEntryCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].maxGetLatency=56]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].maxPutLatency=2]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].maxRemoveLatency=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.creationTime=1506497940098]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.evictions=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.expirations=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.hits=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.lastPersistenceDuration=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.lastPersistenceKeyCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.lastPersistenceTime=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.lastPersistenceWrittenBytes=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.misses=1]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.ownedEntryCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.ownedEntryMemoryCost=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].nearcache.persistenceCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].numberOfEvents=1]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].numberOfOtherOperations=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].ownedEntryCount=1]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].ownedEntryMemoryCost=162]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].putCount=1]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].removeCount=0]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].totalGetLatency=56]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].totalPutLatency=2]
27-09-2017 10:39:13 1506497953570 Metric[LocalMapStatsImpl[foo].totalRemoveLatency=0]
```
