### PR TITLE
Improve code coverage of equals & hashCode methods in some config classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -749,11 +749,11 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof CacheSimpleConfig)) {
             return false;
         }
 
@@ -838,7 +838,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + (keyType != null ? keyType.hashCode() : 0);
         result = 31 * result + (valueType != null ? valueType.hashCode() : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -116,11 +116,11 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof CacheSimpleEntryListenerConfig)) {
             return false;
         }
 
@@ -142,7 +142,7 @@ public class CacheSimpleEntryListenerConfig implements IdentifiedDataSerializabl
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = cacheEntryListenerFactory != null ? cacheEntryListenerFactory.hashCode() : 0;
         result = 31 * result + (cacheEntryEventFilterFactory != null ? cacheEntryEventFilterFactory.hashCode() : 0);
         result = 31 * result + (oldValueRequired ? 1 : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -184,11 +184,11 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof CardinalityEstimatorConfig)) {
             return false;
         }
 
@@ -203,14 +203,15 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + backupCount;
         result = 31 * result + asyncBackupCount;
         return result;
     }
 
-    private static class CardinalityEstimatorConfigReadOnly extends CardinalityEstimatorConfig {
+    // not private for testing
+    static class CardinalityEstimatorConfigReadOnly extends CardinalityEstimatorConfig {
 
         CardinalityEstimatorConfigReadOnly(CardinalityEstimatorConfig config) {
             super(config);

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -248,11 +248,11 @@ public abstract class CollectionConfig<T extends CollectionConfig>
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof CollectionConfig)) {
             return false;
         }
 
@@ -276,7 +276,7 @@ public abstract class CollectionConfig<T extends CollectionConfig>
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + getItemListenerConfigs().hashCode();
         result = 31 * result + backupCount;

--- a/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
@@ -200,11 +200,11 @@ public class DurableExecutorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof DurableExecutorConfig)) {
             return false;
         }
 
@@ -222,7 +222,7 @@ public class DurableExecutorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + poolSize;
         result = 31 * result + durability;
@@ -230,7 +230,8 @@ public class DurableExecutorConfig implements IdentifiedDataSerializable {
         return result;
     }
 
-    private static class DurableExecutorConfigReadOnly extends DurableExecutorConfig {
+    // not private for testing
+    static class DurableExecutorConfigReadOnly extends DurableExecutorConfig {
 
         DurableExecutorConfigReadOnly(DurableExecutorConfig config) {
             super(config);

--- a/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
@@ -255,11 +255,11 @@ public class EventJournalConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings("checkstyle:npathcomplexity")
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof EventJournalConfig)) {
             return false;
         }
 
@@ -280,7 +280,7 @@ public class EventJournalConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = mapName != null ? mapName.hashCode() : 0;
         result = 31 * result + (cacheName != null ? cacheName.hashCode() : 0);
         result = 31 * result + (enabled ? 1 : 0);
@@ -289,8 +289,9 @@ public class EventJournalConfig implements IdentifiedDataSerializable {
         return result;
     }
 
+    // not private for testing
     @Beta
-    private static class EventJournalConfigReadOnly extends EventJournalConfig {
+    static class EventJournalConfigReadOnly extends EventJournalConfig {
         EventJournalConfigReadOnly(EventJournalConfig config) {
             super(config);
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -338,11 +338,11 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof EvictionConfig)) {
             return false;
         }
 
@@ -365,7 +365,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = size;
         result = 31 * result + (maxSizePolicy != null ? maxSizePolicy.hashCode() : 0);
         result = 31 * result + (evictionPolicy != null ? evictionPolicy.hashCode() : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -198,11 +198,11 @@ public class ExecutorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ExecutorConfig)) {
             return false;
         }
 
@@ -221,7 +221,7 @@ public class ExecutorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + poolSize;
         result = 31 * result + queueCapacity;

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
@@ -108,11 +108,11 @@ public class HotRestartConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof HotRestartConfig)) {
             return false;
         }
 
@@ -124,7 +124,7 @@ public class HotRestartConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = (enabled ? 1 : 0);
         result = 31 * result + (fsync ? 1 : 0);
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
@@ -152,11 +152,11 @@ public class LockConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof LockConfig)) {
             return false;
         }
 
