### PR TITLE
Fix for client tests where server is shutdown

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.impl.CacheEventData;
 import com.hazelcast.cache.impl.CacheEventListenerAdaptor;
 import com.hazelcast.cache.impl.CacheSyncListenerCompleter;
 import com.hazelcast.cache.impl.operation.MutableOperation;
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheAddEntryListenerCodec;
@@ -42,7 +43,6 @@ import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
@@ -691,7 +691,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
                 }
                 currentTimeoutMs -= COMPLETION_LATCH_WAIT_TIME_STEP;
                 if (!getContext().isActive()) {
-                    throw new HazelcastInstanceNotActiveException();
+                    throw new HazelcastClientNotActiveException("Client is not active.");
                 } else if (isClosed()) {
                     throw new IllegalStateException("Cache (" + nameWithPrefix + ") is closed!");
                 } else if (isDestroyed()) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.cardinality.CardinalityEstimator;
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Client;
@@ -25,7 +26,6 @@ import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.ICacheManager;
@@ -293,7 +293,7 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     protected HazelcastClientInstanceImpl getClient() {
         final HazelcastClientInstanceImpl c = client;
         if (c == null || !c.getLifecycleService().isRunning()) {
-            throw new HazelcastInstanceNotActiveException();
+            throw new HazelcastClientNotActiveException("Client is not active.");
         }
         return c;
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -64,6 +64,17 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         client.getMap(randomMapName());
     }
 
+    @Test(expected = HazelcastClientNotActiveException.class)
+    public void testAsyncStartTrueNoCluster_thenShutdown() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        client.shutdown();
+
+        client.getMap(randomMapName());
+    }
+
+
     @Test
     public void testAsyncStartTrue() {
         final CountDownLatch connectedLatch = new CountDownLatch(1);
@@ -161,6 +172,7 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 
         clientConfig.getConnectionStrategyConfig().setReconnectMode(ASYNC);
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final CountDownLatch disconnectedLatch = new CountDownLatch(1);
         client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
@@ -174,7 +186,6 @@ public class ConfiguredBehaviourTest extends ClientTestSupport {
 
         hazelcastInstance.shutdown();
         assertOpenEventually(disconnectedLatch);
-
         client.getMap(randomMapName());
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ProxyManagerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ProxyManagerTest.java
@@ -132,6 +132,7 @@ public class ProxyManagerTest extends HazelcastTestSupport {
         HazelcastInstance instance = factory.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "1");
+        config.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         HazelcastInstance client = factory.newHazelcastClient(config);
         instance.shutdown();
         client.getMap("test");


### PR DESCRIPTION
Clients are expected to be up in the tests. But sometimes
clients are closed earlier than expected,because of delay
caused by environment. That was causing spurious failures
Fixed by setting connection attempt limit to Integer.MAX

Secondly, HazelcastInstanceNotActive exception is thrown
instead of HazelcastClientNotActiveException in the test
failure. Exception is corrected.

fixes https://github.com/hazelcast/hazelcast/issues/10810
fixes https://github.com/hazelcast/hazelcast/issues/11483