### PR TITLE
Findbugs fails for deadstore to unused variables

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -22,7 +22,6 @@ import com.hazelcast.cache.impl.CacheEventType;
 import com.hazelcast.cache.impl.CacheProxyUtil;
 import com.hazelcast.cache.impl.event.CachePartitionLostEvent;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
-import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheAddEntryListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheAddPartitionLostListenerCodec;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -402,7 +402,6 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V> {
     protected void updateCacheListenerConfigOnOtherNodes(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration,
                                                          boolean isRegister) {
         final Collection<Member> members = clientContext.getClusterService().getMemberList();
-        final HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
         for (Member member : members) {
             try {
                 final Address address = member.getAddress();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
@@ -370,8 +370,6 @@ public class ClientScheduledExecutorProxy
     private <T> ClientDelegatingFuture<T> doSubmitOnAddress(ClientMessage clientMessage,
                                                             ClientMessageDecoder clientMessageDecoder,
                                                             Address address) {
-        SerializationService serializationService = getContext().getSerializationService();
-
         try {
             ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage, getName(), address).invoke();
             return new ClientDelegatingFuture<T>(future, getSerializationService(), clientMessageDecoder);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
@@ -36,7 +36,6 @@ import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.scheduledexecutor.impl.ScheduledRunnableAdapter;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl;
 import com.hazelcast.scheduledexecutor.impl.TaskDefinition;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.UuidUtil;
 


### PR DESCRIPTION
Fix for findbugs failures:

[INFO] <<< findbugs-maven-plugin:3.0.1:check (default) < :findbugs @ hazelcast-client <<<
[INFO]
[INFO] --- findbugs-maven-plugin:3.0.1:check (default) @ hazelcast-client ---
[INFO] BugInstance size is 2
[INFO] Error size is 0
[INFO] Total bugs: 2
[INFO] Dead store to client in com.hazelcast.client.cache.impl.ClientCacheProxy.updateCacheListenerConfigOnOtherNodes(CacheEntryListenerConfiguration, boolean) [com.hazelcast.client.cache.impl.ClientCacheProxy] At ClientCacheProxy.java:[line 405]
[INFO] Dead store to serializationService in com.hazelcast.client.proxy.ClientScheduledExecutorProxy.doSubmitOnAddress(ClientMessage, ClientMessageDecoder, Address) [com.hazelcast.client.proxy.ClientScheduledExecutorProxy] At ClientScheduledExecutorProxy.java:[line 373]