### PR TITLE
[WIP] Assert CachingProviders are cleaned up after each test class

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -56,6 +56,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.cache.jsr.JsrTestUtil.getCachingProviderRegistrySize;
 import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
 import static java.lang.Integer.getInteger;
 
@@ -337,6 +338,10 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
                     String message = "Instances haven't been shut down: " + instances;
                     Hazelcast.shutdownAll();
                     throw new IllegalStateException(message);
+                }
+                int cachingProviderRegistrySize = getCachingProviderRegistrySize();
+                if (cachingProviderRegistrySize > 0) {
+                    throw new IllegalStateException("CachingProviders haven't been cleanup");
                 }
             }
         };


### PR DESCRIPTION
Usage of `Caching.getCachingProviders` may actually create `CachingProvider`s in `clearCachingProviderRegistry`. Also, `CachingProvider`s created with `ClassLoader`s other than the default will not be closed, as `getCachingProviders` only handles `CachingProvider`s accessible by the default `ClassLoader`.

Also includes a WIP improvement to track not-closed `CachingProvider`s after each test class (courtesy of @Donnerbart ).