### PR TITLE
Avoid cache and map config lookup when writing to event journal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl.journal;
 
 import com.hazelcast.cache.CacheEventType;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.journal.EventJournal;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
@@ -52,13 +53,15 @@ public interface CacheEventJournal extends EventJournal<InternalEventJournalCach
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the cache namespace, containing the full prefixed cache name
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param oldValue    the old value
-     * @param newValue    the new value
+     * @param journalConfig the event journal config for the cache in which the event occurred
+     * @param namespace     the cache namespace, containing the full prefixed cache name
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param oldValue      the old value
+     * @param newValue      the new value
      */
-    void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue);
+    void writeUpdateEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                          Data key, Object oldValue, Object newValue);
 
     /**
      * Writes an {@link CacheEventType#CREATED} to the event journal.
@@ -66,12 +69,13 @@ public interface CacheEventJournal extends EventJournal<InternalEventJournalCach
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the cache namespace, containing the full prefixed cache name
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the cache in which the event occurred
+     * @param namespace     the cache namespace, containing the full prefixed cache name
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeCreatedEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeCreatedEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 
     /**
      * Writes an {@link CacheEventType#REMOVED} to the event journal.
@@ -79,12 +83,13 @@ public interface CacheEventJournal extends EventJournal<InternalEventJournalCach
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the cache namespace, containing the full prefixed cache name
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the cache in which the event occurred
+     * @param namespace     the cache namespace, containing the full prefixed cache name
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeRemoveEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 
     /**
      * Writes an {@link CacheEventType#EVICTED} to the event journal.
@@ -92,12 +97,13 @@ public interface CacheEventJournal extends EventJournal<InternalEventJournalCach
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the cache namespace, containing the full prefixed cache name
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the cache in which the event occurred
+     * @param namespace     the cache namespace, containing the full prefixed cache name
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeEvictEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 
     /**
      * Writes an {@link CacheEventType#EXPIRED} to the event journal.
@@ -105,10 +111,11 @@ public interface CacheEventJournal extends EventJournal<InternalEventJournalCach
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the cache namespace, containing the full prefixed cache name
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the cache in which the event occurred
+     * @param namespace     the cache namespace, containing the full prefixed cache name
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeExpiredEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeExpiredEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.IFunction;
@@ -110,6 +111,8 @@ public class MapContainer {
 
     protected volatile Evictor evictor;
     protected volatile MapConfig mapConfig;
+    protected final EventJournalConfig eventJournalConfig;
+
 
     /**
      * Operations which are done in this constructor should obey the rules defined
@@ -119,6 +122,7 @@ public class MapContainer {
     public MapContainer(final String name, final Config config, final MapServiceContext mapServiceContext) {
         this.name = name;
         this.mapConfig = config.findMapConfig(name);
+        this.eventJournalConfig = config.findMapEventJournalConfig(name);
         this.mapServiceContext = mapServiceContext;
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         this.partitioningStrategy = createPartitioningStrategy();
@@ -282,6 +286,10 @@ public class MapContainer {
 
     public void setMapConfig(MapConfig mapConfig) {
         this.mapConfig = mapConfig;
+    }
+
+    public EventJournalConfig getEventJournalConfig() {
+        return eventJournalConfig;
     }
 
     public String getName() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.journal;
 
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.journal.EventJournal;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
@@ -51,13 +52,15 @@ public interface MapEventJournal extends EventJournal<InternalEventJournalMapEve
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the map namespace
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param oldValue    the old value
-     * @param newValue    the new value
+     * @param journalConfig the event journal config for the map in which the event occurred
+     * @param namespace     the map namespace
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param oldValue      the old value
+     * @param newValue      the new value
      */
-    void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue);
+    void writeUpdateEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                          Data key, Object oldValue, Object newValue);
 
     /**
      * Writes an {@link com.hazelcast.core.EntryEventType#ADDED} to the event journal.
@@ -65,12 +68,14 @@ public interface MapEventJournal extends EventJournal<InternalEventJournalMapEve
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the map namespace
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the map in which the event occurred
+     * @param namespace     the map namespace
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeAddEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeAddEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                       Data key, Object value);
 
     /**
      * Writes an {@link com.hazelcast.core.EntryEventType#REMOVED} to the event journal.
@@ -78,12 +83,13 @@ public interface MapEventJournal extends EventJournal<InternalEventJournalMapEve
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the map namespace
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the map in which the event occurred
+     * @param namespace     the map namespace
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeRemoveEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 
     /**
      * Writes an {@link com.hazelcast.core.EntryEventType#EVICTED} to the event journal.
@@ -91,12 +97,13 @@ public interface MapEventJournal extends EventJournal<InternalEventJournalMapEve
      * If an event is added to the event journal, all parked operations waiting for
      * new events on that journal will be unparked.
      *
-     * @param namespace   the map namespace
-     * @param partitionId the entry key partition
-     * @param key         the entry key
-     * @param value       the entry value
+     * @param journalConfig the event journal config for the map in which the event occurred
+     * @param namespace     the map namespace
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
      */