@@ -168,7 +168,7 @@ public class LockConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (quorumName != null ? quorumName.hashCode() : 0);
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -866,11 +866,11 @@ public class MapConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings("checkstyle:methodlength")
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MapConfig)) {
             return false;
         }
 
@@ -956,7 +956,7 @@ public class MapConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + backupCount;
         result = 31 * result + asyncBackupCount;
@@ -977,6 +977,7 @@ public class MapConfig implements IdentifiedDataSerializable {
         result = 31 * result + getMapIndexConfigs().hashCode();
         result = 31 * result + getMapAttributeConfigs().hashCode();
         result = 31 * result + getQueryCacheConfigs().hashCode();
+        result = 31 * result + getPartitionLostListenerConfigs().hashCode();
         result = 31 * result + (statisticsEnabled ? 1 : 0);
         result = 31 * result + (partitioningStrategyConfig != null ? partitioningStrategyConfig.hashCode() : 0);
         result = 31 * result + (quorumName != null ? quorumName.hashCode() : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
@@ -168,11 +168,11 @@ public class MapIndexConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MapIndexConfig)) {
             return false;
         }
 
@@ -184,7 +184,7 @@ public class MapIndexConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = attribute != null ? attribute.hashCode() : 0;
         result = 31 * result + (ordered ? 1 : 0);
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -341,7 +341,7 @@ public class MapStoreConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
@@ -384,7 +384,7 @@ public class MapStoreConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:npathcomplexity"})
-    public int hashCode() {
+    public final int hashCode() {
         final int prime = 31;
         int result = (enabled ? 1 : 0);
         result = prime * result + (writeCoalescing ? 1 : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
@@ -185,11 +185,11 @@ public class MaxSizeConfig implements DataSerializable, Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MaxSizeConfig)) {
             return false;
         }
 
@@ -201,7 +201,7 @@ public class MaxSizeConfig implements DataSerializable, Serializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = maxSizePolicy != null ? maxSizePolicy.hashCode() : 0;
         result = 31 * result + size;
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
@@ -498,11 +498,11 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof QueryCacheConfig)) {
             return false;
         }
 
@@ -547,7 +547,7 @@ public class QueryCacheConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings("checkstyle:npathcomplexity")
-    public int hashCode() {
+    public final int hashCode() {
         int result = batchSize;
         result = 31 * result + bufferSize;
         result = 31 * result + delaySeconds;

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -363,11 +363,11 @@ public class QueueConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof QueueConfig)) {
             return false;
         }
 
@@ -378,7 +378,7 @@ public class QueueConfig implements IdentifiedDataSerializable {
         if (asyncBackupCount != that.asyncBackupCount) {
             return false;
         }
-        if (getMaxSize() != getMaxSize()) {
+        if (getMaxSize() != that.getMaxSize()) {
             return false;
         }
         if (emptyQueueTtl != that.emptyQueueTtl) {
@@ -401,7 +401,7 @@ public class QueueConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + getItemListenerConfigs().hashCode();
         result = 31 * result + backupCount;

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -168,11 +168,11 @@ public class QueueStoreConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof QueueStoreConfig)) {
             return false;
         }
 
@@ -200,7 +200,7 @@ public class QueueStoreConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings("checkstyle:npathcomplexity")
-    public int hashCode() {
+    public final int hashCode() {
         int result = (isEnabled() ? 1 : 0);
         result = 31 * result + (getClassName() != null ? getClassName().hashCode() : 0);
         result = 31 * result + (getFactoryClassName() != null ? getFactoryClassName().hashCode() : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -322,11 +322,11 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ReliableTopicConfig)) {
             return false;
         }
 
@@ -351,7 +351,7 @@ public class ReliableTopicConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = executor != null ? executor.hashCode() : 0;
         result = 31 * result + readBatchSize;
         result = 31 * result + name.hashCode();

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -368,21 +368,15 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ReplicatedMapConfig)) {
             return false;
         }
 
         ReplicatedMapConfig that = (ReplicatedMapConfig) o;
