### PR TITLE
ClientMessageChannelInboundhandler cleanup

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
@@ -53,9 +53,9 @@ class ClientChannelInitializer implements ChannelInitializer {
         final ClientConnection connection = (ClientConnection) channel.attributeMap().get(ClientConnection.class);
 
         ChannelInboundHandler inboundHandler = new ClientMessageChannelInboundHandler(
-                new ClientMessageChannelInboundHandler.MessageHandler() {
+                new ClientMessageChannelInboundHandler.ClientMessageHandler() {
                     @Override
-                    public void handleMessage(ClientMessage message) {
+                    public void handle(ClientMessage message) {
                         connection.handleClientMessage(message);
                     }
                 });

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageChannelInboundHandler.java
@@ -33,11 +33,11 @@ public class ClientMessageChannelInboundHandler extends ChannelInboundHandlerWit
 
     private final Long2ObjectHashMap<BufferBuilder> builderBySessionIdMap = new Long2ObjectHashMap<BufferBuilder>();
 
-    private final MessageHandler delegate;
+    private final ClientMessageHandler messageHandler;
     private ClientMessage message = ClientMessage.create();
 
-    public ClientMessageChannelInboundHandler(MessageHandler messageHandler) {
-        this.delegate = messageHandler;
+    public ClientMessageChannelInboundHandler(ClientMessageHandler messageHandler) {
+        this.messageHandler = messageHandler;
     }
 
     @Override
@@ -90,19 +90,19 @@ public class ClientMessageChannelInboundHandler extends ChannelInboundHandlerWit
 
     private void handleMessage(ClientMessage message) {
         message.index(message.getDataOffset());
-        delegate.handleMessage(message);
+        messageHandler.handle(message);
     }
 
     /**
-     * Implementers will be responsible to delegate the constructed message
+     * Implementers will be responsible to messageHandler the constructed message
      */
-    public interface MessageHandler {
+    public interface ClientMessageHandler {
 
         /**
          * Received message to be processed
          *
          * @param message the ClientMessage
          */
-        void handleMessage(ClientMessage message);
+        void handle(ClientMessage message);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageHandlerImpl.java
@@ -24,21 +24,21 @@ import com.hazelcast.nio.Connection;
 import java.io.IOException;
 
 /**
- * A {@link com.hazelcast.client.impl.protocol.util.ClientMessageChannelInboundHandler.MessageHandler} implementation
+ * A {@link ClientMessageChannelInboundHandler.ClientMessageHandler} implementation
  * that passes the message to the {@link ClientEngine}.
  */
-public class MessageHandlerImpl implements ClientMessageChannelInboundHandler.MessageHandler {
+public class ClientMessageHandlerImpl implements ClientMessageChannelInboundHandler.ClientMessageHandler {
 
     private final Connection connection;
     private final ClientEngine clientEngine;
 
-    public MessageHandlerImpl(Connection connection, ClientEngine clientEngine) throws IOException {
+    public ClientMessageHandlerImpl(Connection connection, ClientEngine clientEngine) throws IOException {
         this.connection = connection;
         this.clientEngine = clientEngine;
     }
 
     @Override
-    public void handleMessage(ClientMessage message) {
+    public void handle(ClientMessage message) {
         clientEngine.handleClientMessage(message, connection);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
@@ -141,7 +141,7 @@ public class MemberChannelInitializer implements ChannelInitializer {
         ByteBuffer inputBuffer = newInputBuffer(channel, ioService.getSocketClientReceiveBufferSize());
 
         ChannelInboundHandler inboundHandler
-                = new ClientMessageChannelInboundHandler(new MessageHandlerImpl(connection, ioService.getClientEngine()));
+                = new ClientMessageChannelInboundHandler(new ClientMessageHandlerImpl(connection, ioService.getClientEngine()));
 
         return new InitResult<ChannelInboundHandler>(inputBuffer, inboundHandler);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -52,9 +52,9 @@ public class ClientMessageSplitAndBuildTest {
         expectedClientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
         List<ClientMessage> subFrames = ClientMessageSplitter.getSubFrames(FRAME_SIZE, expectedClientMessage);
         ClientMessageChannelInboundHandler clientMessageReadHandler = new ClientMessageChannelInboundHandler(
-                new ClientMessageChannelInboundHandler.MessageHandler() {
+                new ClientMessageChannelInboundHandler.ClientMessageHandler() {
                     @Override
-                    public void handleMessage(ClientMessage message) {
+                    public void handle(ClientMessage message) {
                         message.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
                         assertEquals(expectedClientMessage, message);
                     }
@@ -100,9 +100,9 @@ public class ClientMessageSplitAndBuildTest {
         }
 
         ClientMessageChannelInboundHandler clientMessageReadHandler = new ClientMessageChannelInboundHandler(
-                new ClientMessageChannelInboundHandler.MessageHandler() {
+                new ClientMessageChannelInboundHandler.ClientMessageHandler() {
                     @Override
-                    public void handleMessage(ClientMessage message) {
+                    public void handle(ClientMessage message) {
                         int correlationId = (int) message.getCorrelationId();
                         message.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
                         assertEquals(expectedClientMessages.get(correlationId), message);
@@ -133,9 +133,9 @@ public class ClientMessageSplitAndBuildTest {
         expectedClientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
         List<ClientMessage> subFrames = ClientMessageSplitter.getSubFrames(expectedClientMessage.getFrameLength() + 1, expectedClientMessage);
         ClientMessageChannelInboundHandler clientMessageReadHandler = new ClientMessageChannelInboundHandler(
-                new ClientMessageChannelInboundHandler.MessageHandler() {
+                new ClientMessageChannelInboundHandler.ClientMessageHandler() {
                     @Override
-                    public void handleMessage(ClientMessage message) {
+                    public void handle(ClientMessage message) {
                         message.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
                         assertEquals(expectedClientMessage, message);
                     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageHandlerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageHandlerImplTest.java
@@ -40,9 +40,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MessageHandlerImplTest {
+public class ClientMessageHandlerImplTest {
 
-    private MessageHandlerImpl messageHandler;
+    private ClientMessageHandlerImpl messageHandler;
     private IOService ioService;
     private Connection connection;
     private SwCounter counter;
@@ -55,7 +55,7 @@ public class MessageHandlerImplTest {
         connection = mock(Connection.class);
         counter = SwCounter.newSwCounter();
         clientEngine = mock(ClientEngine.class);
-        messageHandler = new MessageHandlerImpl(connection, clientEngine);
+        messageHandler = new ClientMessageHandlerImpl(connection, clientEngine);
         inboundHandler = new ClientMessageChannelInboundHandler(messageHandler);
         inboundHandler.setNormalPacketsRead(counter);
     }


### PR DESCRIPTION
 Minor ClientMessage handler cleanup
    
 Renamed ClientMessageChannelInboundHandler delegate to messageHandler:
 delegate doesn't say much.
    
 Renamed the ClientMessageHandler.handleMessage to rename. Handling messages
 is already implied by the interface name.
    
 Renamed the MessageHandler to ClientMessagehandler since it will only process
 clientmessages.
