### PR TITLE
Increased code coverage of HazelcastClientOfflineException

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientOfflineException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientOfflineException.java
@@ -24,8 +24,4 @@ public class HazelcastClientOfflineException extends IllegalStateException {
     public HazelcastClientOfflineException(String message) {
         super(message);
     }
-
-    public HazelcastClientOfflineException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }


### PR DESCRIPTION
That constructor is unused, so the class has just 50% code coverage.