### PR TITLE
Cleanup the taskExecutor when tearing down the bouncing member rule

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -345,6 +345,7 @@ public class BounceMemberRule implements TestRule {
             LOGGER.info("Tearing down BounceMemberRule");
             if (taskExecutor != null) {
                 taskExecutor.shutdownNow();
+                taskExecutor = null;
             }
             // shutdown test drivers first
             if (testDrivers != null) {


### PR DESCRIPTION
After shutdown, we set the reference to null. This allows the rule to be
used together with the @Repeat annotation on the test/class. Otherwise
the bounce rule failes on the next run with "Cannot start test tasks
on a bouncing member test that is already executing tasks"