### PR TITLE
Improved JavaDoc and small cleanup of MergePolicy related classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/BuiltInCacheMergePolicies.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/BuiltInCacheMergePolicies.java
@@ -22,20 +22,15 @@ import com.hazelcast.cache.merge.PassThroughCacheMergePolicy;
 import com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy;
 
 /**
- * <p>
  * Enum that represents all built-in {@link com.hazelcast.cache.CacheMergePolicy} implementations.
- * </p>
- *
  * <p>
- * <b>Note:</b>
- *      When a new built-in {@link com.hazelcast.cache.CacheMergePolicy} is implemented,
- *      its definition should be added here also.
- * </p>
+ * <b>Note:</b> When a new built-in {@link com.hazelcast.cache.CacheMergePolicy} is implemented,
+ * its definition should be added here.
  */
 public enum BuiltInCacheMergePolicies {
 
     /**
-     * Cache merge policy that merges cache entry from source to destination directly.
+     * Cache merge policy that merges cache entries from source to destination directly.
      */
     PASS_THROUGH(PassThroughCacheMergePolicy.class, new CacheMergePolicyInstanceFactory() {
         @Override
@@ -45,8 +40,8 @@ public enum BuiltInCacheMergePolicies {
     }),
 
     /**
-     * Cache merge policy that merges cache entry from source to destination
-     * if it does not exist in the destination cache.
+     * Cache merge policy that merges cache entries from source to destination
+     * if they don't exist in the destination cache.
      */
     PUT_IF_ABSENT(PutIfAbsentCacheMergePolicy.class, new CacheMergePolicyInstanceFactory() {
         @Override
@@ -56,8 +51,8 @@ public enum BuiltInCacheMergePolicies {
     }),
 
     /**
-     * Cache merge policy that merges cache entry from source to destination cache
-     * if source entry has more hits than the destination one.
+     * Cache merge policy that merges cache entries from source to destination cache
+     * if the source entry has more hits than the destination one.
      */
     HIGHER_HITS(HigherHitsCacheMergePolicy.class, new CacheMergePolicyInstanceFactory() {
         @Override
@@ -67,8 +62,8 @@ public enum BuiltInCacheMergePolicies {
     }),
 
     /**
-     * Cache merge policy that merges cache entry from source to destination cache
-     * if source entry has been accessed more recently than the destination entry.
+     * Cache merge policy that merges cache entries from source to destination cache
+     * if the source entry has been accessed more recently than the destination entry.
      */
     LATEST_ACCESS(LatestAccessCacheMergePolicy.class, new CacheMergePolicyInstanceFactory() {
         @Override
@@ -80,8 +75,7 @@ public enum BuiltInCacheMergePolicies {
     private Class<? extends CacheMergePolicy> implClass;
     private CacheMergePolicyInstanceFactory instanceFactory;
 
-    BuiltInCacheMergePolicies(Class<? extends CacheMergePolicy> implClass,
-                              CacheMergePolicyInstanceFactory instanceFactory) {
+    BuiltInCacheMergePolicies(Class<? extends CacheMergePolicy> implClass, CacheMergePolicyInstanceFactory instanceFactory) {
         this.implClass = implClass;
         this.instanceFactory = instanceFactory;
     }
@@ -93,7 +87,7 @@ public enum BuiltInCacheMergePolicies {
     /**
      * Gets the name of the implementation class of {@link CacheMergePolicy}.
      *
-     * @return the name of the implementation class of {@link CacheMergePolicy}.
+     * @return the name of the implementation class of {@link CacheMergePolicy}
      */
     public String getImplementationClassName() {
         return implClass.getName();
@@ -120,5 +114,4 @@ public enum BuiltInCacheMergePolicies {
     private interface CacheMergePolicyInstanceFactory {
         CacheMergePolicy create();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
@@ -24,8 +24,7 @@ import com.hazelcast.internal.eviction.EvictableEntryView;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-public interface CacheEntryView<K, V>
-        extends EvictableEntryView<K, V> {
+public interface CacheEntryView<K, V> extends EvictableEntryView<K, V> {
 
     /**
      * Gets the key of the cache entry.
@@ -61,5 +60,4 @@ public interface CacheEntryView<K, V>
      * @return the count of how many time this cache entry has been accessed
      */
     long getAccessHit();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
@@ -21,36 +21,37 @@ import com.hazelcast.nio.serialization.BinaryInterface;
 import java.io.Serializable;
 
 /**
+ * Policy for merging cache entries after a split-brain has been healed.
  * <p>
- * Policy for merging cache entries.
- * </p>
+ * Passed {@link CacheEntryView} instances wrap the key and value as their original types
+ * with conversion to object from their storage types. If you don't need the original types
+ * of key and value, you should use {@link StorageTypeAwareCacheMergePolicy} which is
+ * a sub-type of this interface.
  *
- * <p>
- * Passed {@link CacheEntryView} instances wraps the key and value as their original types
- * with convertion to object from their storage types. If user doesn't need to original types of key and value,
- * (s)he should use {@link StorageTypeAwareCacheMergePolicy} which is sub-type of this interface.
- * </p>
+ * @see com.hazelcast.cache.merge.HigherHitsCacheMergePolicy
+ * @see com.hazelcast.cache.merge.LatestAccessCacheMergePolicy
+ * @see com.hazelcast.cache.merge.PassThroughCacheMergePolicy
+ * @see com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy
  */
 @BinaryInterface
 public interface CacheMergePolicy extends Serializable {
 
     /**
-     * <p>
      * Selects one of the merging and existing cache entries to be merged.
-     * </p>
-     *
      * <p>
-     * Note that as mentioned also in arguments, the {@link CacheEntryView} instance that represents existing cache entry
-     * may be null if there is no existing entry for the specified key in the the {@link CacheEntryView} instance
-     * that represents merging cache entry.
-     * </p>
+     * Note that the {@code existingEntry} may be {@code null} if there
+     * is no entry with the same key in the destination cache.
+     * This happens, when the entry for that key was
+     * <ul>
+     * <li>only created in the smaller sub-cluster during the split-brain</li>
+     * <li>removed in the larger sub-cluster during the split-brain</li>
+     * </ul>
      *
      * @param cacheName     name of the cache
-     * @param mergingEntry  {@link CacheEntryView} instance that has cache entry to be merged
-     * @param existingEntry {@link CacheEntryView} instance that has existing cache entry.
-     *                      This entry may be <code>null</code> if there is no existing cache entry.
-     * @return the selected value for merging
+     * @param mergingEntry  {@link CacheEntryView} instance that has the cache entry to be merged
+     * @param existingEntry {@link CacheEntryView} instance that has the existing cache entry
+     *                      or {@code null} if there is no existing cache entry
+     * @return the selected value for merging or {@code null} if the entry should be removed
      */
     Object merge(String cacheName, CacheEntryView mergingEntry, CacheEntryView existingEntry);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/StorageTypeAwareCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/StorageTypeAwareCacheMergePolicy.java
@@ -24,7 +24,7 @@ package com.hazelcast.cache;
  * So there is no need to convert them to their original types.
  * <p>
  * In the worst case, the value is returned from the merge method as selected, which means that in all cases
- * the value is accessed. So although the convertion is done lazily, it will be processed at this point.
+ * the value is accessed. So although the conversion is done lazily, it will be processed at this point.
  * But by default, the key and value are converted to their original types
  * unless this {@link com.hazelcast.cache.StorageTypeAwareCacheMergePolicy} is used.
  * <p>

--- a/hazelcast/src/main/java/com/hazelcast/cache/StorageTypeAwareCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/StorageTypeAwareCacheMergePolicy.java
@@ -17,39 +17,28 @@
 package com.hazelcast.cache;
 
 /**
- * <p>
  * Marker interface for indicating that key and value wrapped by
  * {@link com.hazelcast.cache.CacheEntryView} will be not converted to their original types.
- * </p>
- *
  * <p>
- * The motivation of this interface is that generally while merging cache entries, actual key and value is not checked.
- * So no need to convert them to their original types.
- * </p>
- *
+ * The motivation of this interface is that generally while merging cache entries, actual key and value are not checked.
+ * So there is no need to convert them to their original types.
  * <p>
- * At worst case, value is returned from the merge method as selected and this means that at all cases
- * value is accessed. So even the the convertion is done as lazy, it will be processed at this point.
- * But by default, they (key and value) converted to their original types
+ * In the worst case, the value is returned from the merge method as selected, which means that in all cases
+ * the value is accessed. So although the convertion is done lazily, it will be processed at this point.
+ * But by default, the key and value are converted to their original types
  * unless this {@link com.hazelcast.cache.StorageTypeAwareCacheMergePolicy} is used.
- * </p>
- *
  * <p>
  * Another motivation for using this interface is that at server side
  * there is no need to locate classes of stored entries.
- * It means that entries can be put from client with `BINARY` in-memory format and
+ * It means that entries can be put from client with {@code BINARY} in-memory format and
  * classpath of client can be different from server.
  * So in this case, if entries are tried to convert to their original types while merging,
  * {@link java.lang.ClassNotFoundException} is thrown here.
- * </p>
- *
  * <p>
  * As a result, both of performance and {@link java.lang.ClassNotFoundException} as mentioned above,
  * it is strongly recommended to use this interface if original values of key and values are not needed.
- * </p>
  *
  * @see com.hazelcast.cache.CacheMergePolicy
  */
 public interface StorageTypeAwareCacheMergePolicy extends CacheMergePolicy {
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -237,8 +237,8 @@ public class CacheRecordStore
 
     private CacheEntryView createCacheEntryView(Object key, Object value, long creationTime, long expirationTime,
                                                 long lastAccessTime, long accessHit, CacheMergePolicy mergePolicy) {
-        // null serialization service means that use as storage type without convertion,
-        // non-null serialization service means that convertion is required
+        // null serialization service means that use as storage type without conversion,
+        // non-null serialization service means that conversion is required
         SerializationService ss = mergePolicy instanceof StorageTypeAwareCacheMergePolicy ? null : serializationService;
         return new LazyCacheEntryView(key, value, creationTime, expirationTime, lastAccessTime, accessHit, ss);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/SplitBrainAwareCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/SplitBrainAwareCacheRecordStore.java
@@ -29,16 +29,14 @@ import com.hazelcast.nio.serialization.Data;
  * @see CacheEntryView
  * @see CacheMergePolicy
  */
-public interface SplitBrainAwareCacheRecordStore
-        extends ICacheRecordStore {
+public interface SplitBrainAwareCacheRecordStore extends ICacheRecordStore {
 
     /**
      * Merges given record (inside given {@link CacheEntryView}) with the existing record as given {@link CacheMergePolicy}.
      *
-     * @param cacheEntryView    the {@link CacheEntryView} instance that wraps key/value for merging and existing entry
-     * @param mergePolicy       the {@link CacheMergePolicy} instance for handling merge policy
-     * @return the used {@link CacheRecord} if merge is applied, otherwise <code>null</code>
+     * @param cacheEntryView the {@link CacheEntryView} instance that wraps key/value for merging and existing entry
+     * @param mergePolicy    the {@link CacheMergePolicy} instance for handling merge policy
+     * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
      */
     CacheRecord merge(CacheEntryView<Data, Data> cacheEntryView, CacheMergePolicy mergePolicy);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
@@ -36,7 +36,7 @@ public class LazyCacheEntryView<K, V>
 
     public LazyCacheEntryView(Object key, Object value, long creationTime,
                               long expirationTime, long lastAccessTime, long accessHit) {
-        // `null` `serializationService` means, use raw type without any convertion
+        // `null` `serializationService` means, use raw type without any conversion
         this(key, value, creationTime, expirationTime, lastAccessTime, accessHit, null);
     }
 
@@ -54,7 +54,7 @@ public class LazyCacheEntryView<K, V>
 
     @Override
     public K getKey() {
-        // `null` `serializationService` means, use raw type without any convertion
+        // `null` `serializationService` means, use raw type without any conversion
         if (serializationService != null) {
             key = serializationService.toObject(key);
         }
@@ -63,7 +63,7 @@ public class LazyCacheEntryView<K, V>
 
     @Override
     public V getValue() {
-        // `null` `serializationService` means, use raw type without any convertion
+        // `null` `serializationService` means, use raw type without any conversion
         if (serializationService != null) {
             value = serializationService.toObject(value);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/policy/CacheMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/policy/CacheMergePolicyProvider.java
@@ -33,7 +33,7 @@ import static com.hazelcast.nio.ClassLoaderUtil.newInstance;
  */
 public final class CacheMergePolicyProvider {
 
-    private final ConcurrentMap<String, CacheMergePolicy> mergePolicyMap;
+    private final ConcurrentMap<String, CacheMergePolicy> mergePolicyMap = new ConcurrentHashMap<String, CacheMergePolicy>();
     private final NodeEngine nodeEngine;
 
     private final ConstructorFunction<String, CacheMergePolicy> policyConstructorFunction
@@ -51,16 +51,15 @@ public final class CacheMergePolicyProvider {
 
     public CacheMergePolicyProvider(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        this.mergePolicyMap = new ConcurrentHashMap<String, CacheMergePolicy>();
         addOutOfBoxPolicies();
     }
 
     private void addOutOfBoxPolicies() {
         for (BuiltInCacheMergePolicies mergePolicy : BuiltInCacheMergePolicies.values()) {
-            final CacheMergePolicy cacheMergePolicy = mergePolicy.newInstance();
-            // Register `CacheMergePolicy` by its constant
+            CacheMergePolicy cacheMergePolicy = mergePolicy.newInstance();
+            // register `CacheMergePolicy` by its constant
             mergePolicyMap.put(mergePolicy.name(), cacheMergePolicy);
-            // Register `CacheMergePolicy` by its name
+            // register `CacheMergePolicy` by its name
             mergePolicyMap.put(mergePolicy.getImplementationClassName(), cacheMergePolicy);
         }
     }
@@ -71,5 +70,4 @@ public final class CacheMergePolicyProvider {
         }
         return ConcurrencyUtil.getOrPutIfAbsent(mergePolicyMap, className, policyConstructorFunction);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
@@ -21,15 +21,13 @@ import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
 import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
- * `HigherHitsCacheMergePolicy` merges cache entry from source to destination cache
- * if source entry has more hits than the destination one.
+ * Merges cache entries from source to destination cache if the source entry
+ * has more hits than the destination one.
  */
 @BinaryInterface
-public class HigherHitsCacheMergePolicy
-        implements StorageTypeAwareCacheMergePolicy {
+public class HigherHitsCacheMergePolicy implements StorageTypeAwareCacheMergePolicy {
 
     public HigherHitsCacheMergePolicy() {
-
     }
 
     @Override
@@ -39,5 +37,4 @@ public class HigherHitsCacheMergePolicy
         }
         return existingEntry.getValue();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
@@ -21,23 +21,22 @@ import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
 import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
- * `LatestAccessCacheMergePolicy` merges cache entry from source to destination cache
- * if source entry has been accessed more recently than the destination entry.
+ * Merges cache entries from source to destination cache if the source entry
+ * has been accessed more recently than the destination entry.
+ * <p>
+ * <b>Note:</b> This policy can only be used if the clocks of the nodes are in sync.
  */
 @BinaryInterface
-public class LatestAccessCacheMergePolicy
-        implements StorageTypeAwareCacheMergePolicy {
+public class LatestAccessCacheMergePolicy implements StorageTypeAwareCacheMergePolicy {
 
     public LatestAccessCacheMergePolicy() {
-
     }
 
     @Override
     public Object merge(String cacheName, CacheEntryView mergingEntry, CacheEntryView existingEntry) {
-        if (existingEntry == null ||  mergingEntry.getLastAccessTime() >= existingEntry.getLastAccessTime()) {
+        if (existingEntry == null || mergingEntry.getLastAccessTime() >= existingEntry.getLastAccessTime()) {
             return mergingEntry.getValue();
         }
         return existingEntry.getValue();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
@@ -21,19 +21,16 @@ import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
 import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
- * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination directly.
+ * Merges cache entries from source to destination directly unless the merging entry is {@code null}.
  */
 @BinaryInterface
-public class PassThroughCacheMergePolicy
-        implements StorageTypeAwareCacheMergePolicy {
+public class PassThroughCacheMergePolicy implements StorageTypeAwareCacheMergePolicy {
 
     public PassThroughCacheMergePolicy() {
-
     }
 
     @Override
     public Object merge(String cacheName, CacheEntryView mergingEntry, CacheEntryView existingEntry) {
         return mergingEntry != null ? mergingEntry.getValue() : existingEntry.getValue();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
@@ -21,15 +21,12 @@ import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
 import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
- * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination
- * if it does not exist in the destination cache.
+ * Merges cache entries from source to destination if they don't exist in the destination cache.
  */
 @BinaryInterface
-public class PutIfAbsentCacheMergePolicy
-        implements StorageTypeAwareCacheMergePolicy {
+public class PutIfAbsentCacheMergePolicy implements StorageTypeAwareCacheMergePolicy {
 
     public PutIfAbsentCacheMergePolicy() {
-
     }
 
     @Override
@@ -39,5 +36,4 @@ public class PutIfAbsentCacheMergePolicy
         }
         return existingEntry.getValue();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * <p>This package contains out of the box merge policies.<br/>
+ * Contains out-of-the-box merge policies for {@link com.hazelcast.cache.ICache}.
  */
 package com.hazelcast.cache.merge;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -118,7 +118,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
 
         private static final int TIMEOUT_FACTOR = 500;
 
-        private Map<MapContainer, Collection<Record>> recordMap;
+        private final Map<MapContainer, Collection<Record>> recordMap;
 
         Merger(Map<MapContainer, Collection<Record>> recordMap) {
             this.recordMap = recordMap;
@@ -126,9 +126,8 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
 
         @Override
         public void run() {
-            final Semaphore semaphore = new Semaphore(0);
-            int recordCount = 0;
             final ILogger logger = nodeEngine.getLogger(MapSplitBrainHandlerService.class);
+            final Semaphore semaphore = new Semaphore(0);
 
             ExecutionCallback mergeCallback = new ExecutionCallback() {
                 @Override
@@ -143,6 +142,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                 }
             };
 
+            int recordCount = 0;
             for (Map.Entry<MapContainer, Collection<Record>> recordMapEntry : recordMap.entrySet()) {
                 MapContainer mapContainer = recordMapEntry.getKey();
                 Collection<Record> recordList = recordMapEntry.getValue();
@@ -159,8 +159,8 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                     EntryView entryView = EntryViews.createSimpleEntryView(record.getKey(),
                             mapServiceContext.toData(record.getValue()), record);
 
-                    MapOperation operation = operationProvider.createMergeOperation(mapName,
-                            record.getKey(), entryView, finalMergePolicy, false);
+                    MapOperation operation = operationProvider.createMergeOperation(mapName, record.getKey(), entryView,
+                            finalMergePolicy, false);
                     try {
                         int partitionId = nodeEngine.getPartitionService().getPartitionId(record.getKey());
                         ICompletableFuture f = nodeEngine.getOperationService()
@@ -179,6 +179,5 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                 logger.finest("Interrupted while waiting merge operation...");
             }
         }
-
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/HigherHitsMapMergePolicy.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 
 
 /**
- * HigherHitsMapMergePolicy causes the merging entry to be merged from source to destination map
- * if source entry has more hits than the destination one.
+ * Merges map entries from source to destination map if the source entry
+ * has more hits than the destination one.
  */
 public class HigherHitsMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/IgnoreMergingEntryMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/IgnoreMergingEntryMapMergePolicy.java
@@ -25,8 +25,10 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 
 /**
- * IgnoreMergingEntryMapMergePolicy causes the merging entry to be ignored while collecting merge-needed entries on merging side
- * Its operations are not implemented since it is only used as a marker
+ * Ignores the merging entry while collecting merge-needed entries on merging side.
+ * <p>
+ * <b>Note:</b> Its operations are not implemented since it is only used as a marker.
+ *
  * @since 3.9
  */
 public final class IgnoreMergingEntryMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicy.java
@@ -25,10 +25,10 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 
 /**
- * LatestUpdateMapMergePolicy causes the merging entry to be merged from source to destination map
- * if source entry has updated more recently than the destination entry.
- *
- * This policy can only be used of the clocks of the machines are in sync.
+ * Merges map entries from source to destination map if the source entry
+ * was updated more recently than the destination entry.
+ * <p>
+ * <b>Note:</b> This policy can only be used if the clocks of the nodes are in sync.
  */
 public class LatestUpdateMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/MapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/MapMergePolicy.java
@@ -20,27 +20,31 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.nio.serialization.DataSerializable;
 
 /**
- * A policy for merging maps after a splitbrain was detected and the different network partitions need
- * to be merged.
+ * Policy for merging map entries after a split-brain has been healed.
  *
- * @see com.hazelcast.map.merge.MapMergePolicy
- * @see com.hazelcast.map.merge.PutIfAbsentMapMergePolicy
+ * @see com.hazelcast.map.merge.HigherHitsMapMergePolicy
  * @see com.hazelcast.map.merge.LatestUpdateMapMergePolicy
  * @see com.hazelcast.map.merge.PassThroughMergePolicy
- * @see com.hazelcast.map.merge.HigherHitsMapMergePolicy
+ * @see com.hazelcast.map.merge.PutIfAbsentMapMergePolicy
  */
 public interface MapMergePolicy extends DataSerializable {
 
     /**
-     * Returns the value of the entry after the merge
-     * of entries with the same key.
-     * You should consider the case where existingEntry's value is null.
+     * Selects one of the merging and existing map entries to be merged.
+     * <p>
+     * Note that the {@code existingEntry} may be {@code null} if there
+     * is no entry with the same key in the destination map.
+     * This happens, when the entry for that key was
+     * <ul>
+     * <li>only created in the smaller sub-cluster during the split-brain</li>
+     * <li>removed in the larger sub-cluster during the split-brain</li>
+     * </ul>
      *
      * @param mapName       name of the map
-     * @param mergingEntry  entry merging into the destination cluster
-     * @param existingEntry existing entry in the destination cluster
-     * @return final value of the entry. If returns null, then the entry will be removed.
+     * @param mergingEntry  {@link EntryView} instance that has the map entry to be merged
+     * @param existingEntry {@link EntryView} instance that has the existing map entry
+     *                      or {@code null} if there is no existing map entry
+     * @return the selected value for merging or {@code null} if the entry should be removed
      */
     Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/MergePolicyProvider.java
@@ -28,11 +28,11 @@ import static com.hazelcast.nio.ClassLoaderUtil.newInstance;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * A provider for {@link com.hazelcast.map.merge.MergePolicyProvider} instances.
+ * A provider for {@link com.hazelcast.map.merge.MapMergePolicy} instances.
  */
 public final class MergePolicyProvider {
 
-    private final ConcurrentMap<String, MapMergePolicy> mergePolicyMap;
+    private final ConcurrentMap<String, MapMergePolicy> mergePolicyMap = new ConcurrentHashMap<String, MapMergePolicy>();
 
     private final NodeEngine nodeEngine;
 
@@ -51,7 +51,6 @@ public final class MergePolicyProvider {
 
     public MergePolicyProvider(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        mergePolicyMap = new ConcurrentHashMap<String, MapMergePolicy>();
         addOutOfBoxPolicies();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PassThroughMergePolicy.java
@@ -24,10 +24,8 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
-
 /**
- * PassThroughMergePolicy causes the merging entry to be merged from source to destination map
- * unless merging entry is null.
+ * Merges map entries from source to destination directly unless the merging entry is {@code null}.
  */
 public class PassThroughMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
@@ -24,10 +24,8 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
-
 /**
- * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map
- * if it does not exist in the destination map.
+ * Merges map entries from source to destination if they don't exist in the destination map.
  */
 public class PutIfAbsentMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Contains merge policies for {@link com.hazelcast.core.IMap}
+ * Contains out-of-the-box merge policies for {@link com.hazelcast.core.IMap}.
  */
 package com.hazelcast.map.merge;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
 
 /**
- * Provides base features for predicates, such as extraction and convertion of the attribute's value.
+ * Provides base features for predicates, such as extraction and conversion of the attribute's value.
  * It also handles apply() on MultiResult.
  */
 @BinaryInterface

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
 
 /**
- * Contains split-brain handling logic for {@link com.hazelcast.core.ReplicatedMap}
+ * Contains split-brain handling logic for {@link com.hazelcast.core.ReplicatedMap}.
  */
 public class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerService {
 
@@ -54,8 +54,7 @@ public class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerS
     private final NodeEngine nodeEngine;
     private final SerializationService serializationService;
 
-    public ReplicatedMapSplitBrainHandlerService(ReplicatedMapService service,
-                                                 MergePolicyProvider mergePolicyProvider) {
+    public ReplicatedMapSplitBrainHandlerService(ReplicatedMapService service, MergePolicyProvider mergePolicyProvider) {
         this.service = service;
         this.mergePolicyProvider = mergePolicyProvider;
         this.nodeEngine = service.getNodeEngine();
@@ -100,9 +99,8 @@ public class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerS
 
         @Override
         public void run() {
-            final Semaphore semaphore = new Semaphore(0);
-            int recordCount = 0;
             final ILogger logger = nodeEngine.getLogger(ReplicatedMapService.class);
+            final Semaphore semaphore = new Semaphore(0);
 
             ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
                 @Override
@@ -117,6 +115,7 @@ public class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerS
                 }
             };
 
+            int recordCount = 0;
             for (Map.Entry<String, Collection<ReplicatedRecord>> entry : recordMap.entrySet()) {
                 recordCount++;
                 String name = entry.getKey();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -375,7 +375,6 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             Data dataValue = serializationService.toData(newValue);
             VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
             sendReplicationOperation(false, getName(), dataKey, dataValue, record.getTtlMillis(), responsePair);
-
         }
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
@@ -22,16 +22,14 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
-import java.io.IOException;
-
 /**
- * HigherHitsMapMergePolicy causes the merging entry to be merged from source to destination map
- * if source entry has more hits than the destination one.
+ * Merges replicated map entries from source to destination map if the source entry
+ * has more hits than the destination one.
  */
 public final class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
 
     /**
-     * Single instance of this class
+     * Single instance of this class.
      */
     public static final HigherHitsMapMergePolicy INSTANCE = new HigherHitsMapMergePolicy();
 
@@ -57,14 +55,10 @@ public final class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy,
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
+    public void writeData(ObjectDataOutput out) {
     }
 
     @Override
-    public void readData(ObjectDataInput in) throws IOException {
-    }
-
-    private Object readResolve() {
-        return INSTANCE;
+    public void readData(ObjectDataInput in) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
@@ -22,18 +22,16 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
-import java.io.IOException;
-
 /**
- * LatestUpdateMapMergePolicy causes the merging entry to be merged from source to destination map
- * if source entry has updated more recently than the destination entry.
- * <p/>
- * This policy can only be used of the clocks of the machines are in sync.
+ * Merges replicated map entries from source to destination map if the source entry
+ * was updated more recently than the destination entry.
+ * <p>
+ * <b>Note:</b> This policy can only be used if the clocks of the nodes are in sync.
  */
 public final class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
 
     /**
-     * Single instance of this class
+     * Single instance of this class.
      */
     public static final LatestUpdateMapMergePolicy INSTANCE = new LatestUpdateMapMergePolicy();
 
@@ -59,14 +57,10 @@ public final class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolic
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
+    public void writeData(ObjectDataOutput out) {
     }
 
     @Override
-    public void readData(ObjectDataInput in) throws IOException {
-    }
-
-    private Object readResolve() {
-        return INSTANCE;
+    public void readData(ObjectDataInput in) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
@@ -32,7 +32,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public final class MergePolicyProvider {
 
-    private final ConcurrentMap<String, ReplicatedMapMergePolicy> mergePolicyMap;
+    private final ConcurrentMap<String, ReplicatedMapMergePolicy> mergePolicyMap
+            = new ConcurrentHashMap<String, ReplicatedMapMergePolicy>();
 
     private final NodeEngine nodeEngine;
 
@@ -51,7 +52,6 @@ public final class MergePolicyProvider {
 
     public MergePolicyProvider(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        mergePolicyMap = new ConcurrentHashMap<String, ReplicatedMapMergePolicy>();
         addOutOfBoxPolicies();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
@@ -22,16 +22,13 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
-import java.io.IOException;
-
 /**
- * PassThroughMergePolicy causes the merging entry to be merged from source to destination map
- * unless merging entry is null.
+ * Merges replicated map entries from source to destination directly unless the merging entry is {@code null}.
  */
 public final class PassThroughMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
 
     /**
-     * Single instance of this class
+     * Single instance of this class.
      */
     public static final PassThroughMergePolicy INSTANCE = new PassThroughMergePolicy();
 
@@ -54,14 +51,10 @@ public final class PassThroughMergePolicy implements ReplicatedMapMergePolicy, I
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
+    public void writeData(ObjectDataOutput out) {
     }
 
     @Override
-    public void readData(ObjectDataInput in) throws IOException {
-    }
-
-    private Object readResolve() {
-        return INSTANCE;
+    public void readData(ObjectDataInput in) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
@@ -22,16 +22,13 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
-import java.io.IOException;
-
 /**
- * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map
- * if it does not exist in the destination map.
+ * Merges replicated map entries from source to destination if they don't exist in the destination map.
  */
 public final class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
 
     /**
-     * Single instance of this class
+     * Single instance of this class.
      */
     public static final PutIfAbsentMapMergePolicy INSTANCE = new PutIfAbsentMapMergePolicy();
 
@@ -57,14 +54,10 @@ public final class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
+    public void writeData(ObjectDataOutput out) {
     }
 
     @Override
-    public void readData(ObjectDataInput in) throws IOException {
-    }
-
-    private Object readResolve() {
-        return INSTANCE;
+    public void readData(ObjectDataInput in) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/ReplicatedMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/ReplicatedMapMergePolicy.java
@@ -21,25 +21,31 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 import java.io.Serializable;
 
 /**
- * A policy for merging replicated maps after a split-brain was detected and the different network partitions need
- * to be merged.
+ * Policy for merging replicated map entries after a split-brain has been healed.
  *
  * @see com.hazelcast.replicatedmap.merge.HigherHitsMapMergePolicy
- * @see com.hazelcast.replicatedmap.merge.PutIfAbsentMapMergePolicy
  * @see com.hazelcast.replicatedmap.merge.LatestUpdateMapMergePolicy
  * @see com.hazelcast.replicatedmap.merge.PassThroughMergePolicy
+ * @see com.hazelcast.replicatedmap.merge.PutIfAbsentMapMergePolicy
  */
 public interface ReplicatedMapMergePolicy extends Serializable {
 
     /**
-     * Returns the value of the entry after the merge
-     * of entries with the same key.
-     * You should consider the case where existingEntry's value is null.
+     * Selects one of the merging and existing map entries to be merged.
+     * <p>
+     * Note that the {@code existingEntry} may be {@code null} if there
+     * is no entry with the same key in the destination map.
+     * This happens, when the entry for that key was
+     * <ul>
+     * <li>only created in the smaller sub-cluster during the split-brain</li>
+     * <li>removed in the larger sub-cluster during the split-brain</li>
+     * </ul>
      *
      * @param mapName       name of the replicated map
-     * @param mergingEntry  entry merging into the destination cluster
-     * @param existingEntry existing entry in the destination cluster
-     * @return final value of the entry. If returns null, then the entry will be removed.
+     * @param mergingEntry  {@link ReplicatedMapEntryView} instance that has the map entry to be merged
+     * @param existingEntry {@link ReplicatedMapEntryView} instance that has the existing map entry
+     *                      or {@code null} if there is no existing map entry
+     * @return the selected value for merging or {@code null} if the entry should be removed
      */
     Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry);
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Contains merge policies for {@link com.hazelcast.core.ReplicatedMap}
+ * Contains out-of-the-box merge policies for {@link com.hazelcast.core.ReplicatedMap}.
  */
 package com.hazelcast.replicatedmap.merge;

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/AbstractCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/AbstractCacheMergePolicyTest.java
@@ -48,6 +48,7 @@ public abstract class AbstractCacheMergePolicyTest {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void merge_mergingWins_sinceExistingIsNotExist() {
         CacheEntryView existing = null;
         CacheEntryView merging = entryWithGivenPropertyAndValue(1, MERGING);
@@ -85,5 +86,4 @@ public abstract class AbstractCacheMergePolicyTest {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheMergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheMergePolicyProviderTest.java
@@ -64,50 +64,42 @@ public class CacheMergePolicyProviderTest extends HazelcastTestSupport {
 
     @Test
     public void getMergePolicy_withClassName_PutIfAbsentCacheMergePolicy() {
-        assertMergePolicyCorrectlyInitialised(PutIfAbsentCacheMergePolicy.class.getName(),
-                PutIfAbsentCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(PutIfAbsentCacheMergePolicy.class.getName(), PutIfAbsentCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withConstant_PutIfAbsentCacheMergePolicy() {
-        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.PUT_IF_ABSENT.name(),
-                PutIfAbsentCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.PUT_IF_ABSENT.name(), PutIfAbsentCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withClassName_LatestAccessCacheMergePolicy() {
-        assertMergePolicyCorrectlyInitialised(LatestAccessCacheMergePolicy.class.getName(),
-                LatestAccessCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(LatestAccessCacheMergePolicy.class.getName(), LatestAccessCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withConstant_LatestAccessCacheMergePolicy() {
-        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.LATEST_ACCESS.name(),
-                LatestAccessCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.LATEST_ACCESS.name(), LatestAccessCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withClassName_PassThroughCachePolicy() {
-        assertMergePolicyCorrectlyInitialised(PassThroughCacheMergePolicy.class.getName(),
-                PassThroughCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(PassThroughCacheMergePolicy.class.getName(), PassThroughCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withConstant_PassThroughCachePolicy() {
-        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.PASS_THROUGH.name(),
-                PassThroughCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.PASS_THROUGH.name(), PassThroughCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withClassName_HigherHitsMapCachePolicy() {
-        assertMergePolicyCorrectlyInitialised(HigherHitsCacheMergePolicy.class.getName(),
-                HigherHitsCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(HigherHitsCacheMergePolicy.class.getName(), HigherHitsCacheMergePolicy.class);
     }
 
     @Test
     public void getMergePolicy_withConstant_HigherHitsMapCachePolicy() {
-        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.HIGHER_HITS.name(),
-                HigherHitsCacheMergePolicy.class);
+        assertMergePolicyCorrectlyInitialised(BuiltInCacheMergePolicies.HIGHER_HITS.name(), HigherHitsCacheMergePolicy.class);
     }
 
     private void assertMergePolicyCorrectlyInitialised(String mergePolicyName,
@@ -117,5 +109,4 @@ public class CacheMergePolicyProviderTest extends HazelcastTestSupport {
         assertNotNull(mergePolicy);
         assertEquals(expectedMergePolicyClass, mergePolicy.getClass());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicyTest.java
@@ -31,5 +31,4 @@ public class HigherHitsCacheMergePolicyTest extends AbstractCacheMergePolicyTest
     protected CacheMergePolicy createCacheMergePolicy() {
         return new HigherHitsCacheMergePolicy();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicyTest.java
@@ -31,5 +31,4 @@ public class LatestAccessCacheMergePolicyTest extends AbstractCacheMergePolicyTe
     protected CacheMergePolicy createCacheMergePolicy() {
         return new LatestAccessCacheMergePolicy();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicyTest.java
@@ -53,6 +53,7 @@ public class PassThroughCacheMergePolicyTest {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void merge_mergingNull() {
         CacheEntryView existing = entryWithGivenValue(EXISTING);
         CacheEntryView merging = null;
@@ -69,5 +70,4 @@ public class PassThroughCacheMergePolicyTest {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicyTest.java
@@ -46,6 +46,7 @@ public class PutIfAbsentCacheMergePolicyTest {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void merge_existingValueAbsent() {
         CacheEntryView existing = null;
         CacheEntryView merging = entryWithGivenValue(MERGING);
@@ -78,5 +79,4 @@ public class PutIfAbsentCacheMergePolicyTest {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/AbstractMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/AbstractMapMergePolicyTest.java
@@ -67,7 +67,5 @@ public abstract class AbstractMapMergePolicyTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/HigherHitsMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/HigherHitsMapMergePolicyTest.java
@@ -31,5 +31,4 @@ public class HigherHitsMapMergePolicyTest extends AbstractMapMergePolicyTest {
     public void given() {
         policy = new HigherHitsMapMergePolicy();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicyTest.java
@@ -31,5 +31,4 @@ public class LatestUpdateMapMergePolicyTest extends AbstractMapMergePolicyTest {
     public void given() {
         policy = new LatestUpdateMapMergePolicy();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MergePolicyProviderTest.java
@@ -85,5 +85,4 @@ public class MergePolicyProviderTest extends HazelcastTestSupport {
         assertNotNull(mergePolicy);
         assertEquals(mergePolicyName, mergePolicy.getClass().getName());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/PassThroughMapMergePolicyTest.java
@@ -52,6 +52,7 @@ public class PassThroughMapMergePolicyTest {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void merge_mergingNull() {
         EntryView existing = entryWithGivenValue(EXISTING);
         EntryView merging = null;
@@ -67,7 +68,5 @@ public class PassThroughMapMergePolicyTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicyTest.java
@@ -76,7 +76,5 @@ public class PutIfAbsentMapMergePolicyTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
@@ -66,6 +66,5 @@ public class PassThroughMapMergePolicyTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
 }


### PR DESCRIPTION
I grouped the cleanup in three commits (`ICache`, `IMap` and `ReplicatedMap`), so it should be easy to review commit by commit.

There should be no logic changes, just unification of JavaDoc and very small cleanups.