-        if (concurrencyLevel != that.concurrencyLevel) {
-            return false;
-        }
-        if (replicationDelayMillis != that.replicationDelayMillis) {
-            return false;
-        }
         if (asyncFillup != that.asyncFillup) {
             return false;
         }
@@ -395,11 +389,6 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable {
         if (inMemoryFormat != that.inMemoryFormat) {
             return false;
         }
-        if (replicatorExecutorService != null
-                ? !replicatorExecutorService.equals(that.replicatorExecutorService)
-                : that.replicatorExecutorService != null) {
-            return false;
-        }
         if (mergePolicy != null ? !mergePolicy.equals(that.mergePolicy) : that.mergePolicy != null) {
             return false;
         }
@@ -408,12 +397,9 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings("checkstyle:npathcomplexity")
-    public int hashCode() {
+    public final int hashCode() {
         int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + concurrencyLevel;
-        result = 31 * result + (int) (replicationDelayMillis ^ (replicationDelayMillis >>> 32));
         result = 31 * result + (inMemoryFormat != null ? inMemoryFormat.hashCode() : 0);
-        result = 31 * result + (replicatorExecutorService != null ? replicatorExecutorService.hashCode() : 0);
         result = 31 * result + (asyncFillup ? 1 : 0);
         result = 31 * result + (statisticsEnabled ? 1 : 0);
         result = 31 * result + (mergePolicy != null ? mergePolicy.hashCode() : 0);

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -362,11 +362,11 @@ public class RingbufferConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof RingbufferConfig)) {
             return false;
         }
 
@@ -394,7 +394,7 @@ public class RingbufferConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + capacity;
         result = 31 * result + backupCount;

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
@@ -168,11 +168,11 @@ public class RingbufferStoreConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof RingbufferStoreConfig)) {
             return false;
         }
 
