### PR TITLE
Fix OOME iobalancer when single threaded

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -100,11 +100,23 @@ public class IOBalancer {
     }
 
     public void channelAdded(MigratableHandler readHandler, MigratableHandler writeHandler) {
+        // if not enabled, then don't schedule tasks that will not get processed.
+        // See https://github.com/hazelcast/hazelcast/issues/11501
+        if (!enabled) {
+            return;
+        }
+
         inLoadTracker.notifyHandlerAdded(readHandler);
         outLoadTracker.notifyHandlerAdded(writeHandler);
     }
 
     public void channelRemoved(MigratableHandler readHandler, MigratableHandler writeHandler) {
+        // if not enabled, then don't schedule tasks that will not get processed.
+        // See https://github.com/hazelcast/hazelcast/issues/11501
+        if (!enabled) {
+            return;
+        }
+
         inLoadTracker.notifyHandlerRemoved(readHandler);
         outLoadTracker.notifyHandlerRemoved(writeHandler);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -39,6 +39,8 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
  * {@link #removeHandler(MigratableHandler)}
  */
 class LoadTracker {
+    final Queue<Runnable> tasks = new LinkedBlockingQueue<Runnable>();
+
     private final ILogger logger;
 
     //all known IO ioThreads. we assume no. of ioThreads is constant during a lifespan of a member
@@ -57,8 +59,6 @@ class LoadTracker {
     private final Set<MigratableHandler> handlers = new HashSet<MigratableHandler>();
 
     private final LoadImbalance imbalance;
-
-    private final Queue<Runnable> tasks = new LinkedBlockingQueue<Runnable>();
 
     LoadTracker(NioThread[] ioThreads, ILogger logger) {
         this.logger = logger;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
@@ -1,0 +1,48 @@
+package com.hazelcast.internal.networking.nio.iobalancer;
+
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.NioThread;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IOBalancerTest {
+    private final LoggingService loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
+
+    // https://github.com/hazelcast/hazelcast/issues/11501
+    @Test
+    public void whenChannelAdded_andDisabled_thenSkipTaskCreation() {
+        IOBalancer ioBalancer = new IOBalancer(new NioThread[1], new NioThread[1], "foo", 1, loggingService);
+        MigratableHandler readHandler = mock(MigratableHandler.class);
+        MigratableHandler writeHandler = mock(MigratableHandler.class);
+
+        ioBalancer.channelAdded(readHandler, writeHandler);
+
+        assertTrue(ioBalancer.getInLoadTracker().tasks.isEmpty());
+        assertTrue(ioBalancer.getOutLoadTracker().tasks.isEmpty());
+    }
+
+    // https://github.com/hazelcast/hazelcast/issues/11501
+    @Test
+    public void whenChannelRemoved_andDisabled_thenSkipTaskCreation() {
+        IOBalancer ioBalancer = new IOBalancer(new NioThread[1], new NioThread[1], "foo", 1, loggingService);
+        MigratableHandler readHandler = mock(MigratableHandler.class);
+        MigratableHandler writeHandler = mock(MigratableHandler.class);
+
+        ioBalancer.channelRemoved(readHandler, writeHandler);
+
+        assertTrue(ioBalancer.getInLoadTracker().tasks.isEmpty());
+        assertTrue(ioBalancer.getOutLoadTracker().tasks.isEmpty());
+    }
+}


### PR DESCRIPTION
When io system is single threaded, the io balancer is disabled.

WHen a channel (connection) is registered, a task is queued containing
the connection, but the task doesn't get processed because the iobalancer
is disabled. So you these tasks remain on the queue and cause OOME

Very good work @Danny-Hazelcast finding the OOME

Very good work @mmedenjak / @sancar for the initial analysis.

Fix https://github.com/hazelcast/hazelcast/issues/11501