### PR TITLE
Fix race between member join and listener registration/deregistration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -25,7 +25,7 @@ import com.hazelcast.spi.DistributedObjectNamespace;
 import com.hazelcast.spi.impl.eventservice.impl.EventEnvelope;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 import com.hazelcast.spi.impl.eventservice.impl.operations.DeregistrationOperation;
-import com.hazelcast.spi.impl.eventservice.impl.operations.PostJoinRegistrationOperation;
+import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOperation;
 import com.hazelcast.spi.impl.eventservice.impl.operations.RegistrationOperation;
 import com.hazelcast.spi.impl.eventservice.impl.operations.SendEventOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
@@ -57,7 +57,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int CALL_TIMEOUT_RESPONSE = 8;
     public static final int ERROR_RESPONSE = 9;
     public static final int DEREGISTRATION = 10;
-    public static final int POST_JOIN_REGISTRATION = 11;
+    public static final int ON_JOIN_REGISTRATION = 11;
     public static final int REGISTRATION = 12;
     public static final int SEND_EVENT = 13;
     public static final int DIST_OBJECT_INIT = 14;
@@ -102,8 +102,8 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new ErrorResponse();
                     case DEREGISTRATION:
                         return new DeregistrationOperation();
-                    case POST_JOIN_REGISTRATION:
-                        return new PostJoinRegistrationOperation();
+                    case ON_JOIN_REGISTRATION:
+                        return new OnJoinRegistrationOperation();
                     case REGISTRATION:
                         return new RegistrationOperation();
                     case SEND_EVENT:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/InternalEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/InternalEventService.java
@@ -19,13 +19,14 @@ package com.hazelcast.spi.impl.eventservice;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.PostJoinAwareService;
+import com.hazelcast.spi.PreJoinAwareService;
 import com.hazelcast.spi.impl.PacketHandler;
 
 /**
  * The InternalEventService is an {@link EventService} interface that adds additional capabilities
  * we don't want to expose to the end user. So they are purely meant to be used internally.
  */
