### PR TITLE
Fixed various client class naming violations

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -180,7 +180,7 @@ final class ClientCacheHelper {
         } else {
             address = client.getConnectionManager().getOwnerConnectionAddress();
             if (address == null) {
-                throw new IOException("ClientNonSmartInvocationServiceImpl: Owner connection is not available.");
+                throw new IOException("NonSmartClientInvocationService: Owner connection is not available.");
             }
         }
         return address;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.spi.ClientInvocationService;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.internal.metrics.Probe;
@@ -252,7 +252,7 @@ public class ClientConnection implements Connection {
         ClientInvocationService invocationService = client.getInvocationService();
         incrementPendingPacketCount();
         if (message.isFlagSet(ClientMessage.LISTENER_EVENT_FLAG)) {
-            ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) client.getListenerService();
+            AbstractClientListenerService listenerService = (AbstractClientListenerService) client.getListenerService();
             listenerService.handleClientMessage(message, this);
         } else {
             invocationService.handleClientMessage(message, this);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -48,17 +48,17 @@ import com.hazelcast.client.spi.impl.AwsAddressProvider;
 import com.hazelcast.client.spi.impl.ClientClusterServiceImpl;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
 import com.hazelcast.client.spi.impl.ClientInvocation;
-import com.hazelcast.client.spi.impl.ClientInvocationServiceImpl;
-import com.hazelcast.client.spi.impl.ClientNonSmartInvocationServiceImpl;
+import com.hazelcast.client.spi.impl.AbstractClientInvocationService;
+import com.hazelcast.client.spi.impl.NonSmartClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientPartitionServiceImpl;
-import com.hazelcast.client.spi.impl.ClientSmartInvocationServiceImpl;
+import com.hazelcast.client.spi.impl.SmartClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientTransactionManagerServiceImpl;
 import com.hazelcast.client.spi.impl.ClientUserCodeDeploymentService;
 import com.hazelcast.client.spi.impl.DefaultAddressProvider;
 import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressProvider;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
-import com.hazelcast.client.spi.impl.listener.ClientNonSmartListenerService;
-import com.hazelcast.client.spi.impl.listener.ClientSmartListenerService;
+import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
+import com.hazelcast.client.spi.impl.listener.NonSmartClientListenerService;
+import com.hazelcast.client.spi.impl.listener.SmartClientListenerService;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.collection.impl.list.ListService;
@@ -182,9 +182,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ClientConnectionManagerImpl connectionManager;
     private final ClientClusterServiceImpl clusterService;
     private final ClientPartitionServiceImpl partitionService;
-    private final ClientInvocationServiceImpl invocationService;
+    private final AbstractClientInvocationService invocationService;
     private final ClientExecutionServiceImpl executionService;
-    private final ClientListenerServiceImpl listenerService;
+    private final AbstractClientListenerService listenerService;
     private final ClientTransactionManagerServiceImpl transactionManager;
     private final NearCacheManager nearCacheManager;
     private final ProxyManager proxyManager;
@@ -360,12 +360,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return c;
     }
 
-    private ClientInvocationServiceImpl initInvocationService() {
+    @SuppressWarnings("checkstyle:illegaltype")
+    private AbstractClientInvocationService initInvocationService() {
         final ClientNetworkConfig networkConfig = config.getNetworkConfig();
         if (networkConfig.isSmartRouting()) {
-            return new ClientSmartInvocationServiceImpl(this, loadBalancer);
+            return new SmartClientInvocationService(this, loadBalancer);
         } else {
-            return new ClientNonSmartInvocationServiceImpl(this);
+            return new NonSmartClientInvocationService(this);
         }
     }
 
@@ -389,14 +390,15 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return new DefaultClientExtension();
     }
 
