### PR TITLE
Client can give priority to member list addresses during cluster connection

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -71,6 +71,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -885,13 +886,20 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             addresses.add(member.getAddress());
         }
 
-        for (AddressProvider addressProvider : addressProviders) {
-            addresses.addAll(addressProvider.loadAddresses());
-        }
-
         if (shuffleMemberList) {
             Collections.shuffle(addresses);
         }
+
+        List<Address> providerAddresses = new ArrayList<Address>();
+        for (AddressProvider addressProvider : addressProviders) {
+            providerAddresses.addAll(addressProvider.loadAddresses());
+        }
+
+        if (shuffleMemberList) {
+            Collections.shuffle(providerAddresses);
+        }
+
+        addresses.addAll(providerAddresses);
 
         return addresses;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -23,7 +23,9 @@ import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.util.AddressUtil;
 
+import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -68,6 +70,22 @@ public final class TestNodeRegistry {
 
     public HazelcastInstance getInstance(Address address) {
         Node node = nodes.get(address);
+        if (node == null) {
+            String host = address.getHost();
+            if (host != null) {
+                try {
+                    if (AddressUtil.isIpAddress(host)) {
+                        // try using hostname
+                        node = nodes.get(new Address(address.getInetAddress().getHostName(), address.getPort()));
+                    } else {
+                        // try using ip address
+                        node = nodes.get(new Address(address.getInetAddress().getHostAddress(), address.getPort()));
+                    }
+                } catch (UnknownHostException e) {
+                    // suppress
+                }
+            }
+        }
         return node != null && node.isRunning() ? node.hazelcastInstance : null;
     }
 


### PR DESCRIPTION
During connection and reconnection, the client can always try the existing members first and then use the statically configured or addressprovider provided addresses.