-    void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value);
+    void writeEvictEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 
     /**
      * Returns {@code true} if the object has a configured and enabled event journal.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -56,23 +56,27 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
     }
 
     @Override
-    public void writeUpdateEvent(ObjectNamespace namespace, int partitionId, Data key, Object oldValue, Object newValue) {
-        addToEventRingbuffer(namespace, partitionId, UPDATED, key, oldValue, newValue);
+    public void writeUpdateEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                                 Data key, Object oldValue, Object newValue) {
+        addToEventRingbuffer(journalConfig, namespace, partitionId, UPDATED, key, oldValue, newValue);
     }
 
     @Override
-    public void writeAddEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
-        addToEventRingbuffer(namespace, partitionId, ADDED, key, null, value);
+    public void writeAddEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                              Data key, Object value) {
+        addToEventRingbuffer(journalConfig, namespace, partitionId, ADDED, key, null, value);
     }
 
     @Override
-    public void writeRemoveEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
-        addToEventRingbuffer(namespace, partitionId, REMOVED, key, value, null);
+    public void writeRemoveEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                                 Data key, Object value) {
+        addToEventRingbuffer(journalConfig, namespace, partitionId, REMOVED, key, value, null);
     }
 
     @Override
-    public void writeEvictEvent(ObjectNamespace namespace, int partitionId, Data key, Object value) {
-        addToEventRingbuffer(namespace, partitionId, EVICTED, key, value, null);
+    public void writeEvictEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                                Data key, Object value) {
+        addToEventRingbuffer(journalConfig, namespace, partitionId, EVICTED, key, value, null);
     }
 
     @Override
@@ -149,8 +153,11 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
                 .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
     }
 
-    private void addToEventRingbuffer(ObjectNamespace namespace, int partitionId, EntryEventType eventType,
-                                      Data key, Object oldValue, Object newValue) {
+    private void addToEventRingbuffer(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
+                                      EntryEventType eventType, Data key, Object oldValue, Object newValue) {
+        if (journalConfig == null || !journalConfig.isEnabled()) {
+            return;
+        }
         final RingbufferContainer<InternalEventJournalMapEvent> eventContainer = getRingbufferOrNull(namespace, partitionId);
         if (eventContainer == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -133,7 +133,8 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     protected void updateRecord(Data key, Record record, Object value, long now) {
         updateStatsOnPut(false, now);
         record.onUpdate(now);
-        eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue(), value);
+        eventJournal.writeUpdateEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                record.getKey(), record.getValue(), value);
         storage.updateRecordValue(key, record, value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -230,7 +230,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void putRecord(Data key, Record record) {
         markRecordStoreExpirable(record.getTtl());
         storage.put(key, record);
-        eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
+        eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                key, record.getValue());
         updateStatsOnPut(record.getHits());
     }
 
@@ -248,7 +249,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             record = createRecord(value, ttl, now);
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    key, record.getValue());
         } else {
             updateRecord(key, record, value, now);
         }
@@ -432,7 +434,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (value != null) {
             record = createRecord(value, DEFAULT_TTL, getNow());
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    key, record.getValue());
             if (!backup) {
                 saveIndex(record, null);
             }
@@ -476,7 +479,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         Iterator<Record> iterator = recordsToRemove.iterator();
         while (iterator.hasNext()) {
             Record record = iterator.next();
-            eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+            eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    record.getKey(), record.getValue());
             storage.removeRecord(record);
             updateStatsOnRemove(record.getHits());
             iterator.remove();
@@ -524,7 +528,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = record.getValue();
             mapDataStore.flush(key, value, backup);
             removeIndex(record);
-            eventJournal.writeEvictEvent(mapContainer.getObjectNamespace(), partitionId, key, value);
+            eventJournal.writeEvictEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    key, value);
             storage.removeRecord(record);
             updateStatsOnRemove(record.getHits());
             if (!backup) {
@@ -552,7 +557,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             return;
         }
-        eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+        eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                record.getKey(), record.getValue());
         storage.removeRecord(record);
         updateStatsOnRemove(record.getHits());
         mapDataStore.removeBackup(key, now);
@@ -597,7 +603,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             removeIndex(record);
             mapDataStore.remove(key, now);
             onStore(record);
-            eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, key, oldValue);
+            eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    key, oldValue);
             storage.removeRecord(record);
             updateStatsOnRemove(record.getHits());
             removed = true;
@@ -784,7 +791,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (record == null) {
             record = createRecord(value, ttl, now);
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    record.getKey(), record.getValue());
         } else {
             updateRecord(key, record, value, now);
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
@@ -814,7 +822,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             record = createRecord(newValue, DEFAULT_TTL, now);
             mergeRecordExpiration(record, mergingEntry);
             storage.put(key, record);
-            eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, key, null, record.getValue());
+            eventJournal.writeUpdateEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    key, null, record.getValue());
         } else {
             oldValue = record.getValue();
             EntryView existingEntry = EntryViews.createLazyEntryView(record.getKey(), record.getValue(),
@@ -825,7 +834,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 removeIndex(record);
                 mapDataStore.remove(key, now);
                 onStore(record);
-                eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, key, oldValue, null);
+                eventJournal.writeUpdateEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(),
+                        partitionId, key, oldValue, null);
                 storage.removeRecord(record);
                 updateStatsOnRemove(record.getHits());
                 return true;
@@ -839,7 +849,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             }
             newValue = mapDataStore.add(key, newValue, now);
             onStore(record);
-            eventJournal.writeUpdateEvent(mapContainer.getObjectNamespace(), partitionId, key, oldValue, newValue);
+            eventJournal.writeUpdateEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    key, oldValue, newValue);
             storage.updateRecordValue(key, record, newValue);
         }
         saveIndex(record, oldValue);
@@ -901,7 +912,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    record.getKey(), record.getValue());
         } else {
             oldValue = record.getValue();
             value = mapServiceContext.interceptPut(name, oldValue, value);
@@ -946,7 +958,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    record.getKey(), record.getValue());
         } else {
             oldValue = record.getValue();
             value = mapServiceContext.interceptPut(name, oldValue, value);
@@ -992,7 +1005,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             if (oldValue != null) {
                 record = createRecord(oldValue, DEFAULT_TTL, now);
                 storage.put(key, record);
-                eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+                eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                        record.getKey(), record.getValue());
             }
         } else {
             accessRecord(record, now);
@@ -1004,7 +1018,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             onStore(record);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                    record.getKey(), record.getValue());
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
         }
         saveIndex(record, oldValue);
@@ -1025,7 +1040,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             mapDataStore.remove(key, now);
             onStore(record);
         }
-        eventJournal.writeRemoveEvent(mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
+        eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
+                record.getKey(), record.getValue());
         storage.removeRecord(record);
         updateStatsOnRemove(record.getHits());
         return oldValue;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.ringbuffer.impl.operations;
 
+import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.journal.CacheEventJournal;
 import com.hazelcast.config.EventJournalConfig;
@@ -65,6 +66,21 @@ public class ReplicationOperation extends Operation implements IdentifiedDataSer
         }
     }
 
+    /**
+     * Returns the ringbuffer config for the provided namespace. The namespace
+     * provides information whether the requested ringbuffer is a ringbuffer
+     * that the user is directly interacting with through a ringbuffer proxy
+     * or if this is a backing ringbuffer for an event journal.
+     * If a ringbuffer configuration for an event journal is requested, this
+     * method will expect the configuration for the relevant map or cache
+     * to be available.
+     *
+     * @param service the ringbuffer service
+     * @param ns      the object namespace for which we are creating a ringbuffer
+     * @return the ringbuffer configuration
+     * @throws CacheNotExistsException if a config for a cache event journal was requested
+     *                                 and the cache configuration was not found
+     */
     private RingbufferConfig getRingbufferConfig(RingbufferService service, ObjectNamespace ns) {
         final String serviceName = ns.getServiceName();
         if (RingbufferService.SERVICE_NAME.equals(serviceName)) {


### PR DESCRIPTION
This caused two issues:
- the cache config might not be available at a certain moment because
the cache has been destroyed concurrently
- if the event journal is disabled, the config lookup is done on every
action to the map or cache

Instead, we lookup the journal config on initialization of the cache
record store and map container and provide it to the event journal API.

Fixes: https://github.com/hazelcast/hazelcast/issues/11519#issuecomment-335521593
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/1766