### PR TITLE
Fixed setting of wrong expiration and last stored time in EntryViews

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -969,26 +969,25 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V>, Eve
         ClientMessage response = invoke(request, keyData);
 
         MapGetEntryViewCodec.ResponseParameters parameters = MapGetEntryViewCodec.decodeResponse(response);
-        SimpleEntryView<K, V> entryView = new SimpleEntryView<K, V>();
         SimpleEntryView<Data, Data> dataEntryView = parameters.response;
 
         if (dataEntryView == null) {
             return null;
         }
-        entryView.setKey((K) toObject(dataEntryView.getKey()));
-        entryView.setValue((V) toObject(dataEntryView.getValue()));
-        entryView.setCost(dataEntryView.getCost());
-        entryView.setCreationTime(dataEntryView.getCreationTime());
-        entryView.setExpirationTime(dataEntryView.getExpirationTime());
-        entryView.setHits(dataEntryView.getHits());
-        entryView.setLastAccessTime(dataEntryView.getLastAccessTime());
-        entryView.setLastStoredTime(dataEntryView.getLastStoredTime());
-        entryView.setLastUpdateTime(dataEntryView.getLastUpdateTime());
-        entryView.setVersion(dataEntryView.getVersion());
-        entryView.setHits(dataEntryView.getHits());
-        entryView.setTtl(dataEntryView.getTtl());
         // TODO: putCache
