### PR TITLE
Cleanup of SplitBrainTestSupport and SplitBrainHandlerService classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -116,7 +116,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     protected NodeEngine nodeEngine;
     protected CachePartitionSegment[] segments;
     protected CacheEventHandler cacheEventHandler;
-    protected CacheSplitBrainHandler cacheSplitBrainHandler;
+    protected CacheSplitBrainHandlerService splitBrainHandlerService;
     protected RingbufferCacheEventJournalImpl eventJournal;
     protected ILogger logger;
 
@@ -129,7 +129,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
             segments[i] = newPartitionSegment(i);
         }
         this.cacheEventHandler = new CacheEventHandler(nodeEngine);
-        this.cacheSplitBrainHandler = new CacheSplitBrainHandler(nodeEngine, configs, segments);
+        this.splitBrainHandlerService = new CacheSplitBrainHandlerService(nodeEngine, configs, segments);
         this.logger = nodeEngine.getLogger(getClass());
         this.eventJournal = new RingbufferCacheEventJournalImpl(nodeEngine);
         postInit(nodeEngine, properties);
@@ -711,7 +711,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
     @Override
     public Runnable prepareMergeRunnable() {
-        return cacheSplitBrainHandler.prepareMergeRunnable();
+        return splitBrainHandlerService.prepareMergeRunnable();
     }
 
     public CacheEventHandler getCacheEventHandler() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -41,8 +41,12 @@ public final class EntryViews {
         return new NullEntryView<K, V>(key);
     }
 
