### PR TITLE
Add member address provider SPI

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -1842,6 +1842,27 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="reuse-address" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="member-address-provider" type="member-address-provider" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        This configuration is not intended to provide addresses of other cluster members with
+                        which the hazelcast instance will form a cluster. This is an SPI for advanced use in
+                        cases where the DefaultAddressPicker does not pick suitable addresses to bind to
+                        and publish to other cluster members. For instance, this could allow easier
+                        deployment in some cases when running on Docker, AWS or other cloud environments.
+                        That said, if you are just starting with Hazelcast, you will probably want to
+                        set the member addresses by using the tcp-ip or multicast configuration
+                        or adding a discovery strategy.
+                        Member address provider allows to plug in own strategy to customize:
+                          1. What address Hazelcast will bind to
+                          2. What address Hazelcast will advertise to other members on which they can bind to
+
+                        In most environments you don't need to customize this and the default strategy will work just
+                        fine. However in some cloud environments the default strategy does not make the right choice and
+                        the member address provider delegates the process of address picking to external code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
         <xs:attribute name="public-address" type="xs:string" use="optional"/>
         <xs:attribute name="port" type="xs:string" use="required"/>
@@ -2132,6 +2153,28 @@
         <xs:attribute name="salt" use="optional" type="xs:string"/>
         <xs:attribute name="password" use="optional" type="xs:string"/>
         <xs:attribute name="iteration-count" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="member-address-provider">
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attributeGroup ref="class-or-bean-name">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the class implementing the com.hazelcast.spi.MemberAddressProvider interface.
+                    If both the implementation and the class name are provided, the implementation is used
+                    and the class name is ignored.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attributeGroup>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the member address provider SPI is enabled or not. Values can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="hibernate-cache">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMemberAddressProvider.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMemberAddressProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.MemberAddressProvider;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+
+public class DummyMemberAddressProvider implements MemberAddressProvider {
+
+    private final Properties properties;
+
+    public DummyMemberAddressProvider(Properties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public InetSocketAddress getBindAddress() {
+        try {
+            return new Address("localhost", 1234).getInetSocketAddress();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public InetSocketAddress getPublicAddress() {
+        try {
+            return new Address("localhost", 1234).getInetSocketAddress();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spring;
 
+import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -660,6 +661,13 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertTrue("reuse-address", networkConfig.isReuseAddress());
 
         assertDiscoveryConfig(networkConfig.getJoin().getDiscoveryConfig());
+
+        final MemberAddressProviderConfig memberAddressProviderConfig = networkConfig.getMemberAddressProviderConfig();
+        assertFalse(memberAddressProviderConfig.isEnabled());
+        assertEquals("com.hazelcast.spring.DummyMemberAddressProvider", memberAddressProviderConfig.getClassName());
+        assertFalse(memberAddressProviderConfig.getProperties().isEmpty());
+        assertEquals("value", memberAddressProviderConfig.getProperties().getProperty("dummy.property"));
+        assertEquals("value2", memberAddressProviderConfig.getProperties().getProperty("dummy.property.2"));
     }
 
     private void assertAwsConfig(AwsConfig aws) {

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -177,6 +177,12 @@
                                          password="thepass"
                                          iteration-count="19"/>
                 <hz:reuse-address>true</hz:reuse-address>
+                <hz:member-address-provider enabled="false" class-name="com.hazelcast.spring.DummyMemberAddressProvider">
+                    <hz:properties>
+                        <hz:property name="dummy.property">value</hz:property>
+                        <hz:property name="dummy.property.2">value2</hz:property>
+                    </hz:properties>
+                </hz:member-address-provider>
             </hz:network>
             <hz:partition-group enabled="true" group-type="CUSTOM">
                 <hz:member-group>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -88,16 +88,16 @@ public class ConfigXmlGenerator {
         final XmlGenerator gen = new XmlGenerator(xml);
 
         xml.append("<hazelcast ")
-                .append("xmlns=\"http://www.hazelcast.com/schema/config\"\n")
-                .append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n")
-                .append("xsi:schemaLocation=\"http://www.hazelcast.com/schema/config ")
-                .append("http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd\">");
+           .append("xmlns=\"http://www.hazelcast.com/schema/config\"\n")
+           .append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n")
+           .append("xsi:schemaLocation=\"http://www.hazelcast.com/schema/config ")
+           .append("http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd\">");
         gen.open("group")
-                .node("name", config.getGroupConfig().getName())
-                .node("password", MASK_FOR_SESITIVE_DATA)
-                .close()
-                .node("license-key", MASK_FOR_SESITIVE_DATA)
-                .node("instance-name", config.getInstanceName());
+           .node("name", config.getGroupConfig().getName())
+           .node("password", MASK_FOR_SESITIVE_DATA)
+           .close()
+           .node("license-key", MASK_FOR_SESITIVE_DATA)
+           .node("instance-name", config.getInstanceName());
 
 
         manCenterXmlGenerator(gen, config);
@@ -152,10 +152,10 @@ public class ConfigXmlGenerator {
         if (CollectionUtil.isNotEmpty(configs)) {
             for (CollectionConfig c : configs) {
                 gen.open(type, "name", c.getName())
-                        .node("statistics-enabled", c.isStatisticsEnabled())
-                        .node("max-size", c.getMaxSize())
-                        .node("backup-count", c.getBackupCount())
-                        .node("async-backup-count", c.getAsyncBackupCount());
+                   .node("statistics-enabled", c.isStatisticsEnabled())
+                   .node("max-size", c.getMaxSize())
+                   .node("backup-count", c.getBackupCount())
+                   .node("async-backup-count", c.getAsyncBackupCount());
                 appendItemListenerConfigs(gen, c.getItemListenerConfigs());
                 gen.close();
             }
@@ -165,11 +165,11 @@ public class ConfigXmlGenerator {
     private static void replicatedMapConfigXmlGenerator(XmlGenerator gen, Config config) {
         for (ReplicatedMapConfig r : config.getReplicatedMapConfigs().values()) {
             gen.open("replicatedmap", "name", r.getName())
-                    .node("in-memory-format", r.getInMemoryFormat())
-                    .node("concurrency-level", r.getConcurrencyLevel())
-                    .node("replication-delay-millis", r.getReplicationDelayMillis())
-                    .node("async-fillup", r.isAsyncFillup())
-                    .node("statistics-enabled", r.isStatisticsEnabled());
+               .node("in-memory-format", r.getInMemoryFormat())
+               .node("concurrency-level", r.getConcurrencyLevel())
+               .node("replication-delay-millis", r.getReplicationDelayMillis())
+               .node("async-fillup", r.isAsyncFillup())
+               .node("statistics-enabled", r.isStatisticsEnabled());
 
             if (!r.getListenerConfigs().isEmpty()) {
                 gen.open("entry-listeners");
@@ -221,12 +221,12 @@ public class ConfigXmlGenerator {
             return;
         }
         gen.open("serialization")
-                .node("portable-version", c.getPortableVersion())
-                .node("use-native-byte-order", c.isUseNativeByteOrder())
-                .node("byte-order", c.getByteOrder())
-                .node("enable-compression", c.isEnableCompression())
-                .node("enable-shared-object", c.isEnableSharedObject())
-                .node("allow-unsafe", c.isAllowUnsafe());
+           .node("portable-version", c.getPortableVersion())
+           .node("use-native-byte-order", c.isUseNativeByteOrder())
+           .node("byte-order", c.getByteOrder())
+           .node("enable-compression", c.isEnableCompression())
+           .node("enable-shared-object", c.isEnableSharedObject())
+           .node("allow-unsafe", c.isAllowUnsafe());
 
         final Map<Integer, String> dsfClasses = c.getDataSerializableFactoryClasses();
         final Map<Integer, DataSerializableFactory> dsfImpls = c.getDataSerializableFactories();
@@ -268,7 +268,7 @@ public class ConfigXmlGenerator {
             gen.close();
         }
         gen.node("check-class-def-errors", c.isCheckClassDefErrors())
-                .close();
+           .close();
     }
 
     private static String classNameOrClass(String className, Class clazz) {
@@ -307,57 +307,57 @@ public class ConfigXmlGenerator {
     private static void executorXmlGenerator(XmlGenerator gen, Config config) {
         for (ExecutorConfig ex : config.getExecutorConfigs().values()) {
             gen.open("executor-service", "name", ex.getName())
-                    .node("statistics-enabled", ex.isStatisticsEnabled())
-                    .node("pool-size", ex.getPoolSize())
-                    .node("queue-capacity", ex.getQueueCapacity())
-                    .close();
+               .node("statistics-enabled", ex.isStatisticsEnabled())
+               .node("pool-size", ex.getPoolSize())
+               .node("queue-capacity", ex.getQueueCapacity())
+               .close();
         }
     }
 
     private static void durableExecutorXmlGenerator(XmlGenerator gen, Config config) {
         for (DurableExecutorConfig ex : config.getDurableExecutorConfigs().values()) {
             gen.open("durable-executor-service", "name", ex.getName())
-                    .node("pool-size", ex.getPoolSize())
-                    .node("durability", ex.getDurability())
-                    .node("capacity", ex.getCapacity())
-                    .close();
+               .node("pool-size", ex.getPoolSize())
+               .node("durability", ex.getDurability())
+               .node("capacity", ex.getCapacity())
+               .close();
         }
     }
 
     private static void scheduledExecutorXmlGenerator(XmlGenerator gen, Config config) {
         for (ScheduledExecutorConfig ex : config.getScheduledExecutorConfigs().values()) {
             gen.open("scheduled-executor-service", "name", ex.getName())
-                    .node("pool-size", ex.getPoolSize())
-                    .node("durability", ex.getDurability())
-                    .node("capacity", ex.getCapacity())
-                    .close();
+               .node("pool-size", ex.getPoolSize())
+               .node("durability", ex.getDurability())
+               .node("capacity", ex.getCapacity())
+               .close();
         }
     }
 
     private static void cardinalityEstimatorXmlGenerator(XmlGenerator gen, Config config) {
         for (CardinalityEstimatorConfig ex : config.getCardinalityEstimatorConfigs().values()) {
             gen.open("cardinality-estimator", "name", ex.getName())
-                    .node("backup-count", ex.getBackupCount())
-                    .node("async-backup-count", ex.getAsyncBackupCount())
-                    .close();
+               .node("backup-count", ex.getBackupCount())
+               .node("async-backup-count", ex.getAsyncBackupCount())
+               .close();
         }
     }
 
     private static void semaphoreXmlGenerator(XmlGenerator gen, Config config) {
         for (SemaphoreConfig sc : config.getSemaphoreConfigs()) {
             gen.open("semaphore", "name", sc.getName())
-                    .node("initial-permits", sc.getInitialPermits())
-                    .node("backup-count", sc.getBackupCount())
-                    .node("async-backup-count", sc.getAsyncBackupCount())
-                    .close();
+               .node("initial-permits", sc.getInitialPermits())
+               .node("backup-count", sc.getBackupCount())
+               .node("async-backup-count", sc.getAsyncBackupCount())
+               .close();
         }
     }
 
     private static void topicXmlGenerator(XmlGenerator gen, Config config) {
         for (TopicConfig t : config.getTopicConfigs().values()) {
             gen.open("topic", "name", t.getName())
-                    .node("statistics-enabled", t.isStatisticsEnabled())
-                    .node("global-ordering-enabled", t.isGlobalOrderingEnabled());
+               .node("statistics-enabled", t.isStatisticsEnabled())
+               .node("global-ordering-enabled", t.isGlobalOrderingEnabled());
 
             if (!t.getMessageListenerConfigs().isEmpty()) {
                 gen.open("message-listeners");
@@ -374,9 +374,9 @@ public class ConfigXmlGenerator {
     private static void reliableTopicXmlGenerator(XmlGenerator gen, Config config) {
         for (ReliableTopicConfig t : config.getReliableTopicConfigs().values()) {
             gen.open("reliable-topic", "name", t.getName())
-                    .node("statistics-enabled", t.isStatisticsEnabled())
-                    .node("read-batch-size", t.getReadBatchSize())
-                    .node("topic-overload-policy", t.getTopicOverloadPolicy());
+               .node("statistics-enabled", t.isStatisticsEnabled())
+               .node("read-batch-size", t.getReadBatchSize())
+               .node("topic-overload-policy", t.getTopicOverloadPolicy());
 
             if (!t.getMessageListenerConfigs().isEmpty()) {
                 gen.open("message-listeners");
@@ -393,11 +393,11 @@ public class ConfigXmlGenerator {
     private static void multiMapXmlGenerator(XmlGenerator gen, Config config) {
         for (MultiMapConfig mm : config.getMultiMapConfigs().values()) {
             gen.open("multimap", "name", mm.getName())
-                    .node("backup-count", mm.getBackupCount())
-                    .node("async-backup-count", mm.getAsyncBackupCount())
-                    .node("statistics-enabled", mm.isStatisticsEnabled())
-                    .node("binary", mm.isBinary())
-                    .node("value-collection-type", mm.getValueCollectionType());
+               .node("backup-count", mm.getBackupCount())
+               .node("async-backup-count", mm.getAsyncBackupCount())
+               .node("statistics-enabled", mm.isStatisticsEnabled())
+               .node("binary", mm.isBinary())
+               .node("value-collection-type", mm.getValueCollectionType());
 
             if (!mm.getEntryListenerConfigs().isEmpty()) {
                 gen.open("entry-listeners");
@@ -426,30 +426,30 @@ public class ConfigXmlGenerator {
         final Collection<QueueConfig> qCfgs = config.getQueueConfigs().values();
         for (QueueConfig q : qCfgs) {
             gen.open("queue", "name", q.getName())
-                    .node("statistics-enabled", q.isStatisticsEnabled())
-                    .node("max-size", q.getMaxSize())
-                    .node("backup-count", q.getBackupCount())
-                    .node("async-backup-count", q.getAsyncBackupCount())
-                    .node("empty-queue-ttl", q.getEmptyQueueTtl());
+               .node("statistics-enabled", q.isStatisticsEnabled())
+               .node("max-size", q.getMaxSize())
+               .node("backup-count", q.getBackupCount())
+               .node("async-backup-count", q.getAsyncBackupCount())
+               .node("empty-queue-ttl", q.getEmptyQueueTtl());
             appendItemListenerConfigs(gen, q.getItemListenerConfigs());
             final QueueStoreConfig storeConfig = q.getQueueStoreConfig();
             if (storeConfig != null) {
                 gen.open("queue-store", "enabled", storeConfig.isEnabled())
-                        .node("class-name", storeConfig.getClassName())
-                        .node("factory-class-name", storeConfig.getFactoryClassName())
-                        .appendProperties(storeConfig.getProperties())
-                        .close();
+                   .node("class-name", storeConfig.getClassName())
+                   .node("factory-class-name", storeConfig.getFactoryClassName())
+                   .appendProperties(storeConfig.getProperties())
+                   .close();
             }
             gen.node("quorum-ref", q.getQuorumName())
-                    .close();
+               .close();
         }
     }
 
     private static void lockXmlGenerator(XmlGenerator gen, Config config) {
         for (LockConfig c : config.getLockConfigs().values()) {
             gen.open("lock", "name", c.getName())
-                    .node("quorum-ref", c.getQuorumName())
-                    .close();
+               .node("quorum-ref", c.getQuorumName())
+               .close();
         }
     }
 
@@ -457,18 +457,18 @@ public class ConfigXmlGenerator {
         final Collection<RingbufferConfig> configs = config.getRingbufferConfigs().values();
         for (RingbufferConfig rbConfig : configs) {
             gen.open("ringbuffer", "name", rbConfig.getName())
-                    .node("capacity", rbConfig.getCapacity())
-                    .node("time-to-live-seconds", rbConfig.getTimeToLiveSeconds())
-                    .node("backup-count", rbConfig.getBackupCount())
-                    .node("async-backup-count", rbConfig.getAsyncBackupCount())
-                    .node("in-memory-format", rbConfig.getInMemoryFormat());
+               .node("capacity", rbConfig.getCapacity())
+               .node("time-to-live-seconds", rbConfig.getTimeToLiveSeconds())
+               .node("backup-count", rbConfig.getBackupCount())
+               .node("async-backup-count", rbConfig.getAsyncBackupCount())
+               .node("in-memory-format", rbConfig.getInMemoryFormat());
 
             final RingbufferStoreConfig storeConfig = rbConfig.getRingbufferStoreConfig();
             if (storeConfig != null) {
                 gen.open("ringbuffer-store", "enabled", storeConfig.isEnabled())
-                        .node("class-name", storeConfig.getClassName())
-                        .node("factory-class-name", storeConfig.getFactoryClassName())
-                        .appendProperties(storeConfig.getProperties());
+                   .node("class-name", storeConfig.getClassName())
+                   .node("factory-class-name", storeConfig.getFactoryClassName())
+                   .appendProperties(storeConfig.getProperties());
                 gen.close();
             }
             gen.close();
@@ -480,10 +480,10 @@ public class ConfigXmlGenerator {
             gen.open("wan-replication", "name", wan.getName());
             for (WanPublisherConfig p : wan.getWanPublisherConfigs()) {
                 gen.open("wan-publisher", "group-name", p.getGroupName())
-                        .node("class-name", p.getClassName())
-                        .node("queue-full-behavior", p.getQueueFullBehavior())
-                        .node("queue-capacity", p.getQueueCapacity())
-                        .appendProperties(p.getProperties());
+                   .node("class-name", p.getClassName())
+                   .node("queue-full-behavior", p.getQueueFullBehavior())
+                   .node("queue-capacity", p.getQueueCapacity())
+                   .appendProperties(p.getProperties());
                 awsConfigXmlGenerator(gen, p.getAwsConfig());
                 discoveryStrategyConfigXmlGenerator(gen, p.getDiscoveryConfig());
                 gen.close();
@@ -492,10 +492,10 @@ public class ConfigXmlGenerator {
             final WanConsumerConfig consumerConfig = wan.getWanConsumerConfig();
             if (consumerConfig != null) {
                 gen.open("wan-consumer")
-                        .node("class-name", classNameOrImplClass(consumerConfig.getClassName(),
-                                consumerConfig.getImplementation()))
-                        .appendProperties(consumerConfig.getProperties())
-                        .close();
+                   .node("class-name", classNameOrImplClass(consumerConfig.getClassName(),
+                           consumerConfig.getImplementation()))
+                   .appendProperties(consumerConfig.getProperties())
+                   .close();
             }
             gen.close();
         }
@@ -504,10 +504,10 @@ public class ConfigXmlGenerator {
     private static void networkConfigXmlGenerator(XmlGenerator gen, Config config) {
         final NetworkConfig netCfg = config.getNetworkConfig();
         gen.open("network")
-                .node("public-address", netCfg.getPublicAddress())
-                .node("port", netCfg.getPort(),
-                        "port-count", netCfg.getPortCount(), "auto-increment", netCfg.isPortAutoIncrement())
-                .node("reuse-address", netCfg.isReuseAddress());
+           .node("public-address", netCfg.getPublicAddress())
+           .node("port", netCfg.getPort(),
+                   "port-count", netCfg.getPortCount(), "auto-increment", netCfg.isPortAutoIncrement())
+           .node("reuse-address", netCfg.isReuseAddress());
 
         final Collection<String> outboundPortDefinitions = netCfg.getOutboundPortDefinitions();
         if (CollectionUtil.isNotEmpty(outboundPortDefinitions)) {
@@ -531,6 +531,7 @@ public class ConfigXmlGenerator {
         sslConfigXmlGenerator(gen, netCfg);
         socketInterceptorConfigXmlGenerator(gen, netCfg);
         symmetricEncInterceptorConfigXmlGenerator(gen, netCfg);
+        memberAddressProviderConfigXmlGenerator(gen, netCfg);
         gen.close();
     }
 
@@ -540,20 +541,20 @@ public class ConfigXmlGenerator {
             final String cacheDeserializedVal = m.getCacheDeserializedValues() != null
                     ? m.getCacheDeserializedValues().name().replaceAll("_", "-") : null;
             gen.open("map", "name", m.getName())
-                    .node("in-memory-format", m.getInMemoryFormat())
-                    .node("statistics-enabled", m.isStatisticsEnabled())
-                    .node("optimize-queries", m.isOptimizeQueries())
-                    .node("cache-deserialized-values", cacheDeserializedVal)
-                    .node("backup-count", m.getBackupCount())
-                    .node("async-backup-count", m.getAsyncBackupCount())
-                    .node("time-to-live-seconds", m.getTimeToLiveSeconds())
-                    .node("max-idle-seconds", m.getMaxIdleSeconds())
-                    .node("eviction-policy", m.getEvictionPolicy())
-                    .node("max-size", m.getMaxSizeConfig().getSize(), "policy", m.getMaxSizeConfig().getMaxSizePolicy())
-                    .node("eviction-percentage", m.getEvictionPercentage())
-                    .node("min-eviction-check-millis", m.getMinEvictionCheckMillis())
-                    .node("merge-policy", m.getMergePolicy())
-                    .node("read-backup-data", m.isReadBackupData());
+               .node("in-memory-format", m.getInMemoryFormat())
+               .node("statistics-enabled", m.isStatisticsEnabled())
+               .node("optimize-queries", m.isOptimizeQueries())
+               .node("cache-deserialized-values", cacheDeserializedVal)
+               .node("backup-count", m.getBackupCount())
+               .node("async-backup-count", m.getAsyncBackupCount())
+               .node("time-to-live-seconds", m.getTimeToLiveSeconds())
+               .node("max-idle-seconds", m.getMaxIdleSeconds())
+               .node("eviction-policy", m.getEvictionPolicy())
+               .node("max-size", m.getMaxSizeConfig().getSize(), "policy", m.getMaxSizeConfig().getMaxSizePolicy())
+               .node("eviction-percentage", m.getEvictionPercentage())
+               .node("min-eviction-check-millis", m.getMinEvictionCheckMillis())
+               .node("merge-policy", m.getMergePolicy())
+               .node("read-backup-data", m.isReadBackupData());
 
             appendHotRestartConfig(gen, m.getHotRestartConfig());
             mapStoreConfigXmlGenerator(gen, m);
@@ -570,8 +571,8 @@ public class ConfigXmlGenerator {
 
     private static void appendHotRestartConfig(XmlGenerator gen, HotRestartConfig m) {
         gen.open("hot-restart", "enabled", m != null && m.isEnabled())
-                .node("fsync", m != null && m.isFsync())
-                .close();
+           .node("fsync", m != null && m.isFsync())
+           .close();
     }
 
     private static void cacheConfigXmlGenerator(XmlGenerator gen, Config config) {
@@ -585,9 +586,9 @@ public class ConfigXmlGenerator {
             }
 
             gen.node("statistics-enabled", c.isStatisticsEnabled())
-                    .node("management-enabled", c.isManagementEnabled())
-                    .node("read-through", c.isReadThrough())
-                    .node("write-through", c.isWriteThrough());
+               .node("management-enabled", c.isManagementEnabled())
+               .node("read-through", c.isReadThrough())
+               .node("write-through", c.isWriteThrough());
 
             checkAndFillCacheLoaderFactoryConfigXml(gen, c.getCacheLoaderFactory());
             checkAndFillCacheLoaderConfigXml(gen, c.getCacheLoader());
@@ -600,14 +601,14 @@ public class ConfigXmlGenerator {
                 gen.open("cache-entry-listener",
                         "old-value-required", el.isOldValueRequired(),
                         "synchronous", el.isSynchronous())
-                        .node("cache-entry-listener-factory", null, "class-name", el.getCacheEntryListenerFactory())
-                        .node("cache-entry-event-filter-factory", null, "class-name", el.getCacheEntryEventFilterFactory())
-                        .close();
+                   .node("cache-entry-listener-factory", null, "class-name", el.getCacheEntryListenerFactory())
+                   .node("cache-entry-event-filter-factory", null, "class-name", el.getCacheEntryEventFilterFactory())
+                   .close();
             }
             gen.close()
-                    .node("in-memory-format", c.getInMemoryFormat())
-                    .node("backup-count", c.getBackupCount())
-                    .node("async-backup-count", c.getAsyncBackupCount());
+               .node("in-memory-format", c.getInMemoryFormat())
+               .node("backup-count", c.getBackupCount())
+               .node("async-backup-count", c.getAsyncBackupCount());
 
             evictionConfigXmlGenerator(gen, c.getEvictionConfig());
             wanReplicationConfigXmlGenerator(gen, c.getWanReplicationRef());
@@ -619,7 +620,7 @@ public class ConfigXmlGenerator {
             appendHotRestartConfig(gen, c.getHotRestartConfig());
 
             gen.node("disable-per-entry-invalidation-events", c.isDisablePerEntryInvalidationEvents())
-                    .close();
+               .close();
         }
     }
 
@@ -664,11 +665,11 @@ public class ConfigXmlGenerator {
                     && timedConfig.getExpiryPolicyType() != null && timedConfig.getDurationConfig() != null) {
                 final DurationConfig duration = timedConfig.getDurationConfig();
                 gen.open("expiry-policy-factory")
-                        .node("timed-expiry-policy-factory", null,
-                                "expiry-policy-type", timedConfig.getExpiryPolicyType(),
-                                "duration-amount", duration.getDurationAmount(),
-                                "time-unit", duration.getTimeUnit().name())
-                        .close();
+                   .node("timed-expiry-policy-factory", null,
+                           "expiry-policy-type", timedConfig.getExpiryPolicyType(),
+                           "duration-amount", duration.getDurationAmount(),
+                           "time-unit", duration.getTimeUnit().name())
+                   .close();
             }
         }
     }
@@ -739,7 +740,7 @@ public class ConfigXmlGenerator {
     private static void wanReplicationConfigXmlGenerator(XmlGenerator gen, WanReplicationRef wan) {
         if (wan != null) {
             gen.open("wan-replication-ref", "name", wan.getName())
-                    .node("merge-policy", wan.getMergePolicy());
+               .node("merge-policy", wan.getMergePolicy());
 
             final List<String> filters = wan.getFilters();
             if (CollectionUtil.isNotEmpty(filters)) {
@@ -750,7 +751,7 @@ public class ConfigXmlGenerator {
                 gen.close();
             }
             gen.node("republishing-enabled", wan.isRepublishingEnabled())
-                    .close();
+               .close();
         }
     }
 
@@ -764,22 +765,22 @@ public class ConfigXmlGenerator {
                     : s.getFactoryClassName();
 
             gen.open("map-store", "enabled", s.isEnabled())
-                    .node("class-name", clazz)
-                    .node("factory-class-name", factoryClass)
-                    .node("write-delay-seconds", s.getWriteDelaySeconds())
-                    .node("write-batch-size", s.getWriteBatchSize())
-                    .appendProperties(s.getProperties())
-                    .close();
+               .node("class-name", clazz)
+               .node("factory-class-name", factoryClass)
+               .node("write-delay-seconds", s.getWriteDelaySeconds())
+               .node("write-batch-size", s.getWriteBatchSize())
+               .appendProperties(s.getProperties())
+               .close();
         }
     }
 
     private static void mapNearCacheConfigXmlGenerator(XmlGenerator gen, NearCacheConfig n) {
         if (n != null) {
             gen.open("near-cache")
-                    .node("in-memory-format", n.getInMemoryFormat())
-                    .node("invalidate-on-change", n.isInvalidateOnChange())
-                    .node("time-to-live-seconds", n.getTimeToLiveSeconds())
-                    .node("max-idle-seconds", n.getMaxIdleSeconds());
+               .node("in-memory-format", n.getInMemoryFormat())
+               .node("invalidate-on-change", n.isInvalidateOnChange())
+               .node("time-to-live-seconds", n.getTimeToLiveSeconds())
+               .node("max-idle-seconds", n.getMaxIdleSeconds());
             evictionConfigXmlGenerator(gen, n.getEvictionConfig());
             gen
                     .node("eviction-policy", n.getEvictionPolicy())
@@ -804,10 +805,10 @@ public class ConfigXmlGenerator {
     private static void multicastConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {
         final MulticastConfig mcast = join.getMulticastConfig();
         gen.open("multicast", "enabled", mcast.isEnabled(), "loopbackModeEnabled", mcast.isLoopbackModeEnabled())
-                .node("multicast-group", mcast.getMulticastGroup())
-                .node("multicast-port", mcast.getMulticastPort())
-                .node("multicast-timeout-seconds", mcast.getMulticastTimeoutSeconds())
-                .node("multicast-time-to-live", mcast.getMulticastTimeToLive());
+           .node("multicast-group", mcast.getMulticastGroup())
+           .node("multicast-port", mcast.getMulticastPort())
+           .node("multicast-timeout-seconds", mcast.getMulticastTimeoutSeconds())
+           .node("multicast-time-to-live", mcast.getMulticastTimeToLive());
 
         if (!mcast.getTrustedInterfaces().isEmpty()) {
             gen.open("trusted-interfaces");
@@ -822,13 +823,13 @@ public class ConfigXmlGenerator {
     private static void tcpConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {
         final TcpIpConfig c = join.getTcpIpConfig();
         gen.open("tcp-ip", "enabled", c.isEnabled(), "connection-timeout-seconds", c.getConnectionTimeoutSeconds())
-                .open("member-list");
+           .open("member-list");
         for (String m : c.getMembers()) {
             gen.node("member", m);
         }
         gen.close()
-                .node("required-member", c.getRequiredMember())
-                .close();
+           .node("required-member", c.getRequiredMember())
+           .close();
     }
 
     private static void awsConfigXmlGenerator(XmlGenerator gen, AwsConfig c) {
@@ -836,15 +837,15 @@ public class ConfigXmlGenerator {
             return;
         }
         gen.open("aws", "enabled", c.isEnabled())
-                .node("access-key", c.getAccessKey())
-                .node("secret-key", c.getSecretKey())
-                .node("iam-role", c.getIamRole())
-                .node("region", c.getRegion())
-                .node("host-header", c.getHostHeader())
-                .node("security-group-name", c.getSecurityGroupName())
-                .node("tag-key", c.getTagKey())
-                .node("tag-value", c.getTagValue())
-                .close();
+           .node("access-key", c.getAccessKey())
+           .node("secret-key", c.getSecretKey())
+           .node("iam-role", c.getIamRole())
+           .node("region", c.getRegion())
+           .node("host-header", c.getHostHeader())
+           .node("security-group-name", c.getSecurityGroupName())
+           .node("tag-key", c.getTagKey())
+           .node("tag-value", c.getTagValue())
+           .close();
     }
 
     private static void discoveryStrategyConfigXmlGenerator(XmlGenerator gen, DiscoveryConfig c) {
@@ -863,8 +864,8 @@ public class ConfigXmlGenerator {
                 gen.open("discovery-strategy",
                         "class", classNameOrImplClass(config.getClassName(), config.getDiscoveryStrategyFactory()),
                         "enabled", "true")
-                        .appendProperties(config.getProperties())
-                        .close();
+                   .appendProperties(config.getProperties())
+                   .close();
             }
         }
         gen.close();
@@ -897,7 +898,7 @@ public class ConfigXmlGenerator {
 
             gen.node("factory-class-name",
                     classNameOrImplClass(ssl.getFactoryClassName(), ssl.getFactoryImplementation()))
-                    .appendProperties(props);
+               .appendProperties(props);
         }
         gen.close();
     }
@@ -930,7 +931,7 @@ public class ConfigXmlGenerator {
         gen.open("socket-interceptor", "enabled", socket != null && socket.isEnabled());
         if (socket != null) {
             gen.node("class-name", classNameOrImplClass(socket.getClassName(), socket.getImplementation()))
-                    .appendProperties(socket.getProperties());
+               .appendProperties(socket.getProperties());
         }
         gen.close();
     }
@@ -941,11 +942,27 @@ public class ConfigXmlGenerator {
             return;
         }
         gen.open("symmetric-encryption", "enabled", sec.isEnabled())
-                .node("algorithm", sec.getAlgorithm())
-                .node("salt", MASK_FOR_SESITIVE_DATA)
-                .node("password", MASK_FOR_SESITIVE_DATA)
-                .node("iteration-count", sec.getIterationCount())
-                .close();
+           .node("algorithm", sec.getAlgorithm())
+           .node("salt", MASK_FOR_SESITIVE_DATA)
+           .node("password", MASK_FOR_SESITIVE_DATA)
+           .node("iteration-count", sec.getIterationCount())
+           .close();
+    }
+
+    private static void memberAddressProviderConfigXmlGenerator(XmlGenerator gen, NetworkConfig netCfg) {
+        final MemberAddressProviderConfig memberAddressProviderConfig = netCfg.getMemberAddressProviderConfig();
+        if (memberAddressProviderConfig == null) {
+            return;
+        }
+        final String className =
+                classNameOrImplClass(memberAddressProviderConfig.getClassName(), memberAddressProviderConfig.getImplementation());
+        if (isNullOrEmpty(className)) {
+            return;
+        }
+        gen.open("member-address-provider", "enabled", memberAddressProviderConfig.isEnabled())
+           .node("class-name", className)
+           .appendProperties(memberAddressProviderConfig.getProperties())
+           .close();
     }
 
     private static void hotRestartXmlGenerator(XmlGenerator gen, Config config) {
@@ -955,15 +972,15 @@ public class ConfigXmlGenerator {
             return;
         }
         gen.open("hot-restart-persistence", "enabled", hrCfg.isEnabled())
-                .node("base-dir", hrCfg.getBaseDir().getAbsolutePath());
+           .node("base-dir", hrCfg.getBaseDir().getAbsolutePath());
         if (hrCfg.getBackupDir() != null) {
             gen.node("backup-dir", hrCfg.getBackupDir().getAbsolutePath());
         }
         gen.node("parallelism", hrCfg.getParallelism())
-                .node("validation-timeout-seconds", hrCfg.getValidationTimeoutSeconds())
-                .node("data-load-timeout-seconds", hrCfg.getDataLoadTimeoutSeconds())
-                .node("cluster-data-recovery-policy", hrCfg.getClusterDataRecoveryPolicy())
-                .close();
+           .node("validation-timeout-seconds", hrCfg.getValidationTimeoutSeconds())
+           .node("data-load-timeout-seconds", hrCfg.getDataLoadTimeoutSeconds())
+           .node("cluster-data-recovery-policy", hrCfg.getClusterDataRecoveryPolicy())
+           .close();
     }
 
     private static void nativeMemoryXmlGenerator(XmlGenerator gen, Config config) {
@@ -975,13 +992,13 @@ public class ConfigXmlGenerator {
         gen.open("native-memory",
                 "enabled", nativeMemoryConfig.isEnabled(),
                 "allocator-type", nativeMemoryConfig.getAllocatorType())
-                .node("size", null,
-                        "unit", nativeMemoryConfig.getSize().getUnit(),
-                        "value", nativeMemoryConfig.getSize().getValue())
-                .node("min-block-size", nativeMemoryConfig.getMinBlockSize())
-                .node("page-size", nativeMemoryConfig.getPageSize())
-                .node("metadata-space-percentage", nativeMemoryConfig.getMetadataSpacePercentage())
-                .close();
+           .node("size", null,
+                   "unit", nativeMemoryConfig.getSize().getUnit(),
+                   "value", nativeMemoryConfig.getSize().getValue())
+           .node("min-block-size", nativeMemoryConfig.getMinBlockSize())
+           .node("page-size", nativeMemoryConfig.getPageSize())
+           .node("metadata-space-percentage", nativeMemoryConfig.getMetadataSpacePercentage())
+           .close();
     }
 
     private static void servicesXmlGenerator(XmlGenerator gen, Config config) {
@@ -993,11 +1010,11 @@ public class ConfigXmlGenerator {
         if (CollectionUtil.isNotEmpty(c.getServiceConfigs())) {
             for (ServiceConfig serviceConfig : c.getServiceConfigs()) {
                 gen.open("service", "enabled", serviceConfig.isEnabled())
-                        .node("name", serviceConfig.getName())
-                        .node("class-name",
-                                classNameOrImplClass(serviceConfig.getClassName(), serviceConfig.getImplementation()))
-                        .appendProperties(serviceConfig.getProperties())
-                        .close();
+                   .node("name", serviceConfig.getName())
+                   .node("class-name",
+                           classNameOrImplClass(serviceConfig.getClassName(), serviceConfig.getImplementation()))
+                   .appendProperties(serviceConfig.getProperties())
+                   .close();
             }
         }
         gen.close();

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
@@ -32,4 +32,8 @@ public class ConfigurationException extends HazelcastException {
     public ConfigurationException(String message) {
         super(message);
     }
+
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAddressProviderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAddressProviderConfig.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.MemberAddressProvider;
+
+import java.util.Properties;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+
+/**
+ * Configuration for a custom {@link MemberAddressProvider} strategy.
+ * <p>
+ * The member address provider allows you to plug your own strategy to customize:
+ * <ul>
+ * <li>What address Hazelcast will bind to</li>
+ * <li>What address Hazelcast will advertise to other members on which they can bind to</li>
+ * </ul>
+ * In most environments you don't need to customize this and the default strategy will work just
+ * fine. However in some cloud environments the default strategy does not make the right choice and
+ * the member address provider delegates the process of address picking to external code.
+ */
+public final class MemberAddressProviderConfig {
+    private boolean enabled;
+    private String className;
+    private Properties properties = new Properties();
+    private MemberAddressProvider implementation;
+
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public MemberAddressProviderConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public MemberAddressProviderConfig setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public MemberAddressProviderConfig setProperties(Properties properties) {
+        checkNotNull(properties, "MemberAddressProvider properties cannot be null");
+        this.properties = properties;
+        return this;
+    }
+
+    public MemberAddressProvider getImplementation() {
+        return implementation;
+    }
+
+    public MemberAddressProviderConfig setImplementation(MemberAddressProvider implementation) {
+        this.implementation = implementation;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "MemberAddressProviderConfig{"
+                + "enabled=" + enabled
+                + ", className='" + className + '\''
+                + ", properties=" + properties
+                + ", implementation=" + implementation
+                + '}';
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MemberAddressProviderConfig that = (MemberAddressProviderConfig) o;
+
+        if (isEnabled() != that.isEnabled()) {
+            return false;
+        }
+        if (getClassName() != null ? !getClassName().equals(that.getClassName()) : that.getClassName() != null) {
+            return false;
+        }
+        if (!getProperties().equals(that.getProperties())) {
+            return false;
+        }
+        return getImplementation() != null ? getImplementation().equals(that.getImplementation())
+                : that.getImplementation() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (isEnabled() ? 1 : 0);
+        result = 31 * result + (getClassName() != null ? getClassName().hashCode() : 0);
+        result = 31 * result + getProperties().hashCode();
+        result = 31 * result + (getImplementation() != null ? getImplementation().hashCode() : 0);
+        return result;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -59,6 +59,8 @@ public class NetworkConfig {
 
     private SSLConfig sslConfig;
 
+    private MemberAddressProviderConfig memberAddressProviderConfig = new MemberAddressProviderConfig();
+
     public NetworkConfig() {
         String os = StringUtil.lowerCaseInternal(System.getProperty("os.name"));
         reuseAddress = (!os.contains("win"));
@@ -320,6 +322,15 @@ public class NetworkConfig {
      */
     public NetworkConfig setSSLConfig(SSLConfig sslConfig) {
         this.sslConfig = sslConfig;
+        return this;
+    }
+
+    public MemberAddressProviderConfig getMemberAddressProviderConfig() {
+        return memberAddressProviderConfig;
+    }
+
+    public NetworkConfig setMemberAddressProviderConfig(MemberAddressProviderConfig memberAddressProviderConfig) {
+        this.memberAddressProviderConfig = memberAddressProviderConfig;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -613,6 +613,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 handleSSLConfig(child);
             } else if ("socket-interceptor".equals(nodeName)) {
                 handleSocketInterceptorConfig(child);
+            } else if ("member-address-provider".equals(nodeName)) {
+               handleMemberAddressProvider(child);
             }
         }
     }
@@ -1784,6 +1786,22 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         }
 
         config.getManagementCenterConfig().setMutualAuthConfig(mcMutualAuthConfig);
+    }
+
+    private void handleMemberAddressProvider(Node node) {
+        Node enabledNode = node.getAttributes().getNamedItem("enabled");
+        boolean enabled = enabledNode != null && getBooleanValue(getTextContent(enabledNode));
+        MemberAddressProviderConfig memberAddressProviderConfig = config.getNetworkConfig().getMemberAddressProviderConfig();
+        memberAddressProviderConfig.setEnabled(enabled);
+        for (Node n : childElements(node)) {
+            String nodeName = cleanNodeName(n);
+            if (nodeName.equals("class-name")) {
+                String className = getTextContent(n);
+                memberAddressProviderConfig.setClassName(className);
+            } else if (nodeName.equals("properties")) {
+                fillProperties(n, memberAddressProviderConfig.getProperties());
+            }
+        }
     }
 
     private void handleSocketInterceptorConfig(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -17,19 +17,28 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.cluster.Joiner;
+import com.hazelcast.config.MemberAddressProviderConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.EventLoopGroup;
 import com.hazelcast.internal.networking.nio.NioEventLoopGroup;
 import com.hazelcast.internal.networking.spinning.SpinningEventLoopGroup;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.NodeIOService;
 import com.hazelcast.nio.tcp.MemberChannelInitializer;
 import com.hazelcast.nio.tcp.TcpIpConnectionChannelErrorHandler;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
+import com.hazelcast.spi.MemberAddressProvider;
 import com.hazelcast.spi.annotation.PrivateApi;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.channels.ServerSocketChannel;
+import java.util.Properties;
 
 @PrivateApi
 public class DefaultNodeContext implements NodeContext {
@@ -41,7 +50,78 @@ public class DefaultNodeContext implements NodeContext {
 
     @Override
     public AddressPicker createAddressPicker(Node node) {
-        return new DefaultAddressPicker(node.getConfig(), node.getProperties(), node.getLogger(AddressPicker.class));
+        Config config = node.getConfig();
+        MemberAddressProviderConfig memberAddressProviderConfig = config.getNetworkConfig().getMemberAddressProviderConfig();
+
+        final ILogger addressPickerLogger = node.getLogger(AddressPicker.class);
+        if (!memberAddressProviderConfig.isEnabled()) {
+            return new DefaultAddressPicker(config, node.getProperties(), addressPickerLogger);
+        }
+
+        MemberAddressProvider implementation = memberAddressProviderConfig.getImplementation();
+        if (implementation != null) {
+            return new DelegatingAddressPicker(implementation, config.getNetworkConfig(), addressPickerLogger);
+        }
+        ClassLoader classLoader = config.getClassLoader();
+        String classname = memberAddressProviderConfig.getClassName();
+        Class<?> clazz = loadMemberAddressProviderClass(classLoader, classname);
+
+        Constructor<?> constructor = findMemberAddressProviderConstructor(clazz);
+        Properties properties = memberAddressProviderConfig.getProperties();
+        MemberAddressProvider memberAddressProvider = newMemberAddressProviderInstance(constructor, properties);
+        return new DelegatingAddressPicker(memberAddressProvider, config.getNetworkConfig(), addressPickerLogger);
+
+    }
+
+    private MemberAddressProvider newMemberAddressProviderInstance(Constructor<?> constructor, Properties properties) {
+        Class<?>[] parameterTypes = constructor.getParameterTypes();
+        Class<?> clazz = constructor.getDeclaringClass();
+        String classname = clazz.getName();
+        try {
+            if (parameterTypes.length == 0) {
+                //we have only the no-arg constructor -> we have to fail-fast when some properties were configured
+                if (properties != null && !properties.isEmpty()) {
+                    throw new ConfigurationException("Cannot find a matching constructor for MemberAddressProvider.  "
+                            + "The member address provider has properties configured, but the class " + "'" + classname
+                            + "' does not have a public constructor accepting properties.");
+                }
+
+                return (MemberAddressProvider) constructor.newInstance();
+            } else {
+                if (properties == null) {
+                    properties = new Properties();
+                }
+                return (MemberAddressProvider) constructor.newInstance(properties);
+            }
+        } catch (InstantiationException e) {
+            throw new ConfigurationException("Cannot create a new instance of MemberAddressProvider '" + clazz + "'", e);
+        } catch (IllegalAccessException e) {
+            throw new ConfigurationException("Cannot create a new instance of MemberAddressProvider '" + clazz + "'", e);
+        } catch (InvocationTargetException e) {
+            throw new ConfigurationException("Cannot create a new instance of MemberAddressProvider '" + clazz + "'", e);
+        }
+    }
+
+    private Constructor<?> findMemberAddressProviderConstructor(Class<?> clazz) {
+        Constructor<?> constructor;
+        try {
+            constructor = clazz.getConstructor(Properties.class);
+        } catch (NoSuchMethodException e) {
+            try {
+                constructor = clazz.getConstructor();
+            } catch (NoSuchMethodException e1) {
+                throw new ConfigurationException("Cannot create a new instance of MemberAddressProvider '" + clazz + "'", e);
+            }
+        }
+        return constructor;
+    }
+
+    private Class<?> loadMemberAddressProviderClass(ClassLoader classLoader, String classname) {
+        try {
+            return ClassLoaderUtil.loadClass(classLoader, classname);
+        } catch (ClassNotFoundException e) {
+            throw new ConfigurationException("Cannot create a new instance of MemberAddressProvider '" + classname + "'", e);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.ConfigurationException;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.spi.MemberAddressProvider;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.channels.ServerSocketChannel;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Delegates picking the bind and public address for this instance
+ * to an implementation of {@link MemberAddressProvider}.
+ */
+public class DelegatingAddressPicker implements AddressPicker {
+    //todo: this should be shared with DefaultAddressPicker
+    private static final int SOCKET_TIMEOUT_MILLIS = (int) TimeUnit.SECONDS.toMillis(1);
+    private static final int SOCKET_BACKLOG_LENGTH = 100;
+
+    private final ILogger logger;
+    private final MemberAddressProvider memberAddressProvider;
+    private final NetworkConfig networkConfig;
+
+    private volatile InetSocketAddress bindAddress;
+    private volatile InetSocketAddress publicAddress;
+
+    private volatile ServerSocketChannel serverSocketChannel;
+
+    public DelegatingAddressPicker(MemberAddressProvider memberAddressProvider, NetworkConfig networkConfig, ILogger logger) {
+        this.memberAddressProvider = memberAddressProvider;
+        this.networkConfig = networkConfig;
+        this.logger = logger;
+    }
+
+
+    @Override
+    public void pickAddress() throws Exception {
+        try {
+            bindAddress = memberAddressProvider.getBindAddress();
+            logger.info("Using bind address: " + publicAddress);
+
+            publicAddress = memberAddressProvider.getPublicAddress();
+            validatePublicAddress(publicAddress);
+            logger.info("Using public address: " + publicAddress);
+
+            serverSocketChannel = createServerSocketChannelInternal();
+
+            if (publicAddress.getPort() == 0) {
+                publicAddress = new InetSocketAddress(publicAddress.getAddress(), serverSocketChannel.socket().getLocalPort());
+            }
+        } catch (Exception e) {
+            logger.severe(e);
+            throw e;
+        }
+    }
+
+
+    private ServerSocketChannel createServerSocketChannelInternal() {
+        int portCount = networkConfig.getPortCount();
+        int port = bindAddress.getPort() == 0 ? networkConfig.getPort() : bindAddress.getPort();
+        boolean portAutoIncrement = networkConfig.isPortAutoIncrement();
+
+        int portTrialCount = port > 0 && portAutoIncrement ? portCount : 1;
+        if (port == 0) {
+            logger.info("No explicit port is given, system will pick up an ephemeral port.");
+        }
+
+        IOException error = null;
+        for (int i = 0; i < portTrialCount; i++) {
+            InetSocketAddress tmpBindAddress = new InetSocketAddress(bindAddress.getAddress(), port + i);
+            boolean reuseAddress = networkConfig.isReuseAddress();
+            logger.finest("inet reuseAddress:" + reuseAddress);
+
+            ServerSocket serverSocket = null;
+            ServerSocketChannel serverSocketChannel = null;
+            try {
+                serverSocketChannel = ServerSocketChannel.open();
+                serverSocket = serverSocketChannel.socket();
+                serverSocket.setReuseAddress(reuseAddress);
+                serverSocket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+
+                logger.fine("Trying to bind inet socket address: " + tmpBindAddress);
+                serverSocket.bind(tmpBindAddress, SOCKET_BACKLOG_LENGTH);
+                logger.fine("Bind successful to inet socket address: " + serverSocket.getLocalSocketAddress());
+
+                serverSocketChannel.configureBlocking(false);
+                //todo: ugly side-effect
+                bindAddress = tmpBindAddress;
+                return serverSocketChannel;
+            } catch (IOException e) {
+                IOUtil.close(serverSocket);
+                IOUtil.closeResource(serverSocketChannel);
+                error = e;
+            }
+        }
+        String message = "Cannot bind to a given address: " + bindAddress + ". Hazelcast cannot start. ";
+        if (networkConfig.isPortAutoIncrement()) {
+            message += "Config-port: " + networkConfig.getPort()
+                    + ", latest-port: " + (port + portTrialCount);
+        } else {
+            message += "Port [" + port + "] is already in use and auto-increment is disabled.";
+        }
+        throw new HazelcastException(message, error);
+    }
+
+    private void validatePublicAddress(InetSocketAddress inetSocketAddress) {
+        InetAddress address = inetSocketAddress.getAddress();
+        if (address == null) {
+            throw new ConfigurationException("Cannot resolve address '" + inetSocketAddress + "'");
+        }
+
+        if (address.isAnyLocalAddress()) {
+            throw new ConfigurationException("Member address provider has to return a specific public address to broadcast to"
+                    + " other members.");
+        }
+    }
+
+    @Override
+    public Address getBindAddress() {
+        return new Address(bindAddress);
+    }
+
+    @Override
+    public Address getPublicAddress() {
+        return new Address(publicAddress);
+    }
+
+    @Override
+    public ServerSocketChannel getServerSocketChannel() {
+        return serverSocketChannel;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -34,6 +34,7 @@ import java.io.ObjectStreamClass;
 import java.io.OutputStream;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
+import java.net.ServerSocket;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -319,6 +320,22 @@ public final class IOUtil {
         }
         try {
             closeable.close();
+        } catch (IOException e) {
+            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
+        }
+    }
+
+    /**
+     * Quietly attempts to close a {@link ServerSocket}, swallowing any exception.
+     *
+     * @param serverSocket server socket to close. If {@code null}, no action is taken.
+     */
+    public static void close(ServerSocket serverSocket) {
+        if (serverSocket == null) {
+            return;
+        }
+        try {
+            serverSocket.close();
         } catch (IOException e) {
             Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAddressProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.spi.annotation.Beta;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * <b>IMPORTANT</b>
+ * This interface is not intended to provide addresses of other cluster members with
+ * which the hazelcast instance will form a cluster. This is an SPI for advanced use in
+ * cases where the {@link com.hazelcast.instance.DefaultAddressPicker} does not
+ * pick suitable addresses to bind to and publish to other cluster members.
+ * For instance, this could allow easier deployment in some cases when running on
+ * Docker, AWS or other cloud environments.
+ *
+ * That said, if you are just starting with Hazelcast, you will probably want to
+ * set the member addresses by using {@link com.hazelcast.config.TcpIpConfig#setMembers(List)},
+ * {@link com.hazelcast.config.MulticastConfig} or adding a discovery strategy.
+ *
+ * Allow to customize:
+ * 1. What address Hazelcast will bind to
+ * 2. What address Hazelcast will advertise to other members on which they can bind to
+ * <p>
+ * This is practical in some cloud environments where the default strategy is not yielding good results.
+ *
+ * @see com.hazelcast.instance.DefaultAddressPicker
+ * @see com.hazelcast.config.NetworkConfig#setMemberAddressProviderConfig(com.hazelcast.config.MemberAddressProviderConfig)
+ */
+@Beta
+public interface MemberAddressProvider {
+    /**
+     * What address should Hazelcast bind to.
+     * When the port is set to {@code 0} then it will use a port as
+     * configured in the Hazelcast network configuration.
+     *
+     * @return address to bind to
+     * @see NetworkConfig#getPort()
+     * @see NetworkConfig#isPortAutoIncrement()
+     */
+    InetSocketAddress getBindAddress();
+
+    /**
+     * What address should Hazelcast advertise to other members and clients.
+     * When the port is set to {@code 0} then it will broadcast the same
+     * port that it is bound to.
+     *
+     * @return address to advertise to others
+     */
+    InetSocketAddress getPublicAddress();
+}

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -1362,6 +1362,28 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="member-address-provider" type="member-address-provider" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        IMPORTANT
+                        This configuration is not intended to provide addresses of other cluster members with
+                        which the hazelcast instance will form a cluster. This is an SPI for advanced use in
+                        cases where the DefaultAddressPicker does not pick suitable addresses to bind to
+                        and publish to other cluster members. For instance, this could allow easier
+                        deployment in some cases when running on Docker, AWS or other cloud environments.
+                        That said, if you are just starting with Hazelcast, you will probably want to
+                        set the member addresses by using the tcp-ip or multicast configuration
+                        or adding a discovery strategy.
+                        Member address provider allows to plug in own strategy to customize:
+                          1. What address Hazelcast will bind to
+                          2. What address Hazelcast will advertise to other members on which they can bind to
+
+                        In most environments you don't need to customize this and the default strategy will work just
+                        fine. However in some cloud environments the default strategy does not make the right choice and
+                        the member address provider delegates the process of address picking to external code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="tcp-ip">
@@ -1429,6 +1451,25 @@
                 <xs:attribute name="port-count" type="xs:unsignedInt" use="optional" default="100"/>
             </xs:extension>
         </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="member-address-provider">
+        <xs:all>
+            <xs:element name="class-name" type="non-space-string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the class implementing the com.hazelcast.spi.MemberAddressProvider interface
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the member address provider SPI is enabled or not. Values can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="outbound-ports">
         <xs:sequence>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -403,6 +403,33 @@ https://hazelcast.org/documentation/.
             <password>thepass</password>
             <iteration-count>19</iteration-count>
         </symmetric-encryption>
+        * <member-address-provider>:
+        IMPORTANT
+        This configuration is not intended to provide addresses of other cluster members with
+        which the hazelcast instance will form a cluster. This is an SPI for advanced use in
+        cases where the DefaultAddressPicker does not pick suitable addresses to bind to
+        and publish to other cluster members. For instance, this could allow easier
+        deployment in some cases when running on Docker, AWS or other cloud environments.
+        That said, if you are just starting with Hazelcast, you will probably want to
+        set the member addresses by using the tcp-ip or multicast configuration
+        or adding a discovery strategy.
+        Member address provider allows to plug in own strategy to customize:
+           1. What address Hazelcast will bind to
+           2. What address Hazelcast will advertise to other members on which they can bind to
+        In most environments you don't need to customize this and the default strategy will work just
+        fine. However in some cloud environments the default strategy does not make the right choice and the
+        member address provider delegates the process of address picking to external code. It has two optional attributes:
+        * enabled:
+        Specifies whether the member address provider SPI is enabled or not. Its default value is false.
+        It has the following sub-elements:
+            - <class-name>:
+                The name of the class implementing the com.hazelcast.spi.MemberAddressProvider interface.
+            - <properties>:
+                The properties that will be provided when constructing the provided MemberAddressProvider. Hazelcast will
+                first try instatiating the provided class by invoking a constructor accepting a single
+                java.util.Properties instance. In the case where there is no such constructor and there are also
+                no properties defined by this configuration, Hazelcast will exceptionally try to use the no-arg
+                constructor.
     -->
     <network>
         <public-address>11.22.33.44:5555</public-address>
@@ -450,6 +477,13 @@ https://hazelcast.org/documentation/.
             <salt>...</salt>
             <iteration-count>7</iteration-count>
         </symmetric-encryption>
+        <member-address-provider enabled="false">
+            <class-name>com.hazelcast.MemberAddressProviderImpl</class-name>
+            <properties>
+                <property name="prop1">prop1-value</property>
+                <property name="prop2">prop2-value</property>
+            </properties>
+        </member-address-provider>
     </network>
     <!--
         ===== PARTITION GROUPING CONFIGURATION =====

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -63,6 +64,26 @@ public class ConfigXmlGeneratorTest {
         assertEquals(theSalt, ConfigXmlGenerator.MASK_FOR_SESITIVE_DATA);
         assertEquals(newConfigViaXMLGenerator.getLicenseKey(), ConfigXmlGenerator.MASK_FOR_SESITIVE_DATA);
         assertEquals(newConfigViaXMLGenerator.getGroupConfig().getPassword(), ConfigXmlGenerator.MASK_FOR_SESITIVE_DATA);
+    }
+
+    @Test
+    public void testMemberAddressProvider() {
+        Config cfg = new Config();
+        final MemberAddressProviderConfig expected = cfg.getNetworkConfig().getMemberAddressProviderConfig();
+        expected.setEnabled(true)
+                .setEnabled(true)
+                .setClassName("ClassName");
+        final Properties props = expected.getProperties();
+        props.setProperty("p1", "v1");
+        props.setProperty("p2", "v2");
+        props.setProperty("p3", "v3");
+
+        Config newConfigViaXMLGenerator = getNewConfigViaXMLGenerator(cfg);
+        final MemberAddressProviderConfig actual = newConfigViaXMLGenerator.getNetworkConfig().getMemberAddressProviderConfig();
+
+        assertEquals(expected.isEnabled(), actual.isEnabled());
+        assertEquals(expected.getClassName(), actual.getClassName());
+        assertEquals(expected.getProperties(), actual.getProperties());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1793,6 +1793,56 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testMemberAddressProvider_classnameIsMandatory() {
+        String xml = HAZELCAST_START_TAG
+                + "<network> "
+                + "  <member-address-provider enabled=\"true\">"
+                + "  </member-address-provider>"
+                + "</network> "
+                + HAZELCAST_END_TAG;
+
+        buildConfig(xml);
+    }
+
+    @Test
+    public void testMemberAddressProviderEnabled() {
+        String xml = HAZELCAST_START_TAG
+                + "<network> "
+                + "  <member-address-provider enabled=\"true\">"
+                + "    <class-name>foo.bar.Clazz</class-name>"
+                + "  </member-address-provider>"
+                + "</network> "
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        MemberAddressProviderConfig memberAddressProviderConfig = config.getNetworkConfig().getMemberAddressProviderConfig();
+
+        assertTrue(memberAddressProviderConfig.isEnabled());
+        assertEquals("foo.bar.Clazz", memberAddressProviderConfig.getClassName());
+    }
+
+    @Test
+    public void testMemberAddressProviderEnabled_withProperties() {
+        String xml = HAZELCAST_START_TAG
+                + "<network> "
+                + "  <member-address-provider enabled=\"true\">"
+                + "    <class-name>foo.bar.Clazz</class-name>"
+                + "    <properties>"
+                + "       <property name=\"propName1\">propValue1</property>"
+                + "    </properties>"
+                + "  </member-address-provider>"
+                + "</network> "
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        MemberAddressProviderConfig memberAddressProviderConfig = config.getNetworkConfig().getMemberAddressProviderConfig();
+
+        Properties properties = memberAddressProviderConfig.getProperties();
+        assertEquals(1, properties.size());
+        assertEquals("propValue1", properties.get("propName1"));
+    }
+
     private static void assertPermissionConfig(PermissionConfig expected, Config config) {
         Iterator<PermissionConfig> permConfigs = config.getSecurityConfig().getClientPermissionConfigs().iterator();
         PermissionConfig configured = permConfigs.next();

--- a/hazelcast/src/test/java/com/hazelcast/spi/memberAddressProvider/MemberAddressProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/memberAddressProvider/MemberAddressProviderTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.memberAddressProvider;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigurationException;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.spi.MemberAddressProvider;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.RootCauseMatcher;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MemberAddressProviderTest {
+
+    @Rule
+    public ExpectedException rule = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        MemberAddressProviderWithStaticProperties.properties = null;
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testPropertiesAreInjected() {
+        final Config config = new Config();
+        config.getNetworkConfig().getMemberAddressProviderConfig()
+              .setEnabled(true)
+              .setClassName(MemberAddressProviderWithStaticProperties.class.getName())
+              .getProperties().setProperty("propName", "propValue");
+
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        Hazelcast.newHazelcastInstance(config);
+        final String property = MemberAddressProviderWithStaticProperties.properties.getProperty("propName");
+        assertEquals("propValue", property);
+    }
+
+    @Test
+    public void testSimpleMemberAddressProviderIsInjected() {
+        final Config config = getConfig(SimpleMemberAddressProvider.class);
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+
+        final InetSocketAddress inetSocketAddress = (InetSocketAddress) instance.getLocalEndpoint().getSocketAddress();
+        assertEquals(inetSocketAddress.getPort(), 9999);
+
+        final Member localMember = instance.getCluster().getLocalMember();
+        assertEquals("1.2.3.4", localMember.getAddress().getHost());
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testFailFastWhenNoMatchingConstructorIsFound() {
+        final Config config = new Config();
+        config.getNetworkConfig().getMemberAddressProviderConfig()
+              .setEnabled(true)
+              .setClassName(SimpleMemberAddressProvider.class.getName())
+              .getProperties().setProperty("foo", "bar"); // <-- this assumes MemberAddressProvider has a constructor accepting Properties
+
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        //this should fail
+        Hazelcast.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void testImplementationIsUsed() {
+        final MemberAddressProvider mock = mock(MemberAddressProvider.class);
+        when(mock.getBindAddress()).thenReturn(new InetSocketAddress("localhost", 9999));
+        when(mock.getPublicAddress()).thenReturn(new InetSocketAddress("1.2.3.4", 0));
+
+        final Config config = getConfig(mock);
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+
+        final InetSocketAddress inetSocketAddress = (InetSocketAddress) instance.getLocalEndpoint().getSocketAddress();
+        assertEquals(inetSocketAddress.getPort(), 9999);
+
+        final Member localMember = instance.getCluster().getLocalMember();
+        assertEquals("1.2.3.4", localMember.getAddress().getHost());
+
+        verify(mock).getBindAddress();
+        verify(mock).getPublicAddress();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void instanceFailsToStartWhenGetBindAddressThrowsException() {
+        final MemberAddressProvider mock = mock(MemberAddressProvider.class);
+        when(mock.getBindAddress()).thenThrow(new RuntimeException("Exception on get bind address"));
+        when(mock.getPublicAddress()).thenReturn(new InetSocketAddress("1.2.3.4", 0));
+
+        final Config config = getConfig(mock);
+
+        //this should fail
+        Hazelcast.newHazelcastInstance(config);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void instanceFailsToStartWhenGetPublicAddressThrowsException() {
+        final MemberAddressProvider mock = mock(MemberAddressProvider.class);
+        when(mock.getBindAddress()).thenReturn(new InetSocketAddress("localhost", 9999));
+        when(mock.getPublicAddress()).thenThrow(new RuntimeException("Exception on get public address"));
+
+        final Config config = getConfig(mock);
+        //this should fail
+        Hazelcast.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void instanceFailsToStartWhenAssignedUnbindableAddress() {
+        final MemberAddressProvider mock = mock(MemberAddressProvider.class);
+        when(mock.getBindAddress()).thenReturn(new InetSocketAddress("1.2.3.4", 9999));
+        when(mock.getPublicAddress()).thenReturn(new InetSocketAddress("1.2.3.4", 0));
+
+        final Config config = getConfig(mock);
+
+        // we expect an BindException to be thrown (wrapped in an IllegalStateException)
+        rule.expect(HazelcastException.class);
+        rule.expect(new RootCauseMatcher(BindException.class));
+        Hazelcast.newHazelcastInstance(config);
+    }
+
+    private Config getConfig(Class memberAddressProviderClass) {
+        Config config = new Config();
+        config.getNetworkConfig().getMemberAddressProviderConfig()
+              .setEnabled(true)
+              .setClassName(memberAddressProviderClass.getName());
+
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        return config;
+    }
+
+    private Config getConfig(MemberAddressProvider implementation) {
+        Config config = new Config();
+        config.getNetworkConfig().getMemberAddressProviderConfig()
+              .setEnabled(true)
+              .setImplementation(implementation);
+
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        return config;
+    }
+
+    public static final class MemberAddressProviderWithStaticProperties implements MemberAddressProvider {
+        public static Properties properties;
+
+        public MemberAddressProviderWithStaticProperties(Properties properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public InetSocketAddress getBindAddress() {
+            return new InetSocketAddress("localhost", 0);
+        }
+
+        @Override
+        public InetSocketAddress getPublicAddress() {
+            return new InetSocketAddress("localhost", 0);
+        }
+    }
+
+    public static final class SimpleMemberAddressProvider implements MemberAddressProvider {
+        @Override
+        public InetSocketAddress getBindAddress() {
+            return new InetSocketAddress("localhost", 9999);
+        }
+
+        @Override
+        public InetSocketAddress getPublicAddress() {
+            return new InetSocketAddress("1.2.3.4", 0);
+        }
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -194,6 +194,12 @@
             <!-- iteration count to use when generating the secret key -->
             <iteration-count>19</iteration-count>
         </symmetric-encryption>
+        <member-address-provider enabled="false">
+            <class-name>DummyMemberAddressProvider</class-name>
+            <properties>
+                <property name="foo">bar</property>
+            </properties>
+        </member-address-provider>
     </network>
     <partition-group enabled="true" group-type="CUSTOM">
         <member-group>


### PR DESCRIPTION
This PR is a continuation of the PR: https://github.com/hazelcast/hazelcast/pull/11476
Things changed:
- added spring configuration support
- changed SPI interface name from `AddressLocator` to `BindAddressProvider` as it provides addresses this and other members bind to. Other options are `MemberAddressProvider` and simply `AddressProvider`
- cleaned up tests and added a couple more
- removed the test with two instances as they did not form a cluster. This was because the addresses the addresses provided by the implementation in the test could not be assigned. I will try and make this test work
- added some logging in the `DelegatingAddressPicker` to log which addresses are returned and errors
- squashed commits


Adds a new SPI for defining the addresses that the hazelcast instance
will bind to and the address which will be advertised to other members
on which they can bind to.
This SPI will allow for implementations for different environments in
which the default address picker does not pick suitable addresses and
manually configuring the public address provides additional complexity
for deploying hazelcast.

The SPI does not necessarily fix all current issues when deploying
hazelcast but provides the user with a way to avoid these issues by
either providing their own implementation or using some implementation
that hazelcast will provide in the future.

Related to:
https://github.com/hazelcast/hazelcast/issues/10477
https://github.com/hazelcast/hazelcast/issues/9963
https://github.com/hazelcast/hazelcast/issues/11118