### PR TITLE
Prevent generic hazelcast exception thrown in transactions

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTransactionUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.proxy.txn;
+
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.Future;
+
+/**
+ * Contains static method that is used from client transaction classes
+ */
+public final class ClientTransactionUtil {
+
+    private ClientTransactionUtil() {
+
+    }
+
+    /**
+     * Handles the invocation exception for transactions so that users will not see internal exceptions.
+     * More specifically IOException, because in case of a IO problem in ClientInvocation that send to a connection
+     * sends IOException to user. This wraps that exception into a TransactionException.
+     */
+    public static ClientMessage invoke(ClientMessage request, HazelcastClientInstanceImpl client, Connection connection) {
+        try {
+            final ClientInvocation clientInvocation = new ClientInvocation(client, request, connection);
+            final Future<ClientMessage> future = clientInvocation.invoke();
+            return future.get();
+        } catch (Exception e) {
+            RuntimeException runtimeException = ExceptionUtil.peel(e);
+            if (runtimeException instanceof TransactionException) {
+                throw runtimeException;
+            } else {
+                throw new TransactionException(runtimeException);
+            }
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnProxy.java
@@ -21,15 +21,10 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
 import com.hazelcast.client.spi.ClientTransactionContext;
-import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionalObject;
-
-import java.util.concurrent.Future;
-
-import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 abstract class ClientTxnProxy implements TransactionalObject {
 
@@ -61,15 +56,9 @@ abstract class ClientTxnProxy implements TransactionalObject {
     abstract void onDestroy();
 
     final ClientMessage invoke(ClientMessage request) {
-        try {
-            HazelcastClientInstanceImpl client = transactionContext.getClient();
-            ClientConnection connection = transactionContext.getConnection();
-            ClientInvocation invocation = new ClientInvocation(client, request, connection);
-            Future<ClientMessage> future = invocation.invoke();
-            return future.get();
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
+        HazelcastClientInstanceImpl client = transactionContext.getClient();
+        ClientConnection connection = transactionContext.getConnection();
+        return ClientTransactionUtil.invoke(request, client, connection);
     }
 
     String getTransactionId() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionContextProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionContextProxy.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.spi.impl.ClientTransactionManagerServiceImpl;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.set.SetService;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.core.TransactionalMultiMap;
@@ -64,7 +63,7 @@ public class TransactionContextProxy implements ClientTransactionContext {
         try {
             connection = transactionManager.connect();
         } catch (Exception e) {
-            throw new HazelcastException("Could not obtain Connection!", e);
+            throw new TransactionException("Could not obtain a connection!", e);
         }
         this.transaction = new TransactionProxy(client, options, connection);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
@@ -254,7 +254,7 @@ public class ClientTxnMapTest {
                     tryPutResult.set(result);
 
                     afterTryPutResult.countDown();
-                } catch (Exception e) {
+                } catch (InterruptedException e) {
                 }
             }
         };
@@ -267,7 +267,7 @@ public class ClientTxnMapTest {
                     txMap.getForUpdate(key);
                     getKeyForUpdateLatch.countDown();
                     afterTryPutResult.await(30, TimeUnit.SECONDS);
-                } catch (Exception e) {
+                } catch (InterruptedException e) {
                 }
                 return true;
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMultiMapTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -131,7 +132,7 @@ public class ClientTxnMultiMapTest {
                         context.commitTransaction();
 
                         assertEquals(3, multiMap.get(key).size());
-                    } catch (Exception e) {
+                    } catch (TransactionException e) {
                         error.compareAndSet(null, e);
                     } finally {
                         latch.countDown();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import org.junit.After;
 import org.junit.Before;
@@ -102,7 +103,7 @@ public class ClientTxnTest extends HazelcastTestSupport {
 
             context.commitTransaction();
             fail("commit should throw exception!!!");
-        } catch (Exception e) {
+        } catch (TransactionException e) {
             context.rollbackTransaction();
             txnRollbackLatch.countDown();
         }
@@ -138,7 +139,7 @@ public class ClientTxnTest extends HazelcastTestSupport {
         try {
             context.commitTransaction();
             fail("commit should throw exception !");
-        } catch (Exception e) {
+        } catch (TransactionException e) {
             context.rollbackTransaction();
             txnRollbackLatch.countDown();
         }
@@ -161,11 +162,15 @@ public class ClientTxnTest extends HazelcastTestSupport {
         TransactionContext context = client.newTransactionContext(options);
         context.beginTransaction();
         try {
-            context.getQueue(name).take();
+            try {
+                context.getQueue(name).take();
+            } catch (InterruptedException e) {
+                fail();
+            }
             sleepAtLeastSeconds(5);
             context.commitTransaction();
             fail();
-        } catch (Exception e) {
+        } catch (TransactionException e) {
             context.rollbackTransaction();
         }
         assertEquals("Queue size should be 1", 1, queue.size());

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
  *
  *      transaction.delistResource(xaResource, XAResource.TMSUCCESS);
  *      tm.commit();
- * } catch (Throwable t) {
+ * } catch (TransactionException t) {
  *      t.printStackTrace();
  *      transaction.delistResource(xaResource, XAResource.TMFAIL);
  *      tm.rollback();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionContext.java
@@ -21,6 +21,8 @@ import javax.transaction.xa.XAResource;
 /**
  * Provides a context to perform transactional operations: beginning/committing transactions, but also retrieving
  * transactional data-structures like the {@link com.hazelcast.core.TransactionalMap}.
+ * Any method accessed through TransactionContext interface can throw TransactionException if transaction is
+ * no longer valid and rolled back.
  */
 public interface TransactionContext extends TransactionalTaskContext {
 


### PR DESCRIPTION
Client invocations are throwing IOExceptions(wrapped in HazelcastException)
when invocations done on connections.

Transactions are the only places that invocations are done always on conenction
and exception is thrown to user.

To prevent HazelcastException(IOException) to escape to user, client transactions
catches and wraps the exceptions from invocations and sends them as
TransactionException.

fixes #10773