### PR TITLE
Introduce member list join versions

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
@@ -95,7 +95,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -129,7 +129,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -169,7 +169,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -224,7 +224,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -279,7 +279,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -514,11 +514,11 @@ public class TcpIpJoiner extends AbstractJoiner {
             return;
         }
         for (Address address : possibleAddresses) {
-            SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
-            if (shouldMerge(response)) {
+            SplitBrainJoinMessage request = sendSplitBrainJoinMessageAndCheckResponse(address);
+            if (request != null) {
                 logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
                 setTargetAddress(address);
-                startClusterMerge(address);
+                startClusterMerge(address, request.getMemberListVersion());
                 return;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -40,7 +40,13 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 @PrivateApi
 public final class MemberImpl extends AbstractMember implements Member, HazelcastInstanceAware, IdentifiedDataSerializable {
 
+    /**
+     * Denotes that member list join version of a member is not known yet.
+     */
+    public static final int NA_MEMBER_LIST_JOIN_VERSION = -1;
+
     private boolean localMember;
+    private volatile int memberListJoinVersion = NA_MEMBER_LIST_JOIN_VERSION;
     private volatile HazelcastInstanceImpl instance;
     private volatile ILogger logger;
 
@@ -62,16 +68,19 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
     }
 
     public MemberImpl(Address address, MemberVersion version, boolean localMember, String uuid,
-            Map<String, Object> attributes, boolean liteMember, HazelcastInstanceImpl instance) {
+                      Map<String, Object> attributes, boolean liteMember,
+                      int memberListJoinVersion, HazelcastInstanceImpl instance) {
         super(address, version, uuid, attributes, liteMember);
         this.localMember = localMember;
         this.instance = instance;
+        this.memberListJoinVersion = memberListJoinVersion;
     }
 
     public MemberImpl(MemberImpl member) {
         super(member);
         this.localMember = member.localMember;
         this.instance = member.instance;
+        this.memberListJoinVersion = member.memberListJoinVersion;
     }
 
     @Override
@@ -187,6 +196,14 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
             MemberAttributeChangedOp op = new MemberAttributeChangedOp(REMOVE, key, null);
             invokeOnAllMembers(op);
         }
+    }
+
+    public void setMemberListJoinVersion(int memberListJoinVersion) {
+        this.memberListJoinVersion = memberListJoinVersion;
+    }
+
+    public int getMemberListJoinVersion() {
+        return memberListJoinVersion;
     }
 
     private void ensureLocalMember() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -92,6 +92,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
 import static com.hazelcast.instance.NodeShutdownHelper.shutdownNodeByFiringEvents;
 import static com.hazelcast.internal.cluster.impl.MulticastService.createMulticastService;
 import static com.hazelcast.spi.properties.GroupProperty.DISCOVERY_SPI_ENABLED;
@@ -193,7 +194,7 @@ public class Node {
             nodeExtension = nodeContext.createNodeExtension(this);
             final Map<String, Object> memberAttributes = findMemberAttributes(config.getMemberAttributeConfig().asReadOnly());
             MemberImpl localMember = new MemberImpl(address, version, true, nodeExtension.createMemberUuid(address),
-                    memberAttributes, liteMember, hazelcastInstance);
+                    memberAttributes, liteMember, NA_MEMBER_LIST_JOIN_VERSION, hazelcastInstance);
             loggingService.setThisMember(localMember);
             logger = loggingService.getLogger(Node.class.getName());
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -142,4 +142,15 @@ public interface ClusterService extends CoreService, Cluster {
      * @return current version of member list
      */
     int getMemberListVersion();
+
+    /**
+     * Returns the member list join version of the local member instance.
+     * @throws IllegalStateException if the local instance is not joined or the cluster version is below 3.10.
+     * If the cluster is upgraded from 3.9 to 3.10, this method can return {@link MemberImpl#NA_MEMBER_LIST_JOIN_VERSION}
+     * until the local node eventually learns its member list join version from the master node.
+     * The caller can cache the member list join version returned from this method.
+     *
+     * @return the member list join version of the local member instance
+     */
+    int getMemberListJoinVersion();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -29,6 +29,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+
 public class MemberInfo implements IdentifiedDataSerializable {
 
     private Address address;
@@ -36,25 +39,33 @@ public class MemberInfo implements IdentifiedDataSerializable {
     private boolean liteMember;
     private MemberVersion version;
     private Map<String, Object> attributes;
+    private int memberListJoinVersion = NA_MEMBER_LIST_JOIN_VERSION;
 
     public MemberInfo() {
     }
 
     public MemberInfo(Address address, String uuid, Map<String, Object> attributes, MemberVersion version) {
-        this(address, uuid, attributes, false, version);
+        this(address, uuid, attributes, false, version, NA_MEMBER_LIST_JOIN_VERSION);
     }
 
     public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, MemberVersion version) {
+        this(address, uuid, attributes, liteMember, version, NA_MEMBER_LIST_JOIN_VERSION);
+    }
+
+    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, MemberVersion version,
+                      int memberListJoinVersion) {
         this.address = address;
         this.uuid = uuid;
         this.attributes = attributes == null || attributes.isEmpty()
                 ? Collections.<String, Object>emptyMap() : new HashMap<String, Object>(attributes);
         this.liteMember = liteMember;
         this.version = version;
+        this.memberListJoinVersion = memberListJoinVersion;
     }
 
     public MemberInfo(MemberImpl member) {
-        this(member.getAddress(), member.getUuid(), member.getAttributes(), member.isLiteMember(), member.getVersion());
+        this(member.getAddress(), member.getUuid(), member.getAttributes(), member.isLiteMember(), member.getVersion(),
+                member.getMemberListJoinVersion());
     }
 
     public Address getAddress() {
@@ -77,8 +88,12 @@ public class MemberInfo implements IdentifiedDataSerializable {
         return liteMember;
     }
 
+    public int getMemberListJoinVersion() {
+        return memberListJoinVersion;
+    }
+
     public MemberImpl toMember() {
-        return new MemberImpl(address, version, false, uuid,  attributes, liteMember);
+        return new MemberImpl(address, version, false, uuid, attributes, liteMember, memberListJoinVersion, null);
     }
 
     @Override
@@ -99,6 +114,9 @@ public class MemberInfo implements IdentifiedDataSerializable {
             attributes.put(key, value);
         }
         version = in.readObject();
+        if (in.getVersion().isGreaterOrEqual(V3_10)) {
+            memberListJoinVersion = in.readInt();
+        }
     }
 
     @Override
@@ -118,6 +136,9 @@ public class MemberInfo implements IdentifiedDataSerializable {
             }
         }
         out.writeObject(version);
+        if (out.getVersion().isGreaterOrEqual(V3_10)) {
+            out.writeInt(memberListJoinVersion);
+        }
     }
 
     @Override
