### PR TITLE
Cache creation should not take into account output of CacheCreateConfigOp

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
@@ -26,6 +26,8 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.NearCacheConfig;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -58,6 +60,14 @@ public class ClientCacheProxyFactory extends ClientProxyFactoryWithContext {
 
     void removeCacheConfig(String cacheName) {
         configs.remove(cacheName);
+    }
+
+    CacheConfig getCacheConfig(String cacheName) {
+        return configs.get(cacheName);
+    }
+
+    Set<Map.Entry<String, CacheConfig>> configs() {
+        return configs.entrySet();
     }
 
     @SuppressFBWarnings("RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED")

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
@@ -119,21 +119,21 @@ public class ClientCacheHelperTest extends HazelcastTestSupport {
 
     @Test
     public void testCreateCacheConfig_whenSyncCreate_thenReturnNewConfig() {
-        CacheConfig<String, String> actualConfig = createCacheConfig(client, configs, CACHE_NAME, newCacheConfig, false, true);
+        CacheConfig<String, String> actualConfig = createCacheConfig(client, cacheConfig, newCacheConfig, false, true);
 
         assertNotEquals(cacheConfig, actualConfig);
     }
 
     @Test
     public void testCreateCacheConfig_whenNotSyncCreate_thenReturnCurrentConfig() {
-        CacheConfig<String, String> actualConfig = createCacheConfig(client, configs, CACHE_NAME, newCacheConfig, false, false);
+        CacheConfig<String, String> actualConfig = createCacheConfig(client, cacheConfig, newCacheConfig, false, false);
 
         assertEquals(cacheConfig, actualConfig);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testCreateCacheConfig_rethrowsExceptions() {
-        createCacheConfig(exceptionThrowingClient, configs, CACHE_NAME, newCacheConfig, false, false);
+        createCacheConfig(exceptionThrowingClient, cacheConfig, newCacheConfig, false, false);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -46,6 +46,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p>
  * This operation's purpose is to pass the required parameters into
  * {@link ICacheService#putCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)}.
+ * <p/>
+ * Caveat: This operation does not return a response when {@code createAlsoOnOthers} is {@code true} and there are at least one
+ * remote members on which the new {@code CacheConfig} needs to be created. When this operation returns {@code null} with {@code
+ * createAlsoOnOthers == true}, it is impossible to tell whether it is because the {@code CacheConfig} was not already registered
+ * or due to sending out the operation to other remote members.
  */
 public class CacheCreateConfigOperation
         extends AbstractNamedOperation

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicSingleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicSingleMemberTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheBasicSingleMemberTest
+        extends CacheBasicAbstractTest {
+
+    TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+    HazelcastInstance instance;
+
+    @Override
+    protected void onSetup() {
+        instance = factory.newHazelcastInstance(createConfig());
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return instance;
+    }
+}


### PR DESCRIPTION
In this PR:
- Added javadoc in `CacheCreateConfigOperation` to document caveats with this operation
- Amended `AbstractHazelcastCacheManager` to disregard ambiguous response of `CacheCreateConfigOperation` (see https://github.com/hazelcast/hazelcast/issues/11432#issuecomment-332513148).
- Removed `HazelcastClientCacheManager.configs` as it duplicates the purpose of `ClientCacheProxyFactory.configs` and in one case was not updated properly.

Fixes #11432 