### PR TITLE
OperationExecutor extends LiveOperationsTracker

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.impl.operationexecutor;
 
-import com.hazelcast.spi.LiveOperations;
+import com.hazelcast.spi.LiveOperationsTracker;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
@@ -34,7 +34,7 @@ import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
  * The actual processing of a operation-packet, Operation, or a PartitionSpecificRunnable is forwarded to the
  * {@link OperationRunner}.
  */
-public interface OperationExecutor extends PacketHandler {
+public interface OperationExecutor extends PacketHandler, LiveOperationsTracker {
 
     // Will be replaced by metrics
     @Deprecated
@@ -128,8 +128,6 @@ public interface OperationExecutor extends PacketHandler {
      * @throws java.lang.NullPointerException if op is null.
      */
     void runOrExecute(Operation op);
-
-    void scan(LiveOperations result);
 
     /**
      * Checks if the {@link Operation} is allowed to run on the current thread.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -238,9 +238,9 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     }
 
     @Override
-    public void scan(LiveOperations result) {
-        scan(partitionOperationRunners, result);
-        scan(genericOperationRunners, result);
+    public void populate(LiveOperations liveOperations) {
+        scan(partitionOperationRunners, liveOperations);
+        scan(genericOperationRunners, liveOperations);
     }
 
     private void scan(OperationRunner[] runners, LiveOperations result) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -254,7 +254,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     @Override
     public void populate(LiveOperations liveOperations) {
-        operationExecutor.scan(liveOperations);
+        operationExecutor.populate(liveOperations);
 
         for (Operation op : asyncOperations) {
             liveOperations.add(op.getCallerAddress(), op.getCallId());


### PR DESCRIPTION
So instead of having a 'scan' method; it has the populate method from
the LiveOperationsTracker interface.