### PR TITLE
Query cache leak fix 

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContext.java
@@ -33,6 +33,7 @@ import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.ContextMutexFactory;
 
 import java.util.Collection;
 
@@ -44,10 +45,11 @@ import java.util.Collection;
 public class ClientQueryCacheContext implements QueryCacheContext {
 
     private final ClientContext clientContext;
+    private final InvokerWrapper invokerWrapper;
+    private final QueryCacheScheduler queryCacheScheduler;
     private final QueryCacheEventService queryCacheEventService;
     private final QueryCacheConfigurator queryCacheConfigurator;
-    private final QueryCacheScheduler queryCacheScheduler;
-    private final InvokerWrapper invokerWrapper;
+    private final ContextMutexFactory mutexFactory = new ContextMutexFactory();
 
     // not final for testing purposes
     private SubscriberContext subscriberContext;
@@ -90,6 +92,11 @@ public class ClientQueryCacheContext implements QueryCacheContext {
     @Override
     public int getPartitionId(Object object) {
         return clientContext.getPartitionService().getPartitionId(object);
+    }
+
+    @Override
+    public ContextMutexFactory getLifecycleMutexFactory() {
+        return mutexFactory;
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/QueryCacheToListenerMapper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/QueryCacheToListenerMapper.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.CollectionUtil.isEmpty;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
 /**
- * This class includes mappings of {@code cacheId --to--> listener collections}.
+ * This class includes mappings for cacheId to its listener-info-collection
  */
 public class QueryCacheToListenerMapper {
 
@@ -49,21 +49,21 @@ public class QueryCacheToListenerMapper {
         this.registrations = new ConcurrentHashMap<String, Collection<ListenerInfo>>();
     }
 
-    public String addListener(String cacheName, ListenerAdapter listenerAdapter, EventFilter filter) {
-        Collection<ListenerInfo> adapters = getOrPutIfAbsent(registrations, cacheName, LISTENER_SET_CONSTRUCTOR);
+    public String addListener(String cacheId, ListenerAdapter listenerAdapter, EventFilter filter) {
+        Collection<ListenerInfo> adapters = getOrPutIfAbsent(registrations, cacheId, LISTENER_SET_CONSTRUCTOR);
         String id = UuidUtil.newUnsecureUuidString();
         ListenerInfo info = new ListenerInfo(filter, listenerAdapter, id);
         adapters.add(info);
         return id;
     }
 
-    public boolean removeListener(String cacheName, String id) {
-        Collection<ListenerInfo> adapters = getOrPutIfAbsent(registrations, cacheName, LISTENER_SET_CONSTRUCTOR);
+    public boolean removeListener(String cacheId, String listenerId) {
+        Collection<ListenerInfo> adapters = getOrPutIfAbsent(registrations, cacheId, LISTENER_SET_CONSTRUCTOR);
         Iterator<ListenerInfo> iterator = adapters.iterator();
         while (iterator.hasNext()) {
             ListenerInfo listenerInfo = iterator.next();
             String listenerInfoId = listenerInfo.getId();
-            if (listenerInfoId.equals(id)) {
+            if (listenerInfoId.equals(listenerId)) {
                 iterator.remove();
                 return true;
             }
@@ -71,9 +71,32 @@ public class QueryCacheToListenerMapper {
         return false;
     }
 
+    /**
+     * Removes all associated listener info for the cache represented with the supplied {@code cacheId}
+     *
+     * @param cacheId id of the cache
+     */
+    public void removeAllListeners(String cacheId) {
+        registrations.remove(cacheId);
+    }
+
+    /**
+     * @return {@code true} if this class contains any registered
+     *  listener for the cache represented with the supplied {@code cacheId} else returns {@code false}
+     */
+    public boolean hasListener(String cacheId) {
+        Collection<ListenerInfo> listenerInfos = registrations.get(cacheId);
+        return !isEmpty(listenerInfos);
+    }
+
+    // this method is only used for testing purposes
+    public boolean hasAnyQueryCacheRegistered() {
+        return !registrations.isEmpty();
+    }
+
     @SuppressWarnings("unchecked")
-    Collection<ListenerInfo> getListenerInfos(String cacheName) {
-        Collection<ListenerInfo> infos = registrations.get(cacheName);
-        return isEmpty(infos) ? Collections.EMPTY_SET : infos;
+    Collection<ListenerInfo> getListenerInfos(String cacheId) {
+        Collection<ListenerInfo> infos = registrations.get(cacheId);
+        return isEmpty(infos) ? Collections.<ListenerInfo>emptySet() : infos;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -180,8 +180,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     QueryCacheContext getQueryCacheContext();
 
-    String addListenerAdapter(String cacheName, ListenerAdapter listenerAdaptor);
-
     String addListenerAdapter(ListenerAdapter listenerAdaptor, EventFilter eventFilter, String mapName);
 
     String addLocalListenerAdapter(ListenerAdapter listenerAdaptor, String mapName);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -104,8 +104,8 @@ import static com.hazelcast.query.impl.predicates.QueryOptimizerFactory.newOptim
 import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
 import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
 import static com.hazelcast.spi.properties.GroupProperty.AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION;
-import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.INDEX_COPY_BEHAVIOR;
+import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
 
 /**
@@ -788,15 +788,6 @@ class MapServiceContextImpl implements MapServiceContext {
     public String addListenerAdapter(ListenerAdapter listenerAdaptor, EventFilter eventFilter, String mapName) {
         EventRegistration registration = getNodeEngine().getEventService().
                 registerListener(MapService.SERVICE_NAME, mapName, eventFilter, listenerAdaptor);
-        return registration.getId();
-    }
-
-    @Override
-    public String addListenerAdapter(String cacheName, ListenerAdapter listenerAdaptor) {
-        EventService eventService = getNodeEngine().getEventService();
-        EventRegistration registration
-                = eventService.registerListener(MapService.SERVICE_NAME,
-                cacheName, TrueEventFilter.INSTANCE, listenerAdaptor);
         return registration.getId();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
@@ -39,6 +39,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.util.ContextMutexFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,11 +55,12 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
 public class NodeQueryCacheContext implements QueryCacheContext {
 
     private final NodeEngine nodeEngine;
+    private final InvokerWrapper invokerWrapper;
     private final MapServiceContext mapServiceContext;
+    private final QueryCacheScheduler queryCacheScheduler;
     private final QueryCacheEventService queryCacheEventService;
     private final QueryCacheConfigurator queryCacheConfigurator;
-    private final QueryCacheScheduler queryCacheScheduler;
-    private final InvokerWrapper invokerWrapper;
+    private final ContextMutexFactory lifecycleMutexFactory = new ContextMutexFactory();
 
     // these fields are not final for testing purposes
     private PublisherContext publisherContext;
@@ -68,7 +70,7 @@ public class NodeQueryCacheContext implements QueryCacheContext {
         this.nodeEngine = mapServiceContext.getNodeEngine();
         this.mapServiceContext = mapServiceContext;
         this.queryCacheScheduler = new NodeQueryCacheScheduler(mapServiceContext);
-        this.queryCacheEventService = new NodeQueryCacheEventService(mapServiceContext);
+        this.queryCacheEventService = new NodeQueryCacheEventService(mapServiceContext, lifecycleMutexFactory);
         this.queryCacheConfigurator = new NodeQueryCacheConfigurator(nodeEngine.getConfig(),
                 nodeEngine.getConfigClassLoader(), queryCacheEventService);
         this.invokerWrapper = new NodeInvokerWrapper(nodeEngine.getOperationService());
@@ -168,11 +170,21 @@ public class NodeQueryCacheContext implements QueryCacheContext {
         return mapServiceContext.toObject(obj);
     }
 
-    private String registerLocalIMapListener(String name) {
+    @Override
+    public ContextMutexFactory getLifecycleMutexFactory() {
+        return lifecycleMutexFactory;
+    }
+
+    private String registerLocalIMapListener(final String name) {
         return mapServiceContext.addLocalListenerAdapter(new ListenerAdapter<IMapEvent>() {
             @Override
             public void onEvent(IMapEvent event) {
                 // NOP
+            }
+
+            @Override
+            public String toString() {
+                return "Local IMap listener for the map '" + name + "'";
             }
         }, name);
     }
@@ -183,5 +195,5 @@ public class NodeQueryCacheContext implements QueryCacheContext {
         public String apply(String name) {
             return registerLocalIMapListener(name);
         }
-    };
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheContext.java
@@ -22,6 +22,7 @@ import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.util.ContextMutexFactory;
 
 import java.util.Collection;
 
@@ -122,6 +123,11 @@ public interface QueryCacheContext {
      * @return partition ID
      */
     int getPartitionId(Object object);
+
+    /**
+     * @return mutex factory for this context. This is mainly intended to use during query-cache create and destroy.
+     */
+    ContextMutexFactory getLifecycleMutexFactory();
 
     /**
      * Destroys everything in this context.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
@@ -20,7 +20,6 @@ import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.spi.EventFilter;
 
-
 /**
  * Event service abstraction to allow different type of implementations
  * on query cache subscriber and query cache publisher sides. Runs locally on query-cache
@@ -35,7 +34,7 @@ public interface QueryCacheEventService<E> {
      * Publishes query-cache events locally.
      *
      * @param mapName  underlying map name of query cache
-     * @param cacheId  id of the query cache
+     * @param cacheId  ID of the query cache
      * @param event    event to publish
      * @param orderKey use same order key for events which are required to be ordered
      */
@@ -45,27 +44,28 @@ public interface QueryCacheEventService<E> {
      * Adds the listener to listen underlying IMap on all nodes.
      *
      * @param mapName         underlying map name of query cache
-     * @param cacheId         id of the query cache
+     * @param cacheId         ID of the query cache
      * @param listenerAdapter listener adapter for the query-cache
      * @return ID of registered event listener
      */
-    String listenPublisher(String mapName, String cacheId, ListenerAdapter listenerAdapter);
+    String addPublisherListener(String mapName, String cacheId, ListenerAdapter listenerAdapter);
 
     /**
      * Removes listener from underlying IMap
      *
      * @param mapName    underlying map name which query cache listens
+     * @param cacheId    ID of the query cache
      * @param listenerId ID of registered listener
      * @return {@code true} if listener is de-registered, {@code false} otherwise
      */
-    boolean removePublisherListener(String mapName, String listenerId);
+    boolean removePublisherListener(String mapName, String cacheId, String listenerId);
 
     /**
      * Adds a user-defined listener to a query-cache. This listener is registered as a local listener
      * on subscriber side.
      *
      * @param mapName  underlying IMap name of query-cache
-     * @param cacheId  id of the query-cache
+     * @param cacheId  ID of the query-cache
      * @param listener listener for receiving events
      * @return ID of registered event listener
      */
@@ -76,7 +76,7 @@ public interface QueryCacheEventService<E> {
      * on subscriber side.
      *
      * @param mapName  underlying IMap name of query-cache
-     * @param cacheId  id of the query-cache
+     * @param cacheId  ID of the query-cache
      * @param listener listener for receiving events
      * @param filter   used to filter events
      * @return ID of registered event listener
@@ -86,18 +86,27 @@ public interface QueryCacheEventService<E> {
     /**
      * Removes listener from this event service.
      *
-     * @param mapName underlying IMap name of query-cache
-     * @param cacheId id of the query cache
-     * @param id      ID of listener
+     * @param mapName    underlying IMap name of query-cache
+     * @param cacheId    ID of the query cache
+     * @param listenerId registration ID of listener
      * @return {@code true} if listener is removed successfully, {@code false} otherwise
      */
-    boolean removeListener(String mapName, String cacheId, String id);
+    boolean removeListener(String mapName, String cacheId, String listenerId);
 
     /**
-     * Returns {@code true} if this query-cache has at least one registered listener otherwise returns {@code false}.
+     * Removes all user defined listeners associated to supplied {@code cacheId}
      *
      * @param mapName underlying IMap name of query-cache
-     * @param cacheId id of the query-cache
+     * @param cacheId ID of the query cache
+     */
+    void removeAllListeners(String mapName, String cacheId);
+
+    /**
+     * Returns {@code true} if this query-cache has at least one registered user defined listener
+     * otherwise returns {@code false}.
+     *
+     * @param mapName underlying IMap name of query-cache
+     * @param cacheId ID of the query-cache
      * @return {@code true} if this query-cache has at least one registered listener otherwise returns {@code false}
      */
     boolean hasListener(String mapName, String cacheId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/QueryCacheListenerRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/QueryCacheListenerRegistry.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class QueryCacheListenerRegistry implements Registry<String, String> {
 
-    private ConstructorFunction<String, String> registryConstructorFunction =
+    private final ConstructorFunction<String, String> registryConstructorFunction =
             new ConstructorFunction<String, String>() {
                 @Override
                 public String createNew(String ignored) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -53,9 +53,9 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
     protected final String cacheId;
     protected final String cacheName;
     protected final IMap delegate;
+    protected final Indexes indexes;
     protected final QueryCacheContext context;
     protected final QueryCacheRecordStore recordStore;
-    protected final Indexes indexes;
     protected final InternalSerializationService serializationService;
     protected final PartitioningStrategy partitioningStrategy;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
@@ -63,7 +63,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
     public final void createSubscriberAccumulator(AccumulatorInfo info) {
         QueryCacheEventService eventService = context.getQueryCacheEventService();
         ListenerAdapter listener = new SubscriberListener(context, info);
-        publisherListenerId = eventService.listenPublisher(info.getMapName(), info.getCacheId(), listener);
+        publisherListenerId = eventService.addPublisherListener(info.getMapName(), info.getCacheId(), listener);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractSubscriberContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractSubscriberContext.java
@@ -40,7 +40,7 @@ public abstract class AbstractSubscriberContext implements SubscriberContext {
     public AbstractSubscriberContext(QueryCacheContext context) {
         this.queryCacheConfigurator = context.getQueryCacheConfigurator();
         this.eventService = context.getQueryCacheEventService();
-        this.queryCacheEndToEndProvider = new QueryCacheEndToEndProvider();
+        this.queryCacheEndToEndProvider = new QueryCacheEndToEndProvider(context.getLifecycleMutexFactory());
         this.mapSubscriberRegistry = new MapSubscriberRegistry(context);
         this.queryCacheFactory = new QueryCacheFactory();
         this.accumulatorInfoSupplier = new DefaultAccumulatorInfoSupplier();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.EventLostEvent;
 import com.hazelcast.map.impl.EntryEventFilter;
 import com.hazelcast.map.impl.ListenerAdapter;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.map.impl.querycache.QueryCacheEventService;
@@ -40,11 +39,14 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.impl.Registration;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.ContextMutexFactory;
 
 import java.util.Collection;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.querycache.ListenerRegistrationHelper.generateListenerName;
 import static com.hazelcast.map.impl.querycache.subscriber.QueryCacheEventListenerAdapters.createQueryCacheListenerAdaptor;
+import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -55,10 +57,15 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public class NodeQueryCacheEventService implements QueryCacheEventService<EventData> {
 
+    private final EventService eventService;
+    private final ContextMutexFactory mutexFactory;
     private final MapServiceContext mapServiceContext;
 
-    public NodeQueryCacheEventService(MapServiceContext mapServiceContext) {
+    public NodeQueryCacheEventService(MapServiceContext mapServiceContext, ContextMutexFactory mutexFactory) {
         this.mapServiceContext = mapServiceContext;
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+        this.eventService = nodeEngine.getEventService();
+        this.mutexFactory = mutexFactory;
     }
 
     // TODO not used order key
@@ -77,14 +84,15 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
     }
 
     @Override
-    public String listenPublisher(String mapName, String cacheId, ListenerAdapter listenerAdapter) {
+    public String addPublisherListener(String mapName, String cacheId, ListenerAdapter listenerAdapter) {
         String listenerName = generateListenerName(mapName, cacheId);
-        return mapServiceContext.addListenerAdapter(listenerName, listenerAdapter);
+        return mapServiceContext.addListenerAdapter(listenerAdapter, TrueEventFilter.INSTANCE, listenerName);
     }
 
     @Override
-    public boolean removePublisherListener(String mapName, String listenerId) {
-        return mapServiceContext.removeEventListener(mapName, listenerId);
+    public boolean removePublisherListener(String mapName, String cacheId, String listenerId) {
+        String listenerName = generateListenerName(mapName, cacheId);
+        return mapServiceContext.removeEventListener(listenerName, listenerId);
     }
 
     @Override
@@ -95,33 +103,44 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
 
         ListenerAdapter queryCacheListenerAdaptor = createQueryCacheListenerAdaptor(listener);
         ListenerAdapter listenerAdaptor = new SimpleQueryCacheListenerAdapter(queryCacheListenerAdaptor);
-        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        EventService eventService = nodeEngine.getEventService();
 
         String listenerName = generateListenerName(mapName, cacheId);
-        EventRegistration registration;
-        if (filter == null) {
-            registration = eventService.registerLocalListener(MapService.SERVICE_NAME,
-                    listenerName, listenerAdaptor);
-        } else {
-            registration = eventService.registerLocalListener(MapService.SERVICE_NAME,
-                    listenerName, filter, listenerAdaptor);
+        ContextMutexFactory.Mutex mutex = mutexFactory.mutexFor(mapName);
+        try {
+            synchronized (mutex) {
+                EventRegistration registration = eventService.registerLocalListener(SERVICE_NAME, listenerName,
+                        filter == null ? TrueEventFilter.INSTANCE : filter, listenerAdaptor);
+                return registration.getId();
+            }
+        } finally {
+            closeResource(mutex);
         }
-        return registration.getId();
     }
 
     @Override
-    public boolean removeListener(String mapName, String cacheId, String id) {
+    public boolean removeListener(String mapName, String cacheId, String listenerId) {
         String listenerName = generateListenerName(mapName, cacheId);
-        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        EventService eventService = nodeEngine.getEventService();
-        return eventService.deregisterListener(MapService.SERVICE_NAME, listenerName, id);
+        return eventService.deregisterListener(SERVICE_NAME, listenerName, listenerId);
+    }
+
+    @Override
+    public void removeAllListeners(String mapName, String cacheId) {
+        String listenerName = generateListenerName(mapName, cacheId);
+        ContextMutexFactory.Mutex mutex = mutexFactory.mutexFor(mapName);
+        try {
+            synchronized (mutex) {
+                eventService.deregisterAllListeners(SERVICE_NAME, listenerName);
+            }
+        } finally {
+            closeResource(mutex);
+        }
     }
 
     @Override
     public boolean hasListener(String mapName, String cacheId) {
         String listenerName = generateListenerName(mapName, cacheId);
         Collection<EventRegistration> eventRegistrations = getRegistrations(listenerName);
+
         if (eventRegistrations.isEmpty()) {
             return false;
         }
@@ -203,18 +222,11 @@ public class NodeQueryCacheEventService implements QueryCacheEventService<EventD
     }
 
     private Collection<EventRegistration> getRegistrations(String mapName) {
-        MapServiceContext mapServiceContext = this.mapServiceContext;
-        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        EventService eventService = nodeEngine.getEventService();
-
-        return eventService.getRegistrations(MapService.SERVICE_NAME, mapName);
+        return eventService.getRegistrations(SERVICE_NAME, mapName);
     }
 
     private void publishEventInternal(EventRegistration registration, Object eventData, int orderKey) {
-        MapServiceContext mapServiceContext = this.mapServiceContext;
-        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        EventService eventService = nodeEngine.getEventService();
-        eventService.publishEvent(MapService.SERVICE_NAME, registration, eventData, orderKey);
+        eventService.publishEvent(SERVICE_NAME, registration, eventData, orderKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -140,6 +140,11 @@ public class EventServiceSegment<S> {
         return registrationIdMap;
     }
 
+    // this method is only used for testing purposes
+    public ConcurrentMap<String, Collection<Registration>> getRegistrations() {
+        return registrations;
+    }
+
     /**
      * Adds a registration for the {@code topic} and notifies the listener and service of the listener
      * registration. Returns if the registration was added. The registration might not be added

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMemoryLeakTest.java
@@ -16,8 +16,11 @@
 
 package com.hazelcast.map.impl.querycache;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.map.QueryCache;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.querycache.accumulator.DefaultAccumulatorInfoSupplier;
@@ -30,6 +33,7 @@ import com.hazelcast.map.impl.querycache.publisher.QueryCacheListenerRegistry;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheFactory;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
+import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
@@ -37,17 +41,21 @@ import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.RandomPicker;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -56,9 +64,147 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
 
+    private static final int STRESS_TEST_RUN_SECONDS = 5;
+    private static final int STRESS_TEST_THREAD_COUNT = 5;
+
     @Test
-    public void removes_internal_query_caches_upon_map_destroy() throws Exception {
-        HazelcastInstance node = createHazelcastInstance();
+    public void event_service_is_empty_after_queryCache_destroy() throws InterruptedException {
+        final String mapName = "test";
+        final String queryCacheName = "cqc";
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        Config config = getConfig();
+        HazelcastInstance node1 = factory.newHazelcastInstance(config);
+        HazelcastInstance node2 = factory.newHazelcastInstance(config);
+        HazelcastInstance node3 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, node1, node2, node3);
+
+        final IMap<Integer, Integer> map = node1.getMap(mapName);
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        ArrayList<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < STRESS_TEST_THREAD_COUNT; i++) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        QueryCache queryCache = map.getQueryCache(queryCacheName, TruePredicate.INSTANCE, true);
+                        queryCache.destroy();
+                    }
+                }
+            };
+            threads.add(thread);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        sleepSeconds(STRESS_TEST_RUN_SECONDS);
+        stop.set(true);
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        map.destroy();
+
+        assertNoUserListenerLeft(node1);
+        assertNoUserListenerLeft(node2);
+        assertNoUserListenerLeft(node3);
+    }
+
+    @Test
+    public void stress_user_listener_removal_upon_query_cache_destroy() throws InterruptedException {
+        final String[] mapNames = new String[]{"mapA", "mapB", "mapC", "mapD"};
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        Config config = getConfig();
+        final HazelcastInstance node1 = factory.newHazelcastInstance(config);
+        HazelcastInstance node2 = factory.newHazelcastInstance(config);
+        HazelcastInstance node3 = factory.newHazelcastInstance(config);
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        ArrayList<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < STRESS_TEST_THREAD_COUNT; i++) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        String name = mapNames[RandomPicker.getInt(0, 4)];
+                        final IMap<Integer, Integer> map = node1.getMap(name);
+                        int key = RandomPicker.getInt(0, Integer.MAX_VALUE);
+                        map.put(key, 1);
+                        QueryCache queryCache = map.getQueryCache(name, TruePredicate.INSTANCE, true);
+                        queryCache.get(key);
+
+                        queryCache.addEntryListener(new EntryAddedListener<Integer, Integer>() {
+                            @Override
+                            public void entryAdded(EntryEvent<Integer, Integer> event) {
+
+                            }
+                        }, true);
+
+                        queryCache.destroy();
+                        map.destroy();
+                    }
+                }
+            };
+            threads.add(thread);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        sleepSeconds(STRESS_TEST_RUN_SECONDS);
+        stop.set(true);
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertNoUserListenerLeft(node1);
+        assertNoUserListenerLeft(node2);
+        assertNoUserListenerLeft(node3);
+    }
+
+    @Test
+    public void removes_user_listener_upon_query_cache_destroy() {
+        String name = "mapA";
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        Config config = getConfig();
+        final HazelcastInstance node1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance node2 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(2, node1, node2);
+
+        final IMap<Integer, Integer> map = node1.getMap(name);
+        int key = RandomPicker.getInt(0, Integer.MAX_VALUE);
+        map.put(key, 1);
+        QueryCache queryCache = map.getQueryCache(name, TruePredicate.INSTANCE, true);
+        queryCache.get(key);
+
+        queryCache.addEntryListener(new EntryAddedListener<Integer, Integer>() {
+            @Override
+            public void entryAdded(EntryEvent<Integer, Integer> event) {
+
+            }
+        }, true);
+
+        queryCache.destroy();
+        map.destroy();
+
+        assertNoUserListenerLeft(node1);
+        assertNoUserListenerLeft(node2);
+    }
+
+    @Test
+    public void removes_internal_query_caches_upon_map_destroy() {
+        Config config = getConfig();
+        HazelcastInstance node = createHazelcastInstance(config);
 
         String mapName = "test";
         IMap<Integer, Integer> map = node.getMap(mapName);
@@ -80,29 +226,35 @@ public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
 
     @Test
     public void no_query_cache_left_after_creating_and_destroying_same_map_concurrently() throws Exception {
-        final HazelcastInstance node = createHazelcastInstance();
+        Config config = getConfig();
+        final HazelcastInstance node = createHazelcastInstance(config);
         final String mapName = "test";
 
-        ExecutorService pool = Executors.newFixedThreadPool(5);
+        ExecutorService pool = Executors.newFixedThreadPool(STRESS_TEST_THREAD_COUNT);
+        final AtomicBoolean stop = new AtomicBoolean();
 
         for (int i = 0; i < 1000; i++) {
             Runnable runnable = new Runnable() {
                 public void run() {
-                    IMap<Integer, Integer> map = node.getMap(mapName);
-                    ;
-                    try {
-                        populateMap(map);
-                        for (int j = 0; j < 10; j++) {
-                            map.getQueryCache(j + "-test-QC", TruePredicate.INSTANCE, true);
+                    while (!stop.get()) {
+                        IMap<Integer, Integer> map = node.getMap(mapName);
+                        try {
+                            populateMap(map);
+                            for (int j = 0; j < 10; j++) {
+                                map.getQueryCache(j + "-test-QC", TruePredicate.INSTANCE, true);
+                            }
+                        } finally {
+                            map.destroy();
                         }
-                    } finally {
-                        map.destroy();
                     }
 
                 }
             };
             pool.submit(runnable);
         }
+
+        sleepSeconds(STRESS_TEST_RUN_SECONDS);
+        stop.set(true);
 
         pool.shutdown();
         pool.awaitTermination(120, TimeUnit.SECONDS);
@@ -113,14 +265,14 @@ public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, provider.getQueryCacheCount(mapName));
             }
         });
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, queryCacheFactory.getQueryCacheCount());
             }
         });
@@ -152,7 +304,7 @@ public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
         PublisherContext publisherContext = getPublisherContext(node);
         MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
         PublisherRegistry registry = mapPublisherRegistry.getOrCreate(mapName);
-        if(registry == null) {
+        if (registry == null) {
             return;
         }
 
@@ -186,5 +338,16 @@ public class QueryCacheMemoryLeakTest extends HazelcastTestSupport {
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
         return queryCacheContext.getPublisherContext();
+    }
+
+    private static void assertNoUserListenerLeft(HazelcastInstance node) {
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(node);
+        EventServiceImpl eventServiceImpl = (EventServiceImpl) nodeEngineImpl.getEventService();
+        EventServiceSegment segment = eventServiceImpl.getSegment(MapService.SERVICE_NAME, false);
+        ConcurrentMap registrations = segment.getRegistrations();
+        ConcurrentMap registrationIdMap = segment.getRegistrationIdMap();
+
+        assertTrue(registrationIdMap.toString(), registrationIdMap.isEmpty());
+        assertTrue(registrations.toString(), registrations.isEmpty());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventServiceTest.java
@@ -1,0 +1,92 @@
+package com.hazelcast.map.impl.querycache.subscriber;
+
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.querycache.QueryCacheContext;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
+import com.hazelcast.spi.impl.eventservice.impl.EventServiceSegment;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class NodeQueryCacheEventServiceTest extends HazelcastTestSupport {
+
+    @Test
+    public void no_left_over_listener_after_concurrent_addition_and_removal_on_same_queryCache() throws InterruptedException {
+        final String mapName = "test";
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        final HazelcastInstance node = factory.newHazelcastInstance();
+
+        SubscriberContext subscriberContext = getSubscriberContext(node);
+        final NodeQueryCacheEventService nodeQueryCacheEventService = (NodeQueryCacheEventService) subscriberContext.getEventService();
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        ArrayList<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < 5; i++) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        nodeQueryCacheEventService.addListener(mapName, "a", new EntryAddedListener() {
+                            @Override
+                            public void entryAdded(EntryEvent event) {
+
+                            }
+                        });
+
+                        nodeQueryCacheEventService.removeAllListeners(mapName, "a");
+                    }
+                }
+            };
+            threads.add(thread);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        sleepSeconds(5);
+        stop.set(true);
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertNoUserListenerLeft(node);
+    }
+
+    private static SubscriberContext getSubscriberContext(HazelcastInstance node) {
+        MapService mapService = getNodeEngineImpl(node).getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
+        return queryCacheContext.getSubscriberContext();
+    }
+
+    private static void assertNoUserListenerLeft(HazelcastInstance node) {
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(node);
+        EventServiceImpl eventServiceImpl = (EventServiceImpl) nodeEngineImpl.getEventService();
+        EventServiceSegment segment = eventServiceImpl.getSegment(MapService.SERVICE_NAME, false);
+        ConcurrentMap registrations = segment.getRegistrations();
+        ConcurrentMap registrationIdMap = segment.getRegistrationIdMap();
+
+        assertTrue(registrations.toString(), registrations.isEmpty());
+        assertTrue(registrationIdMap.toString(), registrationIdMap.isEmpty());
+    }
+}


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/10156

- Removed user-defined listeners upon query-cache destruction 
- Fixed race in NodeQueryCacheEventService under concurrent listener add/remove

TODO
 - [ ] needs backport to 3.9 & 3.8.7