### PR TITLE
Handled possible null value in predicated entry-processors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -167,6 +167,13 @@ public final class EntryOperator {
         }
 
         oldValue = recordStore.get(dataKey, backup);
+        // predicated entry processors can only be applied to existing entries
+        // so if we have a predicate and somehow(due to expiration or split-brain healing)
+        // we found value null, we should skip that entry.
+        if (predicate != null && oldValue == null) {
+            return this;
+        }
+
         Boolean locked = recordStore.isLocked(dataKey);
 
         return operateOnKeyValueInternal(dataKey, clonedOrRawOldValue(), locked);


### PR DESCRIPTION
Things done:
-  Predicated entry processors should only process entry only if it exists in map.

fixes https://github.com/hazelcast/hazelcast/issues/11452

no need backport, only happens in master