@@ -201,7 +201,7 @@ public class RingbufferStoreConfig implements IdentifiedDataSerializable {
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public int hashCode() {
+    public final int hashCode() {
         int result = (enabled ? 1 : 0);
         result = 31 * result + (className != null ? className.hashCode() : 0);
         result = 31 * result + (factoryClassName != null ? factoryClassName.hashCode() : 0);
@@ -212,9 +212,9 @@ public class RingbufferStoreConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * A readonly version of the {@link RingbufferStoreConfig}.
+     * A readonly version of the {@link RingbufferStoreConfig}. Non-private for testing.
      */
-    private static class RingbufferStoreConfigReadOnly extends RingbufferStoreConfig {
+    static class RingbufferStoreConfigReadOnly extends RingbufferStoreConfig {
 
         RingbufferStoreConfigReadOnly(RingbufferStoreConfig config) {
             super(config);

--- a/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
@@ -202,11 +202,11 @@ public class ScheduledExecutorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ScheduledExecutorConfig)) {
             return false;
         }
 
@@ -224,7 +224,7 @@ public class ScheduledExecutorConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name.hashCode();
         result = 31 * result + durability;
         result = 31 * result + capacity;
@@ -232,7 +232,8 @@ public class ScheduledExecutorConfig implements IdentifiedDataSerializable {
         return result;
     }
 
-    private static class ScheduledExecutorConfigReadOnly extends ScheduledExecutorConfig {
+    // non-private for testing
+    static class ScheduledExecutorConfigReadOnly extends ScheduledExecutorConfig {
 
         ScheduledExecutorConfigReadOnly(ScheduledExecutorConfig config) {
             super(config);

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
@@ -224,7 +224,7 @@ public class SemaphoreConfig implements IdentifiedDataSerializable {
 
     @SuppressWarnings("checkstyle:npathcomplexity")
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
@@ -247,7 +247,7 @@ public class SemaphoreConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + initialPermits;
         result = 31 * result + backupCount;

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -928,6 +928,7 @@
             <xs:element name="concurrency-level" type="concurrency-level" minOccurs="0" maxOccurs="1" default="32">
                 <xs:annotation>
                     <xs:documentation>
+                        Deprecated since version 3.6, concurrency-level is ignored.
                         Number of parallel mutexes to minimize contention on keys. The default value is 32 which
                         is a good number for lots of applications. If higher contention is seen on writes to values
                         inside of the replicated map this value can be adjusted to the needs.
@@ -937,6 +938,7 @@
             <xs:element name="replication-delay-millis" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="100">
                 <xs:annotation>
                     <xs:documentation>
+                        Deprecated since version 3.6, replication-delay-millis is ignored.
                         Defines the number of milliseconds after a put is executed before the value is replicated
                         to other nodes. During this time, multiple puts can be operated and cached up to be sent
                         out all at once after the delay.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -20,11 +20,16 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -67,5 +72,32 @@ public class CacheSimpleConfigTest extends HazelcastTestSupport {
 
         expectedException.expect(IllegalStateException.class);
         config.setCacheWriter("foo");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        CacheSimpleEntryListenerConfig redEntryListenerConfig = new CacheSimpleEntryListenerConfig();
+        redEntryListenerConfig.setCacheEntryListenerFactory("red");
+        CacheSimpleEntryListenerConfig blackEntryListenerConfig = new CacheSimpleEntryListenerConfig();
+        blackEntryListenerConfig.setCacheEntryListenerFactory("black");
+        EqualsVerifier.forClass(CacheSimpleConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .withPrefabValues(EvictionConfig.class,
+                              new EvictionConfig(1000, ENTRY_COUNT, EvictionPolicy.LFU),
+                              new EvictionConfig(300, USED_NATIVE_MEMORY_PERCENTAGE, EvictionPolicy.LRU))
+                      .withPrefabValues(WanReplicationRef.class,
+                              new WanReplicationRef("red", null, null,false),
+                              new WanReplicationRef("black", null, null, true))
+                      .withPrefabValues(CacheSimpleConfig.class,
+                              new CacheSimpleConfig().setName("red"),
+                              new CacheSimpleConfig().setName("black"))
+                      .withPrefabValues(CacheSimpleEntryListenerConfig.class,
+                              redEntryListenerConfig,
+                              blackEntryListenerConfig)
+                      .withPrefabValues(CachePartitionLostListenerConfig.class,
+                              new CachePartitionLostListenerConfig("red"),
+                              new CachePartitionLostListenerConfig("black"))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleEntryListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleEntryListenerConfigTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -24,38 +25,22 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class SemaphoreConfigTest {
-
-    @Test
-    public void testSetInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == 1234);
-    }
-
-    @Test
-    public void shouldAcceptZeroInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(0);
-        assertTrue(semaphoreConfig.getInitialPermits() == 0);
-    }
-
-    @Test
-    public void shouldAcceptNegativeInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(-1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == -1234);
-    }
+public class CacheSimpleEntryListenerConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
-        EqualsVerifier.forClass(SemaphoreConfig.class)
+        CacheSimpleEntryListenerConfig redEntryListenerConfig = new CacheSimpleEntryListenerConfig();
+        redEntryListenerConfig.setCacheEntryListenerFactory("red");
+        CacheSimpleEntryListenerConfig blackEntryListenerConfig = new CacheSimpleEntryListenerConfig();
+        blackEntryListenerConfig.setCacheEntryListenerFactory("black");
+        EqualsVerifier.forClass(CacheSimpleEntryListenerConfig.class)
                       .allFieldsShouldBeUsedExcept("readOnly")
                       .suppress(Warning.NONFINAL_FIELDS)
-                      .withPrefabValues(SemaphoreConfigReadOnly.class,
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("red")),
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("black")))
+                      .withPrefabValues(CacheSimpleEntryListenerConfigReadOnly.class,
+                              new CacheSimpleEntryListenerConfigReadOnly(redEntryListenerConfig),
+                              new CacheSimpleEntryListenerConfigReadOnly(blackEntryListenerConfig))
                       .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigTest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -121,5 +124,16 @@ public class CardinalityEstimatorConfigTest extends HazelcastTestSupport {
     @Test
     public void testToString() {
         assertContains(config.toString(), "CardinalityEstimatorConfig");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(CardinalityEstimatorConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(CardinalityEstimatorConfigReadOnly.class,
+                              new CardinalityEstimatorConfigReadOnly(new CardinalityEstimatorConfig("red")),
+                              new CardinalityEstimatorConfigReadOnly(new CardinalityEstimatorConfig("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.DurableExecutorConfig.DurableExecutorConfigReadOnly;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -53,6 +56,17 @@ public class DurableExecutorConfigTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(DurableExecutorConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(DurableExecutorConfigReadOnly.class,
+                              new DurableExecutorConfigReadOnly(new DurableExecutorConfig("red")),
+                              new DurableExecutorConfigReadOnly(new DurableExecutorConfig("black")))
+                      .verify();
     }
 
     private static Object newParameter(Method method) throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/config/EventJournalConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EventJournalConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.EventJournalConfig.EventJournalConfigReadOnly;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EventJournalConfigTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyClass_setCacheName_throwsException() {
+        getReadOnlyConfig().setCacheName("cache-other");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyClass_setCapacity_throwsException() {
+        getReadOnlyConfig().setCapacity(27);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyClass_setEnabled_throwsException() {
+        getReadOnlyConfig().setEnabled(false);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyClass_setMapName_throwsException() {
+        getReadOnlyConfig().setMapName("map-other");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyClass_setTTL_throwsException() {
+        getReadOnlyConfig().setTimeToLiveSeconds(20);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(EventJournalConfig.class)
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+
+    private EventJournalConfigReadOnly getReadOnlyConfig() {
+        EventJournalConfig config = new EventJournalConfig();
+        config.setEnabled(true).setCacheName("cache").setMapName("map").setCapacity(33).setTimeToLiveSeconds(15);
+        return new EventJournalConfigReadOnly(config);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.config;
 
+import com.hazelcast.internal.eviction.EvictionPolicyComparator;
+import com.hazelcast.internal.eviction.impl.comparator.LFUEvictionPolicyComparator;
+import com.hazelcast.internal.eviction.impl.comparator.LRUEvictionPolicyComparator;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -24,38 +28,24 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class SemaphoreConfigTest {
-
-    @Test
-    public void testSetInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == 1234);
-    }
-
-    @Test
-    public void shouldAcceptZeroInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(0);
-        assertTrue(semaphoreConfig.getInitialPermits() == 0);
-    }
-
-    @Test
-    public void shouldAcceptNegativeInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(-1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == -1234);
-    }
+public class EvictionConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
-        EqualsVerifier.forClass(SemaphoreConfig.class)
-                      .allFieldsShouldBeUsedExcept("readOnly")
+        EqualsVerifier.forClass(EvictionConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly", "sizeConfigured")
                       .suppress(Warning.NONFINAL_FIELDS)
-                      .withPrefabValues(SemaphoreConfigReadOnly.class,
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("red")),
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("black")))
+                      .withPrefabValues(EvictionConfig.class,
+                              new EvictionConfig(1000, ENTRY_COUNT, EvictionPolicy.LFU),
+                              new EvictionConfig(300, USED_NATIVE_MEMORY_PERCENTAGE, EvictionPolicy.LRU))
+                      .withPrefabValues(EvictionPolicyComparator.class,
+                              new LFUEvictionPolicyComparator(), new LRUEvictionPolicyComparator())
                       .verify();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ExecutorConfigTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,5 +51,16 @@ public class ExecutorConfigTest {
     @Test(expected = IllegalArgumentException.class)
     public void shouldNotAcceptZeroCorePoolSize() {
         new ExecutorConfig().setPoolSize(0);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(ExecutorConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(ExecutorConfigReadOnly.class,
+                              new ExecutorConfigReadOnly(new ExecutorConfig("red")),
+                              new ExecutorConfigReadOnly(new ExecutorConfig("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -24,38 +25,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class SemaphoreConfigTest {
-
-    @Test
-    public void testSetInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == 1234);
-    }
-
-    @Test
-    public void shouldAcceptZeroInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(0);
-        assertTrue(semaphoreConfig.getInitialPermits() == 0);
-    }
-
-    @Test
-    public void shouldAcceptNegativeInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(-1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == -1234);
-    }
+public class HotRestartConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
-        EqualsVerifier.forClass(SemaphoreConfig.class)
-                      .allFieldsShouldBeUsedExcept("readOnly")
+        EqualsVerifier.forClass(HotRestartConfig.class)
+                      .allFieldsShouldBeUsed()
                       .suppress(Warning.NONFINAL_FIELDS)
-                      .withPrefabValues(SemaphoreConfigReadOnly.class,
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("red")),
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("black")))
                       .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ListConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ListConfigTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -24,38 +25,19 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class SemaphoreConfigTest {
-
-    @Test
-    public void testSetInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == 1234);
-    }
-
-    @Test
-    public void shouldAcceptZeroInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(0);
-        assertTrue(semaphoreConfig.getInitialPermits() == 0);
-    }
-
-    @Test
-    public void shouldAcceptNegativeInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(-1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == -1234);
-    }
+public class ListConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
-        EqualsVerifier.forClass(SemaphoreConfig.class)
+        EqualsVerifier.forClass(ListConfig.class)
                       .allFieldsShouldBeUsedExcept("readOnly")
                       .suppress(Warning.NONFINAL_FIELDS)
-                      .withPrefabValues(SemaphoreConfigReadOnly.class,
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("red")),
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("black")))
+                      .withPrefabValues(ListConfigReadOnly.class,
+                              new ListConfigReadOnly(new ListConfig("red")),
+                              new ListConfigReadOnly(new ListConfig("black")))
                       .verify();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/LockConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LockConfigTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -68,5 +70,13 @@ public class LockConfigTest {
     public void testToString() {
         assertNotNull(config.toString());
         assertContains(config.toString(), "LockConfig");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(LockConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -23,6 +23,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -416,5 +418,32 @@ public class MapConfigTest {
 
         Data data = serializationService.toData(mapConfig);
         MapConfig clone = serializationService.toObject(data);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MapConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(MaxSizeConfig.class,
+                              new MaxSizeConfig(300, MaxSizeConfig.MaxSizePolicy.PER_PARTITION),
+                              new MaxSizeConfig(100, MaxSizeConfig.MaxSizePolicy.PER_NODE))
+                      .withPrefabValues(MapStoreConfig.class,
+                              new MapStoreConfig().setEnabled(true).setClassName("red"),
+                              new MapStoreConfig().setEnabled(true).setClassName("black"))
+                      .withPrefabValues(NearCacheConfig.class,
+                              new NearCacheConfig(10, 20, false, InMemoryFormat.BINARY),
+                              new NearCacheConfig(15, 25, true, InMemoryFormat.OBJECT))
+                      .withPrefabValues(WanReplicationRef.class,
+                              new WanReplicationRef().setName("red"),
+                              new WanReplicationRef().setName("black"))
+                      .withPrefabValues(PartitioningStrategyConfig.class,
+                              new PartitioningStrategyConfig("red"),
+                              new PartitioningStrategyConfig("black"))
+                      .withPrefabValues(MapConfigReadOnly.class,
+                              new MapConfigReadOnly(new MapConfig("red")),
+                              new MapConfigReadOnly(new MapConfig("black")))
+                      .verify();
+
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/MapIndexConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapIndexConfigTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -43,5 +45,16 @@ public class MapIndexConfigTest {
     @Test
     public void testValidation_withKeyKeyword() {
         assertEquals("__key#value", validateIndexAttribute("__key#value"));
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MapIndexConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(MapIndexConfigReadOnly.class,
+                              new MapIndexConfigReadOnly(new MapIndexConfig("red", false)),
+                              new MapIndexConfigReadOnly(new MapIndexConfig("black", true)))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigTest.java
@@ -20,6 +20,8 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -275,5 +277,16 @@ public class MapStoreConfigTest extends HazelcastTestSupport {
     @Test
     public void testToString() {
         assertContains(defaultCfg.toString(), "MapStoreConfig");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MapStoreConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .withPrefabValues(MapStoreConfigReadOnly.class,
+                              new MapStoreConfigReadOnly(cfgNotEnabled),
+                              new MapStoreConfigReadOnly(cfgNonNullClassName))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigTest.java
@@ -20,10 +20,14 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -106,5 +110,22 @@ public class QueryCacheConfigTest extends HazelcastTestSupport {
 
         assertNotNull(config.toString());
         assertContains(config.toString(), "QueryCacheConfig");
+    }
+
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(QueryCacheConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(PredicateConfig.class,
+                              new PredicateConfig("red"), new PredicateConfig("black"))
+                      .withPrefabValues(EvictionConfig.class,
+                              new EvictionConfig(1000, ENTRY_COUNT, EvictionPolicy.LFU),
+                              new EvictionConfig(300, USED_NATIVE_MEMORY_PERCENTAGE, EvictionPolicy.LRU))
+                      .withPrefabValues(QueryCacheConfigReadOnly.class,
+                              new QueryCacheConfigReadOnly(new QueryCacheConfig("red")),
+                              new QueryCacheConfigReadOnly(new QueryCacheConfig("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/QueueConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueueConfigTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -92,5 +94,19 @@ public class QueueConfigTest {
     public void setBackupCount_tooLarge() {
         QueueConfig config = new QueueConfig();
         config.setBackupCount(200); //max allowed is 6..
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(QueueConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .withPrefabValues(QueueConfigReadOnly.class,
+                              new QueueConfigReadOnly(new QueueConfig("red")),
+                              new QueueConfigReadOnly(new QueueConfig("black")))
+                      .withPrefabValues(QueueStoreConfigReadOnly.class,
+                              new QueueStoreConfigReadOnly(new QueueStoreConfig().setClassName("red")),
+                              new QueueStoreConfigReadOnly(new QueueStoreConfig().setClassName("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/QueueStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueueStoreConfigTest.java
@@ -16,32 +16,20 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
-public class ReplicatedMapConfigTest {
-
-    /**
-     * Test method for {@link ReplicatedMapConfigReadOnly#setStatisticsEnabled(boolean)}
-     */
-    @Test(expected = java.lang.UnsupportedOperationException.class)
-    public void testReadOnlyReplicatedMapConfigSetStatisticsEnabled() {
-        new ReplicatedMapConfigReadOnly(new ReplicatedMapConfig()).setStatisticsEnabled(true);
-    }
+public class QueueStoreConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
-        EqualsVerifier.forClass(ReplicatedMapConfig.class)
-                      .allFieldsShouldBeUsed()
+        EqualsVerifier.forClass(QueueStoreConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
                       .suppress(Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(QueueStoreConfigReadOnly.class,
+                              new QueueStoreConfigReadOnly(new QueueStoreConfig().setClassName("red")),
+                              new QueueStoreConfigReadOnly(new QueueStoreConfig().setClassName("black")))
                       .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -20,6 +20,8 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -222,6 +224,14 @@ public class ReliableTopicConfigTest {
 
         assertEquals("ReliableTopicConfig{name='foo', topicOverloadPolicy=BLOCK, executor=null, " +
                 "readBatchSize=10, statisticsEnabled=true, listenerConfigs=[]}", s);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(ReliableTopicConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .verify();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.RingbufferStoreConfig.RingbufferStoreConfigReadOnly;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -261,7 +264,9 @@ public class RingbufferConfigTest {
         assertEquals(original.getCapacity(), readonly.getCapacity());
         assertEquals(original.getTimeToLiveSeconds(), readonly.getTimeToLiveSeconds());
         assertEquals(original.getInMemoryFormat(), readonly.getInMemoryFormat());
-        assertNotEquals(original.getRingbufferStoreConfig(), readonly.getRingbufferStoreConfig());
+        assertEquals(original.getRingbufferStoreConfig(), readonly.getRingbufferStoreConfig());
+        assertFalse("The read-only RingbufferStoreConfig should not be identity-equal to the original RingbufferStoreConfig",
+                original.getRingbufferStoreConfig() == readonly.getRingbufferStoreConfig());
 
         try {
             readonly.setCapacity(10);
@@ -310,5 +315,16 @@ public class RingbufferConfigTest {
 
         assertNotNull(readonly.getRingbufferStoreConfig());
         assertFalse(readonly.getRingbufferStoreConfig().isEnabled());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(RingbufferConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(RingbufferStoreConfigReadOnly.class,
+                              new RingbufferStoreConfigReadOnly(new RingbufferStoreConfig().setClassName("red")),
+                              new RingbufferStoreConfigReadOnly(new RingbufferStoreConfig().setClassName("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.RingbufferStoreConfig.RingbufferStoreConfigReadOnly;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.core.RingbufferStoreFactory;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
@@ -26,6 +27,8 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -103,5 +106,16 @@ public class RingbufferStoreConfigTest {
         config.setFactoryImplementation(factory);
 
         assertEquals(factory, config.getFactoryImplementation());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(RingbufferStoreConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(RingbufferStoreConfigReadOnly.class,
+                              new RingbufferStoreConfigReadOnly(new RingbufferStoreConfig().setClassName("red")),
+                              new RingbufferStoreConfigReadOnly(new RingbufferStoreConfig().setClassName("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigTest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.ScheduledExecutorConfig.ScheduledExecutorConfigReadOnly;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,5 +66,16 @@ public class ScheduledExecutorConfigTest extends HazelcastTestSupport {
     @Test
     public void testToString() {
         assertContains(config.toString(), "ScheduledExecutorConfig");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(ScheduledExecutorConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(ScheduledExecutorConfigReadOnly.class,
+                              new ScheduledExecutorConfigReadOnly(new ScheduledExecutorConfig("red")),
+                              new ScheduledExecutorConfigReadOnly(new ScheduledExecutorConfig("black")))
+                      .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/SetConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SetConfigTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -24,38 +25,19 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class SemaphoreConfigTest {
-
-    @Test
-    public void testSetInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == 1234);
-    }
-
-    @Test
-    public void shouldAcceptZeroInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(0);
-        assertTrue(semaphoreConfig.getInitialPermits() == 0);
-    }
-
-    @Test
-    public void shouldAcceptNegativeInitialPermits() {
-        SemaphoreConfig semaphoreConfig = new SemaphoreConfig().setInitialPermits(-1234);
-        assertTrue(semaphoreConfig.getInitialPermits() == -1234);
-    }
+public class SetConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
-        EqualsVerifier.forClass(SemaphoreConfig.class)
+        EqualsVerifier.forClass(SetConfig.class)
                       .allFieldsShouldBeUsedExcept("readOnly")
                       .suppress(Warning.NONFINAL_FIELDS)
-                      .withPrefabValues(SemaphoreConfigReadOnly.class,
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("red")),
-                              new SemaphoreConfigReadOnly(new SemaphoreConfig().setName("black")))
+                      .withPrefabValues(SetConfigReadOnly.class,
+                              new SetConfigReadOnly(new SetConfig("red")),
+                              new SetConfigReadOnly(new SetConfig("black")))
                       .verify();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapMaxSizeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapMaxSizeConfigTest.java
@@ -17,10 +17,13 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MaxSizeConfigReadOnly;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -76,5 +79,16 @@ public class MapMaxSizeConfigTest extends HazelcastTestSupport {
         maxSizeConfig.setSize(expectedMaxSize);
 
         assertEquals(expectedMaxSize, maxSizeConfig.getSize());
+    }
+
+    @Test
+    public void testEquals() {
+        EqualsVerifier.forClass(MaxSizeConfig.class)
+                      .allFieldsShouldBeUsedExcept("readOnly")
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .withPrefabValues(MaxSizeConfigReadOnly.class,
+                              new MaxSizeConfigReadOnly(new MaxSizeConfig(100, MaxSizeConfig.MaxSizePolicy.PER_PARTITION)),
+                              new MaxSizeConfigReadOnly(new MaxSizeConfig(50, MaxSizeConfig.MaxSizePolicy.FREE_HEAP_PERCENTAGE)))
+                      .verify();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1331,6 +1331,12 @@
             <version>2.7.9</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>1.7.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
- `equals` & `hashCode` methods are now `final` and accept subclasses (so that, for example a `CacheSimpleConfigReadOnly` object which does not introduce any new state can be equal to the corresponding mutable `CacheSimpleConfig` object)
- `equals` & `hashCode` are fully covered with [`equalsverifier`](http://jqno.nl/equalsverifier/)

Issues uncovered and fixed:
- fixes a discrepancy between equals & hashCode in MapConfig (partition lost listener configs were significant for equals but not for hashCode)
- Deprecated and unused fields were used in equals/hashCode of ReplicatedMapConfig
- Equals was not testing properly QueueConfig.maxSize