### PR TITLE
Catch exception when running task for scanning for metrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -220,7 +220,7 @@ public class NodeEngineImpl implements NodeEngine {
         ClassLoadingMetricSet.register(metricsRegistry);
         FileMetricSet.register(metricsRegistry);
         if (node.getProperties().getBoolean(METRICS_DISTRIBUTED_DATASTRUCTURES)) {
-            new StatisticsAwareMetricsSet(serviceManager).register(metricsRegistry);
+            new StatisticsAwareMetricsSet(serviceManager, this).register(metricsRegistry);
         }
 
         metricsRegistry.collectMetrics(operationService, proxyService, eventService, operationParker);


### PR DESCRIPTION
The task is run on a scheduled executor which silently stops the task if
there is an exception. The fix simply logs the exception since we expect
that the exception might only be thrown on the call to
StatisticsAwareService.getStats. This means that the task state will not
be inconsistent even if we don't clean it up.

Fixes: https://github.com/hazelcast/hazelcast/issues/11535