-        return entryView;
+        return new SimpleEntryView<K, V>()
+                .withKey((K) toObject(dataEntryView.getKey()))
+                .withValue((V) toObject(dataEntryView.getValue()))
+                .withCost(dataEntryView.getCost())
+                .withCreationTime(dataEntryView.getCreationTime())
+                .withExpirationTime(dataEntryView.getExpirationTime())
+                .withHits(dataEntryView.getHits())
+                .withLastAccessTime(dataEntryView.getLastAccessTime())
+                .withLastStoredTime(dataEntryView.getLastStoredTime())
+                .withLastUpdateTime(dataEntryView.getLastUpdateTime())
+                .withVersion(dataEntryView.getVersion())
+                .withHits(dataEntryView.getHits())
+                .withTtl(dataEntryView.getTtl());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -24,7 +24,6 @@ import com.hazelcast.cache.impl.operation.CacheMergeOperation;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
@@ -162,9 +161,9 @@ class CacheSplitBrainHandlerService implements SplitBrainHandlerService {
                             cacheMergePolicy);
                     try {
                         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-                        ICompletableFuture<Object> future = nodeEngine.getOperationService()
-                                .invokeOnPartition(ICacheService.SERVICE_NAME, operation, partitionId);
-                        future.andThen(mergeCallback);
+                        nodeEngine.getOperationService()
+                                .invokeOnPartition(ICacheService.SERVICE_NAME, operation, partitionId)
+                                .andThen(mergeCallback);
                     } catch (Throwable t) {
                         throw rethrow(t);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -46,49 +46,45 @@ public final class EntryViews {
     }
 
     public static <K, V> EntryView<K, V> createSimpleEntryView(K key, V value, Record record) {
-        final SimpleEntryView<K, V> simpleEntryView = new SimpleEntryView<K, V>(key, value);
-        simpleEntryView.setCost(record.getCost());
-        simpleEntryView.setVersion(record.getVersion());
-        simpleEntryView.setHits(record.getHits());
-        simpleEntryView.setLastAccessTime(record.getLastAccessTime());
-        simpleEntryView.setLastUpdateTime(record.getLastUpdateTime());
-        simpleEntryView.setTtl(record.getTtl());
-        simpleEntryView.setCreationTime(record.getCreationTime());
-        simpleEntryView.setExpirationTime(record.getExpirationTime());
-        simpleEntryView.setLastStoredTime(record.getLastStoredTime());
-        return simpleEntryView;
+        return new SimpleEntryView<K, V>(key, value)
+                .withCost(record.getCost())
+                .withVersion(record.getVersion())
+                .withHits(record.getHits())
+                .withLastAccessTime(record.getLastAccessTime())
+                .withLastUpdateTime(record.getLastUpdateTime())
+                .withTtl(record.getTtl())
+                .withCreationTime(record.getCreationTime())
+                .withExpirationTime(record.getExpirationTime())
+                .withLastStoredTime(record.getLastStoredTime());
     }
 
     public static <K, V> EntryView<K, V> createLazyEntryView(K key, V value, Record record,
                                                              SerializationService serializationService,
                                                              MapMergePolicy mergePolicy) {
-        LazyEntryView<K, V> lazyEntryView = new LazyEntryView<K, V>(key, value, serializationService, mergePolicy);
-        lazyEntryView.setCost(record.getCost());
-        lazyEntryView.setVersion(record.getVersion());
-        lazyEntryView.setHits(record.getHits());
-        lazyEntryView.setLastAccessTime(record.getLastAccessTime());
-        lazyEntryView.setLastUpdateTime(record.getLastUpdateTime());
-        lazyEntryView.setTtl(record.getTtl());
-        lazyEntryView.setCreationTime(record.getCreationTime());
-        lazyEntryView.setExpirationTime(record.getExpirationTime());
-        lazyEntryView.setLastStoredTime(record.getLastStoredTime());
-        return lazyEntryView;
+        return new LazyEntryView<K, V>(key, value, serializationService, mergePolicy)
+                .setCost(record.getCost())
+                .setVersion(record.getVersion())
+                .setHits(record.getHits())
+                .setLastAccessTime(record.getLastAccessTime())
+                .setLastUpdateTime(record.getLastUpdateTime())
+                .setTtl(record.getTtl())
+                .setCreationTime(record.getCreationTime())
+                .setExpirationTime(record.getExpirationTime())
+                .setLastStoredTime(record.getLastStoredTime());
     }
 
     public static <K, V> EntryView<K, V> convertToLazyEntryView(EntryView<K, V> entryView,
                                                                 SerializationService serializationService,
                                                                 MapMergePolicy mergePolicy) {
-        final LazyEntryView<K, V> lazyEntryView = new LazyEntryView<K, V>(entryView.getKey(), entryView.getValue(),
-                serializationService, mergePolicy);
-        lazyEntryView.setCost(entryView.getCost());
-        lazyEntryView.setVersion(entryView.getVersion());
-        lazyEntryView.setLastAccessTime(entryView.getLastAccessTime());
-        lazyEntryView.setLastUpdateTime(entryView.getLastUpdateTime());
-        lazyEntryView.setTtl(entryView.getTtl());
-        lazyEntryView.setCreationTime(entryView.getCreationTime());
-        lazyEntryView.setHits(entryView.getHits());
-        lazyEntryView.setExpirationTime(entryView.getExpirationTime());
-        lazyEntryView.setLastStoredTime(entryView.getLastStoredTime());
-        return lazyEntryView;
+        return new LazyEntryView<K, V>(entryView.getKey(), entryView.getValue(), serializationService, mergePolicy)
+                .setCost(entryView.getCost())
+                .setVersion(entryView.getVersion())
+                .setLastAccessTime(entryView.getLastAccessTime())
+                .setLastUpdateTime(entryView.getLastUpdateTime())
+                .setTtl(entryView.getTtl())
+                .setCreationTime(entryView.getCreationTime())
+                .setHits(entryView.getHits())
+                .setExpirationTime(entryView.getExpirationTime())
+                .setLastStoredTime(entryView.getLastStoredTime());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -70,8 +70,8 @@ public final class EntryViews {
         lazyEntryView.setLastUpdateTime(record.getLastUpdateTime());
         lazyEntryView.setTtl(record.getTtl());
         lazyEntryView.setCreationTime(record.getCreationTime());
-        lazyEntryView.setExpirationTime(lazyEntryView.getExpirationTime());
-        lazyEntryView.setLastStoredTime(lazyEntryView.getLastStoredTime());
+        lazyEntryView.setExpirationTime(record.getExpirationTime());
+        lazyEntryView.setLastStoredTime(record.getLastStoredTime());
         return lazyEntryView;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
@@ -64,8 +64,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return key;
     }
 
-    public void setKey(K key) {
+    public LazyEntryView<K, V> setKey(K key) {
         this.key = key;
+        return this;
     }
 
     @Override
@@ -84,8 +85,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
                 || mergePolicy instanceof LatestUpdateMapMergePolicy;
     }
 
-    public void setValue(V value) {
+    public LazyEntryView<K, V> setValue(V value) {
         this.value = value;
+        return this;
     }
 
     @Override
@@ -93,8 +95,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return cost;
     }
 
-    public void setCost(long cost) {
+    public LazyEntryView<K, V> setCost(long cost) {
         this.cost = cost;
+        return this;
     }
 
     @Override
@@ -102,8 +105,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return creationTime;
     }
 
-    public void setCreationTime(long creationTime) {
+    public LazyEntryView<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
+        return this;
     }
 
     @Override
@@ -111,8 +115,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return expirationTime;
     }
 
-    public void setExpirationTime(long expirationTime) {
+    public LazyEntryView<K, V> setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;
+        return this;
     }
 
     @Override
@@ -120,8 +125,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return hits;
     }
 
