### PR TITLE
OperationParker.unpark simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
@@ -153,15 +153,11 @@ public class OperationParkerImpl implements OperationParker, LiveOperationsTrack
             parkQueue.poll();
 
             parkedOp = parkQueue.peek();
-
-            // If parkQueue.peek() returns null, we should deregister this specific
-            // key to avoid memory leak. By contract we know that park() and unpark()
-            // cannot be called in parallel.
-            // We can safely remove this queue from registration map here.
-            if (parkedOp == null) {
-                parkQueueMap.remove(key);
-            }
         }
+
+        // We should deregister this specific key to avoid memory leak. By contract we know that park() and unpark()
+        // cannot be called in parallel. We can safely remove this queue from registration map here.
+        parkQueueMap.remove(key);
     }
 
     @Probe


### PR DESCRIPTION
In the loop a check is done if is the last parked operation from the queue,
and if it is, the key is removed from the parkQueueMap. But at the end of the loop,
you also know you have processed the last item.

So tis logic was pulled out of the loop to below the loop.