### PR TITLE
Defer cache key-value type resolution until actually needed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -147,8 +147,9 @@ public final class CacheDataSerializerHook
     public static final short EVENT_JOURNAL_DESERIALIZING_CACHE_EVENT = 58;
     public static final short EVENT_JOURNAL_INTERNAL_CACHE_EVENT = 59;
     public static final short EVENT_JOURNAL_READ_RESULT_SET = 60;
+    public static final int PRE_JOIN_CACHE_CONFIG = 61;
 
-    private static final int LEN = EVENT_JOURNAL_READ_RESULT_SET + 1;
+    private static final int LEN = PRE_JOIN_CACHE_CONFIG + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -449,6 +450,13 @@ public final class CacheDataSerializerHook
                 return new CacheEventJournalReadResultSetImpl<Object, Object, Object>();
             }
         };
+        constructors[PRE_JOIN_CACHE_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new PreJoinCacheConfig();
+                    }
+                };
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.config.AbstractCacheConfig;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * This subclass of {@link CacheConfig} is used to communicate cache configurations in pre-join cache operations when cluster
+ * version is at least 3.9. The key difference against {@link CacheConfig} is that the key/value class names are used in its
+ * serialized form, instead of the actual {@code Class} objects. Thus the actual key-value classes are only resolved when first
+ * used (by means of {@link CacheConfig#getKeyType()} or {@link CacheConfig#getValueType()}). This allows resolution of
+ * these classes from remote user code deployment repositories (which are not available while the pre-join operation is being
+ * deserialized and executed).
+ *
+ * @param <K> the key type of this cache configuration
+ * @param <V> the value type
+ * @since 3.9
+ */
+public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements IdentifiedDataSerializable {
+
+    public PreJoinCacheConfig() {
+        super();
+    }
+
+    /**
+     * Constructor that copies given {@code cacheConfig}'s properties to a new {@link PreJoinCacheConfig}. It is assumed that
+     * the given {@code cacheConfig}'s key-value types have already been resolved to loaded classes.
+     * @param cacheConfig   the original {@link CacheConfig} to copy into a new {@link PreJoinCacheConfig}
+     */
+    public PreJoinCacheConfig(CacheConfig cacheConfig) {
+        this(cacheConfig, true);
+    }
+
+    public PreJoinCacheConfig(CacheConfig cacheConfig, boolean resolved) {
+        cacheConfig.copy(this, resolved);
+    }
+
+    @Override
+    protected void writeKeyValueTypes(ObjectDataOutput out)
+            throws IOException {
+        out.writeUTF(getKeyClassName());
+        out.writeUTF(getValueClassName());
+    }
+
+    @Override
+    protected void readKeyValueTypes(ObjectDataInput in)
+            throws IOException {
+        setKeyClassName(in.readUTF());
+        setValueClassName(in.readUTF());
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.PRE_JOIN_CACHE_CONFIG;
+    }
+
+    /**
+     * @return this configuration as a {@link CacheConfig}
+     */
+    public CacheConfig asCacheConfig() {
+        return this.copy(new CacheConfig(), false);
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:illegaltype")
+    protected boolean keyValueTypesEqual(AbstractCacheConfig that) {
+        if (!this.getKeyClassName().equals(that.getKeyClassName())) {
+            return false;
+        }
+
+        if (!this.getValueClassName().equals(that.getValueClassName())) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.cache.impl.PreJoinCacheConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -59,7 +60,14 @@ public class OnJoinCacheOperation extends Operation implements IdentifiedDataSer
         if (isJCacheAvailable(getNodeEngine().getConfigClassLoader())) {
             ICacheService cacheService = getService();
             for (CacheConfig cacheConfig : configs) {
-                cacheService.putCacheConfigIfAbsent(cacheConfig);
+                // RU_COMPAT_38 since 3.9, configs are instances of PreJoinCacheConfig
+                CacheConfig cacheConfigToAdd;
+                if (cacheConfig instanceof PreJoinCacheConfig) {
+                    cacheConfigToAdd = ((PreJoinCacheConfig) cacheConfig).asCacheConfig();
+                } else {
+                    cacheConfigToAdd = cacheConfig;
+                }
+                cacheService.putCacheConfigIfAbsent(cacheConfigToAdd);
             }
         } else {
             // if JCache is not in classpath and no Cache configurations need to be processed, do not fail the operation

--- a/hazelcast/src/test/java/classloading/domain/PersonEntryProcessor.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonEntryProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading.domain;
+
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.MutableEntry;
+import java.io.Serializable;
+
+public class PersonEntryProcessor implements EntryProcessor<String, Person, Person>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Person process(MutableEntry<String, Person> entry, Object... arguments)
+            throws EntryProcessorException {
+        return new Person();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import classloading.domain.Person;
+import classloading.domain.PersonEntryProcessor;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.UserCodeDeploymentConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.FilteringClassLoader;
+import com.hazelcast.util.RootCauseMatcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hazelcast.config.UserCodeDeploymentConfig.ClassCacheMode.OFF;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test transfer of CacheConfig's of typed Caches to a joining member
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheTypesConfigTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    protected String cacheName;
+    protected TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory();
+        cacheName = randomName();
+    }
+
+    // Even when the key or value class is not present in the classpath of the target member, a joining member will join.
+    // Some Cache operations that require deserialization on the member will fail (eg entry processors)
+    @Test
+    public void cacheConfigShouldBeAddedOnJoiningMember_whenClassNotResolvable() {
+        // create a HazelcastInstance with a CacheConfig referring to a Class not resolvable on the joining member
+        HazelcastInstance hz1 = factory.newHazelcastInstance(getConfig());
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hz1);
+        cachingProvider.getCacheManager().createCache(cacheName, createCacheConfig());
+        sleepSeconds(5);
+
+        // joining member cannot resolve Person class
+        List<String> excludes = Arrays.asList("classloading");
+        ClassLoader classLoader = new FilteringClassLoader(excludes, null);
+        Config hz2Config = getConfig();
+        hz2Config.setClassLoader(classLoader);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(hz2Config);
+        assertClusterSize(2, hz1, hz2);
+
+        ICache<String, Person> cache = hz1.getCacheManager().getCache(cacheName);
+        String key = generateKeyOwnedBy(hz2);
+        // a simple put will work as hz2 will just receive a Data value blob
+        cache.put(key, new Person());
+
+        expect.expectCause(new RootCauseMatcher(ClassNotFoundException.class, "classloading.domain.PersonEntryProcessor - "
+                + "Package excluded explicitly"));
+        cache.invoke(key, new PersonEntryProcessor());
+    }
+
+    // When the joining member is not aware of key or value class but it is later resolvable via user code deployment, then
+    // all Cache features should work
+    @Test
+    public void cacheConfigShouldBeAddedOnJoiningMember_whenKVTypesAvailableViaUserCodeDeployment() {
+        // create a HazelcastInstance with a CacheConfig referring to a Class resolvable via user code deployment
+        Config config = getConfig();
+        UserCodeDeploymentConfig codeDeploymentConfig = new UserCodeDeploymentConfig()
+                .setEnabled(true)
+                .setClassCacheMode(OFF)
+                .setWhitelistedPrefixes("classloading");
+        config.setUserCodeDeploymentConfig(codeDeploymentConfig);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hz1);
+        cachingProvider.getCacheManager().createCache(cacheName, createCacheConfig());
+
+        // joining member cannot resolve Person class but it is resolvable on other member via user code deployment
+        List<String> excludes = Arrays.asList("classloading");
+        ClassLoader classLoader = new FilteringClassLoader(excludes, null);
+        Config joiningMemberConfig = getConfig();
+        joiningMemberConfig.setClassLoader(classLoader);
+        joiningMemberConfig.setUserCodeDeploymentConfig(codeDeploymentConfig);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(joiningMemberConfig);
+        assertClusterSize(2, hz1, hz2);
+
+        ICache<String, Person> testCache = hz1.getCacheManager().getCache(cacheName);
+        String key = generateKeyOwnedBy(hz2);
+        testCache.put(key, new Person());
+        testCache.invoke(key, new PersonEntryProcessor());
+        assertNotNull(testCache.get(key));
+    }
+
+    // overridden in another context
+    CacheConfig createCacheConfig() {
+        CacheConfig cacheConfig = new CacheConfig();
+        cacheConfig.setTypes(String.class, Person.class).setManagementEnabled(true);
+        return cacheConfig;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.CacheConfigTest;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigByClassName;
+import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigByImplementation;
+import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigByPolicy;
+import static com.hazelcast.config.helpers.CacheConfigHelper.newCompleteCacheConfig;
+import static com.hazelcast.config.helpers.CacheConfigHelper.newDefaultCacheConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PreJoinCacheConfigTest {
+
+    private SerializationService serializationService;
+
+    @Before
+    public void setup() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    // Test transformation of CacheConfig to PreJoinCacheConfig and back to CacheConfig again
+    @Test
+    public void equalsCacheConfig_whenDefaultCacheConfig() {
+        CacheConfig cacheConfig = newDefaultCacheConfig("test");
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        assertEquals(cacheConfig, preJoinCacheConfig);
+    }
+
+    @Test
+    public void equalsCacheConfig_whenCompleteCacheConfig() {
+        CacheConfig cacheConfig = newCompleteCacheConfig("test");
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        assertEquals(cacheConfig, preJoinCacheConfig);
+    }
+
+    @Test
+    public void equalsCacheConfig_whenCacheConfig_withCacheLoaderAndWriter() {
+        CacheConfig cacheConfig = newCompleteCacheConfig("test");
+        cacheConfig.setCacheLoaderFactory(new CacheConfigTest.MyCacheLoaderFactory());
+        cacheConfig.setCacheWriterFactory(new CacheConfigTest.MyCacheWriterFactory());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        assertEquals(cacheConfig, preJoinCacheConfig);
+    }
+
+    @Test
+    public void equalsCacheConfig_whenCacheConfig_withEvictionConfigByPolicy() {
+        CacheConfig cacheConfig = newCompleteCacheConfig("test");
+        cacheConfig.setEvictionConfig(getEvictionConfigByPolicy());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        assertEquals(cacheConfig, preJoinCacheConfig);
+    }
+
+    @Test
+    public void equalsCacheConfig_whenCacheConfig_withEvictionConfigByClassName() {
+        CacheConfig cacheConfig = newCompleteCacheConfig("test");
+        cacheConfig.setEvictionConfig(getEvictionConfigByClassName());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        assertEquals(cacheConfig, preJoinCacheConfig);
+    }
+
+    @Test
+    public void equalsCacheConfig_whenCacheConfig_withEvictionConfigByImplementation() {
+        CacheConfig cacheConfig = newCompleteCacheConfig("test");
+        cacheConfig.setEvictionConfig(getEvictionConfigByImplementation());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        assertEquals(cacheConfig, preJoinCacheConfig);
+    }
+
+    // Test serialization & deserialization in the presence/absence of specified key/value types
+    @Test
+    public void serializationSucceeds_whenKVTypesNotSpecified() {
+        CacheConfig cacheConfig = newDefaultCacheConfig("test");
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+    }
+
+    @Test
+    public void serializationSucceeds_whenKVTypes_setAsClassObjects() {
+        CacheConfig cacheConfig = newDefaultCacheConfig("test");
+        cacheConfig.setKeyType(Integer.class);
+        cacheConfig.setValueType(String.class);
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+    }
+
+    @Test
+    public void serializationSucceeds_whenKVTypes_setAsClassNames() {
+        CacheConfig cacheConfig = newDefaultCacheConfig("test");
+        cacheConfig.setKeyClassName("java.lang.Integer");
+        cacheConfig.setValueClassName("java.lang.String");
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+    }
+
+    @Test
+    public void serializationSucceeds_whenKeyTypeNotResolvable() {
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(newDefaultCacheConfig("test"));
+        preJoinCacheConfig.setKeyClassName("some.inexistent.Class");
+        preJoinCacheConfig.setValueClassName("java.lang.String");
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertEquals(deserialized, preJoinCacheConfig);
+        try {
+            Class klass = deserialized.asCacheConfig().getKeyType();
+            fail("Getting the key type on deserialized CacheConfig should fail because the key type cannot be resolved");
+        } catch (HazelcastException e) {
+            if (!(e.getCause() instanceof ClassNotFoundException)) {
+                fail("Unexpected exception: " + e.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void serializationSucceeds_whenValueTypeNotResolvable() {
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(newDefaultCacheConfig("test"));
+        preJoinCacheConfig.setKeyClassName("java.lang.String");
+        preJoinCacheConfig.setValueClassName("some.inexistent.Class");
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertEquals(deserialized, preJoinCacheConfig);
+        try {
+            Class klass = deserialized.asCacheConfig().getValueType();
+            fail("Getting the value type on deserialized CacheConfig should fail because the value type cannot be resolved");
+        } catch (HazelcastException e) {
+            if (!(e.getCause() instanceof ClassNotFoundException)) {
+                fail("Unexpected exception: " + e.getCause());
+            }
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/CacheConfigHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/CacheConfigHelper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.helpers;
+
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.CacheConfigTest;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.HotRestartConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.WanReplicationRef;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigTest;
+
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import java.util.Collections;
+
+import static com.hazelcast.test.HazelcastTestSupport.randomName;
+
+public abstract class CacheConfigHelper {
+
+    public static EvictionConfig getEvictionConfigByPolicy() {
+        return new EvictionConfig(39, EvictionConfig.MaxSizePolicy.ENTRY_COUNT, EvictionPolicy.RANDOM);
+    }
+
+    public static EvictionConfig getEvictionConfigByClassName() {
+        return new EvictionConfig(39, EvictionConfig.MaxSizePolicy.ENTRY_COUNT, "com.hazelcast.Comparator");
+    }
+
+    public static EvictionConfig getEvictionConfigByImplementation() {
+        return new EvictionConfig(39, EvictionConfig.MaxSizePolicy.ENTRY_COUNT, new DynamicConfigTest.SampleEvictionPolicyComparator());
+    }
+
+    public static CacheConfig newDefaultCacheConfig(String name) {
+        return new CacheConfig(name);
+    }
+
+    public static CacheConfig newCompleteCacheConfig(String name) {
+        CacheConfig cacheConfig = new CacheConfig();
+        cacheConfig.setName(name);
+        cacheConfig.setQuorumName("quorum");
+        cacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        cacheConfig.setBackupCount(3);
+        cacheConfig.setAsyncBackupCount(2);
+        cacheConfig.setWanReplicationRef(new WanReplicationRef(randomName(), "com.hazelcast.MergePolicy",
+                Collections.singletonList("filter"), true));
+        cacheConfig.addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration(
+                new CacheConfigTest.EntryListenerFactory(), null, false, true));
+        cacheConfig.setMergePolicy("mergePolicy");
+        cacheConfig.setStatisticsEnabled(true);
+        cacheConfig.setManagementEnabled(true);
+        cacheConfig.setDisablePerEntryInvalidationEvents(true);
+        cacheConfig.setKeyClassName("java.lang.Integer");
+        cacheConfig.setValueClassName("java.lang.String");
+        cacheConfig.setReadThrough(true);
+        cacheConfig.setWriteThrough(true);
+        cacheConfig.setHotRestartConfig(new HotRestartConfig().setEnabled(true).setFsync(true));
+        return cacheConfig;
+    }
+}


### PR DESCRIPTION
Introduces new wire format for transferring cache configs in the pre-join `Cache` op.

Reasoning: the pre-join op must not resolve the key/value classes if
defined in the cache config, because user code deployment cannot kick
in as the pre-join op is being deserialized and may result in unexpected
failure to add the cache config. Instead, the key/value types are loaded
whenever getKeyType/getValueType is invoked which only occurs after the
joining member's member list has been updated, allowing resolution of
classes from remote user code deployment repository.

Fixes #11505 