-    public void setHits(long hits) {
+    public LazyEntryView<K, V> setHits(long hits) {
         this.hits = hits;
+        return this;
     }
 
     @Override
@@ -129,8 +135,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return lastAccessTime;
     }
 
-    public void setLastAccessTime(long lastAccessTime) {
+    public LazyEntryView<K, V> setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
+        return this;
     }
 
     @Override
@@ -138,8 +145,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return lastStoredTime;
     }
 
-    public void setLastStoredTime(long lastStoredTime) {
+    public LazyEntryView<K, V> setLastStoredTime(long lastStoredTime) {
         this.lastStoredTime = lastStoredTime;
+        return this;
     }
 
     @Override
@@ -147,8 +155,9 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return lastUpdateTime;
     }
 
-    public void setLastUpdateTime(long lastUpdateTime) {
+    public LazyEntryView<K, V> setLastUpdateTime(long lastUpdateTime) {
         this.lastUpdateTime = lastUpdateTime;
+        return this;
     }
 
     @Override
@@ -156,15 +165,17 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return version;
     }
 
-    public void setVersion(long version) {
+    public LazyEntryView<K, V> setVersion(long version) {
         this.version = version;
+        return this;
     }
 
     public long getEvictionCriteriaNumber() {
         return 0;
     }
 
-    public void setEvictionCriteriaNumber(long evictionCriteriaNumber) {
+    public LazyEntryView<K, V> setEvictionCriteriaNumber(long evictionCriteriaNumber) {
+        return this;
     }
 
     @Override
@@ -172,7 +183,8 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
         return ttl;
     }
 
-    public void setTtl(long ttl) {
+    public LazyEntryView<K, V> setTtl(long ttl) {
         this.ttl = ttl;
+        return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
@@ -154,15 +153,14 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                             mergePolicy, false);
                     try {
                         int partitionId = nodeEngine.getPartitionService().getPartitionId(record.getKey());
-                        ICompletableFuture<Object> future = nodeEngine.getOperationService()
-                                .invokeOnPartition(SERVICE_NAME, operation, partitionId);
-                        future.andThen(mergeCallback);
+                        nodeEngine.getOperationService()
+                                .invokeOnPartition(SERVICE_NAME, operation, partitionId)
+                                .andThen(mergeCallback);
                     } catch (Throwable t) {
                         throw rethrow(t);
                     }
                 }
             }
