### PR TITLE
[BACKPORT] Fix race conditions in client tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -395,6 +395,8 @@ public class ClientHeartbeatTest extends ClientTestSupport {
 
         HazelcastInstance hazelcastInstance2 = hazelcastFactory.newHazelcastInstance();
 
+        assertSizeEventually(2, clientInstanceImpl.getConnectionManager().getActiveConnections());
+
         blockMessagesFromInstance(hazelcastInstance2, client);
         assertOpenEventually(heartbeatStopped);
         blockIncoming.countDown();


### PR DESCRIPTION
There are two detected race conditions :
- in TestClientRegistry the methods block or unblock are called before the connection to the member is established. This caused a NPE. The new code allows traffic to be blocked before the connection is established
- in ClientHeartbeatTest when the connection is established after the messages are blocked the test client would not send heartbeats to that client and the test would fail. This is changed so that the test waits for the client to connect to all members before blocking the messages

Fixes : https://github.com/hazelcast/hazelcast/issues/10021
Backport of: https://github.com/hazelcast/hazelcast/pull/10030
(cherry picked from commit af211a1)