### PR TITLE
[3.9] fix for redundant partition migration when mancenter is configured

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -101,7 +101,7 @@ public class LocalMapStatsProvider {
 
         PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
         for (PartitionContainer partitionContainer : partitionContainers) {
-            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
+            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId(), false);
             Collection<RecordStore> allRecordStores = partitionContainer.getAllRecordStores();
 
             for (RecordStore recordStore : allRecordStores) {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -1,0 +1,41 @@
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalMapStatsProviderTest extends HazelcastTestSupport {
+
+    //https://github.com/hazelcast/hazelcast/issues/11598
+    @Test
+    public void testRedundantPartitionMigrationWhenManCenterConfigured() {
+        Config config = new Config();
+        config.getManagementCenterConfig().setEnabled(true);
+        config.getManagementCenterConfig().setUrl(format("http://localhost:%d%s/", 8085, "/mancenter"));
+
+        //don't need start mancenter, just configure it
+        final HazelcastInstance instance = createHazelcastInstance(config);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                //check partition migration triggered or not
+                int partitionStateVersion = getNode(instance).getPartitionService().getPartitionStateVersion();
+                assertEquals(0, partitionStateVersion);
+            }
+        }, 5);
+    }
+
+}


### PR DESCRIPTION
[3.8.7] --> https://github.com/hazelcast/hazelcast/pull/11635