### PR TITLE
Skip logging that event journal cannot be destroyed on shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -107,7 +107,9 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
         try {
             service = getRingbufferService();
         } catch (Exception e) {
-            logger.fine("Could not retrieve ringbuffer service to destroy event journal " + namespace, e);
+            if (nodeEngine.isRunning()) {
+                logger.fine("Could not retrieve ringbuffer service to destroy event journal " + namespace, e);
+            }
             return;
         }
         service.destroyContainer(partitionId, namespace);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -95,7 +95,9 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
         try {
             service = getRingbufferService();
         } catch (Exception e) {
-            logger.fine("Could not retrieve ringbuffer service to destroy event journal " + namespace, e);
+            if (nodeEngine.isRunning()) {
+                logger.fine("Could not retrieve ringbuffer service to destroy event journal " + namespace, e);
+            }
             return;
         }
         service.destroyContainer(partitionId, namespace);


### PR DESCRIPTION
Logs the error that the ringbuffer service cannot be retrieved only if
the instance not shutting down. If the instance is shutting down, we
assume that the ringbuffers will be reset anyway.

Fixes: https://github.com/hazelcast/hazelcast/issues/11662