-public interface InternalEventService extends EventService, PacketHandler, PostJoinAwareService {
+public interface InternalEventService extends EventService, PacketHandler, PreJoinAwareService, PostJoinAwareService {
 
     /**
      * Closes an EventRegistration.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.util.Preconditions;
 
 import java.io.IOException;
 
@@ -45,8 +46,8 @@ public class Registration implements EventRegistration {
 
     public Registration(String id, String serviceName, String topic,
                         EventFilter filter, Address subscriber, Object listener, boolean localOnly) {
+        this.id = Preconditions.checkNotNull(id, "Registration id cannot be null!");
         this.filter = filter;
-        this.id = id;
         this.listener = listener;
         this.serviceName = serviceName;
         this.topic = topic;
@@ -86,46 +87,23 @@ public class Registration implements EventRegistration {
         return listener;
     }
 
-    //CHECKSTYLE:OFF
+    // Registration equals() and hashCode() relies on only id field.
+    // Because registration id is unique in cluster.
     @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Registration)) {
             return false;
         }
-
         Registration that = (Registration) o;
-
-        if (id != null ? !id.equals(that.id) : that.id != null) {
-            return false;
-        }
-        if (serviceName != null ? !serviceName.equals(that.serviceName) : that.serviceName != null) {
-            return false;
-        }
-        if (topic != null ? !topic.equals(that.topic) : that.topic != null) {
-            return false;
-        }
-        if (filter != null ? !filter.equals(that.filter) : that.filter != null) {
-            return false;
-        }
-        if (subscriber != null ? !subscriber.equals(that.subscriber) : that.subscriber != null) {
-            return false;
-        }
-
-        return true;
+        return id.equals(that.id);
     }
-    //CHECKSTYLE:ON
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (serviceName != null ? serviceName.hashCode() : 0);
-        result = 31 * result + (topic != null ? topic.hashCode() : 0);
-        result = 31 * result + (filter != null ? filter.hashCode() : 0);
-        result = 31 * result + (subscriber != null ? subscriber.hashCode() : 0);
-        return result;
+        return id.hashCode();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/AbstractRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/AbstractRegistrationOperation.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.eventservice.impl.operations;
+
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.internal.cluster.impl.ClusterTopologyChangedException;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+abstract class AbstractRegistrationOperation extends Operation
+        implements AllowedDuringPassiveState, IdentifiedDataSerializable, Versioned {
+
+    private int memberListVersion = -1;
+
+    AbstractRegistrationOperation() {
+    }
+
+    AbstractRegistrationOperation(int memberListVersion) {
+        this.memberListVersion = memberListVersion;
+    }
+
+    @Override
+    public final void run() throws Exception {
+        runInternal();
+        checkMemberListVersion();
+    }
+
+    protected abstract void runInternal() throws Exception;
+
+    private void checkMemberListVersion() {
+        if (memberListVersion == -1) {
+            // RU_COMPAT_38
+            // operation sent by a 3.8 member
+            return;
+        }
+        ClusterService clusterService = getNodeEngine().getClusterService();
+        if (clusterService.isMaster()) {
+            int currentMemberListVersion = clusterService.getMemberListVersion();
+            if (currentMemberListVersion != memberListVersion) {
+                throw new ClusterTopologyChangedException(
+                        format("Current member list version %d does not match expected %d", currentMemberListVersion,
+                                memberListVersion));
+            }
+        }
+    }
+
+    @Override
+    protected final void writeInternal(ObjectDataOutput out) throws IOException {
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_9)) {
+            out.writeInt(memberListVersion);
+        }
+        writeInternalImpl(out);
+    }
+
+    protected abstract void writeInternalImpl(ObjectDataOutput out) throws IOException;
+
+    @Override
+    protected final void readInternal(ObjectDataInput in) throws IOException {
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_9)) {
+            memberListVersion = in.readInt();
+        }
+        readInternalImpl(in);
+    }
+
+    protected abstract void readInternalImpl(ObjectDataInput in) throws IOException;
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        return (throwable instanceof ClusterTopologyChangedException)
+                ? ExceptionAction.THROW_EXCEPTION
+                : super.onInvocationException(throwable);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SpiDataSerializerHook.F_ID;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperation.java
@@ -18,16 +18,13 @@ package com.hazelcast.spi.impl.eventservice.impl.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
 
 import java.io.IOException;
 
-public class DeregistrationOperation extends Operation implements AllowedDuringPassiveState, IdentifiedDataSerializable {
+public class DeregistrationOperation extends AbstractRegistrationOperation {
 
     private String topic;
     private String id;
@@ -35,13 +32,14 @@ public class DeregistrationOperation extends Operation implements AllowedDuringP
     public DeregistrationOperation() {
     }
 
-    public DeregistrationOperation(String topic, String id) {
+    public DeregistrationOperation(String topic, String id, int memberListVersion) {
+        super(memberListVersion);
         this.topic = topic;
         this.id = id;
     }
 
     @Override
-    public void run() throws Exception {
+    protected void runInternal() throws Exception {
         EventServiceImpl eventService = (EventServiceImpl) getNodeEngine().getEventService();
         EventServiceSegment segment = eventService.getSegment(getServiceName(), false);
         if (segment != null) {
@@ -55,20 +53,15 @@ public class DeregistrationOperation extends Operation implements AllowedDuringP
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
+    protected void writeInternalImpl(ObjectDataOutput out) throws IOException {
         out.writeUTF(topic);
         out.writeUTF(id);
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
+    protected void readInternalImpl(ObjectDataInput in) throws IOException {
         topic = in.readUTF();
         id = in.readUTF();
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SpiDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperationFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.eventservice.impl.operations;
+
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.eventservice.impl.Registration;
+
+import java.io.IOException;
+
+/**
+ * Factory that creates {@link DeregistrationOperation}s for a listener registration.
+ */
+public class DeregistrationOperationFactory implements OperationFactory {
+    private final Registration registration;
+    private final ClusterService clusterService;
+
+    public DeregistrationOperationFactory() {
+        registration = null;
+        clusterService = null;
+    }
+
+    public DeregistrationOperationFactory(Registration reg, ClusterService clusterService) {
+        registration = reg;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    public Operation createOperation() {
+        return new DeregistrationOperation(registration.getTopic(), registration.getId(), clusterService.getMemberListVersion())
+                .setServiceName(registration.getServiceName());
+    }
+
+    @Override
+    public int getFactoryId() {
+        throw new UnsupportedOperationException("DeregistrationOperationFactory must not be serialized");
+    }
+
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException("DeregistrationOperationFactory must not be serialized");
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        throw new UnsupportedOperationException("DeregistrationOperationFactory must not be serialized");
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        throw new UnsupportedOperationException("DeregistrationOperationFactory must not be serialized");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/OnJoinRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/OnJoinRegistrationOperation.java
@@ -29,14 +29,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class PostJoinRegistrationOperation extends Operation implements IdentifiedDataSerializable {
+public class OnJoinRegistrationOperation extends Operation implements IdentifiedDataSerializable {
 
     private Collection<Registration> registrations;
 
-    public PostJoinRegistrationOperation() {
+    public OnJoinRegistrationOperation() {
     }
 
-    public PostJoinRegistrationOperation(Collection<Registration> registrations) {
+    public OnJoinRegistrationOperation(Collection<Registration> registrations) {
         this.registrations = registrations;
     }
 
@@ -91,6 +91,6 @@ public class PostJoinRegistrationOperation extends Operation implements Identifi
 
     @Override
     public int getId() {
-        return SpiDataSerializerHook.POST_JOIN_REGISTRATION;
+        return SpiDataSerializerHook.ON_JOIN_REGISTRATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperation.java
@@ -18,16 +18,13 @@ package com.hazelcast.spi.impl.eventservice.impl.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 import com.hazelcast.spi.impl.eventservice.impl.Registration;
 
 import java.io.IOException;
 
-public class RegistrationOperation extends Operation implements AllowedDuringPassiveState, IdentifiedDataSerializable {
+public class RegistrationOperation extends AbstractRegistrationOperation {
 
     private Registration registration;
     private boolean response;
@@ -35,12 +32,13 @@ public class RegistrationOperation extends Operation implements AllowedDuringPas
     public RegistrationOperation() {
     }
 
-    public RegistrationOperation(Registration registration) {
+    public RegistrationOperation(Registration registration, int memberListVersion) {
+        super(memberListVersion);
         this.registration = registration;
     }
 
     @Override
-    public void run() throws Exception {
+    protected void runInternal() throws Exception {
         EventServiceImpl eventService = (EventServiceImpl) getNodeEngine().getEventService();
         response = eventService.handleRegistration(registration);
     }
@@ -51,19 +49,14 @@ public class RegistrationOperation extends Operation implements AllowedDuringPas
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
+    protected void writeInternalImpl(ObjectDataOutput out) throws IOException {
         registration.writeData(out);
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
+    protected void readInternalImpl(ObjectDataInput in) throws IOException {
         registration = new Registration();
         registration.readData(in);
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SpiDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperationFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.eventservice.impl.operations;
+
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.eventservice.impl.Registration;
+
+import java.io.IOException;
+
+/**
+ * Factory that creates {@link RegistrationOperation}s for a listener registration.
+ */
+public class RegistrationOperationFactory implements OperationFactory {
+    private final Registration reg;
+    private final ClusterService clusterService;
+
+    public RegistrationOperationFactory() {
+        reg = null;
+        clusterService = null;
+    }
+
+    public RegistrationOperationFactory(Registration reg, ClusterService clusterService) {
+        this.reg = reg;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    public Operation createOperation() {
+        return new RegistrationOperation(reg, clusterService.getMemberListVersion());
+    }
+
+    @Override
+    public int getFactoryId() {
+        throw new UnsupportedOperationException("RegistrationOperationFactory must not be serialized");
+    }
+
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException("RegistrationOperationFactory must not be serialized");
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        throw new UnsupportedOperationException("RegistrationOperationFactory must not be serialized");
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        throw new UnsupportedOperationException("RegistrationOperationFactory must not be serialized");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceTest.java
@@ -16,128 +16,112 @@
 
 package com.hazelcast.spi.impl.eventservice.impl;
 
-import com.hazelcast.core.ITopic;
-import com.hazelcast.core.Message;
-import com.hazelcast.core.MessageListener;
-import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.instance.HazelcastInstanceProxy;
-import com.hazelcast.instance.MemberImpl;
-import com.hazelcast.nio.Address;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.EventRegistration;
-import com.hazelcast.spi.EventService;
-import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.topic.impl.TopicEvent;
-import com.hazelcast.topic.impl.TopicService;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.lang.reflect.Field;
 import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class EventServiceTest extends HazelcastTestSupport {
 
-    @Test(timeout = 90000)
-    public void testEventService() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+    private final String serviceName = "dummy-service";
+    private final String topic = "dummy-topic";
 
-        HazelcastInstanceProxy h1 = (HazelcastInstanceProxy) factory.newHazelcastInstance();
-        HazelcastInstanceProxy h2 = (HazelcastInstanceProxy) factory.newHazelcastInstance();
-        HazelcastInstanceProxy h3 = (HazelcastInstanceProxy) factory.newHazelcastInstance();
+    @Test
+    public void test_registration_whileNewMemberJoining() throws Exception {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
-        CountDownLatch l1 = new CountDownLatch(1000);
-        CountDownLatch l2 = new CountDownLatch(1000);
-        CountDownLatch l3 = new CountDownLatch(1000);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(newConfigWithDummyService());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(newConfigWithDummyService());
 
-        ITopic t1 = h1.getTopic("foo");
-        ITopic t2 = h2.getTopic("foo");
-        ITopic t3 = h3.getTopic("foo");
-
-        t1.addMessageListener(createMessageListener(l1));
-        t2.addMessageListener(createMessageListener(l2));
-        t3.addMessageListener(createMessageListener(l3));
-
-        MemberImpl m1 = (MemberImpl) h1.getCluster().getLocalMember();
-        MemberImpl m2 = (MemberImpl) h2.getCluster().getLocalMember();
-        MemberImpl m3 = (MemberImpl) h3.getCluster().getLocalMember();
-
-        Address a1 = m1.getAddress();
-        Address a2 = m2.getAddress();
-        Address a3 = m3.getAddress();
-
-        Field original = HazelcastInstanceProxy.class.getDeclaredField("original");
-        original.setAccessible(true);
-
-        HazelcastInstanceImpl impl1 = (HazelcastInstanceImpl) original.get(h1);
-        HazelcastInstanceImpl impl2 = (HazelcastInstanceImpl) original.get(h2);
-        HazelcastInstanceImpl impl3 = (HazelcastInstanceImpl) original.get(h3);
-
-        EventService es1 = impl1.node.nodeEngine.getEventService();
-        EventService es2 = impl2.node.nodeEngine.getEventService();
-        EventService es3 = impl3.node.nodeEngine.getEventService();
-
-        SerializationService ss1 = impl1.node.nodeEngine.getSerializationService();
-        SerializationService ss2 = impl2.node.nodeEngine.getSerializationService();
-        SerializationService ss3 = impl3.node.nodeEngine.getSerializationService();
-
-        int counter = 0;
-        for (int i = 0; i < 3000; i++) {
-            if (counter == 0) {
-                TopicEvent event = builTopicEvent("Foo" + i, m1, ss1);
-                Collection<EventRegistration> registrations = es1.getRegistrations(TopicService.SERVICE_NAME, "foo");
-                EventRegistration registration = findEventRegistration(a3, registrations);
-                es1.publishEvent(TopicService.SERVICE_NAME, registration, event, 0);
-            } else if (counter == 1) {
-                TopicEvent event = builTopicEvent("Foo" + i, m2, ss2);
-                Collection<EventRegistration> registrations = es2.getRegistrations(TopicService.SERVICE_NAME, "foo");
-                EventRegistration registration = findEventRegistration(a1, registrations);
-                es2.publishEvent(TopicService.SERVICE_NAME, registration, event, 0);
-            } else if (counter == 2) {
-                TopicEvent event = builTopicEvent("Foo" + i, m3, ss3);
-                Collection<EventRegistration> registrations = es3.getRegistrations(TopicService.SERVICE_NAME, "foo");
-                EventRegistration registration = findEventRegistration(a2, registrations);
-                es3.publishEvent(TopicService.SERVICE_NAME, registration, event, 0);
-            }
-            counter++;
-            if (counter == 3) {
-                counter = 0;
-            }
-        }
-
-        l1.await(30, TimeUnit.SECONDS);
-        l2.await(30, TimeUnit.SECONDS);
-        l3.await(30, TimeUnit.SECONDS);
-    }
-
-    private TopicEvent builTopicEvent(String value, MemberImpl member, SerializationService ss) {
-        return new TopicEvent("foo", ss.toData(value), member.getAddress());
-    }
-
-    private EventRegistration findEventRegistration(Address address, Collection<EventRegistration> registrations) {
-        for (EventRegistration registration : registrations) {
-            if (registration.getSubscriber().equals(address)) {
-                return registration;
-            }
-        }
-        return null;
-    }
-
-    private MessageListener createMessageListener(final CountDownLatch latch) {
-        return new MessageListener() {
+        Future<HazelcastInstance> future = spawn(new Callable<HazelcastInstance>() {
             @Override
-            public void onMessage(Message message) {
-                latch.countDown();
+            public HazelcastInstance call() throws Exception {
+                return factory.newHazelcastInstance(newConfigWithDummyService());
             }
-        };
+        });
+
+        InternalEventService eventService = getEventService(hz2);
+        Set<String> registrationIds = new HashSet<String>();
+        Object listener = new Object();
+        while (getClusterService(hz2).getSize() < 3) {
+            EventRegistration registration = eventService.registerListener(serviceName, topic, listener);
+            registrationIds.add(registration.getId());
+        }
+
+        HazelcastInstance hz3 = future.get();
+        InternalEventService eventService3 = getEventService(hz3);
+        Collection<EventRegistration> registrations = eventService3.getRegistrations(serviceName, topic);
+
+        assertEquals(registrationIds.size(), registrations.size());
+        for (EventRegistration registration : registrations) {
+            assertThat(registrationIds, hasItem(registration.getId()));
+        }
     }
 
+    @Test
+    public void test_deregistration_whileNewMemberJoining() throws Exception {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(newConfigWithDummyService());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(newConfigWithDummyService());
+
+        InternalEventService eventService = getEventService(hz2);
+        Set<String> registrationIds = new HashSet<String>();
+        Object listener = new Object();
+        for (int i = 0; i < 500; i++) {
+            EventRegistration registration = eventService.registerListener(serviceName, topic, listener);
+            registrationIds.add(registration.getId());
+        }
+
+        Future<HazelcastInstance> future = spawn(new Callable<HazelcastInstance>() {
+            @Override
+            public HazelcastInstance call() throws Exception {
+                return factory.newHazelcastInstance(newConfigWithDummyService());
+            }
+        });
+
+        for (String registrationId : registrationIds) {
+            eventService.deregisterListener(serviceName, topic, registrationId);
+        }
+
+        assertThat(eventService.getRegistrations(serviceName, topic), Matchers.<EventRegistration>empty());
+
+        HazelcastInstance hz3 = future.get();
+        InternalEventService eventService3 = getEventService(hz3);
+        assertThat(eventService3.getRegistrations(serviceName, topic), Matchers.<EventRegistration>empty());
+    }
+
+    private Config newConfigWithDummyService() {
+        final Config config = new Config();
+        ServiceConfig serviceConfig =
+                new ServiceConfig().setEnabled(true).setName(serviceName).setImplementation(new Object());
+        config.getServicesConfig().addServiceConfig(serviceConfig);
+        return config;
+    }
+
+    private static InternalEventService getEventService(HazelcastInstance hz) {
+        return getNodeEngineImpl(hz).getEventService();
+    }
 }


### PR DESCRIPTION
Registering/deregistering a listener is racy while a new member is joining
cluster.
Solution is to use `InvocationUtil.invokeOnStableClusterSerial()` to submit operations
and check memberlist version while registering/deregistering the listener. A similar
mechanism used by dynamic data-structure config registration...

Additionally, EventService supports both post-join operation and pre-join operation.
Prejoin operation ensures that data structure operations cannot be executed on newly joining
member before event listener is registered. Postjoin operation is required newly joining member
to register listeners on the cluster, such as proxy service listener.

Fixes https://github.com/hazelcast/hazelcast/issues/11490
Fixes https://github.com/hazelcast/hazelcast/issues/11115