### PR TITLE
Fix 3.10 version in hazelcast configuration.

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-default.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-default.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.9.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
            xmlns="http://www.hazelcast.com/schema/client-config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.9.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -25,6 +25,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.util.StringUtil;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -211,7 +212,8 @@ public abstract class AbstractXmlConfigHelper {
 
     protected String getReleaseVersion() {
         BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
-        return buildInfo.getVersion().substring(0, 3);
+        String[] versionTokens = StringUtil.tokenizeVersionString(buildInfo.getVersion());
+        return versionTokens[0] + "." + versionTokens[1];
     }
 
     protected String xmlToJavaName(final String name) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
@@ -30,8 +30,13 @@ public final class Versions {
      */
     public static final Version V3_9 = Version.of(3, 9);
 
-    public static final Version PREVIOUS_CLUSTER_VERSION = V3_8;
-    public static final Version CURRENT_CLUSTER_VERSION = V3_9;
+    /**
+     * Represents cluster version 3.10
+     */
+    public static final Version V3_10 = Version.of(3, 10);
+
+    public static final Version PREVIOUS_CLUSTER_VERSION = V3_9;
+    public static final Version CURRENT_CLUSTER_VERSION = V3_10;
 
     private Versions() {
     }

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -21,7 +21,7 @@
     or the documentation at https://hazelcast.org/documentation/
 -->
 <!--suppress XmlDefaultAttributeValue -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -23,7 +23,7 @@ https://hazelcast.com/schema/config/hazelcast-config-3.9.xsd or the Reference Ma
 https://hazelcast.org/documentation/.
 -->
 <!--suppress XmlDefaultAttributeValue -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <!--

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.cluster;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PartitionGroupConfig;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.ConfigMismatchException;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -25,7 +26,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.version.Version;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -114,7 +114,7 @@ public class ConfigCheckTest {
         ObjectDataOutput odo = mock(ObjectDataOutput.class);
 
         try {
-            ConfigCheck configCheck = new ConfigCheck(config, "multicast", Version.of(3, 9));
+            ConfigCheck configCheck = new ConfigCheck(config, "multicast", Versions.CURRENT_CLUSTER_VERSION);
             configCheck.writeData(odo);
         } catch (IOException e) {
             fail(e.getMessage());

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -51,6 +51,7 @@ import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1841,6 +1842,33 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         Properties properties = memberAddressProviderConfig.getProperties();
         assertEquals(1, properties.size());
         assertEquals("propValue1", properties.get("propName1"));
+    }
+
+    @Test
+    public void testXsdVersion() {
+        String origVersionOverride = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
+        assertXsdVersion("0.0", "0.0");
+        assertXsdVersion("3.9", "3.9");
+        assertXsdVersion("3.9-SNAPSHOT", "3.9");
+        assertXsdVersion("3.9.1-SNAPSHOT", "3.9");
+        assertXsdVersion("3.10", "3.10");
+        assertXsdVersion("3.10-SNAPSHOT", "3.10");
+        assertXsdVersion("3.10.1-SNAPSHOT", "3.10");
+        assertXsdVersion("99.99.99", "99.99");
+        assertXsdVersion("99.99.99-SNAPSHOT", "99.99");
+        assertXsdVersion("99.99.99-Beta", "99.99");
+        assertXsdVersion("99.99.99-Beta-SNAPSHOT", "99.99");
+        if (origVersionOverride!=null) {
+            System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, origVersionOverride);
+        } else {
+            System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
+        }
+    }
+
+    private void assertXsdVersion(String buildVersion, String expectedXsdVersion) {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, buildVersion);
+        assertEquals("Unexpected release version retrieved for build version " + buildVersion, expectedXsdVersion,
+                new XmlConfigBuilder().getReleaseVersion());
     }
 
     private static void assertPermissionConfig(PermissionConfig expected, Config config) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/VersionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/VersionsTest.java
@@ -45,4 +45,9 @@ public class VersionsTest extends HazelcastTestSupport {
     public void version_3_9() {
         assertEquals(Version.of(3, 9), Versions.V3_9);
     }
+
+    @Test
+    public void version_3_10() {
+        assertEquals(Version.of(3, 10), Versions.V3_10);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
@@ -35,7 +36,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -228,7 +228,7 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
     @Test(expected = UnsupportedOperationException.class)
     // RU_COMPAT_WITH_3_8
     public void noMigration_notSupported_beforeV39()  {
-        System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Version.of(3, 8).toString());
+        System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_8.toString());
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance hz = factory.newHazelcastInstance();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.PromoteLiteMemberOp;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.nio.Address;
@@ -37,7 +38,6 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.UuidUtil;
-import com.hazelcast.version.Version;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -328,7 +328,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
     @Test(expected = UnsupportedOperationException.class)
     // RU_COMPAT_WITH_3_8
     public void liteMemberPromotion_notSupported_beforeV39()  {
-        System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Version.of(3, 8).toString());
+        System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_8.toString());
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
         HazelcastInstance hz = factory.newHazelcastInstance(new Config().setLiteMember(true));


### PR DESCRIPTION
These PR comes with 2 commits. 
* The first fixes #11586 - problem with using XSD for Hazelcast version where major or minor has more than one digit;
* The second commit updates XSD version in hazelcast default and example configurations.