### PR TITLE
Suppress authenticationException in ClientReAuthOperation.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
@@ -65,6 +65,13 @@ public class ClientReAuthOperation
     }
 
     @Override
+    public void logError(Throwable e) {
+        if (!(e instanceof AuthenticationException)) {
+            super.logError(e);
+        }
+    }
+
+    @Override
     public boolean returnsResponse() {
         return Boolean.TRUE;
     }


### PR DESCRIPTION
exception is already logged as info in `run` method.