### PR TITLE
Improved output of thread leak tests

### DIFF
--- a/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
@@ -42,10 +42,13 @@ public class ThreadLeakClientTest extends AbstractThreadLeakTest {
     @Test
     public void testThreadLeak_withoutCluster() {
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
+        clientConfig.getConnectionStrategyConfig()
+                .setAsyncStart(true);
         clientConfig.getNetworkConfig()
                 .setConnectionAttemptLimit(Integer.MAX_VALUE);
+
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
         client.shutdown();
     }
 }

--- a/hazelcast/src/test/java/classloading/ThreadLeakTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTest.java
@@ -24,6 +24,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static classloading.ThreadLeakTestUtils.getAndLogThreads;
+import static classloading.ThreadLeakTestUtils.getThreads;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ThreadLeakTest extends AbstractThreadLeakTest {
@@ -32,5 +41,33 @@ public class ThreadLeakTest extends AbstractThreadLeakTest {
     public void testThreadLeak() {
         HazelcastInstance hz = Hazelcast.newHazelcastInstance();
         hz.shutdown();
+    }
+
+    @Test
+    public void testThreadLeakUtils() {
+        final Set<Thread> threads = getThreads();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        Thread thread = new Thread("leaking-thread") {
+            @Override
+            public void run() {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+        thread.start();
+
+        Thread[] runningThreads = getAndLogThreads("There should be one thread running!", threads);
+        assertNotNull("Expected to get running threads, but was null", runningThreads);
+        assertEquals("Expected exactly one running thread", 1, runningThreads.length);
+
+        latch.countDown();
+        assertJoinable(thread);
+
+        runningThreads = getAndLogThreads("There should be no threads running!", threads);
+        assertNull("Expected to get null, but found running threads", runningThreads);
     }
 }

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -55,7 +55,7 @@ public final class ThreadLeakTestUtils {
     }
 
     public static void assertHazelcastThreadShutdown(Set<Thread> oldThreads) {
-        Thread[] joinableThreads = getAndLogThreads("There are still Hazelcast threads running after shutdown!\n", oldThreads);
+        Thread[] joinableThreads = getAndLogThreads("There are still Hazelcast threads running after shutdown!", oldThreads);
         if (joinableThreads == null) {
             return;
         }
@@ -63,12 +63,12 @@ public final class ThreadLeakTestUtils {
         try {
             assertJoinable(ASSERT_TIMEOUT_SECONDS, joinableThreads);
         } catch (AssertionError e) {
-            getAndLogThreads("There are threads which survived assertJoinable()!\n", oldThreads);
+            getAndLogThreads("There are threads which survived assertJoinable()!", oldThreads);
             throw e;
         }
     }
 
-    private static Thread[] getAndLogThreads(String message, Set<Thread> oldThreads) {
+    public static Thread[] getAndLogThreads(String message, Set<Thread> oldThreads) {
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
         Thread[] joinableThreads = getJoinableThreads(oldThreads, stackTraces.keySet());
         if (joinableThreads.length == 0) {
@@ -103,7 +103,7 @@ public final class ThreadLeakTestUtils {
         StringBuilder sb = new StringBuilder(message);
         for (Thread thread : threads) {
             String stackTrace = Arrays.toString(stackTraces.get(thread));
-            sb.append(format("-> %s (id: %s) (group: %s) (daemon: %b) (alive: %b) (interrupted: %b) (state: %s)%n%s%n%n",
+            sb.append(format("%n-> %s (id: %s) (group: %s) (daemon: %b) (alive: %b) (interrupted: %b) (state: %s)%n%s%n",
                     thread.getName(), thread.getId(), getThreadGroupName(thread), thread.isDaemon(), thread.isAlive(),
                     thread.isInterrupted(), thread.getState(), stackTrace));
         }

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -31,6 +31,7 @@ import static com.hazelcast.test.HazelcastTestSupport.assertJoinable;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
+@SuppressWarnings("WeakerAccess")
 public final class ThreadLeakTestUtils {
 
     private static final int ASSERT_TIMEOUT_SECONDS = 300;
@@ -38,7 +39,7 @@ public final class ThreadLeakTestUtils {
     private static final ILogger LOGGER = Logger.getLogger(ThreadLeakTestUtils.class);
 
     static {
-        LOGGER.info("Initializing Logger (required for thread leak tests).");
+        LOGGER.info("Initializing Logger (required for thread leak tests)");
     }
 
     /**
@@ -54,22 +55,27 @@ public final class ThreadLeakTestUtils {
     }
 
     public static void assertHazelcastThreadShutdown(Set<Thread> oldThreads) {
-        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
-        Thread[] joinableThreads = getJoinableThreads(oldThreads, stackTraces.keySet());
-        if (joinableThreads.length == 0) {
+        Thread[] joinableThreads = getAndLogThreads("There are still Hazelcast threads running after shutdown!\n", oldThreads);
+        if (joinableThreads == null) {
             return;
         }
 
-        StringBuilder sb = new StringBuilder("There are still Hazelcast threads running after shutdown!\n");
-        for (Thread thread : joinableThreads) {
-            String stackTrace = Arrays.toString(stackTraces.get(thread));
-            sb.append(format("-> %s (id: %s) (group: %s) (daemon: %b) (alive: %b) (interrupted: %b) (state: %s)%n%s%n%n",
-                    thread.getName(), thread.getId(), getThreadGroupName(thread), thread.isDaemon(), thread.isAlive(),
-                    thread.isInterrupted(), thread.getState(), stackTrace));
+        try {
+            assertJoinable(ASSERT_TIMEOUT_SECONDS, joinableThreads);
+        } catch (AssertionError e) {
+            getAndLogThreads("There are threads which survived assertJoinable()!\n", oldThreads);
+            throw e;
         }
-        System.err.println(sb.toString());
+    }
 
-        assertJoinable(ASSERT_TIMEOUT_SECONDS, joinableThreads);
+    private static Thread[] getAndLogThreads(String message, Set<Thread> oldThreads) {
+        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+        Thread[] joinableThreads = getJoinableThreads(oldThreads, stackTraces.keySet());
+        if (joinableThreads.length == 0) {
+            return null;
+        }
+        logThreads(stackTraces, joinableThreads, message);
+        return joinableThreads;
     }
 
     private static Thread[] getJoinableThreads(Set<Thread> oldThreads, Set<Thread> newThreads) {
@@ -91,6 +97,17 @@ public final class ThreadLeakTestUtils {
                 iterator.remove();
             }
         }
+    }
+
+    private static void logThreads(Map<Thread, StackTraceElement[]> stackTraces, Thread[] threads, String message) {
+        StringBuilder sb = new StringBuilder(message);
+        for (Thread thread : threads) {
+            String stackTrace = Arrays.toString(stackTraces.get(thread));
+            sb.append(format("-> %s (id: %s) (group: %s) (daemon: %b) (alive: %b) (interrupted: %b) (state: %s)%n%s%n%n",
+                    thread.getName(), thread.getId(), getThreadGroupName(thread), thread.isDaemon(), thread.isAlive(),
+                    thread.isInterrupted(), thread.getState(), stackTrace));
+        }
+        LOGGER.severe(sb.toString());
     }
 
     private static String getThreadGroupName(Thread thread) {


### PR DESCRIPTION
* added a second thread stack trace dump after the `assertJoinable()` failed
* moved logging to `LOGGER.severe()` to have timestamps, which `System.out.err` don't provide
* added basic test for `ThreadLeakTestUtils` methods

No fix yet, but should provide better log output for https://github.com/hazelcast/hazelcast/issues/10628