-
             try {
                 semaphore.tryAcquire(recordCount, recordCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -20,8 +20,8 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.BinaryInterface;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -47,12 +47,6 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
     private long lastUpdateTime;
     private long version;
     private long ttl;
-    /**
-     * @deprecated this field is not used any more but it is here to prevent `client <-> member` binary compatibility issues
-     * due to the its usage in SimpleEntryViewCodec.
-     */
-    @Deprecated
-    private long evictionCriteriaNumber;
 
     public SimpleEntryView(K key, V value) {
         this.key = key;
@@ -71,6 +65,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         this.key = key;
     }
 
+    public SimpleEntryView<K, V> withKey(K key) {
+        this.key = key;
+        return this;
+    }
+
     @Override
     public V getValue() {
         return value;
@@ -78,6 +77,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
 
     public void setValue(V value) {
         this.value = value;
+    }
+
+    public SimpleEntryView<K, V> withValue(V value) {
+        this.value = value;
+        return this;
     }
 
     @Override
@@ -89,6 +93,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         this.cost = cost;
     }
 
+    public SimpleEntryView<K, V> withCost(long cost) {
+        this.cost = cost;
+        return this;
+    }
+
     @Override
     public long getCreationTime() {
         return creationTime;
@@ -96,6 +105,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
 
     public void setCreationTime(long creationTime) {
         this.creationTime = creationTime;
+    }
+
+    public SimpleEntryView<K, V> withCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+        return this;
     }
 
     @Override
@@ -107,6 +121,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         this.expirationTime = expirationTime;
     }
 
+    public SimpleEntryView<K, V> withExpirationTime(long expirationTime) {
+        this.expirationTime = expirationTime;
+        return this;
+    }
+
     @Override
     public long getHits() {
         return hits;
@@ -114,6 +133,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
 
     public void setHits(long hits) {
         this.hits = hits;
+    }
+
+    public SimpleEntryView<K, V> withHits(long hits) {
+        this.hits = hits;
+        return this;
     }
 
     @Override
@@ -125,6 +149,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         this.lastAccessTime = lastAccessTime;
     }
 
+    public SimpleEntryView<K, V> withLastAccessTime(long lastAccessTime) {
+        this.lastAccessTime = lastAccessTime;
+        return this;
+    }
+
     @Override
     public long getLastStoredTime() {
         return lastStoredTime;
@@ -132,6 +161,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
 
     public void setLastStoredTime(long lastStoredTime) {
         this.lastStoredTime = lastStoredTime;
+    }
+
+    public SimpleEntryView<K, V> withLastStoredTime(long lastStoredTime) {
+        this.lastStoredTime = lastStoredTime;
+        return this;
     }
 
     @Override
@@ -143,6 +177,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         this.lastUpdateTime = lastUpdateTime;
     }
 
+    public SimpleEntryView<K, V> withLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+        return this;
+    }
+
     @Override
     public long getVersion() {
         return version;
@@ -150,6 +189,11 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
 
     public void setVersion(long version) {
         this.version = version;
+    }
+
+    public SimpleEntryView<K, V> withVersion(long version) {
+        this.version = version;
+        return this;
     }
 
     @Override
@@ -161,10 +205,23 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         this.ttl = ttl;
     }
 
+    public SimpleEntryView<K, V> withTtl(long ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    /**
+     * Needed for client protocol compatibility.
+     */
+    @SuppressWarnings("unused")
     public long getEvictionCriteriaNumber() {
         return 0;
     }
 
+    /**
+     * Needed for client protocol compatibility.
+     */
+    @SuppressWarnings("unused")
     public void setEvictionCriteriaNumber(long evictionCriteriaNumber) {
     }
 
@@ -180,7 +237,8 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         out.writeLong(lastStoredTime);
         out.writeLong(lastUpdateTime);
         out.writeLong(version);
-        out.writeLong(evictionCriteriaNumber);
+        // writes the deprecated evictionCriteriaNumber to the data output (client protocol compatibility)
+        out.writeLong(0);
         out.writeLong(ttl);
     }
 
