### PR TITLE
Configures surefire to rerun failing tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/FlakyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/FlakyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FlakyTest {
+
+    private static final AtomicInteger TEST_COUNT = new AtomicInteger();
+
+    @Test
+    public void failsFirstTime_succeedsSubsequently() {
+        if (TEST_COUNT.getAndIncrement() == 0) {
+            fail("First time execution always fails");
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
 
         <h2.version>1.3.160</h2.version>
         <atomikos.version>3.9.3</atomikos.version>
+        <flakyTestRerunCount>3</flakyTestRerunCount>
         <extraVmArgs/>
     </properties>
     <licenses>
@@ -268,6 +269,7 @@
                         com.hazelcast.test.annotation.SlowTest,
                         com.hazelcast.test.annotation.NightlyTest
                     </excludedGroups>
+                    <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -364,6 +366,7 @@
                                     <systemPropertyVariables>
                                         <multipleJVM>true</multipleJVM>
                                     </systemPropertyVariables>
+                                    <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                                 </configuration>
                             </execution>
                             <execution>
@@ -444,6 +447,7 @@
                                 com.hazelcast.test.annotation.SlowTest,
                                 com.hazelcast.test.annotation.NightlyTest
                             </excludedGroups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                         <dependencies>
                             <dependency>
@@ -617,6 +621,7 @@
                             <excludedGroups>
                                 com.hazelcast.test.annotation.NightlyTest
                             </excludedGroups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                         <dependencies>
                             <dependency>
@@ -763,6 +768,7 @@
                             <excludedGroups>
                                 com.hazelcast.test.annotation.NightlyTest
                             </excludedGroups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                     </plugin>
 
@@ -1024,6 +1030,7 @@
                                 com.hazelcast.test.annotation.NightlyTest,
                                 com.hazelcast.test.annotation.SlowTest
                             </groups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                         <dependencies>
                             <dependency>
@@ -1101,6 +1108,7 @@
                                 com.hazelcast.test.annotation.SlowTest,
                                 com.hazelcast.test.annotation.NightlyTest
                             </groups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                         <dependencies>
                             <dependency>
@@ -1179,6 +1187,7 @@
                                 com.hazelcast.test.annotation.SlowTest,
                                 com.hazelcast.test.annotation.NightlyTest
                             </excludedGroups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                         <dependencies>
                             <dependency>
@@ -1238,6 +1247,7 @@
                                 com.hazelcast.test.annotation.SlowTest,
                                 com.hazelcast.test.annotation.NightlyTest
                             </excludedGroups>
+                            <rerunFailingTestsCount>${flakyTestRerunCount}</rerunFailingTestsCount>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Configure surefire to rerun failed tests up to 3 times. Tests which fail-then-succeed will be reported separately as "flaky tests" in test results.