### PR TITLE
Coverity - Add call to superclass - PartitionWideEntryWithPredicateOperation.toString(StringBuilder)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -119,6 +119,14 @@ public class PartitionWideEntryOperation extends MapOperation
         return backupOperation;
     }
 
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", entryProcessor=").append(entryProcessor);
+    }
+
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -56,7 +56,8 @@ public class PartitionWideEntryWithPredicateOperation extends PartitionWideEntry
 
     @Override
     protected void toString(StringBuilder sb) {
-        sb.append(", entryProcessor=").append(entryProcessor);
+        super.toString(sb);
+
         sb.append(", predicate=").append(predicate);
     }
 


### PR DESCRIPTION
Fix for Coverity reported "Missing call to superclass".

https://scan4.coverity.com/reports.htm#v32322/p13030/fileInstanceId=29223138&defectInstanceId=5757075&mergedDefectId=202146