@@ -156,6 +177,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
                 + "address=" + address
                 + ", uuid=" + uuid
                 + ", liteMember=" + liteMember
+                + ", memberListJoinVersion=" + memberListJoinVersion
                 + '}';
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -47,6 +47,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.version.MemberVersion;
+import com.hazelcast.version.Version;
 
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -58,6 +59,11 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.internal.cluster.impl.MemberMap.SINGLETON_MEMBER_LIST_VERSION;
+import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.CANNOT_MERGE;
+import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
+import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -481,13 +487,13 @@ public class ClusterJoinManager {
 
             clusterService.getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
             clusterService.setClusterId(UuidUtil.createClusterUuid());
+            clusterService.getMembershipManager().setLocalMemberListJoinVersion(SINGLETON_MEMBER_LIST_VERSION);
             clusterService.setJoined(true);
 
             return true;
         } finally {
             clusterServiceLock.unlock();
         }
-
     }
 
     /**
@@ -784,6 +790,164 @@ public class ClusterJoinManager {
         return nodeEngine.getOperationService()
                 .createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME, op, target)
                 .setTryCount(CLUSTER_OPERATION_RETRY_COUNT).invoke();
+    }
+
+    @SuppressWarnings({"checkstyle:returncount", "checkstyle:npathcomplexity"})
+    public SplitBrainJoinMessage.SplitBrainMergeCheckResult shouldMerge(SplitBrainJoinMessage joinMessage) {
+        if (logger.isFineEnabled()) {
+            logger.fine("Checking if we should merge to: " + joinMessage);
+        }
+
+        if (joinMessage == null) {
+            return CANNOT_MERGE;
+        }
+
+        if (!checkValidSplitBrainJoinMessage(joinMessage)) {
+            return CANNOT_MERGE;
+        }
+
+        if (!checkCompatibleSplitBrainJoinMessage(joinMessage)) {
+            return CANNOT_MERGE;
+        }
+
+        if (!checkMergeTargetIsNotMember(joinMessage)) {
+            return CANNOT_MERGE;
+        }
+
+        if (!checkClusterStateAllowsJoinBeforeMerge(joinMessage)) {
+            return CANNOT_MERGE;
+        }
+
+        if (!checkMembershipIntersectionSetEmpty(joinMessage)) {
+            return CANNOT_MERGE;
+        }
+
+        int targetDataMemberCount = joinMessage.getDataMemberCount();
+        int currentDataMemberCount = clusterService.getSize(DATA_MEMBER_SELECTOR);
+
+        if (targetDataMemberCount > currentDataMemberCount) {
+            logger.info("We should merge to " + joinMessage.getAddress()
+                    + ", because their data member count is bigger than ours ["
+                    + (targetDataMemberCount + " > " + currentDataMemberCount) + ']');
+            return LOCAL_NODE_SHOULD_MERGE;
+        }
+
+        if (targetDataMemberCount < currentDataMemberCount) {
+            logger.info(joinMessage.getAddress() + " should merge to us "
+                    + ", because our data member count is bigger than theirs ["
+                    + (currentDataMemberCount + " > " + targetDataMemberCount) + ']');
+            return REMOTE_NODE_SHOULD_MERGE;
+        }
+
+        // targetDataMemberCount == currentDataMemberCount
+        if (shouldMergeTo(node.getThisAddress(), joinMessage.getAddress())) {
+            logger.info("We should merge to " + joinMessage.getAddress()
+                    + ", both have the same data member count: " + currentDataMemberCount);
+            return LOCAL_NODE_SHOULD_MERGE;
+        }
+
+        logger.info(joinMessage.getAddress() + " should merge to us "
+                + ", both have the same data member count: " + currentDataMemberCount);
+        return REMOTE_NODE_SHOULD_MERGE;
+    }
+
+    private boolean checkValidSplitBrainJoinMessage(SplitBrainJoinMessage joinMessage) {
+        try {
+            if (!validateJoinMessage(joinMessage)) {
+                logger.fine("Cannot process split brain merge message from " + joinMessage.getAddress()
+                        + ", since join-message could not be validated.");
+                return false;
+            }
+        } catch (Exception e) {
+            logger.fine("failure during validating join message", e);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkCompatibleSplitBrainJoinMessage(SplitBrainJoinMessage joinMessage) {
+        Version clusterVersion = clusterService.getClusterVersion();
+        if (!clusterVersion.isEqualTo(joinMessage.getClusterVersion())) {
+            if (logger.isFineEnabled()) {
+                logger.fine("Should not merge to " + joinMessage.getAddress() + " because other cluster version is "
+                        + joinMessage.getClusterVersion() + " while this cluster version is "
+                        + clusterVersion);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkMergeTargetIsNotMember(SplitBrainJoinMessage joinMessage) {
+        if (clusterService.getMember(joinMessage.getAddress()) != null) {
+            if (logger.isFineEnabled()) {
+                logger.fine("Should not merge to " + joinMessage.getAddress()
+                        + ", because it is already member of this cluster.");
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkClusterStateAllowsJoinBeforeMerge(SplitBrainJoinMessage joinMessage) {
+        ClusterState clusterState = clusterService.getClusterState();
+        if (!clusterState.isJoinAllowed()) {
+            if (logger.isFineEnabled()) {
+                logger.fine("Should not merge to " + joinMessage.getAddress() + ", because this cluster is in "
+                        + clusterState + " state.");
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkMembershipIntersectionSetEmpty(SplitBrainJoinMessage joinMessage) {
+        Collection<Address> targetMemberAddresses = joinMessage.getMemberAddresses();
+        Address joinMessageAddress = joinMessage.getAddress();
+        if (targetMemberAddresses.contains(node.getThisAddress())) {
+            // Join request is coming from master of the split and it thinks that I am its member.
+            // This is partial split case and we want to convert it to a full split.
+            // So it should remove me from its cluster.
+            MembersViewMetadata membersViewMetadata = new MembersViewMetadata(joinMessageAddress, joinMessage.getUuid(),
+                    joinMessageAddress, joinMessage.getMemberListVersion());
+            clusterService.sendExplicitSuspicion(membersViewMetadata);
+            logger.info(node.getThisAddress() + " CANNOT merge to " + joinMessageAddress
+                    + ", because it thinks this-node as its member.");
+            return false;
+        }
+
+        for (Address address : clusterService.getMemberAddresses()) {
+            if (targetMemberAddresses.contains(address)) {
+                logger.info(node.getThisAddress() + " CANNOT merge to " + joinMessageAddress
+                        + ", because it thinks " + address + " as its member. "
+                        + "But " + address + " is member of this cluster.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Determines whether this address should merge to target address and called when two sides are equal on all aspects.
+     * This is a pure function that must produce always the same output when called with the same parameters.
+     * This logic should not be changed, otherwise compatibility will be broken.
+     *
+     * @param thisAddress this address
+     * @param targetAddress target address
+     * @return true if this address should merge to target, false otherwise
+     */
+    private boolean shouldMergeTo(Address thisAddress, Address targetAddress) {
+        String thisAddressStr = "[" + thisAddress.getHost() + "]:" + thisAddress.getPort();
+        String targetAddressStr = "[" + targetAddress.getHost() + "]:" + targetAddress.getPort();
+
+        if (thisAddressStr.equals(targetAddressStr)) {
+            throw new IllegalArgumentException("Addresses should be different! This: "
+                    + thisAddress + ", Target: " + targetAddress);
+        }
+
+        // Since strings are guaranteed to be different, result will always be non-zero.
+        int result = thisAddressStr.compareTo(targetAddressStr);
+        return result > 0;
     }
 
     void reset() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -312,6 +312,7 @@ public class ClusterStateManager {
             } else if (stateChange.isOfType(Version.class)) {
                 // version is validated on cluster-state-lock, thus we can commit without checking compatibility
                 doSetClusterVersion((Version) stateChange.getNewState());
+                node.getClusterService().getMembershipManager().scheduleMemberListVersionIncrement();
             } else {
                 throw new IllegalArgumentException("Illegal ClusterStateChange of type " + stateChange.getType() + ".");
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static java.lang.Math.max;
 import static java.util.Collections.unmodifiableList;
 
 /**
@@ -58,9 +59,14 @@ public final class MembersView implements IdentifiedDataSerializable {
     static MembersView cloneAdding(MembersView source, Collection<MemberInfo> newMembers) {
         List<MemberInfo> list = new ArrayList<MemberInfo>(source.size() + newMembers.size());
         list.addAll(source.getMembers());
-        list.addAll(newMembers);
+        int newVersion = max(source.version, source.size());
+        for (MemberInfo newMember : newMembers) {
+            MemberInfo m = new MemberInfo(newMember.getAddress(), newMember.getUuid(), newMember.getAttributes(),
+                    newMember.isLiteMember(), newMember.getVersion(), ++newVersion);
+            list.add(m);
+        }
 
-        return new MembersView(source.version + 1, unmodifiableList(list));
+        return new MembersView(newVersion, unmodifiableList(list));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -59,11 +59,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
+import static com.hazelcast.internal.cluster.Versions.V3_10;
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.EXECUTOR_NAME;
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.MEMBERSHIP_EVENT_EXECUTOR_NAME;
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SERVICE_NAME;
 import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.spi.properties.GroupProperty.MASTERSHIP_CLAIM_TIMEOUT_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT;
+import static java.lang.Math.max;
 import static java.util.Collections.unmodifiableSet;
 
 /**
@@ -72,10 +76,10 @@ import static java.util.Collections.unmodifiableSet;
  *
  * @since 3.9
  */
-@SuppressWarnings("checkstyle:methodcount")
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class MembershipManager {
 
-    private static final long FETCH_MEMBERLIST_SLEEP_INTERVAL = 100;
+    private static final long FETCH_MEMBER_LIST_SLEEP_INTERVAL = 100;
 
     private final Node node;
     private final NodeEngineImpl nodeEngine;
@@ -249,11 +253,7 @@ public class MembershipManager {
             MemberImpl member = currentMemberMap.getMember(address);
 
             if (member != null && member.getUuid().equals(memberInfo.getUuid())) {
-                if (member.isLiteMember() && !memberInfo.isLiteMember()) {
-                    // lite member promoted
-                    logger.info(member + " is promoted to normal member.");
-                    member = createMember(memberInfo);
-                }
+                member = createNewMemberImplIfChanged(memberInfo, member);
                 members[memberIndex++] = member;
                 continue;
             }
@@ -284,6 +284,7 @@ public class MembershipManager {
         }
 
         setMembers(MemberMap.createNew(membersView.getVersion(), members));
+        setLocalMemberListJoinVersion(membersView.getMember(node.getThisAddress()).getMemberListJoinVersion());
 
         for (MemberImpl member : removedMembers) {
             handleMemberRemove(memberMapRef.get(), member);
@@ -298,6 +299,22 @@ public class MembershipManager {
         clusterService.printMemberList();
     }
 
+    private MemberImpl createNewMemberImplIfChanged(MemberInfo newMemberInfo, MemberImpl member) {
+        if (member.isLiteMember() && !newMemberInfo.isLiteMember()) {
+            // lite member promoted
+            logger.info(member + " is promoted to normal member.");
+            member = createMember(newMemberInfo);
+        } else if (member.getMemberListJoinVersion() != newMemberInfo.getMemberListJoinVersion()) {
+            if (member.getMemberListJoinVersion() != NA_MEMBER_LIST_JOIN_VERSION) {
+                logger.fine("Member list join version of " + member + " is changed to "
+                        + newMemberInfo.getMemberListJoinVersion() + " from " + member.getMemberListJoinVersion());
+            }
+            member = createMember(newMemberInfo);
+        }
+
+        return member;
+    }
+
     private MemberImpl createMember(MemberInfo memberInfo) {
         Address address = memberInfo.getAddress();
         Address thisAddress = node.getThisAddress();
@@ -305,8 +322,19 @@ public class MembershipManager {
         address.setScopeId(ipV6ScopeId);
         boolean localMember = thisAddress.equals(address);
 
-        return new MemberImpl(address, memberInfo.getVersion(), localMember, memberInfo.getUuid(),
-                memberInfo.getAttributes(), memberInfo.isLiteMember(), node.hazelcastInstance);
+        return new MemberImpl(address, memberInfo.getVersion(), localMember, memberInfo.getUuid(), memberInfo.getAttributes(),
+                memberInfo.isLiteMember(), memberInfo.getMemberListJoinVersion(), node.hazelcastInstance);
+    }
+
+    void setLocalMemberListJoinVersion(int memberListJoinVersion) {
+        MemberImpl localMember = clusterService.getLocalMember();
+        if (memberListJoinVersion != NA_MEMBER_LIST_JOIN_VERSION) {
+            localMember.setMemberListJoinVersion(memberListJoinVersion);
+            logger.fine("Local member list join version is set to " + memberListJoinVersion);
+        } else {
+            logger.fine("No member list join version is available during join. Local member list join version: "
+                    + localMember.getMemberListJoinVersion());
+        }
     }
 
     void setMembers(MemberMap memberMap) {
@@ -420,7 +448,7 @@ public class MembershipManager {
         assert !suspectedMember.equals(clusterService.getLocalMember()) : "Cannot suspect from myself!";
         assert !suspectedMember.localMember() : "Cannot be local member";
 
-        final MembersView localMemberView;
+        final MemberMap localMemberMap;
         final Set<Member> membersToAsk;
 
         clusterServiceLock.lock();
@@ -444,24 +472,23 @@ public class MembershipManager {
                 return;
             }
 
-            MemberMap memberMap = getMemberMap();
-            localMemberView = memberMap.toMembersView();
+            localMemberMap = getMemberMap();
             membersToAsk = new HashSet<Member>();
-            for (MemberImpl member : memberMap.getMembers()) {
+            for (MemberImpl member : localMemberMap.getMembers()) {
                 if (member.localMember() || suspectedMembers.contains(member.getAddress())) {
                     continue;
                 }
 
                 membersToAsk.add(member);
             }
-            logger.info("Local " + localMemberView + " with suspected members: "  + suspectedMembers
+            logger.info("Local " + localMemberMap.toMembersView() + " with suspected members: "  + suspectedMembers
                     + " and initial addresses to ask: " + membersToAsk);
         } finally {
             clusterServiceLock.unlock();
         }
 
         ExecutorService executor = nodeEngine.getExecutionService().getExecutor(SYSTEM_EXECUTOR);
-        executor.submit(new DecideNewMembersViewTask(localMemberView, membersToAsk));
+        executor.submit(new DecideNewMembersViewTask(localMemberMap, membersToAsk));
     }
 
     private boolean tryStartMastershipClaim() {
@@ -635,14 +662,13 @@ public class MembershipManager {
         return true;
     }
 
-    private MembersView decideNewMembersView(MembersView localMembersView, Set<Member> members) {
+    private MembersView decideNewMembersView(MemberMap localMemberMap, Set<Member> members) {
         Map<Address, Future<MembersView>> futures = new HashMap<Address, Future<MembersView>>();
-        MembersView latestMembersView = fetchLatestMembersView(localMembersView, members, futures);
+        MembersView latestMembersView = fetchLatestMembersView(localMemberMap, members, futures);
 
         logger.fine("Latest " + latestMembersView + " before final decision...");
 
         // within the most recent members view, select the members that have reported their members view successfully
-        int finalVersion = latestMembersView.getVersion() + 1;
         List<MemberInfo> finalMembers = new ArrayList<MemberInfo>();
         for (MemberInfo memberInfo : latestMembersView.getMembers()) {
             Address address = memberInfo.getAddress();
@@ -672,13 +698,14 @@ public class MembershipManager {
             }
         }
 
+        int finalVersion = getMastershipClaimMemberListVersion(localMemberMap, latestMembersView.getVersion());
         return new MembersView(finalVersion, finalMembers);
     }
 
-    private MembersView fetchLatestMembersView(MembersView localMembersView,
+    private MembersView fetchLatestMembersView(MemberMap localMemberMap,
                                                Set<Member> members,
                                                Map<Address, Future<MembersView>> futures) {
-        MembersView latestMembersView = localMembersView;
+        MembersView latestMembersView = localMemberMap.toTailMembersView(node.getLocalMember(), true);
 
         // once an address is put into the futures map,
         // we wait until either we suspect of that address or find its result in the futures.
@@ -722,7 +749,7 @@ public class MembershipManager {
             }
 
             try {
-                Thread.sleep(FETCH_MEMBERLIST_SLEEP_INTERVAL);
+                Thread.sleep(FETCH_MEMBER_LIST_SLEEP_INTERVAL);
             } catch (InterruptedException ignored) {
                 Thread.currentThread().interrupt();
             }
@@ -756,6 +783,44 @@ public class MembershipManager {
                 .createInvocationBuilder(SERVICE_NAME, op, target)
                 .setTryCount(mastershipClaimTimeoutSeconds)
                 .setCallTimeout(TimeUnit.SECONDS.toMillis(mastershipClaimTimeoutSeconds)).invoke();
+    }
+
+    private int getMastershipClaimMemberListVersion(MemberMap localMemberMap, int latestMemberListVersion) {
+        int localMemberIndex = localMemberMap.getMemberIndex(nodeEngine.getLocalMember());
+        int inc = node.getProperties().getInteger(MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT);
+        int versionIncPerMember = max(inc, localMemberMap.size());
+        int newMemberListVersion = latestMemberListVersion + localMemberIndex * versionIncPerMember;
+        return max(newMemberListVersion, localMemberMap.size());
+    }
+
+    private MembersView generateMissingMemberListJoinVersions(MembersView membersView) {
+        if (clusterService.getClusterVersion().isGreaterOrEqual(V3_10)) {
+            return membersView;
+        }
+
+        int missingCount = 0;
+        for (MemberInfo memberInfo : membersView.getMembers()) {
+            if (memberInfo.getMemberListJoinVersion() == NA_MEMBER_LIST_JOIN_VERSION) {
+                missingCount++;
+            }
+        }
+
+        assert missingCount == membersView.size() : ("All member list join versions should be missing in: " + membersView);
+
+        int memberListJoinVersion = (membersView.getVersion() - membersView.size()) + 1;
+        List<MemberInfo> memberInfos = new ArrayList<MemberInfo>();
+        for (MemberInfo member : membersView.getMembers()) {
+            MemberInfo m = new MemberInfo(member.getAddress(), member.getUuid(), member.getAttributes(),
+                    member.isLiteMember(), member.getVersion(), memberListJoinVersion);
+            memberInfos.add(m);
+            memberListJoinVersion++;
+        }
+
+        membersView = new MembersView(membersView.getVersion(), memberInfos);
+
+        logger.fine("Member list join versions are generated: " + membersView);
+
+        return membersView;
     }
 
     boolean isMemberRemovedInNotJoinableState(Address target) {
@@ -846,7 +911,7 @@ public class MembershipManager {
         try {
             ensureLiteMemberPromotionIsAllowed();
 
-            MemberMap memberMap = memberMapRef.get();
+            MemberMap memberMap = getMemberMap();
             MemberImpl member = memberMap.getMember(address, uuid);
             if (member == null) {
                 throw new IllegalStateException(uuid + "/" + address + " is not a member!");
@@ -861,8 +926,9 @@ public class MembershipManager {
             MemberImpl[] members = memberMap.getMembers().toArray(new MemberImpl[0]);
             for (int i = 0; i < members.length; i++) {
                 if (member.equals(members[i])) {
-                    member = new MemberImpl(member.getAddress(), member.getVersion(), member.localMember(),
-                            member.getUuid(), member.getAttributes(), false, node.hazelcastInstance);
+                    member = new MemberImpl(member.getAddress(), member.getVersion(), member.localMember(), member.getUuid(),
+                            member.getAttributes(), false, members[i].getMemberListJoinVersion(),
+                            node.hazelcastInstance);
                     members[i] = member;
                     break;
                 }
@@ -892,6 +958,112 @@ public class MembershipManager {
         }
     }
 
+    /*
+     * For 3.9 compatibility
+     * When the cluster is upgraded from 3.9 to 3.10, all nodes have the same member list but only the master node has
+     * the member list join versions. Therefore, we increment the member list version and publish the member list to make
+     * each node discover member list join versions
+     */
+    void scheduleMemberListVersionIncrement() {
+        clusterServiceLock.lock();
+        try {
+            if (!checkMemberListVersionIncrementIsAllowed()) {
+                return;
+            }
+
+            int memberListVersion = getMemberListVersion();
+            ExecutorService executor = nodeEngine.getExecutionService().getExecutor(SYSTEM_EXECUTOR);
+            executor.submit(new IncrementMemberListVersion(memberListVersion));
+        } finally {
+            clusterServiceLock.unlock();
+        }
+    }
+
+    private void incrementMemberListVersion(int expectedMemberListVersion) {
+        clusterServiceLock.lock();
+        try {
+            if (!checkMemberListVersionIncrementIsAllowed()) {
+                return;
+            }
+
+            MemberMap memberMap = getMemberMap();
+            if (memberMap.getVersion() != expectedMemberListVersion) {
+                logger.fine("Ignoring member list version increment since current member list version: " + memberMap.getVersion()
+                        + " is different than expected version: " + expectedMemberListVersion);
+                return;
+            }
+
+            MemberImpl[] members = memberMap.getMembers().toArray(new MemberImpl[0]);
+            int newVersion = memberMap.getVersion() + 1;
+            logger.fine("Incrementing member list version to " + newVersion);
+            MemberMap newMemberMap = MemberMap.createNew(newVersion, members);
+            setMembers(newMemberMap);
+            sendMemberListToOthers();
+            clusterService.printMemberList();
+        } finally {
+            clusterServiceLock.unlock();
+        }
+    }
+
+    private boolean checkMemberListVersionIncrementIsAllowed() {
+        if (!clusterService.isJoined()) {
+            return false;
+        }
+
+        if (!clusterService.isMaster()) {
+            return false;
+        }
+
+        if (clusterService.getClusterJoinManager().isMastershipClaimInProgress()) {
+            throw new IllegalStateException("Cannot increment member list version since mastership claim is in progress!");
+        }
+
+        if (!clusterService.getClusterVersion().isEqualTo(V3_10)) {
+            throw new IllegalStateException("Cannot increment member list version for cluster version: "
+                    + clusterService.getClusterVersion());
+        }
+
+        return true;
+    }
+
+    public boolean verifySplitBrainMergeMemberListVersion(SplitBrainJoinMessage joinMessage) {
+        Address caller = joinMessage.getAddress();
+        int callerMemberListVersion = joinMessage.getMemberListVersion();
+
+        clusterServiceLock.lock();
+        try {
+            if (!clusterService.isMaster()) {
+                logger.warning("Cannot verify member list version: " + callerMemberListVersion + " from " + caller
+                        + " because this node is not master");
+                return false;
+            } else if (clusterService.getClusterJoinManager().isMastershipClaimInProgress()) {
+                logger.warning("Cannot verify member list version: " + callerMemberListVersion + " from " + caller
+                        + " because mastership claim is in progress");
+                return false;
+            }
+
+            MemberMap memberMap = getMemberMap();
+            if (memberMap.getVersion() < callerMemberListVersion) {
+                int newVersion = callerMemberListVersion + 1;
+
+                logger.info("Updating local member list version: " + memberMap.getVersion() + " to " + newVersion
+                        + " because of split brain merge caller: " + caller + " with member list version: "
+                        + callerMemberListVersion);
+
+                MemberImpl[] members = memberMap.getMembers().toArray(new MemberImpl[0]);
+                MemberMap newMemberMap = MemberMap.createNew(newVersion, members);
+                setMembers(newMemberMap);
+                sendMemberListToOthers();
+
+                clusterService.printMemberList();
+            }
+
+            return true;
+        } finally {
+            clusterServiceLock.unlock();
+        }
+    }
+
     void reset() {
         clusterServiceLock.lock();
         try {
@@ -904,18 +1076,17 @@ public class MembershipManager {
     }
 
     private class DecideNewMembersViewTask implements Runnable {
-
-        final MembersView localMemberView;
+        final MemberMap localMemberMap;
         final Set<Member> membersToAsk;
 
-        DecideNewMembersViewTask(MembersView localMemberView, Set<Member> membersToAsk) {
-            this.localMemberView = localMemberView;
+        DecideNewMembersViewTask(MemberMap localMemberMap, Set<Member> membersToAsk) {
+            this.localMemberMap = localMemberMap;
             this.membersToAsk = membersToAsk;
         }
 
         @Override
         public void run() {
-            MembersView newMembersView = decideNewMembersView(localMemberView, membersToAsk);
+            MembersView newMembersView = decideNewMembersView(localMemberMap, membersToAsk);
             clusterServiceLock.lock();
             try {
                 if (!clusterService.isJoined()) {
@@ -932,6 +1103,7 @@ public class MembershipManager {
                     return;
                 }
 
+                newMembersView = generateMissingMemberListJoinVersions(newMembersView);
                 updateMembers(newMembersView);
                 clusterService.getClusterJoinManager().reset();
                 sendMemberListToOthers();
@@ -939,6 +1111,19 @@ public class MembershipManager {
             } finally {
                 clusterServiceLock.unlock();
             }
+        }
+    }
+
+    private class IncrementMemberListVersion implements Runnable {
+        private int expectedMemberListVersion;
+
+        public IncrementMemberListVersion(int expectedMemberListVersion) {
+            this.expectedMemberListVersion = expectedMemberListVersion;
+        }
+
+        @Override
+        public void run() {
+            incrementMemberListVersion(expectedMemberListVersion);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -129,10 +129,10 @@ public class MulticastJoiner extends AbstractJoiner {
                     Thread.sleep(2 * node.getProperties().getMillis(GroupProperty.WAIT_SECONDS_BEFORE_JOIN));
                 }
 
-                SplitBrainJoinMessage response = sendSplitBrainJoinMessage(targetAddress);
-                if (shouldMerge(response)) {
+                SplitBrainJoinMessage request = sendSplitBrainJoinMessageAndCheckResponse(targetAddress);
+                if (request != null) {
                     logger.warning(node.getThisAddress() + " is merging [multicast] to " + targetAddress);
-                    startClusterMerge(targetAddress);
+                    startClusterMerge(targetAddress, request.getMemberListVersion());
                     return;
                 }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -32,6 +32,21 @@ import java.util.Collection;
  */
 public class SplitBrainJoinMessage extends JoinMessage implements Versioned {
 
+    public enum SplitBrainMergeCheckResult {
+        /**
+         * Denotes that the two endpoints of the SplitBrainJoinMessage cannot merge to each other
+         */
+        CANNOT_MERGE,
+        /**
+         * Denotes that the local node should merge to the other endpoint of the SplitBrainJoinMessage
+         */
+        LOCAL_NODE_SHOULD_MERGE,
+        /**
+         * Denotes that the remote node that sent the SplitBrainJoinMessage should merge
+         */
+        REMOTE_NODE_SHOULD_MERGE
+    }
+
     private Version clusterVersion;
 
     private int memberListVersion;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
@@ -30,6 +30,8 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
 
+import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
+
 /**
  * Validate whether clusters may merge to recover from a split brain, based on configuration & cluster version.
  */
@@ -78,7 +80,9 @@ public class SplitBrainMergeValidationOp extends AbstractJoinOperation {
                     // the cluster, the user would be forced to upgrade the member to 3.9.0 codebase version.
                     // The implicit change of cluster version ("sneaky upgrade") and the change in membership would be a
                     // surprise to users and may cause unexpected issues.
-                    if (service.getClusterVersion().equals(request.getClusterVersion())) {
+                    if (service.getClusterVersion().equals(request.getClusterVersion())
+                            && (service.getClusterJoinManager().shouldMerge(request) == REMOTE_NODE_SHOULD_MERGE)
+                            && service.getMembershipManager().verifySplitBrainMergeMemberListVersion(request)) {
                         response = node.createSplitBrainJoinMessage();
                     } else {
                         logger.info("Join check from " + getCallerAddress() + " failed validation due to incompatible version,"

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -414,6 +414,16 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.heartbeat.failuredetector.type", "deadline");
 
     /**
+     * The Hazelcast master node increments the member list version for each joining member. Then, member list versions
+     * are used to identify joined members with unique integers. For this algorithm to work under network partitioning scenarios
+     * without generating duplicate member list join versions for different members, a mastership-claiming node increments
+     * the member list version as specified by this parameter. The value of the parameter must be bigger than the cluster size.
+     * Introduced in 3.10.
+     */
+    public static final HazelcastProperty MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT =
+            new HazelcastProperty("hazelcast.mastership.claim.member.list.version.increment", 25);
+
+    /**
      * The interval at which the master sends the member lists are sent to other non-master members
      */
     public static final HazelcastProperty MEMBER_LIST_PUBLISH_INTERVAL_SECONDS

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
@@ -62,7 +62,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -102,7 +102,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -130,7 +130,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -171,7 +171,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;
@@ -212,7 +212,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
-            if (m == h2.getCluster().getLocalMember()) {
+            if (m.equals(h2.getCluster().getLocalMember())) {
                 continue;
             }
             member = m;

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -93,7 +94,8 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withHazelcastInstance() throws Exception {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid2342", null, false, hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid2342", null, false,
+                NA_MEMBER_LIST_JOIN_VERSION, hazelcastInstance);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -106,7 +108,8 @@ public class MemberImplTest extends HazelcastTestSupport {
         attributes.put("key1", "value");
         attributes.put("key2", 12345);
 
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid2342", attributes, false, hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid2342", attributes, false,
+                NA_MEMBER_LIST_JOIN_VERSION, hazelcastInstance);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -230,7 +233,8 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAttribute_withHazelcastInstance() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid", null, false, hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid", null, false,
+                NA_MEMBER_LIST_JOIN_VERSION, hazelcastInstance);
 
         member.removeAttribute("removeKeyWithInstance");
         assertNull(member.getStringAttribute("removeKeyWithInstance"));
@@ -238,7 +242,8 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testSetAttribute_withHazelcastInstance() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid", null, false, hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true, "uuid", null, false,
+                NA_MEMBER_LIST_JOIN_VERSION, hazelcastInstance);
 
         member.setStringAttribute("setKeyWithInstance", "setValueWithInstance");
         assertEquals("setValueWithInstance", member.getStringAttribute("setKeyWithInstance"));

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
@@ -1,0 +1,290 @@
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGED;
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
+import static com.hazelcast.internal.cluster.Versions.V3_9;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEARTBEAT;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.SPLIT_BRAIN_MERGE_VALIDATION;
+import static com.hazelcast.internal.cluster.impl.MemberMap.SINGLETON_MEMBER_LIST_VERSION;
+import static com.hazelcast.internal.cluster.impl.MembershipUpdateTest.assertMemberViewsAreSame;
+import static com.hazelcast.internal.cluster.impl.MembershipUpdateTest.getMemberMap;
+import static com.hazelcast.spi.properties.GroupProperty.HEARTBEAT_INTERVAL_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT;
+import static com.hazelcast.spi.properties.GroupProperty.MAX_NO_HEARTBEAT_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
+import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberListJoinVersionTest extends HazelcastTestSupport {
+
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void init() {
+        factory = createHazelcastInstanceFactory();
+    }
+
+    @Test
+    public void when_singletonClusterStarted_then_memberListJoinVersionShouldBeAssigned() {
+        HazelcastInstance instance = factory.newHazelcastInstance();
+
+        MemberImpl localMember = getNode(instance).getLocalMember();
+
+        assertEquals(SINGLETON_MEMBER_LIST_VERSION, localMember.getMemberListJoinVersion());
+        assertEquals(SINGLETON_MEMBER_LIST_VERSION, getClusterService(instance).getMemberListJoinVersion());
+        MemberImpl member = getClusterService(instance).getMember(localMember.getAddress());
+        assertEquals(SINGLETON_MEMBER_LIST_VERSION, member.getMemberListJoinVersion());
+    }
+
+    @Test
+    public void when_multipleMembersStarted_then_memberListJoinVersionShouldBeAssigned() {
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance slave1 = factory.newHazelcastInstance();
+        HazelcastInstance slave2 = factory.newHazelcastInstance();
+        HazelcastInstance slave3 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(4, slave1, slave2);
+
+        assertJoinMemberListVersions(master, slave1, slave2, slave3);
+    }
+
+    @Test
+    public void when_masterShutsDown_then_memberListVersionShouldIncrementSufficiently() {
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance slave1 = factory.newHazelcastInstance();
+
+        ClusterService slave1ClusterService = getClusterService(slave1);
+        int memberListVersion = slave1ClusterService.getMemberListVersion();
+
+        master.shutdown();
+
+        assertClusterSizeEventually(1, slave1);
+
+        int newMemberListVersion = slave1ClusterService.getMemberListVersion();
+        int versionIncPerMember = getMastershipClaimMemberListVersionIncrementConfig(slave1);
+
+        assertTrue((newMemberListVersion - memberListVersion) >= versionIncPerMember);
+    }
+
+    @Test
+    public void when_masterTerminates_then_memberListVersionShouldIncrementSufficiently() {
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance slave1 = factory.newHazelcastInstance();
+
+        ClusterService slave1ClusterService = getClusterService(slave1);
+        int memberListVersion = slave1ClusterService.getMemberListVersion();
+
+        master.getLifecycleService().terminate();
+
+        assertClusterSizeEventually(1, slave1);
+
+        int newMemberListVersion = slave1ClusterService.getMemberListVersion();
+        int versionIncPerMember = getMastershipClaimMemberListVersionIncrementConfig(slave1);
+
+        assertTrue((newMemberListVersion - memberListVersion) >= versionIncPerMember);
+    }
+
+    @Test
+    public void when_masterAndNextMasterTerminates_then_memberListVersionShouldIncrementBasedOnMemberIndex() {
+        HazelcastInstance master = factory.newHazelcastInstance();
+        HazelcastInstance slave1 = factory.newHazelcastInstance();
+        HazelcastInstance slave2 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(3, slave1);
+
+        ClusterService slave2ClusterService = getClusterService(slave2);
+        int memberListVersion = slave2ClusterService.getMemberListVersion();
+
+        dropOperationsBetween(master, slave2, F_ID, singletonList(MEMBER_INFO_UPDATE));
+
+        slave1.getLifecycleService().terminate();
+        master.getLifecycleService().terminate();
+
+        assertClusterSizeEventually(1, slave2);
+
+        int newMemberListVersion = slave2ClusterService.getMemberListVersion();
+        int versionIncPerMember = getMastershipClaimMemberListVersionIncrementConfig(slave2);
+
+        assertTrue((newMemberListVersion - memberListVersion) >= (versionIncPerMember * 2));
+    }
+
+    @Test
+    public void when_splitSubClustersMerge_then_targetClusterShouldIncrementMemberListVersion() {
+        Config config = new Config();
+        config.setProperty(MAX_NO_HEARTBEAT_SECONDS.getName(), "15")
+              .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+              .setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5")
+              .setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
+              .setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
+        HazelcastInstance member1 = factory.newHazelcastInstance(config);
+        HazelcastInstance member2 = factory.newHazelcastInstance(config);
+        HazelcastInstance member3 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, member2);
+
+        final CountDownLatch mergeLatch = new CountDownLatch(1);
+        member3.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (event.getState() == MERGED) {
+                    mergeLatch.countDown();
+                }
+            }
+        });
+
+        dropOperationsFrom(member3, F_ID, asList(HEARTBEAT, SPLIT_BRAIN_MERGE_VALIDATION));
+
+        assertClusterSizeEventually(2, member1, member2);
+
+        dropOperationsFrom(member3, F_ID, singletonList(SPLIT_BRAIN_MERGE_VALIDATION));
+
+        assertClusterSizeEventually(1, member3);
+
+        int memberListVersionBeforeMerge = getClusterService(member3).getMemberListVersion();
+
+        resetPacketFiltersFrom(member3);
+
+        assertOpenEventually(mergeLatch);
+        assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
+        assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member3));
+
+        int memberListVersionAfterMerge = getClusterService(member1).getMemberListVersion();
+        assertTrue(memberListVersionAfterMerge != memberListVersionBeforeMerge);
+        assertEquals(memberListVersionAfterMerge, getNode(member3).getLocalMember().getMemberListJoinVersion());
+
+        assertJoinMemberListVersions(member1, member2, member3);
+    }
+
+    @Test
+    public void when_memberListIncrementIsConfiguredTooLow_then_itShouldIncrementAtLeastAsMemberCount() {
+        int memberCount = 3;
+        Config config = new Config();
+        config.setProperty(MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT.toString(), "1");
+        HazelcastInstance[] instances = factory.newInstances(config, memberCount);
+
+        HazelcastInstance slave1 = instances[1];
+        assertClusterSizeEventually(3, slave1);
+
+        ClusterService slave1ClusterService = getClusterService(slave1);
+        int memberListVersion = slave1ClusterService.getMemberListVersion();
+
+        instances[0].getLifecycleService().terminate();
+
+        assertClusterSizeEventually(2, slave1);
+
+        int newMemberListVersion = slave1ClusterService.getMemberListVersion();
+
+        assertTrue((newMemberListVersion - memberListVersion) >= memberCount);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void when_310MemberJoinsWith39Mode_memberListJoinVersionCannotBeQueried() {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, V3_9.toString());
+
+        HazelcastInstance member1 = factory.newHazelcastInstance();
+
+        getClusterService(member1).getMemberListJoinVersion();
+    }
+
+    @Test
+    public void when_310MemberJoinsWith39Mode_itDoesNotPublishJoinVersions() {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, V3_9.toString());
+
+        HazelcastInstance member1 = factory.newHazelcastInstance();
+        HazelcastInstance member2 = factory.newHazelcastInstance();
+        HazelcastInstance member3 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(3, member2);
+
+        assertNotEquals(NA_MEMBER_LIST_JOIN_VERSION, getNode(member1).getLocalMember().getMemberListJoinVersion());
+        assertEquals(NA_MEMBER_LIST_JOIN_VERSION, getNode(member2).getLocalMember().getMemberListJoinVersion());
+        assertEquals(NA_MEMBER_LIST_JOIN_VERSION, getNode(member3).getLocalMember().getMemberListJoinVersion());
+
+        for (MemberImpl member : getClusterService(member1).getMemberImpls()) {
+            assertNotEquals(NA_MEMBER_LIST_JOIN_VERSION, member.getMemberListJoinVersion());
+        }
+
+        for (HazelcastInstance instance : asList(member2, member3)) {
+            for (MemberImpl member : getClusterService(instance).getMemberImpls()) {
+                assertEquals(NA_MEMBER_LIST_JOIN_VERSION, member.getMemberListJoinVersion());
+            }
+        }
+    }
+
+    @Test
+    public void when_310MemberClaimsMastershipWith39Mode_itGeneratesJoinVersions() {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, V3_9.toString());
+
+        HazelcastInstance member1 = factory.newHazelcastInstance();
+        HazelcastInstance member2 = factory.newHazelcastInstance();
+        HazelcastInstance member3 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(3, member2);
+
+        member1.getLifecycleService().terminate();
+
+        assertClusterSizeEventually(2, member2, member3);
+
+        // new master has created its local member list join version but it is not exposed
+        assertNotEquals(NA_MEMBER_LIST_JOIN_VERSION, getNode(member2).getLocalMember().getMemberListJoinVersion());
+
+        // others has not learnt their member list join versions
+        assertEquals(NA_MEMBER_LIST_JOIN_VERSION, getNode(member3).getLocalMember().getMemberListJoinVersion());
+
+        for (MemberImpl member : getClusterService(member2).getMemberImpls()) {
+            assertNotEquals(NA_MEMBER_LIST_JOIN_VERSION, member.getMemberListJoinVersion());
+        }
+
+        for (MemberImpl member : getClusterService(member3).getMemberImpls()) {
+            assertEquals(NA_MEMBER_LIST_JOIN_VERSION, member.getMemberListJoinVersion());
+        }
+    }
+
+    public static void assertJoinMemberListVersions(HazelcastInstance... instances) {
+        for (HazelcastInstance instance1 : instances) {
+            assertNotEquals(NA_MEMBER_LIST_JOIN_VERSION, getClusterService(instance1).getMemberListJoinVersion());
+            for (MemberImpl instance1Member : getClusterService(instance1).getMemberImpls()) {
+                assertNotEquals(NA_MEMBER_LIST_JOIN_VERSION, instance1Member.getMemberListJoinVersion());
+                for (HazelcastInstance instance2 : instances) {
+                    MemberImpl instance2Member = getClusterService(instance2).getMember(instance1Member.getUuid());
+                    assertEquals(instance1Member.getMemberListJoinVersion(), instance2Member.getMemberListJoinVersion());
+                }
+            }
+        }
+    }
+
+    private int getMastershipClaimMemberListVersionIncrementConfig(HazelcastInstance instance) {
+        return getNode(instance).getProperties().getInteger(MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewTest.java
@@ -61,7 +61,7 @@ public class MembersViewTest {
         MembersView view =
                 MembersView.cloneAdding(MembersView.createNew(version, Arrays.asList(members)), additionalMembers);
 
-        assertEquals(version + 1, view.getVersion());
+        assertEquals(version + additionalMembers.size(), view.getVersion());
 
         MemberImpl[] newMembers = Arrays.copyOf(members, members.length + additionalMembers.size());
         for (int i = 0; i < additionalMembers.size(); i++) {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -152,9 +152,10 @@ class MockJoiner extends AbstractJoiner {
         possibleAddresses.remove(node.getThisAddress());
         possibleAddresses.removeAll(node.getClusterService().getMemberAddresses());
         for (Address address : possibleAddresses) {
-            SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
-            if (shouldMerge(response)) {
-                startClusterMerge(address);
+            SplitBrainJoinMessage request = sendSplitBrainJoinMessageAndCheckResponse(address);
+            if (request != null) {
+                startClusterMerge(address, request.getMemberListVersion());
+                return;
             }
         }
     }


### PR DESCRIPTION
A member list version that denotes when a node joins to the cluster is named "member list join version". It is the version number of the member list in which a node is present for the first time. It is used for identifying nodes in the cluster. A node discovers its "member list join version" when it finalizes its join process and can use the value as its unique integer identifier.

The master node reserves a separate member list join version for each node. The overall solution guarantees uniqueness of the member list join versions during the lifetime of the cluster, including occurrences of network partitioning failures to a certain degree.

Please see the TDD for more info about the solution:

https://hazelcast.atlassian.net/wiki/spaces/EN/pages/209748001/ID+Generator+backed+by+Flake+IDs+Design