### PR TITLE
Minor AtomicReference operation cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
@@ -17,10 +17,11 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.ALTER_AND_GET;
 
 public class AlterAndGetOperation extends AbstractAlterOperation {
 
@@ -35,9 +36,9 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
+        AtomicReferenceContainer container = getReferenceContainer();
 
-        Data originalData = atomicReferenceContainer.get();
+        Data originalData = container.get();
         Object input = nodeEngine.toObject(originalData);
         //noinspection unchecked
         Object output = f.apply(input);
@@ -45,13 +46,13 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
         shouldBackup = !isEquals(originalData, serializedOutput);
         if (shouldBackup) {
             backup = serializedOutput;
-            atomicReferenceContainer.set(backup);
+            container.set(backup);
         }
         response = output;
     }
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.ALTER_AND_GET;
+        return ALTER_AND_GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
@@ -17,10 +17,11 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.ALTER;
 
 public class AlterOperation extends AbstractAlterOperation {
 
@@ -35,9 +36,9 @@ public class AlterOperation extends AbstractAlterOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        AtomicReferenceContainer reference = getReferenceContainer();
+        AtomicReferenceContainer container = getReferenceContainer();
 
-        Data originalData = reference.get();
+        Data originalData = container.get();
         Object input = nodeEngine.toObject(originalData);
         //noinspection unchecked
         Object output = f.apply(input);
@@ -45,13 +46,13 @@ public class AlterOperation extends AbstractAlterOperation {
         shouldBackup = !isEquals(originalData, serializedOutput);
         if (shouldBackup) {
             backup = serializedOutput;
-            reference.set(backup);
+            container.set(backup);
         }
     }
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.ALTER;
+        return ALTER;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -25,6 +24,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.APPLY;
 
 public class ApplyOperation extends AbstractAtomicReferenceOperation {
 
@@ -43,9 +44,9 @@ public class ApplyOperation extends AbstractAtomicReferenceOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
+        AtomicReferenceContainer container = getReferenceContainer();
 
-        Object input = nodeEngine.toObject(atomicReferenceContainer.get());
+        Object input = nodeEngine.toObject(container.get());
         //noinspection unchecked
         Object output = f.apply(input);
         returnValue = nodeEngine.toData(output);
@@ -58,7 +59,7 @@ public class ApplyOperation extends AbstractAtomicReferenceOperation {
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.APPLY;
+        return APPLY;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -29,6 +28,8 @@ import java.io.IOException;
 import java.util.Map;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.F_ID;
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.REPLICATION;
 
 public class AtomicReferenceReplicationOperation extends Operation
         implements IdentifiedDataSerializable {
@@ -44,12 +45,12 @@ public class AtomicReferenceReplicationOperation extends Operation
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceService atomicReferenceService = getService();
+        AtomicReferenceService service = getService();
         for (Map.Entry<String, Data> entry : migrationData.entrySet()) {
             String name = entry.getKey();
-            AtomicReferenceContainer atomicReferenceContainer = atomicReferenceService.getReferenceContainer(name);
+            AtomicReferenceContainer container = service.getReferenceContainer(name);
             Data value = entry.getValue();
-            atomicReferenceContainer.set(value);
+            container.set(value);
         }
     }
 
@@ -60,12 +61,12 @@ public class AtomicReferenceReplicationOperation extends Operation
 
     @Override
     public int getFactoryId() {
-        return AtomicReferenceDataSerializerHook.F_ID;
+        return F_ID;
     }
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.REPLICATION;
+        return REPLICATION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/CompareAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/CompareAndSetOperation.java
@@ -17,13 +17,14 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.COMPARE_AND_SET;
 
 public class CompareAndSetOperation extends AtomicReferenceBackupAwareOperation {
 
@@ -42,8 +43,8 @@ public class CompareAndSetOperation extends AtomicReferenceBackupAwareOperation 
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        returnValue = atomicReferenceContainer.compareAndSet(expect, update);
+        AtomicReferenceContainer container = getReferenceContainer();
+        returnValue = container.compareAndSet(expect, update);
         shouldBackup = returnValue;
     }
 
@@ -64,7 +65,7 @@ public class CompareAndSetOperation extends AtomicReferenceBackupAwareOperation 
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.COMPARE_AND_SET;
+        return COMPARE_AND_SET;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
@@ -17,12 +17,13 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.CONTAINS;
 
 public class ContainsOperation extends AbstractAtomicReferenceOperation {
 
@@ -39,8 +40,8 @@ public class ContainsOperation extends AbstractAtomicReferenceOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        returnValue = atomicReferenceContainer.contains(contains);
+        AtomicReferenceContainer container = getReferenceContainer();
+        returnValue = container.contains(contains);
     }
 
     @Override
@@ -50,7 +51,7 @@ public class ContainsOperation extends AbstractAtomicReferenceOperation {
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.CONTAINS;
+        return CONTAINS;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
@@ -17,10 +17,11 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.GET_AND_ALTER;
 
 public class GetAndAlterOperation extends AbstractAlterOperation {
 
@@ -35,22 +36,22 @@ public class GetAndAlterOperation extends AbstractAlterOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
+        AtomicReferenceContainer container = getReferenceContainer();
 
-        response = atomicReferenceContainer.get();
-        Object input = nodeEngine.toObject(atomicReferenceContainer.get());
+        response = container.get();
+        Object input = nodeEngine.toObject(container.get());
         //noinspection unchecked
         Object output = f.apply(input);
         Data serializedOutput = nodeEngine.toData(output);
         shouldBackup = !isEquals(response, serializedOutput);
         if (shouldBackup) {
-            atomicReferenceContainer.set(serializedOutput);
+            container.set(serializedOutput);
             backup = serializedOutput;
         }
     }
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.GET_AND_ALTER;
+        return GET_AND_ALTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndSetOperation.java
@@ -17,13 +17,14 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.GET_AND_SET;
 
 public class GetAndSetOperation extends AtomicReferenceBackupAwareOperation {
 
@@ -40,8 +41,8 @@ public class GetAndSetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        returnValue = atomicReferenceContainer.getAndSet(newValue);
+        AtomicReferenceContainer container = getReferenceContainer();
+        returnValue = container.getAndSet(newValue);
     }
 
     @Override
@@ -56,7 +57,7 @@ public class GetAndSetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.GET_AND_SET;
+        return GET_AND_SET;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.concurrent.atomicreference.operations;
 
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ReadonlyOperation;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.GET;
 
 public class GetOperation extends AbstractAtomicReferenceOperation implements ReadonlyOperation {
 
@@ -43,6 +44,6 @@ public class GetOperation extends AbstractAtomicReferenceOperation implements Re
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.GET;
+        return GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
@@ -17,7 +17,8 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.IS_NULL;
 
 public class IsNullOperation extends AbstractAtomicReferenceOperation {
 
@@ -32,8 +33,8 @@ public class IsNullOperation extends AbstractAtomicReferenceOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        returnValue = atomicReferenceContainer.isNull();
+        AtomicReferenceContainer container = getReferenceContainer();
+        returnValue = container.isNull();
     }
 
     @Override
@@ -43,6 +44,6 @@ public class IsNullOperation extends AbstractAtomicReferenceOperation {
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.IS_NULL;
+        return IS_NULL;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetAndGetOperation.java
@@ -17,13 +17,14 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.SET_AND_GET;
 
 public class SetAndGetOperation extends AtomicReferenceBackupAwareOperation {
 
@@ -40,8 +41,8 @@ public class SetAndGetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        atomicReferenceContainer.getAndSet(newValue);
+        AtomicReferenceContainer container = getReferenceContainer();
+        container.getAndSet(newValue);
         returnValue = newValue;
     }
 
@@ -57,7 +58,7 @@ public class SetAndGetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.SET_AND_GET;
+        return SET_AND_GET;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
@@ -17,13 +17,14 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.SET_BACKUP;
 
 public class SetBackupOperation extends AbstractAtomicReferenceOperation implements BackupOperation {
 
@@ -39,13 +40,13 @@ public class SetBackupOperation extends AbstractAtomicReferenceOperation impleme
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        atomicReferenceContainer.set(newValue);
+        AtomicReferenceContainer container = getReferenceContainer();
+        container.set(newValue);
     }
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.SET_BACKUP;
+        return SET_BACKUP;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetOperation.java
@@ -17,13 +17,14 @@
 package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.SET;
 
 public class SetOperation extends AtomicReferenceBackupAwareOperation {
 
@@ -39,8 +40,8 @@ public class SetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
-        atomicReferenceContainer.set(newValue);
+        AtomicReferenceContainer container = getReferenceContainer();
+        container.set(newValue);
     }
 
     @Override
@@ -50,7 +51,7 @@ public class SetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public int getId() {
-        return AtomicReferenceDataSerializerHook.SET;
+        return SET;
     }
 
     @Override


### PR DESCRIPTION
Renamed atomicreferencecontainer variables to container since
we already know that the containers used are for the AtomicReference.

Also static imports for the factoryid's