### PR TITLE
Allow Backup operation to run in PASSIVE state

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/IndeterminateOperationStateExceptionTest.java
@@ -239,10 +239,11 @@ public class IndeterminateOperationStateExceptionTest extends HazelcastTestSuppo
     }
 
     public static class BackupOperation extends Operation {
+        public static final String EXECUTION_DONE = "execution-done";
 
         @Override
         public void run() throws Exception {
-
+            getNodeEngine().getHazelcastInstance().getUserContext().put(EXECUTION_DONE, new Object());
         }
     }
 


### PR DESCRIPTION
`Backup` operations are created and send by valid/executed operations on
primary. Either because primary operation is also allowed to run in PASSIVE
state or because primary is executed just before state changes to PASSIVE.
In either case, `Backup` operation is valid and should be allowed to run.

Additionally, `Backup` and anti-entropy operations should not be allowed
before startup is completed. During Hot Restart, startup completed flag is not set
until restore process completes.