### PR TITLE
[WIP] fixes race between join and listener registration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -63,8 +63,6 @@ public final class InvocationUtil {
     public static ICompletableFuture<Object> invokeOnStableClusterSerial(NodeEngine nodeEngine,
                                                                          OperationFactory operationFactory,
                                                                          int maxRetries) {
-        warmUpPartitions(nodeEngine);
-
         final OperationService operationService = nodeEngine.getOperationService();
         ClusterService clusterService = nodeEngine.getClusterService();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -240,9 +240,9 @@ public class NodeEngineImpl implements NodeEngine {
 
         metricsRegistry.collectMetrics(operationService, proxyService, eventService, operationParker);
 
+        operationService.start();
         serviceManager.start();
         proxyService.init();
-        operationService.start();
         quorumService.start();
         diagnostics.start();
 


### PR DESCRIPTION
fixed by making use of `invokeOnStableClusterSerial`

Without changing operationService start order and deleting warmupPartitions from `invokeOnStableClusterSerial` node was not able to start. I am not sure what could these changes affect, review accordingly .

fix attempt for #11490