### PR TITLE
prevent ClientReauthOperation retry when a member left

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
@@ -21,13 +21,18 @@ import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.ClientDataSerializerHook;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.client.ClientPrincipal;
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.UrgentSystemOperation;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 import java.util.Set;
+
+import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
 public class ClientReAuthOperation
         extends AbstractClientOperation
@@ -69,6 +74,14 @@ public class ClientReAuthOperation
         if (!(e instanceof AuthenticationException)) {
             super.logError(e);
         }
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
+            return THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
     }
 
     @Override


### PR DESCRIPTION
In both fail tests, we saw client authentication timeout.
Fail scenerio:
We have two cluster members. A and B
Client chooses A as owner.
B dies.
Client disconnected.
Client sends authentication to A.
A's memberlist is still [A B] at this moment
A sends `ClientReauthOperation` to B.
A's memberlist updated as [A]
Eventough A's memberlist is updated the invocation is retried.
Client authentication timed out, and causes client to not able
to connect back.

As a fix, `ClientReauthOperation` should not be retried.

fixes https://github.com/hazelcast/hazelcast/issues/3422
fixes https://github.com/hazelcast/hazelcast/issues/10410
fixes https://github.com/hazelcast/hazelcast/issues/7134