### PR TITLE
[BACKPORT] Fixed setting of wrong expiration and last stored time in EntryViews

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -71,8 +71,8 @@ public final class EntryViews {
         lazyEntryView.setLastUpdateTime(record.getLastUpdateTime());
         lazyEntryView.setTtl(record.getTtl());
         lazyEntryView.setCreationTime(record.getCreationTime());
-        lazyEntryView.setExpirationTime(lazyEntryView.getExpirationTime());
-        lazyEntryView.setLastStoredTime(lazyEntryView.getLastStoredTime());
+        lazyEntryView.setExpirationTime(record.getExpirationTime());
+        lazyEntryView.setLastStoredTime(record.getLastStoredTime());
         return lazyEntryView;
     }
 


### PR DESCRIPTION
(cherry picked from commit 0d6be46)

Partial backport of https://github.com/hazelcast/hazelcast/pull/11718