### PR TITLE
Node joining cluster should shutdown if it cannot deserialize pre-/post-join ops

### DIFF
--- a/hazelcast/src/test/java/classloading/domain/Person.java
+++ b/hazelcast/src/test/java/classloading/domain/Person.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading.domain;
+
+import java.io.Serializable;
+
+/**
+ * Sample domain class defined outside com.hazelcast package for classloader-related tests
+ */
+public class Person implements Serializable {
+
+}


### PR DESCRIPTION
Inability to deserialize the pre- or post-join operations in `FinalizeJoinOp` indicates that the joining node will not be able to function properly as a member of the cluster. In particular for `Cache` functionality, it could lead to inconsistent state of dynamically loaded `CacheConfig`s across cluster members and would result in breaking JCache contract when getting a `Cache` with specific key/value types. Instead the joining member should shutdown, as we do in case the master member detects a mismatch in the joining node's static config.

Fixes #10728 