### PR TITLE
QueryEngine improvements & Partition processing batching

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryDispatcher.java
@@ -32,6 +32,7 @@ import com.hazelcast.util.executor.ManagedExecutorService;
 import com.hazelcast.version.Version;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -115,14 +116,15 @@ final class QueryDispatcher {
     }
 
     protected List<Future<Result>> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
-            Query query, Collection<Integer> partitionIds) {
+            Query query, BitSet partitionIds) {
         if (shouldSkipPartitionsQuery(partitionIds)) {
             return Collections.emptyList();
         }
-
         List<Future<Result>> futures = new ArrayList<Future<Result>>(partitionIds.size());
-        for (Integer partitionId : partitionIds) {
-            futures.add(dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(query, partitionId));
+        for (int partitionId = 0; partitionId < partitionIds.length(); partitionId++) {
+            if (partitionIds.get(partitionId)) {
+                futures.add(dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(query, partitionId));
+            }
         }
         return futures;
     }
@@ -147,7 +149,7 @@ final class QueryDispatcher {
         }
     }
 
-    private static boolean shouldSkipPartitionsQuery(Collection<Integer> partitionIds) {
+    private static boolean shouldSkipPartitionsQuery(BitSet partitionIds) {
         return partitionIds == null || partitionIds.isEmpty();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -33,7 +33,6 @@ import com.hazelcast.spi.OperationService;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -123,7 +122,7 @@ public class QueryRunner {
         return populateResult(query, initialPartitions, entries);
     }
 
-    // MIGRATION UNSAFE QUERYING - MIGRATION STAMPTS ARE NOT VALIDATED, so assumes a run on partition-thread
+    // MIGRATION UNSAFE QUERYING - MIGRATION STAMPS ARE NOT VALIDATED, so assumes a run on partition-thread
     // for a single partition. If the index is global it won't be asked
     public Result runPartitionIndexOrPartitionScanQueryOnGivenOwnedPartition(Query query, int partitionId) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
@@ -142,31 +141,6 @@ public class QueryRunner {
         }
 
         updateStatistics(mapContainer);
-        return populateResult(query, partitions, entries);
-    }
-
-    // MIGRATION UNSAFE QUERYING - MIGRATION STAMPTS ARE NOT VALIDATED, so assumes a run on partition-thread
-    // for a single partition. If the index is global it won't be asked
-    public Result runPartitionIndexOrPartitionScanQueryOnGivenOwnedPartition(Query query, Collection<Integer> partitions) {
-        MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
-
-        Predicate predicate = null;
-        Collection<QueryableEntry> entries = new LinkedList<QueryableEntry>();
-        for (int partitionId : partitions) {
-            if (predicate == null) {
-                predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes(partitionId));
-            }
-            Indexes indexes = mapContainer.getIndexes(partitionId);
-            if (indexes != null && !indexes.isGlobal()) {
-                Collection<QueryableEntry> partitionEntries = indexes.query(predicate);
-                if (partitionEntries == null) {
-                    partitionEntries = partitionScanExecutor.execute(query.getMapName(), predicate, partitions);
-                }
-                entries.addAll(partitionEntries);
-            }
-        }
-
-        // updateStatistics(mapContainer);
         return populateResult(query, partitions, entries);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl.batching;
+
+/**
+ * Partition callable that is guaranteed to have an exclusive Read-Write access to partition data.
+ * Typically created by the {@link PartitionAwareCallableFactory}
+ *
+ * @param <V> type of result
+ * @see PartitionAwareCallableFactory
+ * @see PartitionAwareCallableBatchingRunnable
+ * @since 3.9
+ */
+public interface PartitionAwareCallable<V> {
+
+    /**
+     * @param partitionId partitionId of the partition the callable is executed for
+     * @return call result
+     */
+    V call(int partitionId);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl.batching;
+
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.AbstractCompletableFuture;
+import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.partition.IPartitionService;
+import com.hazelcast.util.ThreadUtil;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * If run on partition thread, it will discover what thread it is run on, and it will run an instance of
+ * PartitionAwareCallable on all partitions this thread is responsible for.
+ *
+ * PartitionAwareCallable will be created using the PartitionAwareCallableFactory class.
+ * There will be one PartitionAwareCallable created per each run() method execution.
+ *
+ * IMPORTANT:
+ * <ul>
+ * <li>Runnable assumes to be run on a partition-thread. If not run on a partition-thread a RuntimeException will be thrown.</li>
+ * <li>This optimization highly relies on the threading-model and has been implemented to speed up invocations that span all
+ * partitions, e.g. HD-index-query, or potentially many more like IMap.size(), etc.</li>
+ * <li>This is a temporary solution to improve performance. Once we get to change the threading model this mechanism
+ * will be removed.</li>
+ * </ul>
+ *
+ * @see PartitionAwareCallable
+ * @see PartitionAwareCallableFactory
+ * @since 3.9
+ */
+public class PartitionAwareCallableBatchingRunnable implements Runnable {
+
+    private final PartitionAwareCallableFactory factory;
+    private final IPartitionService partitionService;
+    private final int partitionThreadCount;
+
+    private final CopyOnWriteArrayList results = new CopyOnWriteArrayList();
+    private final AtomicInteger finished = new AtomicInteger(0);
+
+    private final ResultFuture future;
+
+    /**
+     * @param nodeEngine nodeEngine
+     * @param factory    factory of PartitionAwareCallable to be run on the partition thread.
+     */
+    public PartitionAwareCallableBatchingRunnable(NodeEngine nodeEngine, PartitionAwareCallableFactory factory) {
+        this.factory = factory;
+        this.partitionService = nodeEngine.getPartitionService();
+        this.partitionThreadCount = ((OperationServiceImpl) nodeEngine.getOperationService()).getPartitionThreadCount();
+        this.future = new ResultFuture(nodeEngine, nodeEngine.getLogger(getClass()));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void run() {
+        ThreadUtil.assertRunningOnPartitionThread();
+        PartitionOperationThread currentThread = ((PartitionOperationThread) Thread.currentThread());
+        int currentPartitionId = currentThread.getThreadId();
+        try {
+            IPartition[] partitions = partitionService.getPartitions();
+            runSequentially(currentThread, currentPartitionId, partitions);
+        } finally {
+            int value = finished.incrementAndGet();
+            if (!future.isDone() && value == partitionThreadCount) {
+                future.setResult(results);
+            }
+        }
+    }
+
+    /**
+     * Runs the PartitionAwareCallable instantiated by PartitionAwareCallableFactory on all partitions from given
+     * partitions array that the given PartitionOperationThread is responsible for.
+     *
+     * @param currentThread   thread that the runnable runs in
+     * @param fromPartitionId partitionId to start the processing from
+     * @param partitions      all partitions
+     */
+    private void runSequentially(PartitionOperationThread currentThread, int fromPartitionId, IPartition[] partitions) {
+        int currentPartitionId = fromPartitionId;
+        while (currentPartitionId < partitions.length) {
+            if (future.isDone()) {
+                return;
+            }
+            final IPartition partition = partitions[currentPartitionId];
+            if (currentThread.isInterrupted()) {
+                future.cancel(true);
+                break;
+            }
+            PartitionAwareCallable task = factory.create();
+            if (partition.isLocal()) {
+                try {
+                    results.add(task.call(currentPartitionId));
+                } catch (Exception ex) {
+                    future.setResult(ex);
+                    break;
+                }
+            }
+            currentPartitionId += partitionThreadCount;
+        }
+    }
+
+    public ICompletableFuture getFuture() {
+        return future;
+    }
+
+    private class ResultFuture extends AbstractCompletableFuture {
+        protected ResultFuture(NodeEngine nodeEngine, ILogger logger) {
+            super(nodeEngine, logger);
+        }
+
+        protected void setResult(Object result) {
+            super.setResult(result);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl.batching;
+
+/**
+ * Factory used to instantiate {@link PartitionAwareCallable} instances
+ *
+ * @see PartitionAwareCallable
+ * @see PartitionAwareCallableBatchingRunnable
+ * @since 3.9
+ */
+public interface PartitionAwareCallableFactory<V> {
+
+    /**
+     * Factory method that instantiates {@link PartitionAwareCallable} instances
+     *
+     * @return a new instance of a concrete implmentation of the PartitionAwareCallable
+     */
+    PartitionAwareCallable<V> create();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
@@ -44,6 +44,23 @@ public final class BitSetUtils {
     }
 
     /**
+     * Returns true if at least one bit on a given position is set.
+     *
+     * @param bitSet  the {@link BitSet} to modify
+     * @param indexes the index positions to check
+     * @return {@code true} is {@link BitSet} contains at least one bit at any position from index which is set,
+     * otherwise return {@code false}
+     */
+    public static boolean hasAllBitsSet(BitSet bitSet, Iterable<Integer> indexes) {
+        for (Integer index : indexes) {
+            if (!bitSet.get(index)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Set all bits on a given positions.
      *
      * @param bitSet  the {@link BitSet} to modify
@@ -52,6 +69,18 @@ public final class BitSetUtils {
     public static void setBits(BitSet bitSet, Iterable<Integer> indexes) {
         for (Integer index : indexes) {
             bitSet.set(index);
+        }
+    }
+
+    /**
+     * Unsets all bits on a given positions.
+     *
+     * @param bitSet  the {@link BitSet} to modify
+     * @param indexes the index positions to set
+     */
+    public static void unsetBits(BitSet bitSet, Iterable<Integer> indexes) {
+        for (Integer index : indexes) {
+            bitSet.set(index, false);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
@@ -31,8 +31,8 @@ public final class BitSetUtils {
      *
      * @param bitSet  the {@link BitSet} to modify
      * @param indexes the index positions to check
-     * @return {@code true} is {@link BitSet} contains at least one bit at any position from index which is set,
-     * otherwise return {@code false}
+     * @return {@code true} if {@link BitSet} contains at least one bit at any position from index which is set,
+     * otherwise returns {@code false}
      */
     public static boolean hasAtLeastOneBitSet(BitSet bitSet, Iterable<Integer> indexes) {
         for (Integer index : indexes) {
@@ -44,12 +44,12 @@ public final class BitSetUtils {
     }
 
     /**
-     * Returns true if at least one bit on a given position is set.
+     * Returns true if all bits at given {@code indexes} are set.
      *
      * @param bitSet  the {@link BitSet} to modify
      * @param indexes the index positions to check
-     * @return {@code true} is {@link BitSet} contains at least one bit at any position from index which is set,
-     * otherwise return {@code false}
+     * @return {@code true} if {@link BitSet} all bits at given {@code indexes} are set.
+     * otherwise returns {@code false}
      */
     public static boolean hasAllBitsSet(BitSet bitSet, Iterable<Integer> indexes) {
         for (Integer index : indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1840,7 +1840,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
 
         Operation operation = new MultipleEntryWithPredicateOperation(MAP_NAME, dataKeys,
-                new NOOPEntryProcessor(), new SqlPredicate("this < " + keyCount));
+                new NoOpEntryProcessor(), new SqlPredicate("this < " + keyCount));
 
         OperationFactory operationFactory = new BinaryOperationFactory(operation, nodeEngineImpl);
 
@@ -1848,13 +1848,6 @@ public class EntryProcessorTest extends HazelcastTestSupport {
 
         for (Object response : partitionResponses.values()) {
             assertEquals(0, ((MapEntries) response).size());
-        }
-    }
-
-    public static class NOOPEntryProcessor extends AbstractEntryProcessor {
-        @Override
-        public Object process(Map.Entry entry) {
-            return null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnableTest.java
@@ -1,0 +1,83 @@
+package com.hazelcast.spi.impl.operationservice.impl.batching;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@RequireAssertEnabled
+@Category({QuickTest.class, ParallelTest.class})
+public class PartitionAwareCallableBatchingRunnableTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void test_NotRunningOnPartitionThread() {
+        PartitionAwareCallableBatchingRunnable runnable = new PartitionAwareCallableBatchingRunnable(
+                getNodeEngineImpl(createHazelcastInstance()), new TestPartitionAwareCallableFactory());
+
+        exception.expect(AssertionError.class);
+        runnable.run();
+    }
+
+    @Test
+    public void test_whenRunningOnPartitionThread() throws IllegalAccessException, ExecutionException, InterruptedException {
+        HazelcastInstance hz = createHazelcastInstance();
+        PartitionAwareCallableBatchingRunnable runnable = new PartitionAwareCallableBatchingRunnable(
+                getNodeEngineImpl(hz), new TestPartitionAwareCallableFactory());
+
+        // init data and partitions
+        IMap map = hz.getMap("testMap");
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i);
+        }
+
+        OperationServiceImpl ops = ((OperationServiceImpl) getNodeEngineImpl(hz).getOperationService());
+        int partitionCount = getNodeEngineImpl(hz).getPartitionService().getPartitionCount();
+
+        OperationExecutorImpl executor = (OperationExecutorImpl) ops.getOperationExecutor();
+        executor.executeOnPartitionThreads(runnable);
+        List result = (List) runnable.getFuture().get();
+
+        assertTrue(runnable.getFuture().isDone());
+        assertEquals(partitionCount, result.size());
+        Set sortedResult = new TreeSet(result);
+        for (int i = 0; i < partitionCount; i++) {
+            assertTrue(sortedResult.contains(i));
+        }
+    }
+
+    private static class TestPartitionAwareCallableFactory implements PartitionAwareCallableFactory {
+        @Override
+        public PartitionAwareCallable create() {
+            return new TestPartitionAwareCallable();
+        }
+    }
+
+    private static class TestPartitionAwareCallable implements PartitionAwareCallable {
+        @Override
+        public Object call(int partitionId) {
+            return partitionId;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/BitSetUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/BitSetUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -77,6 +78,47 @@ public class BitSetUtilsTest extends HazelcastTestSupport {
         BitSetUtils.setBits(bitSet, indexes);
         assertBitsAtPositionsAreSet(bitSet, indexes);
     }
+
+
+    @Test
+    public void hasAllBitsSet_true() {
+        bitSet.set(1);
+        bitSet.set(3);
+        bitSet.set(5);
+
+        assertTrue(BitSetUtils.hasAllBitsSet(bitSet, asList(1, 3, 5)));
+        assertTrue(BitSetUtils.hasAllBitsSet(bitSet, asList(3, 5)));
+    }
+
+    @Test
+    public void hasAllBitsSet_false() {
+        bitSet.set(1);
+        bitSet.set(3);
+        bitSet.set(5);
+
+        assertFalse(BitSetUtils.hasAllBitsSet(bitSet, asList(2, 4, 6)));
+        assertFalse(BitSetUtils.hasAllBitsSet(bitSet, asList(3, 5, 6)));
+    }
+
+    @Test
+    public void unsetBits() {
+        bitSet.set(0, 4);
+        BitSetUtils.unsetBits(bitSet, asList(0, 1, 2, 3, 4));
+
+        assertTrue(bitSet.isEmpty());
+    }
+
+    @Test
+    public void unsetBits_individual() {
+        bitSet.set(0, 2);
+        BitSetUtils.unsetBits(bitSet, asList(0));
+
+        assertFalse(bitSet.get(0));
+        assertTrue(bitSet.get(1));
+    }
+
+    // public static void unsetBits(BitSet bitSet, Iterable<Integer> indexes);
+
 
     private static void assertBitsAtPositionsAreSet(BitSet bitSet, List<Integer> indexes) {
         for (int index : indexes) {


### PR DESCRIPTION
2 separate commits

- first changes the usage of list to BitSet (much faster for a local query)
- second introduces a mechanism to batch the processing for all partitions a thread is responsible for on a single partition-thread ride. Will be used in HD-indexes query only for now. May be explored further once we have interleaving in place. Speeds up the HD-index query 2.2 times.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/1767

Unit test included. It's integration-tested in the EE repo where the query engine uses this mechanism.
