### PR TITLE
Do not kill the thread if single command is not processed properly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -401,7 +401,9 @@ public class TextCommandServiceImpl implements TextCommandService {
                 } catch (OutOfMemoryError e) {
                     OutOfMemoryErrorDispatcher.onOutOfMemory(e);
                     throw e;
-                }
+                } catch (Throwable t) {
+                    logger.severe(t);
+                }                
             }
         }
 


### PR DESCRIPTION
When there is an exception while processing single command, entire thread got killed. It causes unrecoverable condition when system does not process any incoming REST command and causing memory leak (incoming commands are accumulated in blockingQueue).
The only resolution is restart of entire system.

In our case heavy system swapping caused this situation to occur. Here is the full stack trace (for version 3.6.2):
```
Exception in thread "hz.MY_CLUSTER.ascii.service.response" java.lang.NullPointerException
        at com.hazelcast.internal.ascii.TextCommandServiceImpl$ResponseThreadRunnable.run(TextCommandServiceImpl.java:379)
        at java.lang.Thread.run(Thread.java:745)
```