### PR TITLE
Cancel client operations when client connection disconnect

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientDisconnectTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    @Test
+    public void testClientOperationCancelled_whenDisconnected() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+        final String queueName = "q";
+
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                IQueue<Integer> queue = client.getQueue(queueName);
+                try {
+                    queue.take();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }).start();
+
+        SECONDS.sleep(2);
+
+        client.shutdown();
+
+        final IQueue<Integer> queue = hazelcastInstance.getQueue(queueName);
+        queue.add(1);
+        //dead client should not be able to consume item from queue
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(queue.size(), 1);
+            }
+        }, 3);
+    }
+
+    @Test
+    public void testClientOperationCancelled_whenDisconnected_lock() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+        final String name = "m";
+
+        final IMap<Object, Object> map = hazelcastInstance.getMap(name);
+        final String key = "key";
+        map.lock(key);
+
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                IMap<Object, Object> clientMap = client.getMap(name);
+                clientMap.lock(key);
+            }
+        }).start();
+
+        SECONDS.sleep(2);
+
+        client.shutdown();
+
+        map.unlock(key);
+        //dead client should not be able to acquire the lock.
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse(map.isLocked(key));
+            }
+        }, 3);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.impl.xa.XATransactionContextImpl;
@@ -45,6 +46,7 @@ import java.util.concurrent.ConcurrentMap;
 public final class ClientEndpointImpl implements ClientEndpoint {
 
     private final ClientEngineImpl clientEngine;
+    private final NodeEngineImpl nodeEngine;
     private final Connection connection;
     private final ConcurrentMap<String, TransactionContext> transactionContextMap
             = new ConcurrentHashMap<String, TransactionContext>();
@@ -62,8 +64,9 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     private long authenticationCorrelationId;
     private volatile String stats;
 
-    public ClientEndpointImpl(ClientEngineImpl clientEngine, Connection connection) {
+    public ClientEndpointImpl(ClientEngineImpl clientEngine, NodeEngineImpl nodeEngine, Connection connection) {
         this.clientEngine = clientEngine;
+        this.nodeEngine = nodeEngine;
         this.connection = connection;
         if (connection instanceof TcpIpConnection) {
             TcpIpConnection tcpIpConnection = (TcpIpConnection) connection;
@@ -243,6 +246,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     public void destroy() throws LoginException {
         clearAllListeners();
+        nodeEngine.onClientDisconnected(getUuid());
 
         LoginContext lc = loginContext;
         if (lc != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
@@ -59,7 +59,6 @@ public class ClientDisconnectionOperation extends AbstractClientOperation implem
 
         // This part cleans up locks conditions semaphore etc..
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        nodeEngine.onClientDisconnected(clientUuid);
         Collection<ClientAwareService> services = nodeEngine.getServices(ClientAwareService.class);
         for (ClientAwareService service : services) {
             service.clientDisconnected(clientUuid);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -95,7 +95,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
 
     @Override
     protected ClientEndpointImpl getEndpoint() {
-        return new ClientEndpointImpl(clientEngine, connection);
+        return new ClientEndpointImpl(clientEngine, nodeEngine, connection);
     }
 
     @Override


### PR DESCRIPTION
Client operations cleanup were delayed as lock/semaphore
cleanup. Since operations don't have a value when related
connection is dead(they have no way to return response),
they should be cleaned right after client disconnected.

fixes https://github.com/hazelcast/hazelcast/issues/11700