### PR TITLE
Fix oversights in Config

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -91,9 +92,9 @@ public class ClientConfig {
 
     private ConfigPatternMatcher configPatternMatcher = new MatchingPointConfigPatternMatcher();
 
-    private Map<String, NearCacheConfig> nearCacheConfigMap = new ConcurrentHashMap<String, NearCacheConfig>();
+    private final Map<String, NearCacheConfig> nearCacheConfigMap = new ConcurrentHashMap<String, NearCacheConfig>();
 
-    private Map<String, ClientReliableTopicConfig> reliableTopicConfigMap
+    private final Map<String, ClientReliableTopicConfig> reliableTopicConfigMap
             = new ConcurrentHashMap<String, ClientReliableTopicConfig>();
 
     private Map<String, Map<String, QueryCacheConfig>> queryCacheConfigs;
@@ -102,7 +103,7 @@ public class ClientConfig {
 
     private NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig();
 
-    private List<ProxyFactoryConfig> proxyFactoryConfigs = new LinkedList<ProxyFactoryConfig>();
+    private final List<ProxyFactoryConfig> proxyFactoryConfigs = new LinkedList<ProxyFactoryConfig>();
 
     private ManagedContext managedContext;
 
@@ -321,7 +322,11 @@ public class ClientConfig {
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
      */
     public ClientConfig setNearCacheConfigMap(Map<String, NearCacheConfig> nearCacheConfigMap) {
-        this.nearCacheConfigMap = nearCacheConfigMap;
+        this.nearCacheConfigMap.clear();
+        this.nearCacheConfigMap.putAll(nearCacheConfigMap);
+        for (Entry<String, NearCacheConfig> entry : this.nearCacheConfigMap.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
         return this;
     }
 
@@ -635,7 +640,8 @@ public class ClientConfig {
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
      */
     public ClientConfig setProxyFactoryConfigs(List<ProxyFactoryConfig> proxyFactoryConfigs) {
-        this.proxyFactoryConfigs = proxyFactoryConfigs;
+        this.proxyFactoryConfigs.clear();
+        this.proxyFactoryConfigs.addAll(proxyFactoryConfigs);
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -401,7 +401,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         if (simpleName == null) {
             return null;
         }
-        CacheSimpleConfig cacheSimpleConfig = nodeEngine.getConfig().findCacheConfig(simpleName);
+        CacheSimpleConfig cacheSimpleConfig = nodeEngine.getConfig().findCacheConfigOrNull(simpleName);
         if (cacheSimpleConfig == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -401,7 +401,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         if (simpleName == null) {
             return null;
         }
-        CacheSimpleConfig cacheSimpleConfig = nodeEngine.getConfig().findCacheConfigOrNull(simpleName);
+        CacheSimpleConfig cacheSimpleConfig = nodeEngine.getConfig().findCacheConfig(simpleName);
         if (cacheSimpleConfig == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -370,8 +370,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public MapConfig findMapConfig(String name) {
-        String baseName = getBaseName(name);
-        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, baseName);
+        name = getBaseName(name);
+        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, name);
         if (config != null) {
             initDefaultMaxSizeForOnHeapMaps(config.getNearCacheConfig());
             return config.getAsReadOnly();
@@ -392,8 +392,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MapConfig getMapConfigOrNull(String name) {
-        String baseName = getBaseName(name);
-        return lookupByPattern(configPatternMatcher, mapConfigs, baseName);
+        name = getBaseName(name);
+        return lookupByPattern(configPatternMatcher, mapConfigs, name);
     }
 
     /**
@@ -424,8 +424,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MapConfig getMapConfig(String name) {
-        String baseName = getBaseName(name);
-        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, baseName);
+        name = getBaseName(name);
+        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, name);
         if (config != null) {
             return config;
         }
@@ -495,9 +495,34 @@ public class Config {
      * @see #setConfigPatternMatcher(ConfigPatternMatcher)
      * @see #getConfigPatternMatcher()
      */
-    public CacheSimpleConfig findCacheConfig(String name) {
+    public CacheSimpleConfig findCacheConfigOrNull(String name) {
         name = getBaseName(name);
         return lookupByPattern(configPatternMatcher, cacheConfigs, name);
+    }
+
+    /**
+     * Returns a read-only {@link CacheSimpleConfig} configuration for the given name.
+     * <p>
+     * The name is matched by pattern to the configuration and by stripping the
+     * partition ID qualifier from the given {@code name}.
+     * If there is config found by the name, it will return the configuration
+     * with the name {@code default}.
+     *
+     * @param name name of the cardinality estimator config
+     * @return the cardinality estimator configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     * @see EvictionConfig#setSize(int)
+     */
+    public CacheSimpleConfig findCacheConfig(String name) {
+        name = getBaseName(name);
+        final CacheSimpleConfig config = lookupByPattern(configPatternMatcher, cacheConfigs, name);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getCacheConfig("default").getAsReadOnly();
     }
 
     /**
@@ -528,8 +553,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public CacheSimpleConfig getCacheConfig(String name) {
-        String baseName = getBaseName(name);
-        CacheSimpleConfig config = lookupByPattern(configPatternMatcher, cacheConfigs, baseName);
+        name = getBaseName(name);
+        CacheSimpleConfig config = lookupByPattern(configPatternMatcher, cacheConfigs, name);
         if (config != null) {
             return config;
         }
@@ -604,8 +629,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public QueueConfig findQueueConfig(String name) {
-        String baseName = getBaseName(name);
-        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, baseName);
+        name = getBaseName(name);
+        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -640,8 +665,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public QueueConfig getQueueConfig(String name) {
-        String baseName = getBaseName(name);
-        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, baseName);
+        name = getBaseName(name);
+        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, name);
         if (config != null) {
             return config;
         }
@@ -716,8 +741,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public LockConfig findLockConfig(String name) {
-        final String baseName = getBaseName(name);
-        final LockConfig config = lookupByPattern(configPatternMatcher, lockConfigs, baseName);
+        name = getBaseName(name);
+        final LockConfig config = lookupByPattern(configPatternMatcher, lockConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -752,8 +777,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public LockConfig getLockConfig(String name) {
-        final String baseName = getBaseName(name);
-        LockConfig config = lookupByPattern(configPatternMatcher, lockConfigs, baseName);
+        name = getBaseName(name);
+        LockConfig config = lookupByPattern(configPatternMatcher, lockConfigs, name);
         if (config != null) {
             return config;
         }
@@ -828,8 +853,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public ListConfig findListConfig(String name) {
-        String baseName = getBaseName(name);
-        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, baseName);
+        name = getBaseName(name);
+        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -864,8 +889,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ListConfig getListConfig(String name) {
-        String baseName = getBaseName(name);
-        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, baseName);
+        name = getBaseName(name);
+        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, name);
         if (config != null) {
             return config;
         }
@@ -940,8 +965,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public SetConfig findSetConfig(String name) {
-        String baseName = getBaseName(name);
-        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, baseName);
+        name = getBaseName(name);
+        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -976,8 +1001,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public SetConfig getSetConfig(String name) {
-        String baseName = getBaseName(name);
-        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, baseName);
+        name = getBaseName(name);
+        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1052,8 +1077,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public MultiMapConfig findMultiMapConfig(String name) {
-        String baseName = getBaseName(name);
-        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, baseName);
+        name = getBaseName(name);
+        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1088,8 +1113,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MultiMapConfig getMultiMapConfig(String name) {
-        String baseName = getBaseName(name);
-        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, baseName);
+        name = getBaseName(name);
+        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1164,6 +1189,7 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public ReplicatedMapConfig findReplicatedMapConfig(String name) {
+        name = getBaseName(name);
         ReplicatedMapConfig config = lookupByPattern(configPatternMatcher, replicatedMapConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
@@ -1200,6 +1226,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ReplicatedMapConfig getReplicatedMapConfig(String name) {
+        name = getBaseName(name);
         ReplicatedMapConfig config = lookupByPattern(configPatternMatcher, replicatedMapConfigs, name);
         if (config != null) {
             return config;
@@ -1275,8 +1302,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public RingbufferConfig findRingbufferConfig(String name) {
-        String baseName = getBaseName(name);
-        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, baseName);
+        name = getBaseName(name);
+        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1312,8 +1339,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public RingbufferConfig getRingbufferConfig(String name) {
-        String baseName = getBaseName(name);
-        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, baseName);
+        name = getBaseName(name);
+        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1386,8 +1413,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public TopicConfig findTopicConfig(String name) {
-        String baseName = getBaseName(name);
-        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, baseName);
+        name = getBaseName(name);
+        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1422,8 +1449,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public TopicConfig getTopicConfig(String name) {
-        String baseName = getBaseName(name);
-        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, baseName);
+        name = getBaseName(name);
+        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1469,8 +1496,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public ReliableTopicConfig findReliableTopicConfig(String name) {
-        String baseName = getBaseName(name);
-        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, baseName);
+        name = getBaseName(name);
+        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1506,8 +1533,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ReliableTopicConfig getReliableTopicConfig(String name) {
-        String baseName = getBaseName(name);
-        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, baseName);
+        name = getBaseName(name);
+        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1607,8 +1634,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public ExecutorConfig findExecutorConfig(String name) {
-        String baseName = getBaseName(name);
-        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, baseName);
+        name = getBaseName(name);
+        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1632,8 +1659,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public DurableExecutorConfig findDurableExecutorConfig(String name) {
-        String baseName = getBaseName(name);
-        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, baseName);
+        name = getBaseName(name);
+        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1657,8 +1684,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public ScheduledExecutorConfig findScheduledExecutorConfig(String name) {
-        String baseName = getBaseName(name);
-        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, baseName);
+        name = getBaseName(name);
+        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1683,8 +1710,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public CardinalityEstimatorConfig findCardinalityEstimatorConfig(String name) {
-        String baseName = getBaseName(name);
-        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, baseName);
+        name = getBaseName(name);
+        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -1719,8 +1746,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ExecutorConfig getExecutorConfig(String name) {
-        String baseName = getBaseName(name);
-        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, baseName);
+        name = getBaseName(name);
+        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1765,8 +1792,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public DurableExecutorConfig getDurableExecutorConfig(String name) {
-        String baseName = getBaseName(name);
-        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, baseName);
+        name = getBaseName(name);
+        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1811,8 +1838,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ScheduledExecutorConfig getScheduledExecutorConfig(String name) {
-        String baseName = getBaseName(name);
-        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, baseName);
+        name = getBaseName(name);
+        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name);
         if (config != null) {
             return config;
         }
@@ -1857,8 +1884,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public CardinalityEstimatorConfig getCardinalityEstimatorConfig(String name) {
-        String baseName = getBaseName(name);
-        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, baseName);
+        name = getBaseName(name);
+        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2058,8 +2085,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public SemaphoreConfig findSemaphoreConfig(String name) {
-        String baseName = getBaseName(name);
-        SemaphoreConfig config = lookupByPattern(configPatternMatcher, semaphoreConfigs, baseName);
+        name = getBaseName(name);
+        SemaphoreConfig config = lookupByPattern(configPatternMatcher, semaphoreConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -2095,8 +2122,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public SemaphoreConfig getSemaphoreConfig(String name) {
-        String baseName = getBaseName(name);
-        SemaphoreConfig config = lookupByPattern(configPatternMatcher, semaphoreConfigs, baseName);
+        name = getBaseName(name);
+        SemaphoreConfig config = lookupByPattern(configPatternMatcher, semaphoreConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2204,6 +2231,9 @@ public class Config {
     public Config setWanReplicationConfigs(Map<String, WanReplicationConfig> wanReplicationConfigs) {
         this.wanReplicationConfigs.clear();
         this.wanReplicationConfigs.putAll(wanReplicationConfigs);
+        for (final Entry<String, WanReplicationConfig> entry : this.wanReplicationConfigs.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
         return this;
     }
 
@@ -2225,12 +2255,12 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public JobTrackerConfig findJobTrackerConfig(String name) {
-        String baseName = getBaseName(name);
-        JobTrackerConfig config = lookupByPattern(configPatternMatcher, jobTrackerConfigs, baseName);
+        name = getBaseName(name);
+        JobTrackerConfig config = lookupByPattern(configPatternMatcher, jobTrackerConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
-        return getJobTrackerConfig(name);
+        return getJobTrackerConfig("default").getAsReadOnly();
     }
 
     /**
@@ -2262,8 +2292,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public JobTrackerConfig getJobTrackerConfig(String name) {
-        String baseName = getBaseName(name);
-        JobTrackerConfig config = lookupByPattern(configPatternMatcher, jobTrackerConfigs, baseName);
+        name = getBaseName(name);
+        JobTrackerConfig config = lookupByPattern(configPatternMatcher, jobTrackerConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2360,8 +2390,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public QuorumConfig getQuorumConfig(String name) {
-        String baseName = getBaseName(name);
-        QuorumConfig config = lookupByPattern(configPatternMatcher, quorumConfigs, baseName);
+        name = getBaseName(name);
+        QuorumConfig config = lookupByPattern(configPatternMatcher, quorumConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2395,8 +2425,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public QuorumConfig findQuorumConfig(String name) {
-        String baseName = getBaseName(name);
-        QuorumConfig config = lookupByPattern(configPatternMatcher, quorumConfigs, baseName);
+        name = getBaseName(name);
+        QuorumConfig config = lookupByPattern(configPatternMatcher, quorumConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2556,8 +2586,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public EventJournalConfig findMapEventJournalConfig(String name) {
-        final String baseName = getBaseName(name);
-        final EventJournalConfig config = lookupByPattern(configPatternMatcher, mapEventJournalConfigs, baseName);
+        name = getBaseName(name);
+        final EventJournalConfig config = lookupByPattern(configPatternMatcher, mapEventJournalConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -2582,8 +2612,8 @@ public class Config {
      * @see EvictionConfig#setSize(int)
      */
     public EventJournalConfig findCacheEventJournalConfig(String name) {
-        final String baseName = getBaseName(name);
-        final EventJournalConfig config = lookupByPattern(configPatternMatcher, cacheEventJournalConfigs, baseName);
+        name = getBaseName(name);
+        final EventJournalConfig config = lookupByPattern(configPatternMatcher, cacheEventJournalConfigs, name);
         if (config != null) {
             return config.getAsReadOnly();
         }
@@ -2621,8 +2651,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public EventJournalConfig getMapEventJournalConfig(String name) {
-        final String baseName = getBaseName(name);
-        EventJournalConfig config = lookupByPattern(configPatternMatcher, mapEventJournalConfigs, baseName);
+        name = getBaseName(name);
+        EventJournalConfig config = lookupByPattern(configPatternMatcher, mapEventJournalConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2667,8 +2697,8 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public EventJournalConfig getCacheEventJournalConfig(String name) {
-        final String baseName = getBaseName(name);
-        EventJournalConfig config = lookupByPattern(configPatternMatcher, cacheEventJournalConfigs, baseName);
+        name = getBaseName(name);
+        EventJournalConfig config = lookupByPattern(configPatternMatcher, cacheEventJournalConfigs, name);
         if (config != null) {
             return config;
         }
@@ -2702,13 +2732,13 @@ public class Config {
         final String mapName = eventJournalConfig.getMapName();
         final String cacheName = eventJournalConfig.getCacheName();
         if (StringUtil.isNullOrEmpty(mapName) && StringUtil.isNullOrEmpty(cacheName)) {
-            throw new IllegalArgumentException("Event journal config should have non-empty map name and/or cache name");
+            throw new IllegalArgumentException("Event journal config should have either map name or cache name non-empty");
         }
         if (!StringUtil.isNullOrEmpty(mapName)) {
-            mapEventJournalConfigs.put(eventJournalConfig.getMapName(), eventJournalConfig);
+            mapEventJournalConfigs.put(mapName, eventJournalConfig);
         }
         if (!StringUtil.isNullOrEmpty(cacheName)) {
-            cacheEventJournalConfigs.put(eventJournalConfig.getCacheName(), eventJournalConfig);
+            cacheEventJournalConfigs.put(cacheName, eventJournalConfig);
         }
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -492,12 +492,11 @@ public class Config {
      * with the name {@code default}.
      *
      * @param name name of the cardinality estimator config
-     * @return the cardinality estimator configuration
+     * @return the cache configuration
      * @throws ConfigurationException if ambiguous configurations are found
      * @see StringPartitioningStrategy#getBaseName(java.lang.String)
      * @see #setConfigPatternMatcher(ConfigPatternMatcher)
      * @see #getConfigPatternMatcher()
-     * @see EvictionConfig#setSize(int)
      */
     public CacheSimpleConfig findCacheConfig(String name) {
         name = getBaseName(name);
@@ -506,6 +505,23 @@ public class Config {
             return config.getAsReadOnly();
         }
         return getCacheConfig("default").getAsReadOnly();
+    }
+
+    /**
+     * Returns the cache config with the given name or {@code null} if there is none.
+     * The name is matched by pattern to the configuration and by stripping the
+     * partition ID qualifier from the given {@code name}.
+     *
+     * @param name name of the cache config
+     * @return the cache configuration or {@code null} if none was found
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public CacheSimpleConfig findCacheConfigOrNull(String name) {
+        name = getBaseName(name);
+        return lookupByPattern(configPatternMatcher, cacheConfigs, name);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -356,7 +356,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      * For non-default configurations and on-heap maps, it will also
      * initialise the the near-cache eviction if not previously set.
@@ -407,7 +407,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addMapConfig(MapConfig)}.
      * <p>
@@ -505,7 +505,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the cardinality estimator config
@@ -536,7 +536,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addCacheConfig(CacheSimpleConfig)}.
      * <p>
@@ -617,7 +617,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the queue config
@@ -648,7 +648,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addQueueConfig(QueueConfig)}.
      * <p>
@@ -729,7 +729,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the lock config
@@ -760,7 +760,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addLockConfig(LockConfig)}.
      * <p>
@@ -841,7 +841,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the list config
@@ -872,7 +872,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addListConfig(ListConfig)}.
      * <p>
@@ -953,7 +953,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the set config
@@ -984,7 +984,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addSetConfig(SetConfig)}.
      * <p>
@@ -1065,7 +1065,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the multimap config
@@ -1096,7 +1096,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addMultiMapConfig(MultiMapConfig)}.
      * <p>
@@ -1177,7 +1177,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the replicated map config
@@ -1208,7 +1208,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addReplicatedMapConfig(ReplicatedMapConfig)}.
@@ -1290,7 +1290,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the ringbuffer config
@@ -1321,7 +1321,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addRingBufferConfig(RingbufferConfig)}.
@@ -1401,7 +1401,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the topic config
@@ -1432,7 +1432,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addTopicConfig(TopicConfig)}.
      * <p>
@@ -1484,7 +1484,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the reliable topic config
@@ -1515,7 +1515,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addReliableTopicConfig(ReliableTopicConfig)}.
@@ -1622,7 +1622,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the executor config
@@ -1647,7 +1647,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the durable executor config
@@ -1672,7 +1672,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the scheduled executor config
@@ -1698,7 +1698,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the cardinality estimator config
@@ -1729,7 +1729,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking {@link #addExecutorConfig(ExecutorConfig)}.
      * <p>
@@ -1774,7 +1774,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addDurableExecutorConfig(DurableExecutorConfig)}.
@@ -1820,7 +1820,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addScheduledExecutorConfig(ScheduledExecutorConfig)}.
@@ -1866,7 +1866,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addCardinalityEstimatorConfig(CardinalityEstimatorConfig)}.
@@ -2073,7 +2073,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the semaphore config
@@ -2104,7 +2104,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addSemaphoreConfig(SemaphoreConfig)}.
@@ -2243,7 +2243,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the job tracker config
@@ -2274,7 +2274,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addJobTrackerConfig(JobTrackerConfig)}.
@@ -2372,7 +2372,7 @@ public class Config {
      * {@code "default"} configuration and add it to the configuration
      * collection.
      * <p>
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addQuorumConfig(QuorumConfig)}.
@@ -2413,7 +2413,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the split-brain protection config
@@ -2574,7 +2574,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the map event journal config
@@ -2600,7 +2600,7 @@ public class Config {
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
-     * If there is config found by the name, it will return the configuration
+     * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      *
      * @param name name of the cache event journal config
@@ -2633,7 +2633,7 @@ public class Config {
      * <p>
      * If there is no default config as well, it will create one and disable
      * the event journal by default.
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addEventJournalConfig(EventJournalConfig)}.
@@ -2679,7 +2679,7 @@ public class Config {
      * <p>
      * If there is no default config as well, it will create one and disable
      * the event journal by default.
-     * This method is intended to be easily and fluently create and add
+     * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
      * explicitly adding it by invoking
      * {@link #addEventJournalConfig(EventJournalConfig)}.

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -484,23 +484,6 @@ public class Config {
     }
 
     /**
-     * Returns the cache config with the given name or {@code null} if there is none.
-     * The name is matched by pattern to the configuration and by stripping the
-     * partition ID qualifier from the given {@code name}.
-     *
-     * @param name name of the cache config
-     * @return the cache configuration or {@code null} if none was found
-     * @throws ConfigurationException if ambiguous configurations are found
-     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
-     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
-     * @see #getConfigPatternMatcher()
-     */
-    public CacheSimpleConfig findCacheConfigOrNull(String name) {
-        name = getBaseName(name);
-        return lookupByPattern(configPatternMatcher, cacheConfigs, name);
-    }
-
-    /**
      * Returns a read-only {@link CacheSimpleConfig} configuration for the given name.
      * <p>
      * The name is matched by pattern to the configuration and by stripping the

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -114,7 +114,7 @@ public class Node {
 
     public final HazelcastInstanceImpl hazelcastInstance;
 
-    public final Config config;
+    public final DynamicConfigurationAwareConfig config;
 
     public final NodeEngineImpl nodeEngine;
     public final ClientEngineImpl clientEngine;

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -244,6 +244,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public CacheSimpleConfig findCacheConfig(String name) {
+        return getCacheConfigInternal(name, "default").getAsReadOnly();
+    }
+
+    @Override
+    public CacheSimpleConfig findCacheConfigOrNull(String name) {
         //intentional: as of Hazelcast 3.x we do not use default for JCache!
         CacheSimpleConfig cacheConfig = getCacheConfigInternal(name, null);
         if (cacheConfig == null) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfigTest.java
@@ -32,7 +32,7 @@ public class DynamicConfigurationAwareConfigTest {
                 continue;
             }
 
-            //all other public method should be overriden by the dynamic config aware decorator
+            //all other public method should be overridden by the dynamic config aware decorator
             if (!isMethodDeclaredByClass(method, DynamicConfigurationAwareConfig.class)) {
                 Class<?> declaringClass = method.getDeclaringClass();
                 fail("Method " + method + " is declared by " + declaringClass + " whilst it should be" +


### PR DESCRIPTION
The name without the part after "@" is used to look up, however when it is not found, config with full name is inserted to the map.