+    public static <K, V> EntryView<K, V> createSimpleEntryView() {
+        return new SimpleEntryView<K, V>();
+    }
+
     public static <K, V> EntryView<K, V> createSimpleEntryView(K key, V value, Record record) {
-        final SimpleEntryView simpleEntryView = new SimpleEntryView(key, value);
+        final SimpleEntryView<K, V> simpleEntryView = new SimpleEntryView<K, V>(key, value);
         simpleEntryView.setCost(record.getCost());
         simpleEntryView.setVersion(record.getVersion());
         simpleEntryView.setHits(record.getHits());
@@ -52,18 +56,13 @@ public final class EntryViews {
         simpleEntryView.setCreationTime(record.getCreationTime());
         simpleEntryView.setExpirationTime(record.getExpirationTime());
         simpleEntryView.setLastStoredTime(record.getLastStoredTime());
-
         return simpleEntryView;
-    }
-
-    public static <K, V> EntryView<K, V> createSimpleEntryView() {
-        return new SimpleEntryView<K, V>();
     }
 
     public static <K, V> EntryView<K, V> createLazyEntryView(K key, V value, Record record,
                                                              SerializationService serializationService,
                                                              MapMergePolicy mergePolicy) {
-        LazyEntryView lazyEntryView = new LazyEntryView(key, value, serializationService, mergePolicy);
+        LazyEntryView<K, V> lazyEntryView = new LazyEntryView<K, V>(key, value, serializationService, mergePolicy);
         lazyEntryView.setCost(record.getCost());
         lazyEntryView.setVersion(record.getVersion());
         lazyEntryView.setHits(record.getHits());
@@ -76,10 +75,10 @@ public final class EntryViews {
         return lazyEntryView;
     }
 
-    public static <K, V> EntryView<K, V> convertToLazyEntryView(EntryView entryView,
+    public static <K, V> EntryView<K, V> convertToLazyEntryView(EntryView<K, V> entryView,
                                                                 SerializationService serializationService,
                                                                 MapMergePolicy mergePolicy) {
-        final LazyEntryView lazyEntryView = new LazyEntryView(entryView.getKey(), entryView.getValue(),
+        final LazyEntryView<K, V> lazyEntryView = new LazyEntryView<K, V>(entryView.getKey(), entryView.getValue(),
                 serializationService, mergePolicy);
         lazyEntryView.setCost(entryView.getCost());
         lazyEntryView.setVersion(entryView.getVersion());
@@ -92,5 +91,4 @@ public final class EntryViews {
         lazyEntryView.setLastStoredTime(entryView.getLastStoredTime());
         return lazyEntryView;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -34,9 +34,10 @@ public class MergeOperation extends BasePutOperation {
 
     private MapMergePolicy mergePolicy;
     private EntryView<Data, Data> mergingEntry;
-    private boolean merged;
-    private Data mergingValue;
     private boolean disableWanReplicationEvent;
+
+    private transient boolean merged;
+    private transient Data mergingValue;
 
     public MergeOperation(String name, Data dataKey, EntryView<Data, Data> entryView,
                           MapMergePolicy policy) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
@@ -30,7 +30,6 @@ import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,18 +42,19 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * Contains split-brain handling logic for {@link com.hazelcast.core.ReplicatedMap}.
  */
-public class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerService {
+class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerService {
 
     private final ReplicatedMapService service;
     private final MergePolicyProvider mergePolicyProvider;
     private final NodeEngine nodeEngine;
     private final SerializationService serializationService;
 
-    public ReplicatedMapSplitBrainHandlerService(ReplicatedMapService service, MergePolicyProvider mergePolicyProvider) {
+    ReplicatedMapSplitBrainHandlerService(ReplicatedMapService service, MergePolicyProvider mergePolicyProvider) {
         this.service = service;
         this.mergePolicyProvider = mergePolicyProvider;
         this.nodeEngine = service.getNodeEngine();
@@ -132,7 +132,7 @@ public class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerS
                                 .invokeOnPartition(SERVICE_NAME, mergeOperation, partitionId);
                         future.andThen(mergeCallback);
                     } catch (Throwable t) {
-                        throw ExceptionUtil.rethrow(t);
+                        throw rethrow(t);
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainHandlerService.java
@@ -18,20 +18,17 @@ package com.hazelcast.spi;
 
 /**
  * An interface that can be implemented by SPI services that want to be able to resolve a split brain.
- * <p/>
- * So when the 2 separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
- * a Runnable that will merge the clusters.
- *
- * @author mdogan 1/31/13
+ * <p>
+ * When the two separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
+ * a {@link Runnable} that will merge the clusters.
  */
 public interface SplitBrainHandlerService {
 
     /**
-     * When the 2 separate clusters merge (resolve a split brain), this method is called to return
-     * a Runnable that will merge the clusters.
+     * When the two separate clusters merge (resolve a split brain), this method is called to return
+     * a {@link Runnable} that will merge the clusters.
      *
-     * @return a Runnable that will merge the clusters
+     * @return a {@link Runnable} that will merge the clusters
      */
     Runnable prepareMergeRunnable();
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -31,9 +31,9 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class ListSplitBrainTest extends SplitBrainTestSupport {
 
-    private String name = randomString();
-    private int initialCount = 100;
-    private int finalCount = initialCount + 50;
+    private final String name = randomString();
+    private final int initialCount = 100;
+    private final int finalCount = initialCount + 50;
 
     @Override
     protected int[] brains() {
@@ -42,7 +42,7 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) throws Exception {
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         IList<Object> list = instances[0].getList(name);
 
         for (int i = 0; i < initialCount; i++) {
@@ -53,8 +53,7 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain)
-            throws Exception {
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
 
         IList<Object> list1 = firstBrain[0].getList(name);
         for (int i = initialCount; i < finalCount; i++) {
@@ -68,7 +67,7 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         for (HazelcastInstance instance : instances) {
             IList<Object> list = instance.getList(name);
             assertListContents(list);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class QueueSplitBrainTest extends SplitBrainTestSupport {
 
-    private String name = randomString();
+    private final String name = randomString();
     private final int initialCount = 100;
     private final int finalCount = initialCount + 50;
 
@@ -42,7 +42,7 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) throws Exception {
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         IQueue<Object> queue = instances[0].getQueue(name);
 
         for (int i = 0; i < initialCount; i++) {
@@ -53,9 +53,7 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain)
-            throws Exception {
-
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         IQueue<Object> queue1 = firstBrain[0].getQueue(name);
         for (int i = initialCount; i < finalCount; i++) {
             queue1.offer("item" + i);
@@ -68,7 +66,7 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         for (HazelcastInstance instance : instances) {
             IQueue<Object> queue = instance.getQueue(name);
             assertEquals(finalCount, queue.size());

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -41,7 +41,7 @@ public class CountDownLatchSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) throws Exception {
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
         name = generateKeyOwnedBy(instances[instances.length - 1]);
 
@@ -52,9 +52,7 @@ public class CountDownLatchSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain)
-            throws Exception {
-
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         ICountDownLatch latch1 = firstBrain[0].getCountDownLatch(name);
         // count = 4
         latch1.countDown();
@@ -68,7 +66,7 @@ public class CountDownLatchSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         for (HazelcastInstance instance : instances) {
             ICountDownLatch latch = instance.getCountDownLatch(name);
             assertEquals(count, latch.getCount());

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -40,7 +40,7 @@ public class LockSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) throws Exception {
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
 
         HazelcastInstance lastInstance = instances[instances.length - 1];
@@ -53,9 +53,7 @@ public class LockSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain)
-            throws Exception {
-
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         // acquire lock on 1st brain
         firstBrain[0].getLock(key).lock();
 
@@ -64,7 +62,7 @@ public class LockSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         // all instances observe lock as acquired
         for (HazelcastInstance instance : instances) {
             ILock lock = instance.getLock(key);

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -57,16 +57,14 @@ public class SemaphoreSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain)
-            throws Exception {
-
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) throws Exception {
         final ISemaphore semaphore = firstBrain[0].getSemaphore(name);
 
         // when member is down, permits are released.
         // since releasing the permits is async, we use assert eventually
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(permits, semaphore.availablePermits());
             }
         });
@@ -75,7 +73,7 @@ public class SemaphoreSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         for (HazelcastInstance instance : instances) {
             ISemaphore semaphore = instance.getSemaphore(name);
             assertEquals(1, semaphore.availablePermits());

--- a/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
@@ -57,7 +57,7 @@ public class ProxySplitBrainTest extends SplitBrainTestSupport {
     private static void assertDistributedObjectCountEventually(final int expectedCount, final HazelcastInstance hz) {
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 int actualSize = hz.getDistributedObjects().size();
                 assertEquals(expectedCount, actualSize);
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest.java
@@ -1,7 +1,6 @@
 package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -12,7 +11,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -22,7 +20,7 @@ public class DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest exte
     private static final String MAP_NAME = "mapConfigCreatedInSmallerBrain";
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) throws Exception {
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         HazelcastInstance instanceInSmallerBrain = firstBrain[0];
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(TestConfigUtils.NON_DEFAULT_IN_MEMORY_FORMAT);
@@ -31,7 +29,7 @@ public class DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest exte
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         for (HazelcastInstance instance : instances) {
             final Config config = instance.getConfig();
             MapConfig mapConfig = config.findMapConfig(MAP_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest.java
@@ -1,7 +1,6 @@
 package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -12,16 +11,16 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest extends SplitBrainTestSupport {
+
     private static final String MAP_NAME = "mapConfigWithNonDefaultName";
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) throws Exception {
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         HazelcastInstance instanceInSmallerBrain = firstBrain[0];
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(TestConfigUtils.NON_DEFAULT_IN_MEMORY_FORMAT);
@@ -34,7 +33,7 @@ public class DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest e
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         MapConfig defaultMapConfig = new Config().findMapConfig("default");
 
         for (HazelcastInstance instance : instances) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -45,14 +45,10 @@ import static org.junit.Assert.assertThat;
 @Category({QuickTest.class, ParallelTest.class})
 public class IndexSplitBrainTest extends SplitBrainTestSupport {
 
-    private String mapName;
+    private final String mapName = randomMapName();
+
     private String key;
     private ValueObject value;
-
-    @Override
-    protected void onBeforeSetup() {
-        mapName = randomMapName();
-    }
 
     @Override
     protected int[] brains() {
@@ -60,8 +56,7 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances)
-            throws Exception {
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
         key = generateKeyOwnedBy(instances[0]);
         value = new ValueObject(key);
@@ -74,8 +69,7 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain)
-            throws Exception {
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         final IMap<String, ValueObject> map1 = firstBrain[0].getMap(mapName);
         final IMap<String, ValueObject> map2 = secondBrain[0].getMap(mapName);
         map1.remove(key);
@@ -83,22 +77,20 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances)
-            throws Exception {
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
         final IMap<String, ValueObject> map1 = instances[0].getMap(mapName);
         final IMap<String, ValueObject> map2 = instances[1].getMap(mapName);
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() {
                 assertNotNull("Entry should exist in map1 after merge", map1.get(key));
             }
         }, 15);
         map1.remove(key);
         assertTrueAllTheTime(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 Predicate predicate = Predicates.equal("id", value.getId());
                 Collection<ValueObject> values = map1.values(predicate);
                 assertThat(values, empty());
@@ -118,6 +110,7 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
     }
 
     private static class ValueObject implements DataSerializable {
+
         private String id;
 
         public ValueObject() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/WaitNotifySplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/WaitNotifySplitBrainTest.java
@@ -26,12 +26,12 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class WaitNotifySplitBrainTest extends SplitBrainTestSupport {
 
-    private static final int POLLERS_COUNT = 1000;
+    private static final int POLL_COUNT = 1000;
+
     private String queueName;
 
     @Override
@@ -49,7 +49,7 @@ public class WaitNotifySplitBrainTest extends SplitBrainTestSupport {
         assertOnlyOwnerHasWaitingOperationsEventually(queueName, instances);
 
         final IQueue<Object> queue = instances[0].getQueue(queueName);
-        for (int i = 0; i < POLLERS_COUNT; i++) {
+        for (int i = 0; i < POLL_COUNT; i++) {
             queue.offer(i);
         }
         assertWaitingOperationCountEventually(0, instances);
@@ -58,13 +58,13 @@ public class WaitNotifySplitBrainTest extends SplitBrainTestSupport {
     private void assertOnlyOwnerHasWaitingOperationsEventually(String name, HazelcastInstance... instances) {
         for (HazelcastInstance hz : instances) {
             Member owner = hz.getPartitionService().getPartition(name).getOwner();
-            int expectedWaitingOps = owner.equals(hz.getCluster().getLocalMember()) ? POLLERS_COUNT : 0;
+            int expectedWaitingOps = owner.equals(hz.getCluster().getLocalMember()) ? POLL_COUNT : 0;
             assertWaitingOperationCountEventually(expectedWaitingOps, hz);
         }
     }
 
     private void startTakingFromQueue(final IQueue<Object> queue) {
-        for (int i = 0; i < POLLERS_COUNT; i++) {
+        for (int i = 0; i < POLL_COUNT; i++) {
             new Thread() {
                 public void run() {
                     try {
@@ -78,8 +78,6 @@ public class WaitNotifySplitBrainTest extends SplitBrainTestSupport {
     }
 
     private void assertTakeOperationsAreWaitingEventually(HazelcastInstance instance) {
-        assertWaitingOperationCountEventually(POLLERS_COUNT, instance);
+        assertWaitingOperationCountEventually(POLL_COUNT, instance);
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainAddMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainAddMemberTest.java
@@ -23,7 +23,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
- * Tests a node can be added to one of two brains in a {@link SplitBrainTestSupport} test.
+ * Tests that a node can be added to one of two brains in a {@link SplitBrainTestSupport} test.
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})


### PR DESCRIPTION
This cleanup mostly removed warnings, moved tests to the correct package and aligns the naming schema of `SplitBrainHandlerService` implementations (Cache didn't follow the Map implementations here).