### PR TITLE
Adding toString() into ListConfig and SetConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -285,4 +285,12 @@ public abstract class CollectionConfig<T extends CollectionConfig>
         result = 31 * result + (statisticsEnabled ? 1 : 0);
         return result;
     }
+
+    /**
+     * Returns field names with values as concatenated String so it can be used in child classes' toString() methods.
+     */
+    protected String fieldsToString() {
+        return "name='" + name + "', listenerConfigs=" + listenerConfigs + ", backupCount=" + backupCount
+                + ", asyncBackupCount=" + asyncBackupCount + ", maxSize=" + maxSize + ", statisticsEnabled=" + statisticsEnabled;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfig.java
@@ -53,4 +53,11 @@ public class ListConfig extends CollectionConfig<ListConfig> {
         return ConfigDataSerializerHook.LIST_CONFIG;
     }
 
+    @Override
+    public String toString() {
+        return "ListConfig{"
+                + super.fieldsToString()
+                + "}";
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfig.java
@@ -52,4 +52,11 @@ public class SetConfig extends CollectionConfig<SetConfig> {
     public int getId() {
         return ConfigDataSerializerHook.SET_CONFIG;
     }
+
+    @Override
+    public String toString() {
+        return "SetConfig{"
+                + super.fieldsToString()
+                + "}";
+    }
 }


### PR DESCRIPTION
The `ListConfig` and `SetConfig` classes don't override the `toString` method compared to other config classes (`MapConfig`, `QueueConfig`, `LockConfig`, ...).

This commit adds the `toString` implementations similar to the other ones.