### PR TITLE
Small cleanup of diagnostics package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPlugin.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static java.util.Collections.sort;
 
 /**
- * A {@link DiagnosticsPlugin} that displays the {@link Config#getProperties()}
+ * A {@link DiagnosticsPlugin} that displays the {@link Config#getProperties()}.
  */
 public class ConfigPropertiesPlugin extends DiagnosticsPlugin {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.logging.ILogger;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -32,12 +31,13 @@ import java.nio.charset.CharsetEncoder;
 import static com.hazelcast.internal.diagnostics.Diagnostics.MAX_ROLLED_FILE_COUNT;
 import static com.hazelcast.internal.diagnostics.Diagnostics.MAX_ROLLED_FILE_SIZE_MB;
 import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.nio.IOUtil.deleteQuietly;
 import static java.lang.Math.round;
 import static java.lang.String.format;
 
 /**
  * Represents the PerformanceLogFile.
- *
+ * <p>
  * Should only be called from the {@link Diagnostics}.
  */
 final class DiagnosticsLogFile {
@@ -50,12 +50,12 @@ final class DiagnosticsLogFile {
     private final Diagnostics diagnostics;
     private final ILogger logger;
     private final String fileName;
+    private final DiagnosticsLogWriterImpl logWriter;
 
     private int index;
     private PrintWriter printWriter;
     private int maxRollingFileCount;
     private int maxRollingFileSizeBytes;
-    private final DiagnosticsLogWriterImpl logWriter;
 
     DiagnosticsLogFile(Diagnostics diagnostics) {
         this.diagnostics = diagnostics;
@@ -101,7 +101,7 @@ final class DiagnosticsLogFile {
         }
     }
 
-    private void renderPlugin(DiagnosticsPlugin plugin) throws IOException {
+    private void renderPlugin(DiagnosticsPlugin plugin) {
         logWriter.init(printWriter);
 
         plugin.run(logWriter);
@@ -113,7 +113,6 @@ final class DiagnosticsLogFile {
         return new PrintWriter(new BufferedWriter(new OutputStreamWriter(fos, encoder), Short.MAX_VALUE));
     }
 
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     private void rollover() {
         closeResource(printWriter);
         printWriter = null;
@@ -121,7 +120,6 @@ final class DiagnosticsLogFile {
         index++;
 
         File file = new File(format(fileName, index - maxRollingFileCount));
-        // we don't care if the file was deleted or not
-        file.delete();
+        deleteQuietly(file);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
@@ -34,7 +34,7 @@ import static java.util.Calendar.YEAR;
 /**
  * A writer like structure dedicated for the {@link DiagnosticsPlugin} rendering.
  */
-public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
+class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
 
     private static final String STR_LONG_MIN_VALUE = String.format(LOCALE_INTERNAL, "%,d", Long.MIN_VALUE);
 
@@ -67,11 +67,11 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
     // used to write primitives without causing litter
     private StringBuilder stringBuilder = new StringBuilder();
 
-    public DiagnosticsLogWriterImpl() {
+    DiagnosticsLogWriterImpl() {
         this(false);
     }
 
-    public DiagnosticsLogWriterImpl(boolean includeEpochTime) {
+    DiagnosticsLogWriterImpl(boolean includeEpochTime) {
         this.includeEpochTime = includeEpochTime;
     }
 
@@ -257,7 +257,7 @@ public class DiagnosticsLogWriterImpl implements DiagnosticsLogWriter {
     }
 
     // we can't rely on DateFormat since it generates a ton of garbage
-    protected void appendDateTime(long epochMillis) {
+    private void appendDateTime(long epochMillis) {
         date.setTime(epochMillis);
         calendar.setTime(date);
         appendDate();

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsPlugin.java
@@ -20,9 +20,9 @@ import com.hazelcast.logging.ILogger;
 
 /**
  * Plugin for the {@link Diagnostics}.
- *
+ * <p>
  * The plugin will not be called concurrently, unless threads are introduced outside of the {@link Diagnostics}.
- *
+ * <p>
  * There is a happens before relation between {@link #onStart()} and {@link #run(DiagnosticsLogWriter)}, and therefor
  * there is no need to make variables volatile. The source of the happens-before relation is the scheduler.queue inside
  * of the {@link Diagnostics} or the AtomicReference in case of static plugins.
@@ -47,9 +47,9 @@ public abstract class DiagnosticsPlugin {
 
     /**
      * Returns the period of executing the monitor in millis.
-     *
+     * <p>
      * If a monitor is disabled, 0 is returned.
-     *
+     * <p>
      * If a monitor should run only once, a negative value is returned. This is useful for 'static' monitors like the
      * {@link SystemPropertiesPlugin} that run at the beginning of a log file but their contents will not change.
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
@@ -46,16 +46,17 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * The EventQueuePlugin checks the event queue and samples the event types if the size is above a certain threshold.
+ * <p>
  * This is very useful to figure out why the event queue is running full.
  */
 public class EventQueuePlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds this plugin runs.
-     *
+     * <p>
      * With the EventQueuePlugin one can see what is going on inside the event queue.
      * It makes use of sampling to give some impression of the content.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
@@ -32,18 +32,16 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * A {@link DiagnosticsPlugin} that displays all invocations that have been executing for some time.
- *
- * It will display the current invocations.
- *
- * But it will also display the history. E.g. if a entry processor has been running for 5 minutes and
- * the {@link #SAMPLE_PERIOD_SECONDS is set to 1 minute, then there will be 5 samples for that given invocation.
- * This is useful to track which operations have been slow over a longer period of time.
+ * <p>
+ * It will display the current invocations and the invocation history. For example, if an entry processor has been
+ * running for 5 minutes and the {@link #SAMPLE_PERIOD_SECONDS} is set to 1 minute, then there will be 5 samples
+ * for that given invocation. This is useful to track which operations have been slow over a longer period of time.
  */
 public class InvocationPlugin extends DiagnosticsPlugin {
 
     /**
      * The sample period in seconds.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty SAMPLE_PERIOD_SECONDS
@@ -56,7 +54,7 @@ public class InvocationPlugin extends DiagnosticsPlugin {
             = new HazelcastProperty(PREFIX + ".invocation.slow.threshold.seconds", 5, SECONDS);
 
     /**
-     * The maximum number of slow invocations to print
+     * The maximum number of slow invocations to print.
      */
     public static final HazelcastProperty SLOW_MAX_COUNT
             = new HazelcastProperty(PREFIX + ".invocation.slow.max.count", 100);
@@ -113,11 +111,11 @@ public class InvocationPlugin extends DiagnosticsPlugin {
             occurrences.add(operationDesc, 1);
 
             if (durationMs < thresholdMillis) {
-                // short invocation, lets move on to the next.
+                // short invocation, lets move on to the next
                 continue;
             }
 
-            // it is a slow invocation.
+            // it is a slow invocation
             count++;
             if (count < maxCount) {
                 writer.writeEntry(invocation.toString() + " duration=" + durationMs + " ms");

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
@@ -26,16 +26,17 @@ import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Prints all kinds of Hazelcast member specific info. Lots of other information is already captured
- * through the metrics.
+ * Prints all kinds of Hazelcast member specific info.
+ * <p>
+ * Lots of other information is already captured through the metrics.
  */
 public class MemberHazelcastInstanceInfoPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds the HazelcastMemberInstanceInfoPlugin runs.
-     *
+     * <p>
      * This plugin is very cheap to use.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
@@ -28,22 +28,23 @@ import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * A Diagnostics plugin that checks the quality of member/member heartbeats. Normally heartbeats are send at a fixed
- * frequency, but if there is a deviation in this frequency, it could indicate problems.
+ * A Diagnostics plugin that checks the quality of member/member heartbeats.
+ * <p>
+ * Normally heartbeats are sent at a fixed frequency, but if there is a deviation in this frequency, it could indicate problems.
  */
 public class MemberHeartbeatPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds the MemberHeartbeatPlugin runs.
-     *
+     * <p>
      * This plugin is very cheap to use.
-     *
+     * <p>
      * This plugin will only output if there is the max deviation is exceeded.
-     *
+     * <p>
      * Setting the value high will lead to not seeing smaller deviations. E.g if this plugin runs every minute, then
      * it will not see a lot of small deviations. The default of 10 seconds is ok since it will not generate too much
      * overhead and noise and in most cases it is the big outliers we are interested in.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(
@@ -87,7 +88,7 @@ public class MemberHeartbeatPlugin extends DiagnosticsPlugin {
         ClusterService cs = nodeEngine.getClusterService();
         if (!(cs instanceof ClusterServiceImpl)) {
             // lets be lenient for testing etc if some kind of mocked cluster service is encountered;
-            // we don't want to cause problems.
+            // we don't want to cause problems
             return;
         }
         render(writer, (ClusterServiceImpl) cs);
@@ -101,7 +102,7 @@ public class MemberHeartbeatPlugin extends DiagnosticsPlugin {
         for (MemberImpl member : clusterService.getMemberImpls()) {
             long lastHeartbeatMillis = clusterHeartbeatManager.getLastHeartbeatTime(member);
             if (lastHeartbeatMillis == 0L) {
-                // member without a heartbeat; lets skip it.
+                // member without a heartbeat; lets skip it
                 continue;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -33,12 +33,12 @@ public class MetricsPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds the {@link MetricsPlugin} runs.
-     *
+     * <p>
      * The MetricsPlugin periodically writing the content of the MetricsRegistry to the logfile. For debugging purposes
      * make sure the {@link Diagnostics#METRICS_LEVEL} is set to debug.
-     *
+     * <p>
      * This plugin is very cheap to use.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
@@ -72,7 +72,7 @@ public class MetricsPlugin extends DiagnosticsPlugin {
     public void run(DiagnosticsLogWriter writer) {
         probeRenderer.writer = writer;
         // we set the time explicitly so that for this particular rendering of the probes, all metrics have exactly
-        // the same timestamp.
+        // the same timestamp
         probeRenderer.timeMillis = System.currentTimeMillis();
         metricsRegistry.render(probeRenderer);
         probeRenderer.writer = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
@@ -30,17 +30,18 @@ import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * The {@link NetworkingImbalancePlugin} is an experimental plugin meant for detecting imbalance in the io system. This
- * plugin will probably mostly be used for internal purposes to get a better understanding of imbalances. Normally imbalances
- * are taken care of by the IOBalancer; but we need to make sure it makes the right choice.
- *
+ * The {@link NetworkingImbalancePlugin} is an experimental plugin meant for detecting imbalance in the IO system.
+ * <p>
+ * This  plugin will probably mostly be used for internal purposes to get a better understanding of imbalances.
+ * Normally imbalances are taken care of by the IOBalancer; but we need to make sure it makes the right choice.
+ * <p>
  * This plugin can be used on server and client side.
  */
 public class NetworkingImbalancePlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds this plugin runs.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
@@ -101,7 +102,7 @@ public class NetworkingImbalancePlugin extends DiagnosticsPlugin {
 
     private void render(DiagnosticsLogWriter writer, NioThread[] threads) {
         if (threads == null) {
-            // this can become null due to stopping of the system.
+            // this can become null due to stopping of the system
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationDescriptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationDescriptors.java
@@ -25,9 +25,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Converts an operation class into something readable. In most cases the class name is sufficient, but there are certain
- * operations like {@link Backup} and {@link PartitionIteratingOperation} where one needs to see inside the content
- * of an operation.
+ * Converts an operation class into something readable.
+ * <p>
+ * In most cases the class name is sufficient, but there are certain operations like {@link Backup}
+ * and {@link PartitionIteratingOperation} where one needs to see inside the content of an operation.
  */
 public final class OperationDescriptors {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
@@ -34,7 +34,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * A diagnostics plugin that checks how the network is behaving by checking deviations in Operation-heartbeats to assist with
  * network related problems like split-brain.
- *
+ * <p>
  * It does this by checking the deviation in the interval between operation-heartbeat packets. Operation-heartbeat packets
  * are send at a fixed interval (operation-call-timeout/4) and are not processed by operation-threads; but by their own system.
  * If there is a big deviation, then it could indicate networking problems. But it could also indicate other problems like JVM
@@ -44,12 +44,12 @@ public class OperationHeartbeatPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds this plugin runs.
-     *
+     * <p>
      * This plugin is very cheap to run and is enabled by default.
-     *
+     * <p>
      * It will also not print output every time it is executed, only when one or more members have a too high operation-heartbeat
      * deviation, the plugin will render output.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
@@ -65,7 +65,6 @@ public class OperationHeartbeatPlugin extends DiagnosticsPlugin {
 
     private static final float HUNDRED = 100f;
 
-    private final InvocationMonitor invocationMonitor;
     private final long periodMillis;
     private final long expectedIntervalMillis;
     private final int maxDeviationPercentage;
@@ -74,7 +73,7 @@ public class OperationHeartbeatPlugin extends DiagnosticsPlugin {
 
     public OperationHeartbeatPlugin(NodeEngineImpl nodeEngine) {
         super(nodeEngine.getLogger(OperationHeartbeatPlugin.class));
-        this.invocationMonitor = ((OperationServiceImpl) nodeEngine.getOperationService()).getInvocationMonitor();
+        InvocationMonitor invocationMonitor = ((OperationServiceImpl) nodeEngine.getOperationService()).getInvocationMonitor();
         HazelcastProperties properties = nodeEngine.getProperties();
         this.periodMillis = properties.getMillis(PERIOD_SECONDS);
         this.maxDeviationPercentage = properties.getInteger(MAX_DEVIATION_PERCENTAGE);

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
@@ -46,23 +46,24 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * The OverloadedConnectionsPlugin checks all the connections and samples the content of the packet
- * queues if the size is above a certain threshold. This is very useful to figure out when huge
- * amount of memory is consumed due to pending packets.
- *
- * Currently the sampling has a lot of overhead since the value needs to be deserialized. That is why this
- * plugin is disabled by default.
+ * queues if the size is above a certain threshold.
+ * <p>
+ * This is very useful to figure out when huge amount of memory is consumed due to pending packets.
+ * <p>
+ * Currently the sampling has a lot of overhead since the value needs to be deserialized.
+ * That is why this plugin is disabled by default.
  */
 public class OverloadedConnectionsPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds this plugin runs.
-     *
+     * <p>
      * With the OverloadedConnectionsPlugin one can see what is going on inside a connection with a huge
      * number of pending packets. It makes use of sampling to give some impression of the content.
-     *
+     * <p>
      * This plugin can be very expensive to use and should only be used as a debugging aid; should not be
      * used in production due to the fact that packets could be deserialized.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
@@ -198,13 +199,11 @@ public class OverloadedConnectionsPlugin extends DiagnosticsPlugin {
     /**
      * Samples the queue.
      *
-     * @param q the queue to sample.
-     * @return the number of samples. If there were not sufficient samples, -1 is returned.
+     * @param q the queue to sample
+     * @return the number of samples (if there were not sufficient samples, -1 is returned)
      */
     private int sample(Queue<OutboundFrame> q) {
-        for (OutboundFrame frame : q) {
-            packets.add(frame);
-        }
+        packets.addAll(q);
 
         if (packets.size() < threshold) {
             return -1;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
@@ -37,12 +37,12 @@ public final class PendingInvocationsPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds this plugin runs.
-     *
+     * <p>
      * With the pending invocation plugins an aggregation is made per type of operation how many pending
      * invocations there are.
-     *
+     * <p>
      * This plugin is very cheap to use.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
@@ -32,19 +32,20 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * A {@link DiagnosticsPlugin} that displays the slow executing operations. For more information see
- * {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
+ * A {@link DiagnosticsPlugin} that displays the slow executing operations.
+ * <p>
+ * For more information see {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
  */
 public class SlowOperationPlugin extends DiagnosticsPlugin {
 
     /**
      * The period in seconds the SlowOperationPlugin runs.
-     *
+     * <p>
      * With the slow operation plugin, slow executing operation can be found. This is done by checking
      * on the caller side which operations take a lot of time executing.
-     *
+     * <p>
      * This plugin is very cheap to use.
-     *
+     * <p>
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
@@ -50,10 +50,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * <li>Showing membership changes.</li>
  * <li>Optionally showing partition migration</li>
  * </ol>
- *
- * This plugin is very useful to get an idea what is happening inside a cluster; especially when there are connection related
- * problems.
- *
+ * This plugin is very useful to get an idea what is happening inside a cluster;
+ * especially when there are connection related problems.
+ * <p>
  * This plugin has a low overhead and is meant to run in production.
  */
 public class SystemLogPlugin extends DiagnosticsPlugin {

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemPropertiesPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemPropertiesPlugin.java
@@ -68,6 +68,7 @@ public class SystemPropertiesPlugin extends DiagnosticsPlugin {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void run(DiagnosticsLogWriter writer) {
         writer.startSection("SystemProperties");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPluginTest.java
@@ -25,8 +25,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static com.hazelcast.internal.diagnostics.DiagnosticsPlugin.STATIC;
 import static org.junit.Assert.assertEquals;
 
@@ -51,7 +49,7 @@ public class ConfigPropertiesPluginTest extends AbstractDiagnosticsPluginTest {
     }
 
     @Test
-    public void testRun() throws IOException {
+    public void testRun() {
         plugin.run(logWriter);
         assertContains("property1=value1");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
@@ -100,7 +100,7 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
 
         LongProbeFunction f = new LongProbeFunction() {
             @Override
-            public long get(Object source) throws Exception {
+            public long get(Object source) {
                 return 0;
             }
         };
@@ -109,7 +109,7 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
             metricsRegistry.register(this, id + k, ProbeLevel.MANDATORY, f);
         }
 
-        // we run for some time to make sure we get enough rollovers.
+        // we run for some time to make sure we get enough rollovers
         while (files.size() < 3) {
             final File file = diagnosticsLogFile.file;
             if (file != null) {
@@ -119,7 +119,7 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
 
                 assertTrueEventually(new AssertTask() {
                     @Override
-                    public void run() throws Exception {
+                    public void run() {
                         assertExist(file);
                     }
                 });
@@ -128,10 +128,10 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
             sleepMillis(100);
         }
 
-        // eventually all these files should be gone.
+        // eventually all these files should be gone
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 for (File file : files) {
                     assertNotExist(file);
                 }
@@ -148,10 +148,10 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test() throws InterruptedException {
+    public void test() {
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 String content = loadLogfile();
                 assertNotNull(content);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
@@ -298,7 +298,7 @@ public class EventQueuePluginTest extends AbstractDiagnosticsPluginTest {
         try {
             assertTrueEventually(new AssertTask() {
                 @Override
-                public void run() throws Exception {
+                public void run() {
                     plugin.run(logWriter);
 
                     //System.out.println(getContent());

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/InvocationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/InvocationPluginTest.java
@@ -68,7 +68,7 @@ public class InvocationPluginTest extends AbstractDiagnosticsPluginTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
 
                 assertContains(EntryOperation.class.getName());

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPluginTest.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
@@ -48,7 +46,7 @@ public class MemberHazelcastInstanceInfoPluginTest extends AbstractDiagnosticsPl
     }
 
     @Test
-    public void testRun() throws IOException {
+    public void testRun() {
         plugin.run(logWriter);
 
         assertContains("HazelcastInstance[");

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -28,8 +28,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -60,10 +58,10 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
     }
 
     @Test
-    public void testRunWithProblematicProbe() throws Throwable {
+    public void testRunWithProblematicProbe() {
         metricsRegistry.register(this, "broken", MANDATORY, new LongProbeFunction() {
             @Override
-            public long get(Object source) throws Exception {
+            public long get(Object source) {
                 throw new RuntimeException("error");
             }
         });
@@ -73,10 +71,10 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
     }
 
     @Test
-    public void testRun() throws IOException {
+    public void testRun() {
         plugin.run(logWriter);
 
-        // we just test a few to make sure the metrics are written.
+        // we just test a few to make sure the metrics are written
         assertContains("client.endpoint.count=0");
         assertContains("operation.responseQueueSize=0");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePluginTest.java
@@ -54,7 +54,7 @@ public class NetworkingImbalancePluginTest extends AbstractDiagnosticsPluginTest
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
 
                 assertContains("Networking");

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.LinkedList;
 
 import static com.hazelcast.internal.diagnostics.OperationDescriptors.toOperationDesc;
 import static java.lang.String.format;
@@ -67,7 +66,7 @@ public class OperationDescriptorsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPartitionIteratingOperation() throws UnknownHostException {
+    public void testPartitionIteratingOperation() {
         PartitionIteratingOperation op = new PartitionIteratingOperation(new DummyOperationFactory(), new int[0]);
         String result = toOperationDesc(op);
         assertEquals(format("PartitionIteratingOperation(%s)", DummyOperationFactory.class.getName()), result);

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
@@ -51,7 +51,7 @@ public class OverloadedConnectionsPluginTest extends AbstractDiagnosticsPluginTe
     private volatile boolean stop;
 
     @Before
-    public void setup() throws InterruptedException {
+    public void setup() {
         Hazelcast.shutdownAll();
 
         Config config = new Config()
@@ -90,7 +90,7 @@ public class OverloadedConnectionsPluginTest extends AbstractDiagnosticsPluginTe
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
 
                 assertContains(GetOperation.class.getSimpleName() + " sampleCount=");

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/PendingInvocationsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/PendingInvocationsPluginTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -54,7 +53,7 @@ public class PendingInvocationsPluginTest extends AbstractDiagnosticsPluginTest 
     }
 
     @Test
-    public void testGetPeriodMillis() throws IOException {
+    public void testGetPeriodMillis() {
         assertEquals(1000, plugin.getPeriodMillis());
     }
 
@@ -69,7 +68,7 @@ public class PendingInvocationsPluginTest extends AbstractDiagnosticsPluginTest 
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
 
                 assertContains("PendingInvocations[");

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
-import static com.hazelcast.spi.properties.GroupProperty.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
 import static org.junit.Assert.assertEquals;
@@ -48,7 +47,6 @@ public class SlowOperationPluginTest extends AbstractDiagnosticsPluginTest {
         Config config = new Config()
                 .setProperty(SLOW_OPERATION_DETECTOR_ENABLED.getName(), "true")
                 .setProperty(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000")
-                .setProperty(SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000")
                 .setProperty(SlowOperationPlugin.PERIOD_SECONDS.getName(), "1");
 
         hz = createHazelcastInstance(config);
@@ -73,7 +71,7 @@ public class SlowOperationPluginTest extends AbstractDiagnosticsPluginTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
                 assertContains(EntryOperation.class.getName());
                 assertContains("stackTrace");

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
@@ -37,10 +37,10 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
 
-    protected Config config;
-    protected TestHazelcastInstanceFactory hzFactory;
-    protected HazelcastInstance hz;
-    protected SystemLogPlugin plugin;
+    private Config config;
+    private TestHazelcastInstanceFactory hzFactory;
+    private HazelcastInstance hz;
+    private SystemLogPlugin plugin;
 
     @Before
     public void setup() {
@@ -75,7 +75,7 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
 
                 assertContains("Lifecycle[" + LINE_SEPARATOR + "                          SHUTTING_DOWN]");
@@ -88,7 +88,7 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         HazelcastInstance instance = hzFactory.newHazelcastInstance(config);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
                 assertContains("MemberAdded[");
             }
@@ -97,7 +97,7 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         instance.shutdown();
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
                 assertContains("MemberRemoved[");
             }
@@ -115,7 +115,7 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 plugin.run(logWriter);
                 assertContains("MigrationStarted");
                 assertContains("MigrationCompleted");

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemPropertiesPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemPropertiesPluginTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -34,8 +33,8 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class SystemPropertiesPluginTest extends AbstractDiagnosticsPluginTest {
 
-    public static final String FAKE_PROPERTY = "hazelcast.fake.property";
-    public static final String FAKE_PROPERTY_VALUE = "foobar";
+    private static final String FAKE_PROPERTY = "hazelcast.fake.property";
+    private static final String FAKE_PROPERTY_VALUE = "foobar";
 
     private SystemPropertiesPlugin plugin;
 
@@ -58,12 +57,12 @@ public class SystemPropertiesPluginTest extends AbstractDiagnosticsPluginTest {
     }
 
     @Test
-    public void testRun() throws IOException {
+    public void testRun() {
         plugin.run(logWriter);
 
         Properties systemProperties = System.getProperties();
 
-        // we check a few of the regular ones.
+        // we check a few of the regular ones
         assertContains("java.class.version=" + systemProperties.get("java.class.version"));
         assertContains("java.class.path=" + systemProperties.get("java.class.path"));
 


### PR DESCRIPTION
* fixed JavaDoc and comments format
* fixed some variable order (final vs. non-final, package-private etc.)
* fixed some warnings
* fixed `file.delete()` and its FindBugs suppression in `DiagnosticsLogFile`
  with `IOUtil.deleteQuietly()`
* used `addAll()` instead of foreach in `OverloadedConnectionsPlugin`
* made `DiagnosticsLogWriterImpl` package-private
* made `InvocationMonitor` a local variable in `OperationHeartbeatPlugin`
* removed unused method parameter in `StoreLatencyPlugin`
* removed deprecated `GroupProperty` from `SlowOperationPluginTest`