### PR TITLE
DiagnosticLogFiles not deleted when custom directory used

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -74,7 +74,7 @@ final class DiagnosticsLogFile {
     public void write(DiagnosticsPlugin plugin) {
         try {
             if (file == null) {
-                file = new File(diagnostics.directory, format(fileName, index));
+                file = newFile(index);
                 printWriter = newWriter();
                 renderStaticPlugins();
             }
@@ -93,6 +93,10 @@ final class DiagnosticsLogFile {
         } catch (RuntimeException e) {
             logger.warning("Failed to write file: " + file, e);
         }
+    }
+
+    private File newFile(int index) {
+        return new File(diagnostics.directory, format(fileName, index));
     }
 
     private void renderStaticPlugins() throws IOException {
@@ -119,7 +123,7 @@ final class DiagnosticsLogFile {
         file = null;
         index++;
 
-        File file = new File(format(fileName, index - maxRollingFileCount));
+        File file = newFile(index - maxRollingFileCount);
         deleteQuietly(file);
     }
 }


### PR DESCRIPTION
needs to be backported