### PR TITLE
Fix for leak on clientEngine when recovering from split brain

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -17,6 +17,10 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.ClientEngineImpl;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
@@ -28,7 +32,6 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
@@ -39,11 +42,14 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.test.SplitBrainTestSupport.blockCommunicationBetween;
+import static com.hazelcast.test.SplitBrainTestSupport.unblockCommunicationBetween;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(NightlyTest.class)
-public class ClientSplitBrainTest extends HazelcastTestSupport {
+public class ClientSplitBrainTest extends ClientTestSupport {
 
     @After
     public void cleanup() {
@@ -155,4 +161,80 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
         };
     }
 
+    @Test
+    public void testClientEngineCleanup_AfterMergeFromSplitBrain() throws InterruptedException {
+        Config config = new Config();
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "10");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "10");
+        config.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "5");
+        config.setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
+
+        TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+        final HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        final CountDownLatch disconnected = new CountDownLatch(1);
+        final CountDownLatch connected = new CountDownLatch(1);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
+                    connected.countDown();
+                } else if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED.equals(event.getState())) {
+                    disconnected.countDown();
+                }
+            }
+        });
+
+        final HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        final HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+
+        assertSizeEventually(3, clientInstanceImpl.getConnectionManager().getActiveConnections());
+
+        blockCommunicationBetween(h1, h2);
+        blockCommunicationBetween(h1, h3);
+
+        //make sure that cluster is split as [ 1 ] , [ 2 , 3 ]
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, h2.getCluster().getMembers().size());
+                assertEquals(2, h3.getCluster().getMembers().size());
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, h1.getCluster().getMembers().size());
+            }
+        });
+
+        //open communication back for nodes to merge
+        unblockCommunicationBetween(h1, h2);
+        unblockCommunicationBetween(h1, h3);
+
+        //wait for cluster is merged back
+        assertClusterSizeEventually(3, h1, h2, h3);
+
+        //wait for client is disconnected from h1 because of merge
+        assertOpenEventually(disconnected);
+        assertOpenEventually(connected);
+
+        //wait for client to connect back to all nodes
+        assertSizeEventually(3, clientInstanceImpl.getConnectionManager().getActiveConnections());
+
+        //verify endpoints are cleared.
+        ClientEngineImpl clientEngineImpl1 = getClientEngineImpl(h1);
+        ClientEngineImpl clientEngineImpl2 = getClientEngineImpl(h2);
+        ClientEngineImpl clientEngineImpl3 = getClientEngineImpl(h3);
+        assertEquals(1, clientEngineImpl1.getClientEndpointCount());
+        assertEquals(1, clientEngineImpl2.getClientEndpointCount());
+        assertEquals(1, clientEngineImpl3.getClientEndpointCount());
+
+        hazelcastFactory.shutdownAll();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -363,10 +363,15 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
     @Override
     public void reset() {
+        clear("Resetting clientEngine");
     }
 
     @Override
     public void shutdown(boolean terminate) {
+        clear("Shutting down clientEngine");
+    }
+
+    private void clear(String reason) {
         for (ClientEndpoint ce : endpointManager.getEndpoints()) {
             ClientEndpointImpl endpoint = (ClientEndpointImpl) ce;
             try {
@@ -377,7 +382,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             try {
                 final Connection conn = endpoint.getConnection();
                 if (conn.isAlive()) {
-                    conn.close("Shutdown of ClientEngine", null);
+                    conn.close(reason, null);
                 }
             } catch (Exception e) {
                 logger.finest(e);


### PR DESCRIPTION
Implemented ClientEngineImpl.reset properly to reset the state
and cleanup the internals when merging.

MockConnectionManager is changed to make it behave as
TcpIpConnectionManager in  `onConnectionClose` method. It is not
firing events anymore when it is not `live`. This was causing test
to pass without the fix.

fixes #1763
backport of #11596 