### PR TITLE
Changed default brains in SplitBrainTestSupport

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
@@ -69,12 +69,6 @@ public class CacheSplitBrainTest extends SplitBrainTestSupport {
     private MergeLifecycleListener mergeLifecycleListener;
 
     @Override
-    protected int[] brains() {
-        // second half should merge to first 
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
     }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -36,12 +36,6 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
     private final int finalCount = initialCount + 50;
 
     @Override
-    protected int[] brains() {
-        // 2nd merges to the 1st
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         IList<Object> list = instances[0].getList(name);
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -36,12 +36,6 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
     private final int finalCount = initialCount + 50;
 
     @Override
-    protected int[] brains() {
-        // 2nd merges to the 1st
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         IQueue<Object> queue = instances[0].getQueue(name);
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -34,12 +34,6 @@ public class LockSplitBrainTest extends SplitBrainTestSupport {
     private String key;
 
     @Override
-    protected int[] brains() {
-        // 2nd merges to the 1st
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -36,12 +36,6 @@ public class SemaphoreSplitBrainTest extends SplitBrainTestSupport {
     private int permits = 5;
 
     @Override
-    protected int[] brains() {
-        // 2nd merges to the 1st
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) throws Exception {
         warmUpPartitions(instances);
 

--- a/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
@@ -32,17 +32,17 @@ public class ProxySplitBrainTest extends SplitBrainTestSupport {
 
     @Override
     protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
-        HazelcastInstance isolatedInstance = firstBrain[0];
+        HazelcastInstance isolatedInstance = secondBrain[0];
         isolatedInstance.getLock("isolatedLock");
         assertDistributedObjectCountEventually(1, isolatedInstance);
 
-        for (HazelcastInstance hz : secondBrain) {
+        for (HazelcastInstance hz : firstBrain) {
             String name = generateKeyOwnedBy(hz);
             hz.getLock(name);
         }
 
-        for (HazelcastInstance hz : secondBrain) {
-            int expectedCount = secondBrain.length;
+        for (HazelcastInstance hz : firstBrain) {
+            int expectedCount = firstBrain.length;
             assertDistributedObjectCountEventually(expectedCount, hz);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest.java
@@ -21,7 +21,7 @@ public class DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainOnlyTest exte
 
     @Override
     protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
-        HazelcastInstance instanceInSmallerBrain = firstBrain[0];
+        HazelcastInstance instanceInSmallerBrain = secondBrain[0];
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(TestConfigUtils.NON_DEFAULT_IN_MEMORY_FORMAT);
         mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest.java
@@ -21,15 +21,15 @@ public class DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest e
 
     @Override
     protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
-        HazelcastInstance instanceInSmallerBrain = firstBrain[0];
+        HazelcastInstance instanceInBiggerBrain = firstBrain[0];
+        MapConfig defaultMapConfig = new MapConfig(MAP_NAME);
+        instanceInBiggerBrain.getConfig().addMapConfig(defaultMapConfig);
+
+        HazelcastInstance instanceInSmallerBrain = secondBrain[0];
         MapConfig mapConfig = new MapConfig(MAP_NAME);
         mapConfig.setInMemoryFormat(TestConfigUtils.NON_DEFAULT_IN_MEMORY_FORMAT);
         mapConfig.setBackupCount(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT);
         instanceInSmallerBrain.getConfig().addMapConfig(mapConfig);
-
-        HazelcastInstance instanceInBiggerBrain = secondBrain[0];
-        MapConfig defaultMapConfig = new MapConfig(MAP_NAME);
-        instanceInBiggerBrain.getConfig().addMapConfig(defaultMapConfig);
     }
 
     @Override
@@ -37,8 +37,7 @@ public class DynamicConfigSplitBrain_whenDifferentConfigExistsInBothBrainsTest e
         MapConfig defaultMapConfig = new Config().findMapConfig("default");
 
         for (HazelcastInstance instance : instances) {
-            final Config config = instance.getConfig();
-            MapConfig mapConfig = config.findMapConfig(MAP_NAME);
+            MapConfig mapConfig = instance.getConfig().findMapConfig(MAP_NAME);
             assertEquals(defaultMapConfig.getInMemoryFormat(), mapConfig.getInMemoryFormat());
             assertEquals(defaultMapConfig.getBackupCount(), mapConfig.getBackupCount());
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/IgnoreMergingEntriesMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/IgnoreMergingEntriesMapSplitBrainTest.java
@@ -43,6 +43,12 @@ public class IgnoreMergingEntriesMapSplitBrainTest extends SplitBrainTestSupport
     private final CountDownLatch clusterMergedLatch = new CountDownLatch(1);
 
     @Override
+    protected int[] brains() {
+        // first half merges into second half
+        return new int[]{1, 2};
+    }
+
+    @Override
     protected Config config() {
         Config config = super.config();
         config.getMapConfig(testMapName)

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -68,6 +68,12 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
     private String testMapName;
 
     @Override
+    protected int[] brains() {
+        // first half merges into second half
+        return new int[]{1, 2};
+    }
+
+    @Override
     protected Config config() {
         Config config = super.config();
         config.getMapConfig(TEST_MAPS_PREFIX + "*")

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
@@ -64,12 +64,6 @@ public class ReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
     private ReplicatedMap<Object, Object> replicatedMap2;
 
     @Override
-    protected int[] brains() {
-        // second half should merge to first 
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected Config config() {
         Config config = super.config();
         config.getReplicatedMapConfig(replicatedMapName)

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -53,7 +53,8 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
 
     protected TestHazelcastInstanceFactory factory;
 
-    private static final int[] DEFAULT_BRAINS = new int[]{1, 2};
+    // per default the second half should merge into the first half
+    private static final int[] DEFAULT_BRAINS = new int[]{2, 1};
     private static final int DEFAULT_ITERATION_COUNT = 1;
     private HazelcastInstance[] instances;
     private int[] brains;


### PR DESCRIPTION
The motivation behind this is, that the majority of tests overrides the `brains()` method already. This will become worse with the new tests for additional data structures.

Actually `MapSplitBrainTest` and `IgnoreMergingEntriesMapSplitBrainTest` were the only tests, which were not trivial to change (so I kept the `new int[]{1, 2}` brains setup).