### PR TITLE
[BACKPORT][3.x] Tuneable trade-off for index query result copying

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -135,7 +135,8 @@ public class MapContainer {
         this.extractors = new Extractors(mapConfig.getMapAttributeConfigs(), config.getClassLoader());
         if (shouldUseGlobalIndex(mapConfig)) {
             this.globalIndexes = new Indexes((InternalSerializationService) serializationService,
-                    mapServiceContext.getIndexProvider(mapConfig), extractors, true);
+                    mapServiceContext.getIndexProvider(mapConfig), extractors,
+                    true, mapServiceContext.getIndexCopyBehavior());
         } else {
             this.globalIndexes = null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -37,6 +37,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.EventFilter;
@@ -184,4 +185,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     String addListenerAdapter(ListenerAdapter listenerAdaptor, EventFilter eventFilter, String mapName);
 
     String addLocalListenerAdapter(ListenerAdapter listenerAdaptor, String mapName);
+
+    IndexCopyBehavior getIndexCopyBehavior();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -64,6 +64,7 @@ import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.EventFilter;
@@ -104,6 +105,7 @@ import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
 import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
 import static com.hazelcast.spi.properties.GroupProperty.AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
+import static com.hazelcast.spi.properties.GroupProperty.INDEX_COPY_BEHAVIOR;
 import static com.hazelcast.spi.properties.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
 
 /**
@@ -808,5 +810,10 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public QueryCacheContext getQueryCacheContext() {
         return queryCacheContext;
+    }
+
+    @Override
+    public IndexCopyBehavior getIndexCopyBehavior() {
+        return nodeEngine.getProperties().getEnum(INDEX_COPY_BEHAVIOR, IndexCopyBehavior.class);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -122,7 +122,8 @@ public class PartitionContainer {
         InternalSerializationService ss = (InternalSerializationService) nodeEngine.getSerializationService();
         IndexProvider indexProvider = serviceContext.getIndexProvider(mapConfig);
         if (!mapContainer.isGlobalIndexEnabled()) {
-            Indexes indexesForMap = new Indexes(ss, indexProvider, mapContainer.getExtractors(), false);
+            Indexes indexesForMap = new Indexes(ss, indexProvider, mapContainer.getExtractors(), false,
+                    serviceContext.getIndexCopyBehavior());
             indexes.putIfAbsent(name, indexesForMap);
         }
         RecordStore recordStore = serviceContext.createRecordStore(mapContainer, partitionId, keyLoader);
@@ -267,7 +268,7 @@ public class PartitionContainer {
                     mapServiceContext.getNodeEngine().getSerializationService();
             Extractors extractors = mapServiceContext.getMapContainer(name).getExtractors();
             IndexProvider indexProvider = mapServiceContext.getIndexProvider(mapContainer.getMapConfig());
-            Indexes indexesForMap = new Indexes(ss, indexProvider, extractors, false);
+            Indexes indexesForMap = new Indexes(ss, indexProvider, extractors, false, mapServiceContext.getIndexCopyBehavior());
             ixs = indexes.putIfAbsent(name, indexesForMap);
             if (ixs == null) {
                 ixs = indexesForMap;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/DefaultIndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/DefaultIndexProvider.java
@@ -18,12 +18,14 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.getters.Extractors;
 
 public class DefaultIndexProvider implements IndexProvider {
     @Override
-    public Index createIndex(String attributeName, boolean ordered, Extractors extractors, InternalSerializationService ss) {
-        return new IndexImpl(attributeName, ordered, ss, extractors);
+    public Index createIndex(String attributeName, boolean ordered, Extractors extractors,
+                             InternalSerializationService ss, IndexCopyBehavior copyBehavior) {
+        return new IndexImpl(attributeName, ordered, ss, extractors, copyBehavior);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/IndexProvider.java
@@ -18,10 +18,12 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.getters.Extractors;
 
 public interface IndexProvider {
 
-    Index createIndex(String attributeName, boolean ordered, Extractors extractors, InternalSerializationService ss);
+    Index createIndex(String attributeName, boolean ordered, Extractors extractors,
+                      InternalSerializationService ss, IndexCopyBehavior copyBehavior);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -30,6 +30,7 @@ import com.hazelcast.map.impl.querycache.subscriber.record.QueryCacheRecord;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.CachedQueryEntry;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.getters.Extractors;
 
@@ -72,8 +73,9 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
         this.serializationService = context.getSerializationService();
         // We are not using injected index provider since we're not supporting off-heap indexes in CQC due
         // to threading incompatibility. If we injected the IndexProvider from the MapServiceContext
-        // the EE side would create HD indexes which is undesired
-        this.indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        // the EE side would create HD indexes which is undesired.
+        this.indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true,
+                IndexCopyBehavior.COPY_ON_READ);
         this.includeValue = isIncludeValue();
         this.partitioningStrategy = getPartitioningStrategy();
         this.recordStore = new DefaultQueryCacheRecordStore(serializationService, indexes, getQueryCacheConfig(),

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -32,15 +32,17 @@ public abstract class BaseIndexStore implements IndexStore {
 
     static final float LOAD_FACTOR = 0.75F;
 
+    protected final IndexCopyBehavior copyOn;
+
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
     private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
 
     private final CopyFunctor<Data, QueryableEntry> resultCopyFunctor;
-
     private boolean multiResultHasToDetectDuplicates;
 
     BaseIndexStore(IndexCopyBehavior copyOn) {
+        this.copyOn = copyOn;
         if (copyOn == IndexCopyBehavior.COPY_ON_WRITE || copyOn == IndexCopyBehavior.NEVER) {
             resultCopyFunctor = new PassThroughFunctor();
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -22,6 +22,7 @@ import com.hazelcast.query.impl.getters.MultiResult;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -35,7 +36,17 @@ public abstract class BaseIndexStore implements IndexStore {
     private final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
     private final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
 
+    private final CopyFunctor<Data, QueryableEntry> resultCopyFunctor;
+
     private boolean multiResultHasToDetectDuplicates;
+
+    BaseIndexStore(IndexCopyBehavior copyOn) {
+        if (copyOn == IndexCopyBehavior.COPY_ON_WRITE || copyOn == IndexCopyBehavior.NEVER) {
+            resultCopyFunctor = new PassThroughFunctor();
+        } else {
+            resultCopyFunctor = new CopyInputFunctor();
+        }
+    }
 
     abstract void newIndexInternal(Comparable newValue, QueryableEntry record);
 
@@ -141,11 +152,36 @@ public abstract class BaseIndexStore implements IndexStore {
         return multiResultHasToDetectDuplicates ? new DuplicateDetectingMultiResult() : new FastMultiResultSet();
     }
 
-    final void copyToMultiResultSet(MultiResultSet resultSet, Map<Data, QueryableEntry> records) {
-        resultSet.addResultSet(new HashMap<Data, QueryableEntry>(records));
+    interface CopyFunctor<A, B> {
+        Map<A, B> invoke(Map<A, B> map);
     }
 
-    final SingleResultSet toSingleResultSet(Map<Data, QueryableEntry> records) {
-        return new SingleResultSet(records != null ? new HashMap<Data, QueryableEntry>(records) : null);
+    private static class PassThroughFunctor implements CopyFunctor<Data, QueryableEntry> {
+        @Override
+        public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
+            return map;
+        }
+    }
+
+    private static class CopyInputFunctor implements CopyFunctor<Data, QueryableEntry> {
+        @Override
+        public Map<Data, QueryableEntry> invoke(Map<Data, QueryableEntry> map) {
+            if (map != null && !map.isEmpty()) {
+                return new HashMap<Data, QueryableEntry>(map);
+            }
+            return map;
+        }
+    }
+
+    final void copyToMultiResultSet(MultiResultSet resultSet, Map<Data, QueryableEntry> records) {
+        resultSet.addResultSet(resultCopyFunctor.invoke(records));
+    }
+
+    final Set<QueryableEntry> toSingleResultSet(Map<Data, QueryableEntry> records) {
+        return new SingleResultSet(resultCopyFunctor.invoke(records));
+    }
+
+    interface IndexFunctor<A, B> {
+        void invoke(A param1, B param2);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexCopyBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexCopyBehavior.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+/**
+ * Defines the behavior for index copying on index read/write.
+ *
+ * Supported in BINARY and OBJECT in-memory-formats. Ignored in NATIVE in-memory-format.
+ *
+ * Why is it needed? In order to support correctness the internal data-structures used by indexes need to do some copying.
+ * The copying may take place on-read or on-write:
+ *
+ * -> Copying on-read means that each index-read operation will copy the result of the query before returning it to the caller.
+ * This copying may be expensive, depending on the size of the result, since the result is stored in a map, which means
+ * that all entries need to have the hash calculated before being stored in a bucket.
+ * Each index-write operation however will be fast, since there will be no copying taking place.
+ *
+ * -> Copying on-write means that each index-write operation will completely copy the underlying map to provide the
+ * copy-on-write semantics. Depending on the index size, it may be a very expensive operation.
+ * Each index-read operation will be very fast, however, since it may just access the map and return it to the caller.
+ *
+ * -> Never copying is tricky. It means that the internal data structures of the index are concurrently modified without
+ * copy-on-write semantics. Index reads never copy the results of a query to a separate map.
+ * It means that the results backed by the underlying index-map can change after the query has been executed.
+ * Specifically an entry might have been added / removed from an index, or it might have been remapped.
+ * Should be used in cases when a the caller expects "mostly correct" results - specifically, if it's ok
+ * if some entries returned in the result set do not match the initial query criteria.
+ * The fastest solution for read and writes, since no copying takes place.
+ *
+ * It's a tuneable trade-off - the user may decide.
+ */
+public enum IndexCopyBehavior {
+    /**
+     * Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * Index queries copy the results of a query on index read to detach the result from the source map.
+     * Should be used in index-write intensive cases, since the reads will slow down due to the copying.
+     * Default value.
+     */
+    COPY_ON_READ,
+    /**
+     * Internal data structures of the index are modified with copy-on-write semantics.
+     * Previously returned index query results reflect the state of the index at the time of the query and are not
+     * affected by future index modifications.
+     * Should be used in index-read intensive cases, since the writes will slow down due to the copying.
+     */
+    COPY_ON_WRITE,
+    /**
+     * Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * Index reads never copy the results of a query to a separate map.
+     * It means that the results backed by the underlying index-map can change after the query has been executed.
+     * Specifically an entry might have been added / removed from an index, or it might have been remapped.
+     * Should be used in cases when a the caller expects "mostly correct" results - specifically, if it's ok
+     * if some entries returned in the result set do not match the initial query criteria.
+     * The fastest solution for read and writes, since no copying takes place.
+     */
+    NEVER
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexCopyBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexCopyBehavior.java
@@ -19,9 +19,10 @@ package com.hazelcast.query.impl;
 /**
  * Defines the behavior for index copying on index read/write.
  *
- * Supported in BINARY and OBJECT in-memory-formats. Ignored in NATIVE in-memory-format.
+ * Supported for BINARY and OBJECT in-memory formats.
+ * It is also supported for NATIVE in-memory format ONLY in Hazelcast 3.8.7 (and further 3.8.x releases).
  *
- * Why is it needed? In order to support correctness the internal data-structures used by indexes need to do some copying.
+ * Why is it needed? In order to support correctness the underlying data structures used by indexes need to do some copying.
  * The copying may take place on-read or on-write:
  *
  * -> Copying on-read means that each index-read operation will copy the result of the query before returning it to the caller.
@@ -33,7 +34,7 @@ package com.hazelcast.query.impl;
  * copy-on-write semantics. Depending on the index size, it may be a very expensive operation.
  * Each index-read operation will be very fast, however, since it may just access the map and return it to the caller.
  *
- * -> Never copying is tricky. It means that the internal data structures of the index are concurrently modified without
+ * -> Never copying is tricky. It means that the underlying data structures of the index are concurrently modified without
  * copy-on-write semantics. Index reads never copy the results of a query to a separate map.
  * It means that the results backed by the underlying index-map can change after the query has been executed.
  * Specifically an entry might have been added / removed from an index, or it might have been remapped.
@@ -45,21 +46,21 @@ package com.hazelcast.query.impl;
  */
 public enum IndexCopyBehavior {
     /**
-     * Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * Underlying data structures of the index are concurrently modified without copy-on-write semantics.
      * Index queries copy the results of a query on index read to detach the result from the source map.
      * Should be used in index-write intensive cases, since the reads will slow down due to the copying.
      * Default value.
      */
     COPY_ON_READ,
     /**
-     * Internal data structures of the index are modified with copy-on-write semantics.
+     * Underlying data structures of the index are modified with copy-on-write semantics.
      * Previously returned index query results reflect the state of the index at the time of the query and are not
      * affected by future index modifications.
      * Should be used in index-read intensive cases, since the writes will slow down due to the copying.
      */
     COPY_ON_WRITE,
     /**
-     * Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * Underlying data structures of the index are concurrently modified without copy-on-write semantics.
      * Index reads never copy the results of a query to a separate map.
      * It means that the results backed by the underlying index-map can change after the query has been executed.
      * Specifically an entry might have been added / removed from an index, or it might have been remapped.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -39,6 +39,7 @@ public class IndexImpl implements Index {
 
     protected final InternalSerializationService ss;
     protected final IndexStore indexStore;
+    private final IndexCopyBehavior copyQueryResultOn;
 
     private volatile TypeConverter converter;
 
@@ -46,16 +47,18 @@ public class IndexImpl implements Index {
     private final boolean ordered;
     private final Extractors extractors;
 
-    public IndexImpl(String attributeName, boolean ordered, InternalSerializationService ss, Extractors extractors) {
+    public IndexImpl(String attributeName, boolean ordered, InternalSerializationService ss, Extractors extractors,
+                     IndexCopyBehavior copyQueryResultOn) {
         this.attributeName = attributeName;
         this.ordered = ordered;
         this.ss = ss;
+        this.copyQueryResultOn = copyQueryResultOn;
         this.indexStore = createIndexStore(ordered);
         this.extractors = extractors;
     }
 
     public IndexStore createIndexStore(boolean ordered) {
-        return ordered ? new SortedIndexStore() : new UnsortedIndexStore();
+        return ordered ? new SortedIndexStore(copyQueryResultOn) : new UnsortedIndexStore(copyQueryResultOn);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -36,6 +36,7 @@ public class Indexes {
     private static final Index[] EMPTY_INDEX = {};
     private final ConcurrentMap<String, Index> mapIndexes = new ConcurrentHashMap<String, Index>(3);
     private final AtomicReference<Index[]> indexes = new AtomicReference<Index[]>(EMPTY_INDEX);
+    private final IndexCopyBehavior copyBehavior;
     private volatile boolean hasIndex;
     private final InternalSerializationService serializationService;
     private final IndexProvider indexProvider;
@@ -44,11 +45,12 @@ public class Indexes {
 
 
     public Indexes(InternalSerializationService serializationService, IndexProvider indexProvider,
-                   Extractors extractors, boolean global) {
+                   Extractors extractors, boolean global, IndexCopyBehavior copyBehavior) {
         this.serializationService = serializationService;
         this.indexProvider = indexProvider;
         this.extractors = extractors;
         this.global = global;
+        this.copyBehavior = copyBehavior;
     }
 
     public synchronized Index destroyIndex(String attribute) {
@@ -60,7 +62,7 @@ public class Indexes {
         if (index != null) {
             return index;
         }
-        index = indexProvider.createIndex(attribute, ordered, extractors, serializationService);
+        index = indexProvider.createIndex(attribute, ordered, extractors, serializationService, copyBehavior);
         mapIndexes.put(attribute, index);
         Object[] indexObjects = mapIndexes.values().toArray();
         Index[] newIndexes = new Index[indexObjects.length];

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
@@ -67,7 +67,11 @@ public class SortedIndexStore extends BaseIndexStore {
     public void clear() {
         takeWriteLock();
         try {
-            recordsWithNullValue.clear();
+            if (copyOn == IndexCopyBehavior.COPY_ON_WRITE) {
+                recordsWithNullValue = Collections.emptyMap();
+            } else {
+                recordsWithNullValue.clear();
+            }
             recordMap.clear();
         } finally {
             releaseWriteLock();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
@@ -18,60 +18,49 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.nio.serialization.Data;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-
 
 /**
  * Store indexes rankly.
  */
 public class SortedIndexStore extends BaseIndexStore {
 
-    private final ConcurrentMap<Data, QueryableEntry> recordsWithNullValue
-            = new ConcurrentHashMap<Data, QueryableEntry>();
+    private volatile Map<Data, QueryableEntry> recordsWithNullValue;
 
-    private final ConcurrentSkipListMap<Comparable, ConcurrentMap<Data, QueryableEntry>> recordMap
-            = new ConcurrentSkipListMap<Comparable, ConcurrentMap<Data, QueryableEntry>>();
+    private final ConcurrentSkipListMap<Comparable, Map<Data, QueryableEntry>> recordMap
+            = new ConcurrentSkipListMap<Comparable, Map<Data, QueryableEntry>>();
 
-    @Override
-    void newIndexInternal(Comparable newValue, QueryableEntry record) {
-        if (newValue instanceof IndexImpl.NullObject) {
-            recordsWithNullValue.put(record.getKeyData(), record);
+    private final IndexFunctor<Comparable, QueryableEntry> addFunctor;
+    private final IndexFunctor<Comparable, Data> removeFunctor;
+
+    public SortedIndexStore(IndexCopyBehavior copyOn) {
+        super(copyOn);
+        assert copyOn != null;
+        if (copyOn == IndexCopyBehavior.COPY_ON_WRITE) {
+            addFunctor = new CopyOnWriteAddFunctor();
+            removeFunctor = new CopyOnWriteRemoveFunctor();
+            recordsWithNullValue = Collections.emptyMap();
         } else {
-            mapAttributeToEntry(newValue, record);
+            addFunctor = new AddFunctor();
+            removeFunctor = new RemoveFunctor();
+            recordsWithNullValue = new ConcurrentHashMap<Data, QueryableEntry>();
         }
     }
 
-    private void mapAttributeToEntry(Comparable attribute, QueryableEntry entry) {
-        ConcurrentMap<Data, QueryableEntry> records = recordMap.get(attribute);
-        if (records == null) {
-            records = new ConcurrentHashMap<Data, QueryableEntry>(1, LOAD_FACTOR, 1);
-            recordMap.put(attribute, records);
-        }
-        records.put(entry.getKeyData(), entry);
+    @Override
+    void newIndexInternal(Comparable newValue, QueryableEntry record) {
+        addFunctor.invoke(newValue, record);
     }
 
     @Override
     void removeIndexInternal(Comparable oldValue, Data indexKey) {
-        if (oldValue instanceof IndexImpl.NullObject) {
-            recordsWithNullValue.remove(indexKey);
-        } else {
-            removeMappingForAttribute(oldValue, indexKey);
-        }
-    }
-
-    private void removeMappingForAttribute(Comparable attribute, Data indexKey) {
-        ConcurrentMap<Data, QueryableEntry> records = recordMap.get(attribute);
-        if (records != null) {
-            records.remove(indexKey);
-            if (records.size() == 0) {
-                recordMap.remove(attribute);
-            }
-        }
+        removeFunctor.invoke(oldValue, indexKey);
     }
 
     @Override
@@ -90,9 +79,9 @@ public class SortedIndexStore extends BaseIndexStore {
         takeReadLock();
         try {
             MultiResultSet results = createMultiResultSet();
-            SortedMap<Comparable, ConcurrentMap<Data, QueryableEntry>> subMap =
+            SortedMap<Comparable, Map<Data, QueryableEntry>> subMap =
                     recordMap.subMap(from, true, to, true);
-            for (ConcurrentMap<Data, QueryableEntry> value : subMap.values()) {
+            for (Map<Data, QueryableEntry> value : subMap.values()) {
                 copyToMultiResultSet(results, value);
             }
             return results;
@@ -106,7 +95,7 @@ public class SortedIndexStore extends BaseIndexStore {
         takeReadLock();
         try {
             MultiResultSet results = createMultiResultSet();
-            SortedMap<Comparable, ConcurrentMap<Data, QueryableEntry>> subMap;
+            SortedMap<Comparable, Map<Data, QueryableEntry>> subMap;
             switch (comparisonType) {
                 case LESSER:
                     subMap = recordMap.headMap(searchedValue, false);
@@ -124,7 +113,7 @@ public class SortedIndexStore extends BaseIndexStore {
                     // TODO There maybe more efficient way such as
                     // Make a copy of current record map and just remove searched value.
                     // So remaining records are not equal to searched value
-                    for (Map.Entry<Comparable, ConcurrentMap<Data, QueryableEntry>> entry : recordMap.entrySet()) {
+                    for (Map.Entry<Comparable, Map<Data, QueryableEntry>> entry : recordMap.entrySet()) {
                         if (!searchedValue.equals(entry.getKey())) {
                             copyToMultiResultSet(results, entry.getValue());
                         }
@@ -133,7 +122,7 @@ public class SortedIndexStore extends BaseIndexStore {
                 default:
                     throw new IllegalArgumentException("Unrecognized comparisonType: " + comparisonType);
             }
-            for (ConcurrentMap<Data, QueryableEntry> value : subMap.values()) {
+            for (Map<Data, QueryableEntry> value : subMap.values()) {
                 copyToMultiResultSet(results, value);
             }
             return results;
@@ -162,7 +151,7 @@ public class SortedIndexStore extends BaseIndexStore {
         try {
             MultiResultSet results = createMultiResultSet();
             for (Comparable value : values) {
-                ConcurrentMap<Data, QueryableEntry> records;
+                Map<Data, QueryableEntry> records;
                 if (value instanceof IndexImpl.NullObject) {
                     records = recordsWithNullValue;
                 } else {
@@ -178,10 +167,113 @@ public class SortedIndexStore extends BaseIndexStore {
         }
     }
 
+    /**
+     * Adds entry to the given index map without copying it.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class AddFunctor implements IndexFunctor<Comparable, QueryableEntry> {
+        @Override
+        public void invoke(Comparable attribute, QueryableEntry entry) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                recordsWithNullValue.put(entry.getKeyData(), entry);
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records == null) {
+                    records = new ConcurrentHashMap<Data, QueryableEntry>(1, LOAD_FACTOR, 1);
+                    recordMap.put(attribute, records);
+                }
+                records.put(entry.getKeyData(), entry);
+            }
+        }
+    }
+
+    /**
+     * Adds entry to the given index map copying it to secure exclusive access.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class CopyOnWriteAddFunctor implements IndexFunctor<Comparable, QueryableEntry> {
+        @Override
+        public void invoke(Comparable attribute, QueryableEntry entry) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                HashMap<Data, QueryableEntry> copy = new HashMap<Data, QueryableEntry>(recordsWithNullValue);
+                copy.put(entry.getKeyData(), entry);
+                recordsWithNullValue = copy;
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records == null) {
+                    records = Collections.emptyMap();
+                }
+
+                records = new HashMap<Data, QueryableEntry>(records);
+                records.put(entry.getKeyData(), entry);
+
+                recordMap.put(attribute, records);
+            }
+        }
+    }
+
+    /**
+     * Removes entry from the given index map without copying it.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class RemoveFunctor implements IndexFunctor<Comparable, Data> {
+        @Override
+        public void invoke(Comparable attribute, Data indexKey) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                recordsWithNullValue.remove(indexKey);
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records != null) {
+                    records.remove(indexKey);
+                    if (records.size() == 0) {
+                        recordMap.remove(attribute);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes entry from the given index map copying it to secure exclusive access.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class CopyOnWriteRemoveFunctor implements IndexFunctor<Comparable, Data> {
+        @Override
+        public void invoke(Comparable attribute, Data indexKey) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                HashMap<Data, QueryableEntry> copy = new HashMap<Data, QueryableEntry>(recordsWithNullValue);
+                copy.remove(indexKey);
+                recordsWithNullValue = copy;
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records != null) {
+                    records = new HashMap<Data, QueryableEntry>(records);
+                    records.remove(indexKey);
+
+                    if (records.isEmpty()) {
+                        recordMap.remove(attribute);
+                    } else {
+                        recordMap.put(attribute, records);
+                    }
+                }
+            }
+        }
+    }
+
+
     @Override
     public String toString() {
         return "SortedIndexStore{"
                 + "recordMap=" + recordMap.size()
                 + '}';
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
@@ -18,6 +18,8 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.nio.serialization.Data;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,47 +30,35 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class UnsortedIndexStore extends BaseIndexStore {
 
-    private final ConcurrentMap<Data, QueryableEntry> recordsWithNullValue
-            = new ConcurrentHashMap<Data, QueryableEntry>();
+    private volatile Map<Data, QueryableEntry> recordsWithNullValue;
 
-    private final ConcurrentMap<Comparable, ConcurrentMap<Data, QueryableEntry>> recordMap
-            = new ConcurrentHashMap<Comparable, ConcurrentMap<Data, QueryableEntry>>(1000);
+    private final ConcurrentMap<Comparable, Map<Data, QueryableEntry>> recordMap
+            = new ConcurrentHashMap<Comparable, Map<Data, QueryableEntry>>(1000);
 
-    @Override
-    void newIndexInternal(Comparable newValue, QueryableEntry record) {
-        if (newValue instanceof IndexImpl.NullObject) {
-            recordsWithNullValue.put(record.getKeyData(), record);
+    private final IndexFunctor<Comparable, QueryableEntry> addFunctor;
+    private final IndexFunctor<Comparable, Data> removeFunctor;
+
+    public UnsortedIndexStore(IndexCopyBehavior copyOn) {
+        super(copyOn);
+        if (copyOn == IndexCopyBehavior.COPY_ON_WRITE) {
+            addFunctor = new CopyOnWriteAddFunctor();
+            removeFunctor = new CopyOnWriteRemoveFunctor();
+            recordsWithNullValue = Collections.emptyMap();
         } else {
-            mapAttributeToEntry(newValue, record);
+            addFunctor = new AddFunctor();
+            removeFunctor = new RemoveFunctor();
+            recordsWithNullValue = new ConcurrentHashMap<Data, QueryableEntry>();
         }
     }
 
-    private void mapAttributeToEntry(Comparable attribute, QueryableEntry entry) {
-        ConcurrentMap<Data, QueryableEntry> records = recordMap.get(attribute);
-        if (records == null) {
-            records = new ConcurrentHashMap<Data, QueryableEntry>(1, LOAD_FACTOR, 1);
-            recordMap.put(attribute, records);
-        }
-        records.put(entry.getKeyData(), entry);
+    @Override
+    void newIndexInternal(Comparable newValue, QueryableEntry record) {
+        addFunctor.invoke(newValue, record);
     }
 
     @Override
     void removeIndexInternal(Comparable oldValue, Data indexKey) {
-        if (oldValue instanceof IndexImpl.NullObject) {
-            recordsWithNullValue.remove(indexKey);
-        } else {
-            removeMappingForAttribute(oldValue, indexKey);
-        }
-    }
-
-    private void removeMappingForAttribute(Object attribute, Data indexKey) {
-        ConcurrentMap<Data, QueryableEntry> records = recordMap.get(attribute);
-        if (records != null) {
-            records.remove(indexKey);
-            if (records.size() == 0) {
-                recordMap.remove(attribute);
-            }
-        }
+        removeFunctor.invoke(oldValue, indexKey);
     }
 
     @Override
@@ -91,7 +81,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
             Comparable paramTo = to;
             int trend = paramFrom.compareTo(paramTo);
             if (trend == 0) {
-                ConcurrentMap<Data, QueryableEntry> records = recordMap.get(paramFrom);
+                Map<Data, QueryableEntry> records = recordMap.get(paramFrom);
                 if (records != null) {
                     copyToMultiResultSet(results, records);
                 }
@@ -102,10 +92,10 @@ public class UnsortedIndexStore extends BaseIndexStore {
                 paramFrom = to;
                 paramTo = oldFrom;
             }
-            for (Map.Entry<Comparable, ConcurrentMap<Data, QueryableEntry>> recordMapEntry : recordMap.entrySet()) {
+            for (Map.Entry<Comparable, Map<Data, QueryableEntry>> recordMapEntry : recordMap.entrySet()) {
                 Comparable value = recordMapEntry.getKey();
                 if (value.compareTo(paramFrom) <= 0 && value.compareTo(paramTo) >= 0) {
-                    ConcurrentMap<Data, QueryableEntry> records = recordMapEntry.getValue();
+                    Map<Data, QueryableEntry> records = recordMapEntry.getValue();
                     if (records != null) {
                         copyToMultiResultSet(results, records);
                     }
@@ -122,7 +112,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
         takeReadLock();
         try {
             MultiResultSet results = createMultiResultSet();
-            for (Map.Entry<Comparable, ConcurrentMap<Data, QueryableEntry>> recordMapEntry : recordMap.entrySet()) {
+            for (Map.Entry<Comparable, Map<Data, QueryableEntry>> recordMapEntry : recordMap.entrySet()) {
                 Comparable value = recordMapEntry.getKey();
                 boolean valid;
                 int result = searchedValue.compareTo(value);
@@ -146,7 +136,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
                         throw new IllegalStateException("Unrecognized comparisonType: " + comparisonType);
                 }
                 if (valid) {
-                    ConcurrentMap<Data, QueryableEntry> records = recordMapEntry.getValue();
+                    Map<Data, QueryableEntry> records = recordMapEntry.getValue();
                     if (records != null) {
                         copyToMultiResultSet(results, records);
                     }
@@ -178,7 +168,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
         try {
             MultiResultSet results = createMultiResultSet();
             for (Comparable value : values) {
-                ConcurrentMap<Data, QueryableEntry> records;
+                Map<Data, QueryableEntry> records;
                 if (value instanceof IndexImpl.NullObject) {
                     records = recordsWithNullValue;
                 } else {
@@ -191,6 +181,107 @@ public class UnsortedIndexStore extends BaseIndexStore {
             return results;
         } finally {
             releaseReadLock();
+        }
+    }
+
+    /**
+     * Adds entry to the given index map without copying it.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class AddFunctor implements IndexFunctor<Comparable, QueryableEntry> {
+        @Override
+        public void invoke(Comparable attribute, QueryableEntry entry) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                recordsWithNullValue.put(entry.getKeyData(), entry);
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records == null) {
+                    records = new ConcurrentHashMap<Data, QueryableEntry>(1, LOAD_FACTOR, 1);
+                    recordMap.put(attribute, records);
+                }
+                records.put(entry.getKeyData(), entry);
+            }
+        }
+    }
+
+    /**
+     * Adds entry to the given index map copying it to secure exclusive access.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class CopyOnWriteAddFunctor implements IndexFunctor<Comparable, QueryableEntry> {
+        @Override
+        public void invoke(Comparable attribute, QueryableEntry entry) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                HashMap<Data, QueryableEntry> copy = new HashMap<Data, QueryableEntry>(recordsWithNullValue);
+                copy.put(entry.getKeyData(), entry);
+                recordsWithNullValue = copy;
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records == null) {
+                    records = new HashMap<Data, QueryableEntry>();
+                }
+
+                records = new HashMap<Data, QueryableEntry>(records);
+                records.put(entry.getKeyData(), entry);
+
+                recordMap.put(attribute, records);
+            }
+        }
+    }
+
+    /**
+     * Removes entry from the given index map without copying it.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class RemoveFunctor implements IndexFunctor<Comparable, Data> {
+        @Override
+        public void invoke(Comparable attribute, Data indexKey) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                recordsWithNullValue.remove(indexKey);
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records != null) {
+                    records.remove(indexKey);
+                    if (records.size() == 0) {
+                        recordMap.remove(attribute);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes entry from the given index map copying it to secure exclusive access.
+     * Needs to be invoked in a thread-safe way.
+     *
+     * @see IndexCopyBehavior
+     */
+    private class CopyOnWriteRemoveFunctor implements IndexFunctor<Comparable, Data> {
+        @Override
+        public void invoke(Comparable attribute, Data indexKey) {
+            if (attribute instanceof IndexImpl.NullObject) {
+                HashMap<Data, QueryableEntry> copy = new HashMap<Data, QueryableEntry>(recordsWithNullValue);
+                copy.remove(indexKey);
+                recordsWithNullValue = copy;
+            } else {
+                Map<Data, QueryableEntry> records = recordMap.get(attribute);
+                if (records != null) {
+                    records = new HashMap<Data, QueryableEntry>(records);
+                    records.remove(indexKey);
+
+                    if (records.isEmpty()) {
+                        recordMap.remove(attribute);
+                    } else {
+                        recordMap.put(attribute, records);
+                    }
+                }
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
@@ -65,7 +65,11 @@ public class UnsortedIndexStore extends BaseIndexStore {
     public void clear() {
         takeWriteLock();
         try {
-            recordsWithNullValue.clear();
+            if (copyOn == IndexCopyBehavior.COPY_ON_WRITE) {
+                recordsWithNullValue = Collections.emptyMap();
+            } else {
+                recordsWithNullValue.clear();
+            }
             recordMap.clear();
         } finally {
             releaseWriteLock();
@@ -222,7 +226,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
             } else {
                 Map<Data, QueryableEntry> records = recordMap.get(attribute);
                 if (records == null) {
-                    records = new HashMap<Data, QueryableEntry>();
+                    records = Collections.emptyMap();
                 }
 
                 records = new HashMap<Data, QueryableEntry>(records);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.diagnostics.HealthMonitorLevel;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.predicates.QueryOptimizerFactory;
 import com.hazelcast.spi.InvocationBuilder;
 
@@ -389,14 +390,14 @@ public final class GroupProperty {
     /**
      * Heartbeat failure detector type. Available options are:
      * <ul>
-     *    <li><code>deadline</code>:  A deadline based failure detector uses an absolute timeout
-     *    for missing/lost heartbeats. After timeout member is considered as dead/unavailable.
-     *    </li>
-     *    <li><code>phi-accrual</code>: Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al.
-     *    as defined in their paper. Phi Accrual Failure Detector is adaptive to network/environment conditions,
-     *    that's why a lower {@link #MAX_NO_HEARTBEAT_SECONDS} (for example 10 or 15 seconds) can be used to provide
-     *    faster detection of unavailable members.
-     *    </li>
+     * <li><code>deadline</code>:  A deadline based failure detector uses an absolute timeout
+     * for missing/lost heartbeats. After timeout member is considered as dead/unavailable.
+     * </li>
+     * <li><code>phi-accrual</code>: Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al.
+     * as defined in their paper. Phi Accrual Failure Detector is adaptive to network/environment conditions,
+     * that's why a lower {@link #MAX_NO_HEARTBEAT_SECONDS} (for example 10 or 15 seconds) can be used to provide
+     * faster detection of unavailable members.
+     * </li>
      * </ul>
      *
      * Default failure detector is <code>deadline</code>.
@@ -479,10 +480,14 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.connection.monitor.interval", 100, MILLISECONDS);
     public static final HazelcastProperty CONNECTION_MONITOR_MAX_FAULTS
             = new HazelcastProperty("hazelcast.connection.monitor.max.faults", 3);
-    /** Time in seconds to sleep after a migration task. */
+    /**
+     * Time in seconds to sleep after a migration task.
+     */
     public static final HazelcastProperty PARTITION_MIGRATION_INTERVAL
             = new HazelcastProperty("hazelcast.partition.migration.interval", 0, SECONDS);
-    /** Timeout in seconds for all migration operations. */
+    /**
+     * Timeout in seconds for all migration operations.
+     */
     public static final HazelcastProperty PARTITION_MIGRATION_TIMEOUT
             = new HazelcastProperty("hazelcast.partition.migration.timeout", 300, SECONDS);
     public static final HazelcastProperty PARTITION_FRAGMENTED_MIGRATION_ENABLED
@@ -743,6 +748,60 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty QUERY_OPTIMIZER_TYPE
             = new HazelcastProperty("hazelcast.query.optimizer.type", QueryOptimizerFactory.Type.RULES.toString());
+
+    /**
+     * Type of Query Index result copying behavior.
+     *
+     * Defines the behavior for index copying on index read/write.
+     *
+     * Supported in BINARY and OBJECT in-memory-formats. Ignored in NATIVE in-memory-format.
+     *
+     * Why is it needed? In order to support correctness the internal data-structures used by indexes need to do some copying.
+     * The copying may take place on-read or on-write:
+     *
+     * -> Copying on-read means that each index-read operation will copy the result of the query before returning it to the
+     * caller.This copying may be expensive, depending on the size of the result, since the result is stored in a map, which
+     * means that all entries need to have the hash calculated before being stored in a bucket.
+     * Each index-write operation however will be fast, since there will be no copying taking place.
+     *
+     * -> Copying on-write means that each index-write operation will completely copy the underlying map to provide the
+     * copy-on-write semantics. Depending on the index size, it may be a very expensive operation.
+     * Each index-read operation will be very fast, however, since it may just access the map and return it to the caller.
+     *
+     * -> Never copying is tricky. It means that the internal data structures of the index are concurrently modified without
+     * copy-on-write semantics. Index reads never copy the results of a query to a separate map.
+     * It means that the results backed by the underlying index-map can change after the query has been executed.
+     * Specifically an entry might have been added / removed from an index, or it might have been remapped.
+     * Should be used in cases when a the caller expects "mostly correct" results - specifically, if it's ok
+     * if some entries returned in the result set do not match the initial query criteria.
+     * The fastest solution for read and writes, since no copying takes place.
+     *
+     * It's a tuneable trade-off - the user may decide.
+     *
+     * Valid Values:
+     * <ul>
+     * <li>COPY_ON_READY - Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * Index queries copy the results of a query on index read to detach the result from the source map.
+     * Should be used in index-write intensive cases, since the reads will slow down due to the copying.
+     * Default value.
+     * </li>
+     * <li>COPY_ON_WRITE - Internal data structures of the index are modified with copy-on-write semantics.
+     * Previously returned index query results reflect the state of the index at the time of the query and are not
+     * affected by future index modifications.
+     * Should be used in index-read intensive cases, since the writes will slow down due to the copying.
+     * </li>
+     * <li>NEVER - Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * Index reads never copy the results of a query to a separate map.
+     * It means that the results backed by the underlying index-map can change after the query has been executed.
+     * Specifically an entry might have been added / removed from an index, or it might have been remapped.
+     * Should be used in cases when a the caller expects "mostly correct" results - specifically, if it's ok
+     * if some entries returned in the result set do not match the initial query criteria.
+     * The fastest solution for read and writes, since no copying takes place.</li>
+     * </ul>
+     * <p/>
+     */
+    public static final HazelcastProperty INDEX_COPY_BEHAVIOR
+            = new HazelcastProperty("hazelcast.index.copy.behavior", IndexCopyBehavior.COPY_ON_READ.toString());
 
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -754,10 +754,11 @@ public final class GroupProperty {
      *
      * Defines the behavior for index copying on index read/write.
      *
-     * Supported in BINARY and OBJECT in-memory-formats. Ignored in NATIVE in-memory-format.
+     * Supported for BINARY and OBJECT in-memory formats.
+     * It is also supported for NATIVE in-memory format ONLY in Hazelcast 3.8.7 (and further 3.8.x releases).
      *
-     * Why is it needed? In order to support correctness the internal data-structures used by indexes need to do some copying.
-     * The copying may take place on-read or on-write:
+     * Why is it needed? In order to support the correctness of query results, the underlying data structures used by
+     * indexes need to do some copying. The copying may take place on-read or on-write:
      *
      * -> Copying on-read means that each index-read operation will copy the result of the query before returning it to the
      * caller.This copying may be expensive, depending on the size of the result, since the result is stored in a map, which
@@ -768,8 +769,8 @@ public final class GroupProperty {
      * copy-on-write semantics. Depending on the index size, it may be a very expensive operation.
      * Each index-read operation will be very fast, however, since it may just access the map and return it to the caller.
      *
-     * -> Never copying is tricky. It means that the internal data structures of the index are concurrently modified without
-     * copy-on-write semantics. Index reads never copy the results of a query to a separate map.
+     * -> Never copying is tricky. It means that the underlying data structures used by the index are are concurrently
+     * modified without copy-on-write semantics. Index reads never copy the results of a query to a separate map.
      * It means that the results backed by the underlying index-map can change after the query has been executed.
      * Specifically an entry might have been added / removed from an index, or it might have been remapped.
      * Should be used in cases when a the caller expects "mostly correct" results - specifically, if it's ok
@@ -780,17 +781,17 @@ public final class GroupProperty {
      *
      * Valid Values:
      * <ul>
-     * <li>COPY_ON_READY - Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * <li>COPY_ON_READY - Underlying data structures of the index are concurrently modified without copy-on-write semantics.
      * Index queries copy the results of a query on index read to detach the result from the source map.
      * Should be used in index-write intensive cases, since the reads will slow down due to the copying.
      * Default value.
      * </li>
-     * <li>COPY_ON_WRITE - Internal data structures of the index are modified with copy-on-write semantics.
+     * <li>COPY_ON_WRITE - Underlying data structures of the index are modified with copy-on-write semantics.
      * Previously returned index query results reflect the state of the index at the time of the query and are not
      * affected by future index modifications.
      * Should be used in index-read intensive cases, since the writes will slow down due to the copying.
      * </li>
-     * <li>NEVER - Internal data structures of the index are concurrently modified without copy-on-write semantics.
+     * <li>NEVER - Underlying data structures of the index are concurrently modified without copy-on-write semantics.
      * Index reads never copy the results of a query to a separate map.
      * It means that the results backed by the underlying index-map can change after the query has been executed.
      * Specifically an entry might have been added / removed from an index, or it might have been remapped.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
@@ -24,9 +24,10 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
 import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -38,8 +39,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +61,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({SlowTest.class, ParallelTest.class})
 public class QueryIndexMigrationTest extends HazelcastTestSupport {
 
@@ -81,16 +85,34 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
         shutdownNodeFactory();
     }
 
+    @Parameterized.Parameter(0)
+    public IndexCopyBehavior copyBehavior;
+
+    @Parameterized.Parameters(name = "copyBehavior: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {IndexCopyBehavior.COPY_ON_READ},
+                {IndexCopyBehavior.COPY_ON_WRITE},
+                {IndexCopyBehavior.NEVER}
+        });
+    }
+
+    private Config getTestConfig() {
+        Config config = getConfig();
+        config.setProperty(GroupProperty.INDEX_COPY_BEHAVIOR.getName(), copyBehavior.name());
+        return config;
+    }
+
     @Test(timeout = MINUTE)
     public void testQueryDuringAndAfterMigration() throws Exception {
-        HazelcastInstance instance = nodeFactory.newHazelcastInstance();
+        HazelcastInstance instance = nodeFactory.newHazelcastInstance(getTestConfig());
         int count = 500;
         IMap<String, Employee> map = instance.getMap("employees");
         for (int i = 0; i < count; i++) {
             map.put(String.valueOf(i), new Employee("joe" + i, i % 60, ((i & 1) == 1), (double) i));
         }
 
-        nodeFactory.newInstances(new Config(), 3);
+        nodeFactory.newInstances(getTestConfig(), 3);
 
         final IMap<String, Employee> employees = instance.getMap("employees");
         assertTrueAllTheTime(new AssertTask() {
@@ -107,7 +129,7 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
 
     @Test
     public void testQueryDuringAndAfterMigrationWithIndex() throws Exception {
-        Config config = new Config();
+        Config config = getTestConfig();
         HazelcastInstance instance = nodeFactory.newHazelcastInstance(config);
 
         IMap<String, Employee> map = instance.getMap("employees");
@@ -136,7 +158,7 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
 
     @Test
     public void testQueryWithIndexesWhileMigrating() throws Exception {
-        HazelcastInstance instance = nodeFactory.newHazelcastInstance();
+        HazelcastInstance instance = nodeFactory.newHazelcastInstance(getTestConfig());
         IMap<String, Employee> map = instance.getMap("employees");
         map.addIndex("age", true);
         map.addIndex("active", false);
@@ -148,7 +170,7 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
         Set<Map.Entry<String, Employee>> entries = map.entrySet(new SqlPredicate("active=true and age>44"));
         assertEquals(30, entries.size());
 
-        nodeFactory.newInstances(new Config(), 3);
+        nodeFactory.newInstances(getTestConfig(), 3);
 
         long startNow = Clock.currentTimeMillis();
         while ((Clock.currentTimeMillis() - startNow) < 10000) {
@@ -185,7 +207,7 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
     }
 
     private Config newConfigWithIndex(String mapName, String attribute) {
-        Config config = new Config();
+        Config config = getTestConfig();
         config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
         config.getMapConfig(mapName).addMapIndexConfig(new MapIndexConfig(attribute, false));
         return config;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.EntryObject;
@@ -26,13 +27,15 @@ import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
 import com.hazelcast.query.SampleTestObjects.ValueType;
 import com.hazelcast.query.SqlPredicate;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.query.impl.IndexCopyBehavior;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,13 +46,33 @@ import static java.util.UUID.randomUUID;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
 public class QueryIndexTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter(0)
+    public IndexCopyBehavior copyBehavior;
+
+    @Parameterized.Parameters(name = "copyBehavior: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {IndexCopyBehavior.COPY_ON_READ},
+                {IndexCopyBehavior.COPY_ON_WRITE},
+                {IndexCopyBehavior.NEVER}
+        });
+    }
+
+    private HazelcastInstance createTestHazelcastInstance() {
+        Config config = getConfig();
+        config.setProperty(GroupProperty.INDEX_COPY_BEHAVIOR.getName(), copyBehavior.name());
+        HazelcastInstance instance = createHazelcastInstance(config);
+        return instance;
+    }
 
     @Test
     public void testResultsReturned_whenCustomAttributeIndexed() {
-        HazelcastInstance h1 = createHazelcastInstance();
+        HazelcastInstance h1 = createTestHazelcastInstance();
 
         IMap<String, CustomObject> imap = h1.getMap("objects");
         imap.addIndex("attribute", true);
@@ -69,7 +92,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void testDeletingNonExistingObject() {
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createTestHazelcastInstance();
         IMap<Integer, SampleTestObjects.Value> map = instance.getMap(randomMapName());
         map.addIndex("name", false);
 
@@ -78,7 +101,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void testInnerIndex() {
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createTestHazelcastInstance();
         IMap<String, SampleTestObjects.Value> map = instance.getMap("default");
         map.addIndex("name", false);
         map.addIndex("type.typeName", false);
@@ -100,7 +123,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void testInnerIndexSql() {
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createTestHazelcastInstance();
         IMap<String, SampleTestObjects.Value> map = instance.getMap("default");
         map.addIndex("name", false);
         map.addIndex("type.typeName", false);
@@ -120,7 +143,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void issue685RemoveIndexesOnClear() {
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createTestHazelcastInstance();
         IMap<String, SampleTestObjects.Value> map = instance.getMap("default");
         map.addIndex("name", true);
         for (int i = 0; i < 4; i++) {
@@ -135,7 +158,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void testQueryDoesNotMatchOldResults_whenEntriesAreUpdated() {
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createTestHazelcastInstance();
         IMap<String, SampleTestObjects.Value> map = instance.getMap("default");
         map.addIndex("name", true);
 
@@ -148,7 +171,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void testOneIndexedFieldsWithTwoCriteriaField() {
-        HazelcastInstance h1 = createHazelcastInstance();
+        HazelcastInstance h1 = createTestHazelcastInstance();
         IMap<String, Employee> map = h1.getMap("employees");
         map.addIndex("name", false);
         map.put("1", new Employee(1L, "joe", 30, true, 100D));
@@ -161,7 +184,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test(timeout = 1000 * 60)
     public void testPredicateNotEqualWithIndex() {
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = createTestHazelcastInstance();
         IMap<Integer, Value> map1 = instance.getMap("testPredicateNotEqualWithIndex-ordered");
         IMap<Integer, Value> map2 = instance.getMap("testPredicateNotEqualWithIndex-unordered");
         testPredicateNotEqualWithIndex(map1, true);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
@@ -15,30 +15,48 @@
  */
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.SampleTestObjects;
 import com.hazelcast.query.SampleTestObjects.Employee;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.query.impl.IndexCopyBehavior;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
 public class QueryNullIndexingTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter(0)
+    public IndexCopyBehavior copyBehavior;
+
+    @Parameterized.Parameters(name = "copyBehavior: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {IndexCopyBehavior.COPY_ON_READ},
+                {IndexCopyBehavior.COPY_ON_WRITE},
+                {IndexCopyBehavior.NEVER}
+        });
+    }
 
     @Test
     public void testIndexedNullValueOnUnorderedIndexStoreWithLessPredicate() {
@@ -111,7 +129,9 @@ public class QueryNullIndexingTest extends HazelcastTestSupport {
     }
 
     private List<Long> queryIndexedDateFieldAsNullValue(boolean ordered, Predicate pred) {
-        HazelcastInstance instance = createHazelcastInstance();
+        Config config = getConfig();
+        config.setProperty(GroupProperty.INDEX_COPY_BEHAVIOR.getName(), copyBehavior.name());
+        HazelcastInstance instance = createHazelcastInstance(config);
         IMap<Integer, SampleTestObjects.Employee> map = instance.getMap("default");
 
         map.addIndex("date", ordered);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -47,7 +47,7 @@ public class IndexImplTest {
     public void setUp() {
         InternalSerializationService mockSerializationService = mock(InternalSerializationService.class);
         Extractors mockExtractors = new Extractors(Collections.<MapAttributeConfig>emptyList(), null);
-        index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService, mockExtractors);
+        index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService, mockExtractors, IndexCopyBehavior.COPY_ON_READ);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -40,13 +40,16 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.getters.ReflectionHelper;
 import com.hazelcast.query.impl.predicates.AndPredicate;
 import com.hazelcast.query.impl.predicates.EqualPredicate;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,9 +62,22 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category(QuickTest.class)
 public class IndexTest {
+
+    @Parameterized.Parameter(0)
+    public IndexCopyBehavior copyBehavior;
+
+    @Parameterized.Parameters(name = "copyBehavior: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {IndexCopyBehavior.COPY_ON_READ},
+                {IndexCopyBehavior.COPY_ON_WRITE},
+                {IndexCopyBehavior.NEVER}
+        });
+    }
 
     static final short FACTORY_ID = 1;
 
@@ -84,7 +100,7 @@ public class IndexTest {
 
     @Test
     public void testRemoveEnumIndex() {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -98,7 +114,7 @@ public class IndexTest {
 
     @Test
     public void testUpdateEnumIndex() {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
@@ -113,7 +129,7 @@ public class IndexTest {
 
     @Test
     public void testIndex() throws QueryException {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         Index dIndex = is.addOrGetIndex("d", false);
         Index boolIndex = is.addOrGetIndex("bool", false);
         Index strIndex = is.addOrGetIndex("str", false);
@@ -175,7 +191,7 @@ public class IndexTest {
 
     @Test
     public void testIndexWithNull() throws QueryException {
-        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes is = new Indexes(ss, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         Index strIndex = is.addOrGetIndex("str", true);
 
         Data value = ss.toData(new MainPortable(false, 1, null));
@@ -449,7 +465,7 @@ public class IndexTest {
     }
 
     private void testIt(boolean ordered) {
-        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered, ss, Extractors.empty());
+        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered, ss, Extractors.empty(), copyBehavior);
         assertEquals(0, index.getRecords(0L).size());
         assertEquals(0, index.getSubRecordsBetween(0L, 1000L).size());
         QueryRecord record5 = newRecord(5L, 55L);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -25,12 +25,15 @@ import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,15 +41,28 @@ import static com.hazelcast.instance.TestUtil.toData;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category(QuickTest.class)
 public class IndexesTest {
 
     private final InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
 
+    @Parameterized.Parameter(0)
+    public IndexCopyBehavior copyBehavior;
+
+    @Parameterized.Parameters(name = "copyBehavior: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {IndexCopyBehavior.COPY_ON_READ},
+                {IndexCopyBehavior.COPY_ON_WRITE},
+                {IndexCopyBehavior.NEVER}
+        });
+    }
+
     @Test
     public void testAndWithSingleEntry() throws Exception {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         indexes.addOrGetIndex("name", false);
         indexes.addOrGetIndex("age", true);
         indexes.addOrGetIndex("salary", true);
@@ -68,7 +84,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex() throws Exception {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         indexes.addOrGetIndex("name", false);
         indexes.addOrGetIndex("age", true);
         indexes.addOrGetIndex("salary", true);
@@ -86,7 +102,7 @@ public class IndexesTest {
 
     @Test
     public void testIndex2() throws Exception {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         indexes.addOrGetIndex("name", false);
         indexes.saveEntryIndex(new QueryEntry(serializationService, toData(1), new Value("abc"), Extractors.empty()), null);
         indexes.saveEntryIndex(new QueryEntry(serializationService, toData(2), new Value("xyz"), Extractors.empty()), null);
@@ -107,7 +123,7 @@ public class IndexesTest {
      */
     @Test
     public void shouldNotThrowException_withNullValues_whenIndexAddedForValueField() throws Exception {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         indexes.addOrGetIndex("name", false);
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
@@ -115,7 +131,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValues_whenNoIndexAdded() throws Exception {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
     }
@@ -133,7 +149,7 @@ public class IndexesTest {
 
     @Test
     public void shouldNotThrowException_withNullValue_whenIndexAddedForKeyField() throws Exception {
-        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true);
+        Indexes indexes = new Indexes(serializationService, new DefaultIndexProvider(), Extractors.empty(), true, copyBehavior);
         indexes.addOrGetIndex("__key", false);
 
         for (int i = 0; i < 100; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -65,6 +65,7 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
 import static com.hazelcast.query.Predicates.regex;
+import static com.hazelcast.query.impl.IndexCopyBehavior.COPY_ON_READ;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.hamcrest.Matchers.allOf;
@@ -311,7 +312,7 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     @Test
     public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex = new IndexImpl("foo", false, ss, Extractors.empty());
+        Index dummyIndex = new IndexImpl("foo", false, ss, Extractors.empty(), COPY_ON_READ);
         QueryContext mockQueryContext = mock(QueryContext.class);
         when(mockQueryContext.getIndex(anyString())).thenReturn(dummyIndex);
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/11705

Differences:

- fixed a bug in the clear() method of the Sorted and Unsorted IndexStore (forward-ported to master here: https://github.com/hazelcast/hazelcast/pull/11730)
- changed javadoc since also supported in NATIVE as these indexes are still on-heap in 3.8.7
- does not need EE counterpart