### PR TITLE
Increased code coverage of OutOfMemoryHandler implementations

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientOutOfMemoryHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientOutOfMemoryHandler.java
@@ -20,7 +20,8 @@ import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.DefaultOutOfMemoryHandler;
-import com.hazelcast.util.EmptyStatement;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * To clear resources of the client upon OutOfMemory
@@ -37,7 +38,7 @@ public class ClientOutOfMemoryHandler extends DefaultOutOfMemoryHandler {
         try {
             oome.printStackTrace(System.err);
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
     }
 
@@ -46,7 +47,7 @@ public class ClientOutOfMemoryHandler extends DefaultOutOfMemoryHandler {
         private ClientHelper() {
         }
 
-        public static void cleanResources(HazelcastClientInstanceImpl client) {
+        static void cleanResources(HazelcastClientInstanceImpl client) {
             closeSockets(client);
             tryShutdown(client);
         }
@@ -57,19 +58,16 @@ public class ClientOutOfMemoryHandler extends DefaultOutOfMemoryHandler {
                 try {
                     connectionManager.shutdown();
                 } catch (Throwable ignored) {
-                    EmptyStatement.ignore(ignored);
+                    ignore(ignored);
                 }
             }
         }
 
         private static void tryShutdown(HazelcastClientInstanceImpl client) {
-            if (client == null) {
-                return;
-            }
             try {
                 client.doShutdown();
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
@@ -22,6 +22,8 @@ import com.hazelcast.client.connection.ClientConnectionStrategy;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 
+import java.util.concurrent.RejectedExecutionException;
+
 import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.ASYNC;
 import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.OFF;
 
@@ -80,7 +82,11 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
             return;
         }
         if (clientContext.getLifecycleService().isRunning()) {
-            clientContext.getConnectionManager().connectToClusterAsync();
+            try {
+                clientContext.getConnectionManager().connectToClusterAsync();
+            } catch (RejectedExecutionException r) {
+                shutdownWithExternalThread();
+            }
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientOutOfMemoryHandlerTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private HazelcastInstance client;
+    private HazelcastInstance[] instances;
+    private ClientOutOfMemoryHandler outOfMemoryHandler;
+
+    @Before
+    public void setUp() {
+        hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+
+        instances = new HazelcastInstance[2];
+        instances[0] = ((HazelcastClientProxy) client).client;
+        instances[1] = null;
+
+        outOfMemoryHandler = new ClientOutOfMemoryHandler();
+    }
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testOnOutOfMemory() {
+        outOfMemoryHandler.onOutOfMemory(new OutOfMemoryError(), instances);
+
+        assertFalse("The client should be shutdown", client.getLifecycleService().isRunning());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultOutOfMemoryHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultOutOfMemoryHandler.java
@@ -20,9 +20,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OutOfMemoryHandler;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.spi.annotation.PrivateApi;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.MemoryInfoAccessor;
 import com.hazelcast.util.RuntimeMemoryInfoAccessor;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Default OutOfMemoryHandler implementation that tries to release local resources (threads, connections, memory)
@@ -69,8 +70,7 @@ public class DefaultOutOfMemoryHandler extends OutOfMemoryHandler {
     }
 
     public DefaultOutOfMemoryHandler(double freeVersusMaxRatio) {
-        this.freeVersusMaxRatio = freeVersusMaxRatio;
-        this.memoryInfoAccessor = new RuntimeMemoryInfoAccessor();
+        this(freeVersusMaxRatio, new RuntimeMemoryInfoAccessor());
     }
 
     public DefaultOutOfMemoryHandler(double freeVersusMaxRatio, MemoryInfoAccessor memoryInfoAccessor) {
@@ -89,7 +89,7 @@ public class DefaultOutOfMemoryHandler extends OutOfMemoryHandler {
         try {
             oome.printStackTrace(System.err);
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
     }
 
@@ -118,7 +118,7 @@ public class DefaultOutOfMemoryHandler extends OutOfMemoryHandler {
             }
 
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
 
         return true;

--- a/hazelcast/src/test/java/com/hazelcast/core/OutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/OutOfMemoryHandlerTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class OutOfMemoryHandlerTest extends AbstractOutOfMemoryHandlerTest {
 
-    TestOutOfMemoryHandler outOfMemoryHandler;
+    private TestOutOfMemoryHandler outOfMemoryHandler;
 
     @Before
     public void setUp() throws Exception {
@@ -41,7 +41,7 @@ public class OutOfMemoryHandlerTest extends AbstractOutOfMemoryHandlerTest {
     }
 
     @Test
-    public void testShouldHandle() throws Exception {
+    public void testShouldHandle() {
         assertTrue(outOfMemoryHandler.shouldHandle(new OutOfMemoryError()));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
@@ -30,17 +30,6 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
     protected HazelcastInstanceImpl hazelcastInstance;
     protected HazelcastInstanceImpl hazelcastInstanceThrowsException;
 
-    public void initHazelcastInstances() throws Exception {
-        Config config = new Config();
-
-        NodeContext nodeContext = new TestNodeContext();
-        NodeContext nodeContextWithThrowable = new TestNodeContext(new FailingConnectionManager());
-
-        hazelcastInstance = new HazelcastInstanceImpl("OutOfMemoryHandlerHelper", config, nodeContext);
-        hazelcastInstanceThrowsException = new HazelcastInstanceImpl("OutOfMemoryHandlerHelperThrowsException", config,
-                nodeContextWithThrowable);
-    }
-
     @After
     public void tearDown() {
         if (hazelcastInstance != null) {
@@ -52,6 +41,17 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
             ((FailingConnectionManager) connectionManager).switchToDummyMode();
             hazelcastInstanceThrowsException.shutdown();
         }
+    }
+
+    protected void initHazelcastInstances() throws Exception {
+        Config config = new Config();
+
+        NodeContext nodeContext = new TestNodeContext();
+        NodeContext nodeContextWithThrowable = new TestNodeContext(new FailingConnectionManager());
+
+        hazelcastInstance = new HazelcastInstanceImpl("OutOfMemoryHandlerHelper", config, nodeContext);
+        hazelcastInstanceThrowsException = new HazelcastInstanceImpl("OutOfMemoryHandlerHelperThrowsException", config,
+                nodeContextWithThrowable);
     }
 
     private static class FailingConnectionManager implements ConnectionManager {
@@ -134,7 +134,5 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
                 throw new OutOfMemoryError();
             }
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryErrorDispatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryErrorDispatcherTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.instance;
 
-
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OutOfMemoryHandler;
 import com.hazelcast.memory.MemoryUnit;
@@ -79,7 +78,6 @@ public class OutOfMemoryErrorDispatcherTest extends HazelcastTestSupport {
         OutOfMemoryErrorDispatcher.registerServer(hz2);
         assertArrayEquals(new HazelcastInstance[]{hz1, hz2}, OutOfMemoryErrorDispatcher.current());
     }
-
 
     @Test(expected = IllegalArgumentException.class)
     public void register_whenNull() {
@@ -217,7 +215,6 @@ public class OutOfMemoryErrorDispatcherTest extends HazelcastTestSupport {
 
     private void test_DefaultOutOfMemoryHandler_using_accessor(MemoryInfoAccessor memoryInfoAccessor,
                                                                VerificationMode verificationMode) {
-
         OutOfMemoryError oome = new OutOfMemoryError();
 
         HazelcastInstance hz = mock(HazelcastInstance.class);


### PR DESCRIPTION
* `ClientOutOfMemoryHandler` has a code coverage of 2.8%, that's a bit low :)
* `DefaultOutOfMemoryHandler` is at least at 80.8% code coverage, but its `onOutOfMemory()` method is untested