### PR TITLE
[BACKPORT] Fix deadlock in FilteringClassLoader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassloadingMutexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassloadingMutexProvider.java
@@ -26,9 +26,9 @@ import static com.hazelcast.internal.util.JavaVersion.JAVA_1_7;
 /**
  * Java 7+ onwards allows parallel classloading. Therefore we can define use a lock with per-class granularity.
  * However in Java 6 we have to use a fat global lock.
- *
+ * <p>
  * This abstraction provides a suitable mutex depending on the version of underlying platform.
- *
+ * <p>
  * The provided mutexes are closeable as we want to know when the granular mutexes from Java are no longer needed.
  */
 public class ClassloadingMutexProvider {

--- a/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
@@ -30,30 +30,32 @@ import java.util.Map;
  * <p>
  * The returned {@link Mutex}es implement {@link Closeable}, so can be conveniently used in a try-with-resources statement.
  * <p>
- * Typical usage would allow, for example, synchronizing access to a non-thread-safe {@link Map} on a per-key basis,
- * to avoid blocking other threads who would perform updates on other entries of the {@link Map}.
+ * Typical usage would allow, for example, synchronizing access to a {@link java.util.concurrent.ConcurrentMap} on a
+ * per-key basis, to avoid blocking other threads which could perform updates on other entries of the {@link Map}.
  *
- * <pre>
- *     class Test {
+ * <pre>{@code
+ *    class Test {
  *
- *         private final ContextMutexFactory mutexFactory = new ContextMutexFactory();
- *         private final Map&lt;String, String&gt; mapToSync = new HashMap&lt;String, String&gt;();
+ *        private final ContextMutexFactory mutexFactory = new ContextMutexFactory();
+ *        private final ConcurrentMap<String, String> mapToSync = new ConcurrentHashMap<String, String>();
  *
- *         public void test(String key, String value) {
- *             // critical section
- *             ContextMutexFactory.Mutex mutex = mutexFactory.mutexFor(key);
- *             try {
- *                 synchronized (mutex) {
- *                      if (mapToSync.get(key) == null) {
- *                          mapToSync.put(key, value);
- *                      }
- *                 }
- *             } finally {
- *                 mutex.close();
- *             }
- *         }
- *     }
- * </pre>
+ *        public String getValueForKey(String key) {
+ *            ContextMutexFactory.Mutex mutex = mutexFactory.mutexFor(key);
+ *            try {
+ *                synchronized (mutex) {
+ *                    // critical section - this thread is the only one trying to add value under this key
+ *                    String value = mapToSync.get(key);
+ *                    if (value == null) {
+ *                        value = ...; // compute the value
+ *                        mapToSync.put(key, value);
+ *                    }
+ *                    return value;
+ *                }
+ *            } finally {
+ *                mutex.close();
+ *            }
+ *        }
+ * }</pre>
  */
 public final class ContextMutexFactory {
 

--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -51,7 +51,6 @@ public final class ServiceLoader {
     private static final boolean USE_CLASSLOADING_FALLBACK = getBoolean("hazelcast.compat.classloading.hooks.fallback");
 
     private static final ILogger LOGGER = Logger.getLogger(ServiceLoader.class);
-    private static final String FILTERING_CLASS_LOADER = FilteringClassLoader.class.getCanonicalName();
 
     // see https://github.com/hazelcast/hazelcast/issues/3922
     private static final String IGNORED_GLASSFISH_MAGIC_CLASSLOADER =


### PR DESCRIPTION
Backport of #11594 

The registerAsParallelCapable() method was not called for the parallel
class loading to work properly. The code in JDK is written in a way that
if it is not called, a lock on `this` instance is expected to be held,
see the detected deadlock below.

I did not fully investigate the parallel loading, so for the sake
simplicity and also because this code is only used in tests, I rewrote
it to synchronize on `this. The class was also moved to test sources.

Note that the excerpt below never shows "locked .. FilteringClassLoader",
but still claims that the monitor on FilteringClassLoader instance is
held. This is probably due to the fact that the private
`ClassLoader.loadClassInternal` method, which synchronizes on `this`, is
directly called by JVM. However, in the case of
"hz._hzInstance_1_jet.generic-operation.thread-0" thread, the public
`loadClass` is called directly.

=========

Found one Java-level deadlock:
=============================
"hz._hzInstance_1_jet.IOBalancerThread":
  waiting to lock monitor 0x0000000019d35828 (object 0x00000000fc87b2b0, a com.hazelcast.util.FilteringClassLoader),
  which is held by "hz._hzInstance_1_jet.generic-operation.thread-0"
"hz._hzInstance_1_jet.generic-operation.thread-0":
  waiting to lock monitor 0x0000000018ffb998 (object 0x00000000fcba4808, a com.hazelcast.util.ContextMutexFactory$Mutex),
  which is held by "hz._hzInstance_1_jet.partition-operation.thread-5"
"hz._hzInstance_1_jet.partition-operation.thread-5":
  waiting to lock monitor 0x0000000019d35828 (object 0x00000000fc87b2b0, a com.hazelcast.util.FilteringClassLoader),
  which is held by "hz._hzInstance_1_jet.generic-operation.thread-0"

Java stack information for the threads listed above:
===================================================
"hz._hzInstance_1_jet.IOBalancerThread":
	at com.hazelcast.util.ItemCounter.getAndSet(ItemCounter.java:143)
	at com.hazelcast.internal.networking.nio.iobalancer.LoadTracker.getEventCountSinceLastCheck(LoadTracker.java:167)
	at com.hazelcast.internal.networking.nio.iobalancer.LoadTracker.updateHandlerState(LoadTracker.java:157)
	at com.hazelcast.internal.networking.nio.iobalancer.LoadTracker.updateNewWorkingImbalance(LoadTracker.java:152)
	at com.hazelcast.internal.networking.nio.iobalancer.LoadTracker.updateImbalance(LoadTracker.java:85)
	at com.hazelcast.internal.networking.nio.iobalancer.IOBalancer.scheduleMigrationIfNeeded(IOBalancer.java:146)
	at com.hazelcast.internal.networking.nio.iobalancer.IOBalancer.checkReadHandlers(IOBalancer.java:142)
	at com.hazelcast.internal.networking.nio.iobalancer.IOBalancerThread.run(IOBalancerThread.java:51)
"hz._hzInstance_1_jet.generic-operation.thread-0":
	at com.hazelcast.util.FilteringClassLoader.loadClass(FilteringClassLoader.java:98)
	- waiting to lock <0x00000000fcba4808> (a com.hazelcast.util.ContextMutexFactory$Mutex)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at com.hazelcast.map.AbstractEntryProcessor.<init>(AbstractEntryProcessor.java:60)
	at com.hazelcast.map.AbstractEntryProcessor.<init>(AbstractEntryProcessor.java:50)
	at com.hazelcast.map.impl.EntryRemovingProcessor.<init>(EntryRemovingProcessor.java:31)
	at com.hazelcast.map.impl.EntryRemovingProcessor.<clinit>(EntryRemovingProcessor.java:29)
	at com.hazelcast.map.impl.MapDataSerializerHook$131.createNew(MapDataSerializerHook.java:976)
	at com.hazelcast.map.impl.MapDataSerializerHook$131.createNew(MapDataSerializerHook.java:974)
	at com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory.create(ArrayDataSerializableFactory.java:44)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:141)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:105)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:50)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.readObject(AbstractSerializationService.java:267)
	at com.hazelcast.internal.serialization.impl.ByteArrayObjectDataInput.readObject(ByteArrayObjectDataInput.java:570)
	at com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateOperationFactory.readData(PartitionWideEntryWithPredicateOperationFactory.java:109)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:158)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:105)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:50)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.readObject(AbstractSerializationService.java:267)
	at com.hazelcast.internal.serialization.impl.ByteArrayObjectDataInput.readObject(ByteArrayObjectDataInput.java:570)
	at com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.readInternal(PartitionIteratingOperation.java:262)
	at com.hazelcast.spi.Operation.readData(Operation.java:606)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:158)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:105)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:50)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toObject(AbstractSerializationService.java:185)
	at com.hazelcast.spi.impl.NodeEngineImpl.toObject(NodeEngineImpl.java:339)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:394)
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:115)
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.run(OperationThread.java:100)
"hz._hzInstance_1_jet.partition-operation.thread-5":
	at java.lang.ClassLoader.checkCerts(ClassLoader.java:887)
	- waiting to lock <0x00000000fc87b2b0> (a com.hazelcast.util.FilteringClassLoader)
	at java.lang.ClassLoader.preDefineClass(ClassLoader.java:668)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:761)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:642)
	at com.hazelcast.util.FilteringClassLoader.loadAndDefineClass(FilteringClassLoader.java:125)
	at com.hazelcast.util.FilteringClassLoader.loadClass(FilteringClassLoader.java:101)
	- locked <0x00000000fcba4808> (a com.hazelcast.util.ContextMutexFactory$Mutex)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at com.hazelcast.nio.ClassLoaderUtil.tryLoadClass(ClassLoaderUtil.java:173)
	at com.hazelcast.nio.ClassLoaderUtil.loadClass(ClassLoaderUtil.java:132)
	at com.hazelcast.nio.IOUtil$ClassLoaderAwareObjectInputStream.resolveClass(IOUtil.java:552)
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1819)
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1713)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1986)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1535)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:422)
	at com.hazelcast.internal.serialization.impl.JavaDefaultSerializers$JavaSerializer.read(JavaDefaultSerializers.java:219)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.readObject(AbstractSerializationService.java:267)
	at com.hazelcast.internal.serialization.impl.ByteArrayObjectDataInput.readObject(ByteArrayObjectDataInput.java:570)
	at com.hazelcast.map.impl.operation.PartitionWideEntryBackupOperation.readInternal(PartitionWideEntryBackupOperation.java:62)
	at com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateBackupOperation.readInternal(PartitionWideEntryWithPredicateBackupOperation.java:47)
	at com.hazelcast.spi.Operation.readData(Operation.java:606)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:158)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:105)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:50)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.readObject(AbstractSerializationService.java:267)
	at com.hazelcast.internal.serialization.impl.ByteArrayObjectDataInput.readObject(ByteArrayObjectDataInput.java:570)
	at com.hazelcast.spi.impl.operationservice.impl.operations.Backup.readInternal(Backup.java:266)
	at com.hazelcast.spi.Operation.readData(Operation.java:606)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.readInternal(DataSerializableSerializer.java:158)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:105)
	at com.hazelcast.internal.serialization.impl.DataSerializableSerializer.read(DataSerializableSerializer.java:50)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.read(StreamSerializerAdapter.java:48)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toObject(AbstractSerializationService.java:185)
	at com.hazelcast.spi.impl.NodeEngineImpl.toObject(NodeEngineImpl.java:339)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:394)
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:115)
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.run(OperationThread.java:100)

Found 1 deadlock.