### PR TITLE
ExecutorService CachedExecutorServiceDelegate.addNewWorkerIfRequired may fail since not being able to get the lock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
@@ -139,15 +139,14 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
     private void addNewWorkerIfRequired() {
         if (size < maxPoolSize) {
             try {
-                if (lock.tryLock(TIME, TimeUnit.MILLISECONDS)) {
-                    try {
-                        if (size < maxPoolSize && getQueueSize() > 0) {
-                            size++;
-                            cachedExecutor.execute(new Worker());
-                        }
-                    } finally {
-                        lock.unlock();
+                lock.lockInterruptibly();
+                try {
+                    if (size < maxPoolSize && getQueueSize() > 0) {
+                        size++;
+                        cachedExecutor.execute(new Worker());
                     }
+                } finally {
+                    lock.unlock();
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
Failure to get the lock may cause insufficient Worker threads and the waiting task not being processed when the other running tasks are long running.

Changed to use blocking lock addNewWorkerIfRequired method for the executor service.

fixes #10952