### PR TITLE
Fixes double complete when retry on selection is false

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -247,7 +247,6 @@ public class ClientInvocation implements Runnable {
             //when invocation send over address
             //if exception is target not member and
             //address is not available in member list , don't retry
-            clientInvocationFuture.complete(exception);
             return true;
         }
         return false;


### PR DESCRIPTION
Since second complete is no-op, extre complete does not cause any
harm. This fix just for readibility.