### PR TITLE
Minor AtomicLong Operation cleanups

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddAndGetOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.ADD_AND_GET;
 
 public class AddAndGetOperation extends AtomicLongBackupAwareOperation {
 
@@ -39,8 +40,8 @@ public class AddAndGetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        returnValue = atomicLongContainer.addAndGet(delta);
+        AtomicLongContainer container = getLongContainer();
+        returnValue = container.addAndGet(delta);
     }
 
     @Override
@@ -55,7 +56,7 @@ public class AddAndGetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.ADD_AND_GET;
+        return ADD_AND_GET;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.ADD_BACKUP;
 
 public class AddBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
 
@@ -38,13 +39,13 @@ public class AddBackupOperation extends AbstractAtomicLongOperation implements B
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        atomicLongContainer.addAndGet(delta);
+        AtomicLongContainer container = getLongContainer();
+        container.addAndGet(delta);
     }
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.ADD_BACKUP;
+        return ADD_BACKUP;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterAndGetOperation.java
@@ -17,8 +17,9 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.core.IFunction;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.ALTER_AND_GET;
 
 public class AlterAndGetOperation extends AbstractAlterOperation {
 
@@ -31,14 +32,14 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
+        AtomicLongContainer container = getLongContainer();
 
-        long input = atomicLongContainer.get();
+        long input = container.get();
         long output = function.apply(input);
         shouldBackup = input != output;
         if (shouldBackup) {
             backup = output;
-            atomicLongContainer.set(output);
+            container.set(output);
         }
 
         response = output;
@@ -46,6 +47,6 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.ALTER_AND_GET;
+        return ALTER_AND_GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterOperation.java
@@ -17,8 +17,9 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.core.IFunction;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.ALTER;
 
 public class AlterOperation extends AbstractAlterOperation {
 
@@ -29,22 +30,22 @@ public class AlterOperation extends AbstractAlterOperation {
         super(name, function);
     }
 
-    @Override
-    public int getId() {
-        return AtomicLongDataSerializerHook.ALTER;
-    }
-
-    @Override
+   @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
+        AtomicLongContainer container = getLongContainer();
 
-        long input = atomicLongContainer.get();
+        long input = container.get();
         long output = function.apply(input);
         shouldBackup = input != output;
         if (shouldBackup) {
             backup = output;
-            atomicLongContainer.set(backup);
+            container.set(backup);
         }
+    }
+
+    @Override
+    public int getId() {
+        return ALTER;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.APPLY;
 
 public class ApplyOperation<R> extends AbstractAtomicLongOperation {
 
@@ -39,8 +40,8 @@ public class ApplyOperation<R> extends AbstractAtomicLongOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        returnValue = function.apply(atomicLongContainer.get());
+        AtomicLongContainer container = getLongContainer();
+        returnValue = function.apply(container.get());
     }
 
     @Override
@@ -50,7 +51,7 @@ public class ApplyOperation<R> extends AbstractAtomicLongOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.APPLY;
+        return APPLY;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.REPLICATION;
+
 public class AtomicLongReplicationOperation extends Operation
         implements IdentifiedDataSerializable {
 
@@ -45,9 +47,9 @@ public class AtomicLongReplicationOperation extends Operation
         AtomicLongService atomicLongService = getService();
         for (Map.Entry<String, Long> longEntry : migrationData.entrySet()) {
             String name = longEntry.getKey();
-            AtomicLongContainer atomicLongContainer = atomicLongService.getLongContainer(name);
+            AtomicLongContainer container = atomicLongService.getLongContainer(name);
             Long value = longEntry.getValue();
-            atomicLongContainer.set(value);
+            container.set(value);
         }
     }
 
@@ -63,7 +65,7 @@ public class AtomicLongReplicationOperation extends Operation
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.REPLICATION;
+        return REPLICATION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/CompareAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/CompareAndSetOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.COMPARE_AND_SET;
 
 public class CompareAndSetOperation extends AtomicLongBackupAwareOperation {
 
@@ -41,8 +42,8 @@ public class CompareAndSetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        returnValue = atomicLongContainer.compareAndSet(expect, update);
+        AtomicLongContainer container = getLongContainer();
+        returnValue = container.compareAndSet(expect, update);
         shouldBackup = returnValue;
     }
 
@@ -58,7 +59,7 @@ public class CompareAndSetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.COMPARE_AND_SET;
+        return COMPARE_AND_SET;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAddOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.GET_AND_ADD;
 
 public class GetAndAddOperation extends AtomicLongBackupAwareOperation {
 
@@ -39,8 +40,8 @@ public class GetAndAddOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        returnValue = atomicLongContainer.getAndAdd(delta);
+        AtomicLongContainer container = getLongContainer();
+        returnValue = container.getAndAdd(delta);
     }
 
     @Override
@@ -55,7 +56,7 @@ public class GetAndAddOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.GET_AND_ADD;
+        return GET_AND_ADD;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAlterOperation.java
@@ -17,8 +17,9 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.core.IFunction;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.GET_AND_ALTER;
 
 public class GetAndAlterOperation extends AbstractAlterOperation {
 
@@ -31,20 +32,20 @@ public class GetAndAlterOperation extends AbstractAlterOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
+        AtomicLongContainer container = getLongContainer();
 
-        long input = atomicLongContainer.get();
+        long input = container.get();
         response = input;
         long output = function.apply(input);
         shouldBackup = input != output;
         if (shouldBackup) {
             backup = output;
-            atomicLongContainer.set(output);
+            container.set(output);
         }
     }
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.GET_AND_ALTER;
+        return GET_AND_ALTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndSetOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.GET_AND_SET;
 
 public class GetAndSetOperation extends AtomicLongBackupAwareOperation {
 
@@ -39,8 +40,8 @@ public class GetAndSetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        returnValue = atomicLongContainer.getAndSet(newValue);
+        AtomicLongContainer container = getLongContainer();
+        returnValue = container.getAndSet(newValue);
     }
 
     @Override
@@ -55,7 +56,7 @@ public class GetAndSetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.GET_AND_SET;
+        return GET_AND_SET;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
@@ -17,8 +17,9 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.spi.ReadonlyOperation;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.GET;
 
 public class GetOperation extends AbstractAtomicLongOperation implements ReadonlyOperation {
 
@@ -33,8 +34,8 @@ public class GetOperation extends AbstractAtomicLongOperation implements Readonl
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        returnValue = atomicLongContainer.get();
+        AtomicLongContainer container = getLongContainer();
+        returnValue = container.get();
     }
 
     @Override
@@ -44,6 +45,6 @@ public class GetOperation extends AbstractAtomicLongOperation implements Readonl
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.GET;
+        return GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.SET_BACKUP;
 
 public class SetBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
 
@@ -38,13 +39,13 @@ public class SetBackupOperation extends AbstractAtomicLongOperation implements B
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        atomicLongContainer.set(newValue);
+        AtomicLongContainer container = getLongContainer();
+        container.set(newValue);
     }
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.SET_BACKUP;
+        return SET_BACKUP;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.SET_OPERATION;
 
 public class SetOperation extends AtomicLongBackupAwareOperation {
 
@@ -38,8 +39,8 @@ public class SetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicLongContainer atomicLongContainer = getLongContainer();
-        atomicLongContainer.set(newValue);
+        AtomicLongContainer container = getLongContainer();
+        container.set(newValue);
     }
 
     @Override
@@ -49,7 +50,7 @@ public class SetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicLongDataSerializerHook.SET_OPERATION;
+        return SET_OPERATION;
     }
 
     @Override


### PR DESCRIPTION
longContainer renamed to container. Longcontainer is already implied by
the fact that these operations are for the AtomicLong.

Static imports for the factory id's.