### PR TITLE
follow up for fix on client transactions

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTransactionUtil.java
@@ -30,6 +30,14 @@ import java.util.concurrent.Future;
  */
 public final class ClientTransactionUtil {
 
+    private static final ExceptionUtil.RuntimeExceptionFactory TRANSACTION_EXCEPTION_FACTORY =
+            new ExceptionUtil.RuntimeExceptionFactory() {
+                @Override
+                public RuntimeException create(Throwable throwable, String message) {
+                    return new TransactionException(message, throwable);
+                }
+            };
+
     private ClientTransactionUtil() {
 
     }
@@ -46,12 +54,7 @@ public final class ClientTransactionUtil {
             final Future<ClientMessage> future = clientInvocation.invoke();
             return future.get();
         } catch (Exception e) {
-            RuntimeException runtimeException = ExceptionUtil.peel(e);
-            if (runtimeException instanceof TransactionException) {
-                throw runtimeException;
-            } else {
-                throw new TransactionException(runtimeException);
-            }
+            throw ExceptionUtil.rethrow(e, TRANSACTION_EXCEPTION_FACTORY);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -31,6 +31,23 @@ public final class ExceptionUtil {
 
     private static final String EXCEPTION_SEPARATOR = "------ submitted from ------";
     private static final String EXCEPTION_MESSAGE_SEPARATOR = "------ %MSG% ------";
+    private static final RuntimeExceptionFactory HAZELCAST_EXCEPTION_FACTORY = new RuntimeExceptionFactory() {
+        @Override
+        public RuntimeException create(Throwable throwable, String message) {
+            if (message != null) {
+                return new HazelcastException(message, throwable);
+            } else {
+                return new HazelcastException(throwable);
+            }
+        }
+    };
+
+    /**
+     * Interface used by rethrow/peel to wrap the peeled exception
+     */
+    public interface RuntimeExceptionFactory {
+        RuntimeException create(Throwable throwable, String message);
+    }
 
     private ExceptionUtil() {
     }
@@ -49,11 +66,7 @@ public final class ExceptionUtil {
     }
 
     public static RuntimeException peel(final Throwable t) {
-        return (RuntimeException) peel(t, null);
-    }
-
-    public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType) {
-        return peel(t, allowedType, null);
+        return (RuntimeException) peel(t, null, null, HAZELCAST_EXCEPTION_FACTORY);
     }
 
     /**
@@ -62,15 +75,35 @@ public final class ExceptionUtil {
      * {@code HazelcastException} or just returning the same instance {@code t} if it is already an instance of
      * {@code RuntimeException}.
      *
-     * @param t             {@code Throwable} to be peeled
-     * @param allowedType   the type expected to be returned; when {@code null}, this method returns instances
-     *                      of {@code RuntimeException}
-     * @param message       if not {@code null}, used as the message in the {@code HazelcastException} that
-     *                      may wrap the peeled {@code Throwable}
-     * @param <T>           expected type of {@code Throwable}
-     * @return              the peeled {@code Throwable}
+     * @param t           {@code Throwable} to be peeled
+     * @param allowedType the type expected to be returned; when {@code null}, this method returns instances
+     *                    of {@code RuntimeException}
+     * @param message     if not {@code null}, used as the message in the {@code HazelcastException} that
+     *                    may wrap the peeled {@code Throwable}
+     * @param <T>         expected type of {@code Throwable}
+     * @return the peeled {@code Throwable}
      */
     public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType, String message) {
+        return peel(t, allowedType, message, HAZELCAST_EXCEPTION_FACTORY);
+    }
+
+    /**
+     * Processes {@code Throwable t} so that the returned {@code Throwable}'s type matches {@code allowedType} or
+     * {@code RuntimeException}. Processing may include unwrapping {@code t}'s cause hierarchy, wrapping it in a
+     * {@code RuntimeException} created by using runtimeExceptionFactory or just returning the same instance {@code t}
+     * if it is already an instance of {@code RuntimeException}.
+     *
+     * @param t                       {@code Throwable} to be peeled
+     * @param allowedType             the type expected to be returned; when {@code null}, this method returns instances
+     *                                of {@code RuntimeException}
+     * @param message                 if not {@code null}, used as the message in {@code RuntimeException} that
+     *                                may wrap the peeled {@code Throwable}
+     * @param runtimeExceptionFactory wraps the peeled code using this runtimeExceptionFactory
+     * @param <T>                     expected type of {@code Throwable}
+     * @return the peeled {@code Throwable}
+     */
+    public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType,
+                                                       String message, RuntimeExceptionFactory runtimeExceptionFactory) {
         if (t instanceof RuntimeException) {
             return t;
         }
@@ -78,9 +111,9 @@ public final class ExceptionUtil {
         if (t instanceof ExecutionException || t instanceof InvocationTargetException) {
             final Throwable cause = t.getCause();
             if (cause != null) {
-                return peel(cause, allowedType);
+                return peel(cause, allowedType, message, runtimeExceptionFactory);
             } else {
-                return new HazelcastException(t);
+                return runtimeExceptionFactory.create(t, message);
             }
         }
 
@@ -88,33 +121,22 @@ public final class ExceptionUtil {
             return t;
         }
 
-        if (message != null) {
-            return new HazelcastException(message, t);
-        } else {
-            return new HazelcastException(t);
-        }
+        return runtimeExceptionFactory.create(t, message);
     }
 
     public static RuntimeException rethrow(final Throwable t) {
-        if (t instanceof Error) {
-            if (t instanceof OutOfMemoryError) {
-                OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) t);
-            }
-            throw (Error) t;
-        } else {
-            throw peel(t);
-        }
+        rethrowIfError(t);
+        throw peel(t);
+    }
+
+    public static RuntimeException rethrow(final Throwable t, RuntimeExceptionFactory runtimeExceptionFactory) {
+        rethrowIfError(t);
+        throw (RuntimeException) peel(t, null, null, runtimeExceptionFactory);
     }
 
     public static <T extends Throwable> RuntimeException rethrow(final Throwable t, Class<T> allowedType) throws T {
-        if (t instanceof Error) {
-            if (t instanceof OutOfMemoryError) {
-                OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) t);
-            }
-            throw (Error) t;
-        } else {
-            throw (T) peel(t, allowedType);
-        }
+        rethrowIfError(t);
+        throw (T) peel(t, allowedType, null);
     }
 
     /**
@@ -122,15 +144,20 @@ public final class ExceptionUtil {
      */
     public static <T extends Throwable> RuntimeException rethrowAllowedTypeFirst(final Throwable t,
                                                                                  Class<T> allowedType) throws T {
+        rethrowIfError(t);
+        if (allowedType.isAssignableFrom(t.getClass())) {
+            throw (T) t;
+        } else {
+            throw peel(t);
+        }
+    }
+
+    private static void rethrowIfError(final Throwable t) {
         if (t instanceof Error) {
             if (t instanceof OutOfMemoryError) {
                 OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) t);
             }
             throw (Error) t;
-        } else if (allowedType.isAssignableFrom(t.getClass())) {
-            throw (T) t;
-        } else {
-            throw peel(t);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ExceptionUtilTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
@@ -70,5 +71,20 @@ public class ExceptionUtilTest extends HazelcastTestSupport {
 
         assertTrue(result instanceof HazelcastException);
         assertEquals(exception, result.getCause());
+    }
+
+    @Test
+    public void testPeel_whenThrowableIsExecutionExceptionWithCustomFactory_thenReturnCustomException() {
+        IOException expectedException = new IOException();
+        RuntimeException result = (RuntimeException) ExceptionUtil.peel(new ExecutionException(expectedException),
+                null, null, new ExceptionUtil.RuntimeExceptionFactory() {
+                    @Override
+                    public RuntimeException create(Throwable throwable, String message) {
+                        return new IllegalStateException(message, throwable);
+                    }
+                });
+
+        assertEquals(result.getClass(), IllegalStateException.class);
+        assertEquals(result.getCause(), expectedException);
     }
 }


### PR DESCRIPTION
follow up to #11478

Changes in #11478 , caused ClientMapUnboundReturnValues_TxnTest
to fail. This pr aims to fix this test, preserving the behaviour
made in #11478

fixes #11537 