@@ -196,7 +254,8 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         lastStoredTime = in.readLong();
         lastUpdateTime = in.readLong();
         version = in.readLong();
-        evictionCriteriaNumber = in.readLong();
+        // reads the deprecated evictionCriteriaNumber from the data input (client protocol compatibility)
+        in.readLong();
         ttl = in.readLong();
     }
 
@@ -220,7 +279,6 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         }
 
         SimpleEntryView<?, ?> that = (SimpleEntryView<?, ?>) o;
-
         if (cost != that.cost) {
             return false;
         }
@@ -252,7 +310,6 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
             return false;
         }
         return value != null ? value.equals(that.value) : that.value == null;
-
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
@@ -37,11 +37,6 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
     private long lastUpdateTime;
     private long ttl;
 
-    public ReplicatedMapEntryView(K key, V value) {
-        this.key = key;
-        this.value = value;
-    }
-
     public ReplicatedMapEntryView() {
     }
 
@@ -50,8 +45,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return key;
     }
 
-    public void setKey(K key) {
+    public ReplicatedMapEntryView<K, V> setKey(K key) {
         this.key = key;
+        return this;
     }
 
     @Override
@@ -59,8 +55,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return value;
     }
 
-    public void setValue(V value) {
+    public ReplicatedMapEntryView<K, V> setValue(V value) {
         this.value = value;
+        return this;
     }
 
     @Override
@@ -73,8 +70,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return creationTime;
     }
 
-    public void setCreationTime(long creationTime) {
+    public ReplicatedMapEntryView<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
+        return this;
     }
 
     @Override
@@ -87,8 +85,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return hits;
     }
 
-    public void setHits(long hits) {
+    public ReplicatedMapEntryView<K, V> setHits(long hits) {
         this.hits = hits;
+        return this;
     }
 
     @Override
@@ -96,8 +95,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return lastAccessTime;
     }
 
-    public void setLastAccessTime(long lastAccessTime) {
+    public ReplicatedMapEntryView<K, V> setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime = lastAccessTime;
+        return this;
     }
 
     @Override
@@ -110,8 +110,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return lastUpdateTime;
     }
 
-    public void setLastUpdateTime(long lastUpdateTime) {
+    public ReplicatedMapEntryView<K, V> setLastUpdateTime(long lastUpdateTime) {
         this.lastUpdateTime = lastUpdateTime;
+        return this;
     }
 
     @Override
@@ -124,8 +125,9 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return ttl;
     }
 
-    public void setTtl(long ttl) {
+    public ReplicatedMapEntryView<K, V> setTtl(long ttl) {
         this.ttl = ttl;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/EntryViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/EntryViewTest.java
@@ -52,13 +52,14 @@ public class EntryViewTest extends HazelcastTestSupport {
     }
 
     private ReplicatedMapEntryView createEntryView() {
-        ReplicatedMapEntryView entryView = new ReplicatedMapEntryView<String, String>("foo", "bar");
-        entryView.setCreationTime(1);
-        entryView.setLastAccessTime(2);
-        entryView.setLastUpdateTime(3);
-        entryView.setHits(4);
-        entryView.setTtl(5);
-        return entryView;
+        return new ReplicatedMapEntryView<String, String>()
+                .setKey("foo")
+                .setValue("bar")
+                .setCreationTime(1)
+                .setLastAccessTime(2)
+                .setLastUpdateTime(3)
+                .setHits(4)
+                .setTtl(5);
     }
 
     private void verifyFields(ReplicatedMapEntryView entryView) {


### PR DESCRIPTION
* Fixed setting of wrong expiration and last stored time in `EntryViews`
* Made API of `EntryView` implementations fluent  
  * changed setters of `EntryView` implementations to a fluent API
  * made use of fluent API in all related classes

I kept this as two commits, so we can easily backport the fixing part.

The `SimpleEntryView` was a bit hard to deal with, since it's part of the client protocol. So the old interface and the over-the-wire part could not be changed. So just new methods were added for the fluent API.