### PR TITLE
Backport PR https://github.com/hazelcast/hazelcast/pull/11466

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -33,6 +33,7 @@ import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.executor.SingleExecutorThreadFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -115,13 +116,20 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
             addresses.add(member.getAddress());
         }
 
-        for (AddressProvider addressProvider : addressProviders) {
-            addresses.addAll(addressProvider.loadAddresses());
-        }
-
         if (shuffleMemberList) {
             Collections.shuffle(addresses);
         }
+
+        List<Address> providerAddresses = new ArrayList<Address>();
+        for (AddressProvider addressProvider : addressProviders) {
+            providerAddresses.addAll(addressProvider.loadAddresses());
+        }
+
+        if (shuffleMemberList) {
+            Collections.shuffle(providerAddresses);
+        }
+
+        addresses.addAll(providerAddresses);
 
         return addresses;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -23,7 +23,9 @@ import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.util.AddressUtil;
 
+import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -68,6 +70,22 @@ public final class TestNodeRegistry {
 
     public HazelcastInstance getInstance(Address address) {
         Node node = nodes.get(address);
+        if (node == null) {
+            String host = address.getHost();
+            if (host != null) {
+                try {
+                    if (AddressUtil.isIpAddress(host)) {
+                        // try using hostname
+                        node = nodes.get(new Address(address.getInetAddress().getHostName(), address.getPort()));
+                    } else {
+                        // try using ip address
+                        node = nodes.get(new Address(address.getInetAddress().getHostAddress(), address.getPort()));
+                    }
+                } catch (UnknownHostException e) {
+                    // suppress
+                }
+            }
+        }
         return node != null && node.isRunning() ? node.hazelcastInstance : null;
     }
 


### PR DESCRIPTION
Backports PR https://github.com/hazelcast/hazelcast/pull/11466

During connection and reconnection, the client can always try the existing members first and then use the statically configured or addressprovider provided addresses.