-    private ClientListenerServiceImpl initListenerService() {
+    @SuppressWarnings("checkstyle:illegaltype")
+    private AbstractClientListenerService initListenerService() {
         int eventQueueCapacity = properties.getInteger(ClientProperty.EVENT_QUEUE_CAPACITY);
         int eventThreadCount = properties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
         final ClientNetworkConfig networkConfig = config.getNetworkConfig();
         if (networkConfig.isSmartRouting()) {
-            return new ClientSmartListenerService(this, eventThreadCount, eventQueueCapacity);
+            return new SmartClientListenerService(this, eventThreadCount, eventQueueCapacity);
         } else {
-            return new ClientNonSmartListenerService(this, eventThreadCount, eventQueueCapacity);
+            return new NonSmartClientListenerService(this, eventThreadCount, eventQueueCapacity);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
@@ -23,7 +23,7 @@ import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
 import com.hazelcast.core.IMapEvent;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
@@ -87,7 +87,7 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
     private final ClientListenerService listenerService;
 
     public ClientQueryCacheEventService(ClientContext clientContext) {
-        ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) clientContext.getListenerService();
+        AbstractClientListenerService listenerService = (AbstractClientListenerService) clientContext.getListenerService();
         this.listenerService = listenerService;
         this.serializationService = clientContext.getSerializationService();
         this.executor = listenerService.getEventExecutor();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -51,7 +51,7 @@ import com.hazelcast.client.proxy.ClientSetProxy;
 import com.hazelcast.client.proxy.ClientTopicProxy;
 import com.hazelcast.client.proxy.txn.xa.XAResourceProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
-import com.hazelcast.client.spi.impl.ClientInvocationServiceImpl;
+import com.hazelcast.client.spi.impl.AbstractClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientProxyFactoryWithContext;
 import com.hazelcast.client.spi.impl.ClientServiceNotFoundException;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
@@ -215,7 +215,7 @@ public final class ProxyManager {
         }
 
         readProxyDescriptors();
-        ClientInvocationServiceImpl invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
+        AbstractClientInvocationService invocationService = (AbstractClientInvocationService) client.getInvocationService();
         invocationTimeoutMillis = invocationService.getInvocationTimeoutMillis();
         invocationRetryPauseMillis = invocationService.getInvocationRetryPauseMillis();
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
@@ -26,7 +26,7 @@ import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.EventHandler;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.util.concurrent.MPSCQueue;
@@ -48,7 +48,7 @@ import static com.hazelcast.client.spi.properties.ClientProperty.INVOCATION_TIME
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.onOutOfMemory;
 import static com.hazelcast.spi.impl.operationservice.impl.AsyncInboundResponseHandler.getIdleStrategy;
 
-public abstract class ClientInvocationServiceImpl implements ClientInvocationService {
+public abstract class AbstractClientInvocationService implements ClientInvocationService {
 
     private static final HazelcastProperty IDLE_STRATEGY
             = new HazelcastProperty("hazelcast.client.responsequeue.idlestrategy", "block");
@@ -62,7 +62,7 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
 
     protected ClientConnectionManager connectionManager;
     protected ClientPartitionService partitionService;
-    private ClientListenerServiceImpl clientListenerService;
+    private AbstractClientListenerService clientListenerService;
 
     @Probe(name = "pendingCalls", level = ProbeLevel.MANDATORY)
     private ConcurrentMap<Long, ClientInvocation> invocations = new ConcurrentHashMap<Long, ClientInvocation>();
@@ -73,7 +73,7 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
     private final long invocationTimeoutMillis;
     private final long invocationRetryPauseMillis;
 
-    public ClientInvocationServiceImpl(HazelcastClientInstanceImpl client) {
+    public AbstractClientInvocationService(HazelcastClientInstanceImpl client) {
         this.client = client;
         this.invocationLogger = client.getLoggingService().getLogger(ClientInvocationService.class);
         this.invocationTimeoutMillis = initInvocationTimeoutMillis();
@@ -93,7 +93,7 @@ public abstract class ClientInvocationServiceImpl implements ClientInvocationSer
 
     public void start() {
         connectionManager = client.getConnectionManager();
-        clientListenerService = (ClientListenerServiceImpl) client.getListenerService();
+        clientListenerService = (AbstractClientListenerService) client.getListenerService();
         partitionService = client.getClientPartitionService();
         ClassLoader classLoader = client.getClientConfig().getClassLoader();
         responseThread = new ResponseThread(client.getName() + ".response-", classLoader);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -62,7 +62,7 @@ public class ClientInvocation implements Runnable {
     private final ILogger logger;
     private final LifecycleService lifecycleService;
     private final ClientClusterService clientClusterService;
-    private final ClientInvocationServiceImpl invocationService;
+    private final AbstractClientInvocationService invocationService;
     private final ClientExecutionService executionService;
     private final ClientMessage clientMessage;
     private final CallIdSequence callIdSequence;
@@ -85,7 +85,7 @@ public class ClientInvocation implements Runnable {
                                Connection connection) {
         this.clientClusterService = client.getClientClusterService();
         this.lifecycleService = client.getLifecycleService();
-        this.invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
+        this.invocationService = (AbstractClientInvocationService) client.getInvocationService();
         this.executionService = client.getClientExecutionService();
         this.objectName = objectName;
         this.clientMessage = clientMessage;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/NonSmartClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/NonSmartClientInvocationService.java
@@ -22,9 +22,9 @@ import com.hazelcast.nio.Address;
 
 import java.io.IOException;
 
-public class ClientNonSmartInvocationServiceImpl extends ClientInvocationServiceImpl {
+public class NonSmartClientInvocationService extends AbstractClientInvocationService {
 
-    public ClientNonSmartInvocationServiceImpl(HazelcastClientInstanceImpl client) {
+    public NonSmartClientInvocationService(HazelcastClientInstanceImpl client) {
         super(client);
     }
 
@@ -54,7 +54,7 @@ public class ClientNonSmartInvocationServiceImpl extends ClientInvocationService
         Address ownerConnectionAddress = connectionManager.getOwnerConnectionAddress();
         ClientConnection ownerConnection = (ClientConnection) connectionManager.getActiveConnection(ownerConnectionAddress);
         if (ownerConnection == null) {
-            throw new IOException("ClientNonSmartInvocationServiceImpl: Owner connection is not available.");
+            throw new IOException("NonSmartClientInvocationService: Owner connection is not available.");
         }
         return ownerConnection;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
@@ -26,11 +26,11 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 
 import java.io.IOException;
 
-public final class ClientSmartInvocationServiceImpl extends ClientInvocationServiceImpl {
+public final class SmartClientInvocationService extends AbstractClientInvocationService {
 
     private final LoadBalancer loadBalancer;
 
-    public ClientSmartInvocationServiceImpl(HazelcastClientInstanceImpl client, LoadBalancer loadBalancer) {
+    public SmartClientInvocationService(HazelcastClientInstanceImpl client, LoadBalancer loadBalancer) {
         super(client);
         this.loadBalancer = loadBalancer;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/AbstractClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/AbstractClientListenerService.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ThreadFactory;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 
-public abstract class ClientListenerServiceImpl implements ClientListenerService, MetricsProvider {
+public abstract class AbstractClientListenerService implements ClientListenerService, MetricsProvider {
 
     protected final HazelcastClientInstanceImpl client;
     protected final SerializationService serializationService;
@@ -55,7 +55,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
 
     private final StripedExecutor eventExecutor;
 
-    public ClientListenerServiceImpl(HazelcastClientInstanceImpl client, int eventThreadCount, int eventQueueCapacity) {
+    public AbstractClientListenerService(HazelcastClientInstanceImpl client, int eventThreadCount, int eventQueueCapacity) {
         this.client = client;
         serializationService = client.getSerializationService();
         logger = client.getLoggingService().getLogger(ClientListenerService.class);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.java
@@ -38,13 +38,13 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
-public class ClientNonSmartListenerService extends ClientListenerServiceImpl implements ConnectionListener {
+public class NonSmartClientListenerService extends AbstractClientListenerService implements ConnectionListener {
 
     private final Map<ClientRegistrationKey, ClientEventRegistration> activeRegistrations
             = new ConcurrentHashMap<ClientRegistrationKey, ClientEventRegistration>();
     private final Set<ClientRegistrationKey> userRegistrations = new HashSet<ClientRegistrationKey>();
 
-    public ClientNonSmartListenerService(HazelcastClientInstanceImpl client,
+    public NonSmartClientListenerService(HazelcastClientInstanceImpl client,
                                          int eventThreadCount, int eventQueueCapacity) {
         super(client, eventThreadCount, eventQueueCapacity);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
@@ -24,7 +24,7 @@ import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
-import com.hazelcast.client.spi.impl.ClientInvocationServiceImpl;
+import com.hazelcast.client.spi.impl.AbstractClientInvocationService;
 import com.hazelcast.client.spi.impl.ConnectionHeartbeatListener;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.core.HazelcastException;
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.StringUtil.timeToString;
 
-public class ClientSmartListenerService extends ClientListenerServiceImpl
+public class SmartClientListenerService extends AbstractClientListenerService
         implements ConnectionListener, ConnectionHeartbeatListener {
 
     private final long invocationTimeoutMillis;
@@ -59,11 +59,11 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl
     private final Map<Connection, Collection<ClientRegistrationKey>> failedRegistrations
             = new ConcurrentHashMap<Connection, Collection<ClientRegistrationKey>>();
 
-    public ClientSmartListenerService(HazelcastClientInstanceImpl client,
+    public SmartClientListenerService(HazelcastClientInstanceImpl client,
                                       int eventThreadCount, int eventQueueCapacity) {
         super(client, eventThreadCount, eventQueueCapacity);
         clientConnectionManager = client.getConnectionManager();
-        ClientInvocationServiceImpl invocationService = (ClientInvocationServiceImpl) client.getInvocationService();
+        AbstractClientInvocationService invocationService = (AbstractClientInvocationService) client.getInvocationService();
         invocationTimeoutMillis = invocationService.getInvocationTimeoutMillis();
         invocationRetryPauseMillis = invocationService.getInvocationRetryPauseMillis();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientInvocation;
-import com.hazelcast.client.spi.impl.ClientSmartInvocationServiceImpl;
+import com.hazelcast.client.spi.impl.SmartClientInvocationService;
 import com.hazelcast.client.test.bounce.MultiSocketClientDriverFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ExecutionCallback;
@@ -179,8 +179,8 @@ public class ClientBackpressureBouncingTest extends HazelcastTestSupport {
             try {
                 HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
                 ClientInvocationService invocationService = clientImpl.getInvocationService();
-                ClientSmartInvocationServiceImpl smartInvocationService = (ClientSmartInvocationServiceImpl) invocationService;
-                Field callIdMapField = ClientSmartInvocationServiceImpl.class.getSuperclass().getDeclaredField("callIdMap");
+                SmartClientInvocationService smartInvocationService = (SmartClientInvocationService) invocationService;
+                Field callIdMapField = SmartClientInvocationService.class.getSuperclass().getDeclaredField("callIdMap");
                 callIdMapField.setAccessible(true);
                 return (ConcurrentMap<Long, ClientInvocation>) callIdMapField.get(smartInvocationService);
             } catch (Exception e) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.ClientTestUtil;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.impl.listener.ClientEventRegistration;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -554,7 +554,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     private Collection<ClientEventRegistration> getClientEventRegistrations(HazelcastInstance client, String id) {
         HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
-        ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) clientImpl.getListenerService();
+        AbstractClientListenerService listenerService = (AbstractClientListenerService) clientImpl.getListenerService();
         return listenerService.getActiveRegistrations(id);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestSupport.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.ClientTestUtil;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.impl.listener.ClientEventRegistration;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
@@ -71,7 +71,7 @@ public class ListenerLeakTestSupport extends HazelcastTestSupport {
 
     protected Collection<ClientEventRegistration> getClientEventRegistrations(HazelcastInstance client, String id) {
         HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
-        ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) clientImpl.getListenerService();
+        AbstractClientListenerService listenerService = (AbstractClientListenerService) clientImpl.getListenerService();
         return listenerService.getActiveRegistrations(id);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheDestroyResourcesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheDestroyResourcesTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.spi.impl.listener.ClientEventRegistration;
 import com.hazelcast.client.spi.impl.listener.ClientRegistrationKey;
-import com.hazelcast.client.spi.impl.listener.ClientSmartListenerService;
+import com.hazelcast.client.spi.impl.listener.SmartClientListenerService;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PredicateConfig;
@@ -100,13 +100,13 @@ public class ClientQueryCacheDestroyResourcesTest extends HazelcastTestSupport {
         queryCache2.destroy();
         queryCache3.destroy();
 
-        ClientSmartListenerService smartListenerService = getSmartListenerService();
+        SmartClientListenerService smartListenerService = getSmartListenerService();
         Map<ClientRegistrationKey, Map<Connection, ClientEventRegistration>> registrations = smartListenerService.getRegistrations();
 
         assertEquals(registrations.toString(), 0, registrations.size());
     }
 
-    protected ClientSmartListenerService getSmartListenerService() {
-        return (ClientSmartListenerService) ((HazelcastClientProxy) clientInstance).client.getListenerService();
+    protected SmartClientListenerService getSmartListenerService() {
+        return (SmartClientListenerService) ((HazelcastClientProxy) clientInstance).client.getListenerService();
     }
 }


### PR DESCRIPTION
An abstract class normally is called  AbstractFoobar; and not FoobarImpl. Impl is for default
implementations when there is only 1.

Fixes:
ClientInvocationServiceImpl -> AbstractClientInvocationService
ClientListenerServiceImpl -> AbstractClientListenerService

The speciality of a class is normally prefixed in front of the class name:
ClientNonSmartFoobar --> NonSmartClientFoobar
the same goes for the smart.

We use these standard naming patterns on the server, we should do that as well on
the client to keep naming consistent en predictable.