### PR TITLE
Prevent RecordStore interactions from generic partition in MapServiceContext

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -101,6 +101,7 @@ import static com.hazelcast.map.impl.MapListenerFlagOperator.setAndGetListenerFl
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.query.impl.predicates.QueryOptimizerFactory.newOptimizer;
 import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
+import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
 import static com.hazelcast.spi.properties.GroupProperty.AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
@@ -284,6 +285,8 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public PartitionContainer getPartitionContainer(int partitionId) {
+        assert partitionId != GENERIC_PARTITION_ID : "Cannot be called with GENERIC_PARTITION_ID";
+
         return partitionContainers[partitionId];
     }
 
@@ -729,6 +732,8 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public RecordStore createRecordStore(MapContainer mapContainer, int partitionId, MapKeyLoader keyLoader) {
+        assert partitionId != GENERIC_PARTITION_ID : "Cannot be called with GENERIC_PARTITION_ID";
+
         ILogger logger = nodeEngine.getLogger(DefaultRecordStore.class);
         return new DefaultRecordStore(mapContainer, partitionId, keyLoader, logger);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapServiceContextImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapServiceContextImplTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapServiceContextImplTest extends HazelcastTestSupport {
+
+    private MapServiceContext mapServiceContext;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance instance = createHazelcastInstance();
+        MapService service = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
+        mapServiceContext = service.getMapServiceContext();
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testGetPartitionContainer_withGenericPartitionId() {
+        mapServiceContext.getPartitionContainer(GENERIC_PARTITION_ID);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testCreateRecordStore_withGenericPartitionId() {
+        Config config = mapServiceContext.getNodeEngine().getConfig();
+        MapContainer mapContainer = new MapContainer("anyName", config, mapServiceContext);
+
+        mapServiceContext.createRecordStore(mapContainer, GENERIC_PARTITION_ID, null);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testGetRecordStore_withGenericPartitionId() {
+        mapServiceContext.getRecordStore(GENERIC_PARTITION_ID, "anyMap");
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testGetRecordStoreWithSkipLoading_withGenericPartitionId() {
+        mapServiceContext.getRecordStore(GENERIC_PARTITION_ID, "anyMap", true);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testGetExistingRecordStore_withGenericPartitionId() {
+        mapServiceContext.getExistingRecordStore(GENERIC_PARTITION_ID, "anyMap");
+    }
+}


### PR DESCRIPTION
`RecordStore`s are not available for the `GENERIC_PARTITION_ID`. The `MapServiceContext` seems to be a good point to assert, that we don't try to access a `RecordStore` from a generic partition thread. This will safe us to add those guards to operation classes.