### PR TITLE
Moved ResultSet class to util package

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -53,7 +53,7 @@ import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.monitor.LocalReplicatedMapStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.replicatedmap.impl.record.ResultSet;
+import com.hazelcast.internal.util.ResultSet;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.util.IterationType;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ResultSet.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.replicatedmap.impl.record;
+package com.hazelcast.internal.util;
 
 import com.hazelcast.util.IterationType;
 
@@ -24,6 +24,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+/**
+ *
+ * A result set of {@link Map.Entry} objects that can be iterated according to {@link IterationType}
+ *
+ * @param <K> the type of {@link Map.Entry} keys
+ * @param <V> the type of {@link Map.Entry} values
+ */
 public class ResultSet<K, V> extends AbstractSet<Map.Entry<K, V>> {
 
     private final List<Map.Entry<K, V>> entries;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -33,7 +33,7 @@ import com.hazelcast.replicatedmap.impl.operation.VersionResponsePair;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedEntryEventFilter;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedQueryEventFilter;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
-import com.hazelcast.replicatedmap.impl.record.ResultSet;
+import com.hazelcast.internal.util.ResultSet;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.InitializingObject;

--- a/hazelcast/src/main/java/com/hazelcast/util/SortingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SortingUtil.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.internal.util.ResultSet;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.PagingPredicateAccessor;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.replicatedmap.impl.record.ResultSet;
 
 import java.util.Collections;
 import java.util.Comparator;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ResultSetTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.replicatedmap.impl.record;
+package com.hazelcast.internal.util;
 
 import com.hazelcast.map.impl.MapEntrySimple;
 import com.hazelcast.test.HazelcastParallelClassRunner;


### PR DESCRIPTION
__Reasoning__:
This is not a class only used by replicated map also query-engine uses it.