### PR TITLE
fix user code deployment permission test

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -116,6 +116,18 @@ public class ClientUserCodeDeploymentTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testWithMultipleMembersAtStart() {
+        ClientConfig clientConfig = createClientConfig();
+        Config config = createNodeConfig();
+
+        factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+        assertCodeDeploymentWorking(client, new IncrementingEntryProcessor());
+    }
+
+    @Test
     public void testWithMultipleNodes_clientReconnectsToNewNode() {
         ClientConfig clientConfig = createClientConfig();
         Config config = createNodeConfig();

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/UserCodeDeploymentPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/UserCodeDeploymentPermissionTest.java
@@ -26,11 +26,11 @@ import java.security.Permission;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class UserCodeDeploymentPermissionTest extends AbstractGenericPermissionTest {
+public class UserCodeDeploymentPermissionTest extends PermissionTestSupport {
 
     @Override
     protected Permission createPermission(String name, String... actions) {
-        return new CardinalityEstimatorPermission(name, actions);
+        return new UserCodeDeploymentPermission(actions);
     }
 
     @Test
@@ -45,7 +45,7 @@ public class UserCodeDeploymentPermissionTest extends AbstractGenericPermissionT
 
     @Test
     public void checkAllPermission_whenDeploy() {
-        new CheckPermission().of("all").against("deploy").expect(false).run();
+        new CheckPermission().of("all").against("deploy").expect(true).run();
     }
 
 }


### PR DESCRIPTION
Detected by our code coverage reports. 
It was reporting that `UserCodeDeploymentPermission` was not tested. 
Internal coverage report link:
https://hazelcast-l337.sonar.cloudbees.com/resource/index/36418?display_title=true&metric=coverage

Second fix:
coverage report for DeployClassesOperation revealed that operation
was just running locally read/write methods were not tested.
With new test, coverage of `DeployClassesOperation` 100%