### PR TITLE
Makes PutIfAbsent the default Cache merge policy

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -846,7 +846,7 @@
                                                     The entry with the higher number of hits wins.
                                                     <br/>`com.hazelcast.cache.merge.LatestAccessCacheMergePolicy` or `LATEST_ACCESS`:
                                                     The entry which has been accessed more recently wins.
-                                                    <br/>Default policy is 'com.hazelcast.cache.merge.PassThroughCacheMergePolicy'
+                                                    <br/>Default policy is 'com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy'
                                                 </p>
                                             </xs:documentation>
                                         </xs:annotation>

--- a/hazelcast/src/main/java/com/hazelcast/cache/BuiltInCacheMergePolicies.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/BuiltInCacheMergePolicies.java
@@ -114,7 +114,7 @@ public enum BuiltInCacheMergePolicies {
      * @return the definition of the default {@link CacheMergePolicy}
      */
     public static BuiltInCacheMergePolicies getDefault() {
-        return PASS_THROUGH;
+        return PUT_IF_ABSENT;
     }
 
     private interface CacheMergePolicyInstanceFactory {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config;
 
 import com.hazelcast.cache.BuiltInCacheMergePolicies;
-import com.hazelcast.cache.merge.PassThroughCacheMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -69,7 +68,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
     /**
      * Default policy for merging
      */
-    public static final String DEFAULT_CACHE_MERGE_POLICY = PassThroughCacheMergePolicy.class.getName();
+    public static final String DEFAULT_CACHE_MERGE_POLICY = BuiltInCacheMergePolicies.getDefault().getImplementationClassName();
 
     private String name;
 
@@ -106,7 +105,7 @@ public class CacheSimpleConfig implements IdentifiedDataSerializable {
 
     private List<CachePartitionLostListenerConfig> partitionLostListenerConfigs;
 
-    private String mergePolicy = BuiltInCacheMergePolicies.getDefault().getImplementationClassName();
+    private String mergePolicy = DEFAULT_CACHE_MERGE_POLICY;
 
     private HotRestartConfig hotRestartConfig = new HotRestartConfig();
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -577,7 +577,7 @@
                             The entry with the higher number of hits wins.
                             <br/>`com.hazelcast.cache.merge.LatestAccessCacheMergePolicy` or `LATEST_ACCESS`:
                             The entry which has been accessed more recently wins.
-                            <br/>Default policy is 'com.hazelcast.cache.merge.PassThroughCacheMergePolicy'
+                            <br/>Default policy is 'com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy'
                         </p>
                     </xs:documentation>
                 </xs:annotation>


### PR DESCRIPTION
The default cache merge policy should maintain the existing values of the larger cluster and only merge values from the merging cluster when these are not present in the larger cluster. This aligns the default merge policy for `Cache` with `IMap`.