### PR TITLE
Fixes NPE in MapConfig hashCode calculation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -957,7 +957,7 @@ public class MapConfig implements IdentifiedDataSerializable {
 
     @Override
     public final int hashCode() {
-        int result = name.hashCode();
+        int result = (name != null ? name.hashCode() : 0);
         result = 31 * result + backupCount;
         result = 31 * result + asyncBackupCount;
         result = 31 * result + timeToLiveSeconds;
@@ -973,7 +973,6 @@ public class MapConfig implements IdentifiedDataSerializable {
         result = 31 * result + inMemoryFormat.hashCode();
         result = 31 * result + (wanReplicationRef != null ? wanReplicationRef.hashCode() : 0);
         result = 31 * result + getEntryListenerConfigs().hashCode();
-        result = 31 * result + getPartitioningStrategyConfig().hashCode();
         result = 31 * result + getMapIndexConfigs().hashCode();
         result = 31 * result + getMapAttributeConfigs().hashCode();
         result = 31 * result + getQueryCacheConfigs().hashCode();

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -446,4 +446,10 @@ public class MapConfigTest {
                       .verify();
 
     }
+
+    @Test
+    public void testDefaultHashCode() {
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.hashCode();
+    }
 }


### PR DESCRIPTION
In our project we are using the hazelcast-spring integration. I have updated hazelcast from 3.8 to 3.9 in our project.  When I started the application, a NPE occured. I am pasting only the end of the exception, it should be sufficient.

```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'hazelcastConfig': Initialization of bean failed; nested exception is java.lang.NullPointerException
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:564)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:483)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:306)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:302)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197)
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveReference(BeanDefinitionValueResolver.java:351)
	... 63 common frames omitted
Caused by: java.lang.NullPointerException: null
	at com.hazelcast.config.MapConfig.hashCode(MapConfig.java:976)
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964)
	at org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcessor.requiresDestruction(PersistenceAnnotationBeanPostProcessor.java:380)
	at org.springframework.beans.factory.support.DisposableBeanAdapter.hasApplicableProcessors(DisposableBeanAdapter.java:431)
	at org.springframework.beans.factory.support.AbstractBeanFactory.requiresDestruction(AbstractBeanFactory.java:1662)
	at org.springframework.beans.factory.support.AbstractBeanFactory.registerDisposableBeanIfNecessary(AbstractBeanFactory.java:1679)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:597)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:483)
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveInnerBean(BeanDefinitionValueResolver.java:299)
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:129)
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveManagedMap(BeanDefinitionValueResolver.java:407)
	at org.springframework.beans.factory.support.BeanDefinitionValueResolver.resolveValueIfNecessary(BeanDefinitionValueResolver.java:165)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyPropertyValues(AbstractAutowireCapableBeanFactory.java:1531)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1276)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:553)
	... 69 common frames omitted
```

When I was checking the code I figured out that in version 3.9 there are more fields that the hascode is calculated from. One of them is **partitioningStrategyConfig** which is not checked for null value (other are) even if it can be null (it is checked in other places where is being used).

Because of this I have created a simple fix together with a unit test that tries to calculate hashCode on an object created by default constructor. When I created the test I figured out that the same problem is with **name** parameter so I have applied the same fix to that parameter as well though it was not necessary for our use-case.

