### PR TITLE
Fix String.toLowerCase() and toUpperCase() calls - don't use the default locale-dependent variants

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -42,6 +42,7 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
 import com.hazelcast.util.Clock;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
@@ -67,6 +68,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
+import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 import static java.lang.String.format;
 
 
@@ -527,7 +529,8 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
     private void handleEcho(String command) {
-        if (!Thread.currentThread().getName().toLowerCase().contains("main")) {
+        String threadName = lowerCaseInternal(Thread.currentThread().getName());
+        if (!threadName.contains("main")) {
             println(" [" + Thread.currentThread().getName() + "] " + command);
         } else {
             println(command);
@@ -1104,13 +1107,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
 
     protected void handleContains(String[] args) {
         String iteratorStr = args[0];
-        boolean key = false;
-        boolean value = false;
-        if (iteratorStr.toLowerCase().endsWith("key")) {
-            key = true;
-        } else if (iteratorStr.toLowerCase().endsWith("value")) {
-            value = true;
-        }
+        boolean key = lowerCaseInternal(iteratorStr).endsWith("key");
         String data = args[1];
         boolean result = false;
         if (iteratorStr.startsWith("s.")) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/helpers/SimpleClientInterceptor.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/helpers/SimpleClientInterceptor.java
@@ -20,6 +20,7 @@ import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.util.StringUtil;
 
 import java.io.IOException;
 
@@ -46,7 +47,7 @@ public class SimpleClientInterceptor implements MapInterceptor, Portable {
 
     @Override
     public Object interceptPut(Object oldValue, Object newValue) {
-        return newValue.toString().toUpperCase();
+        return newValue.toString().toUpperCase(StringUtil.LOCALE_INTERNAL);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.StringUtil;
 
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
@@ -257,6 +258,6 @@ public abstract class AbstractHazelcastCachingProvider
             }
         }
 
-        return (scheme != null && SUPPORTED_SCHEMES.contains(scheme.toLowerCase()));
+        return (scheme != null && SUPPORTED_SCHEMES.contains(scheme.toLowerCase(StringUtil.LOCALE_INTERNAL)));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.StringUtil;
 
 import java.util.Properties;
 /**
@@ -60,7 +61,7 @@ public class LoginModuleConfig {
 
         public static LoginModuleUsage get(String v) {
             try {
-                return LoginModuleUsage.valueOf(v.toUpperCase());
+                return LoginModuleUsage.valueOf(v.toUpperCase(StringUtil.LOCALE_INTERNAL));
             } catch (Exception ignore) {
                 EmptyStatement.ignore(ignore);
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -19,6 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.StringUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -126,7 +127,7 @@ public class MultiMapConfig implements IdentifiedDataSerializable {
      * @return the collection type for the values of this MultiMap
      */
     public ValueCollectionType getValueCollectionType() {
-        return ValueCollectionType.valueOf(valueCollectionType.toUpperCase());
+        return ValueCollectionType.valueOf(valueCollectionType.toUpperCase(StringUtil.LOCALE_INTERNAL));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -68,6 +68,7 @@ import java.util.concurrent.locks.Lock;
 
 import static com.hazelcast.memory.MemoryUnit.BYTES;
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -498,7 +499,8 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
     }
 
     private void handleEcho(String command) {
-        if (!Thread.currentThread().getName().toLowerCase().contains("main")) {
+        String threadName = lowerCaseInternal(Thread.currentThread().getName());
+        if (!threadName.contains("main")) {
             println(" [" + Thread.currentThread().getName() + "] " + command);
         } else {
             println(command);
@@ -1085,13 +1087,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
 
     protected void handleContains(String[] args) {
         String iteratorStr = args[0];
-        boolean key = false;
-        boolean value = false;
-        if (iteratorStr.toLowerCase().endsWith("key")) {
-            key = true;
-        } else if (iteratorStr.toLowerCase().endsWith("value")) {
-            value = true;
-        }
+        boolean key = lowerCaseInternal(iteratorStr).endsWith("key");
         String data = args[1];
         boolean result = false;
         if (iteratorStr.startsWith("s.")) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.util.StringUtil;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.MIME_TEXT_PLAIN;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_BINARY;
@@ -73,7 +74,8 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         StringBuilder res = new StringBuilder();
         res.append("Hazelcast::NodeState=").append(nodeState).append("\n");
         res.append("Hazelcast::ClusterState=").append(clusterState).append("\n");
-        res.append("Hazelcast::ClusterSafe=").append(Boolean.toString(clusterSafe).toUpperCase()).append("\n");
+        res.append("Hazelcast::ClusterSafe=").append(Boolean.toString(clusterSafe)
+                .toUpperCase(StringUtil.LOCALE_INTERNAL)).append("\n");
         res.append("Hazelcast::MigrationQueueSize=").append(migrationQueueSize).append("\n");
         res.append("Hazelcast::ClusterSize=").append(clusterSize).append("\n");
         command.setResponse(MIME_TEXT_PLAIN, stringToBytes(res.toString()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -33,6 +33,7 @@ import com.hazelcast.security.SecurityService;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.util.StringUtil;
 import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationService;
 
@@ -125,9 +126,9 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 ClusterState state = ClusterState.valueOf(upperCaseInternal(stateParam));
                 if (!state.equals(clusterService.getClusterState())) {
                     clusterService.changeClusterState(state);
-                    res = response(ResponseType.SUCCESS, "state", state.toString().toLowerCase());
+                    res = response(ResponseType.SUCCESS, "state", state.toString().toLowerCase(StringUtil.LOCALE_INTERNAL));
                 } else {
-                    res = response(ResponseType.FAIL, "state", state.toString().toLowerCase());
+                    res = response(ResponseType.FAIL, "state", state.toString().toLowerCase(StringUtil.LOCALE_INTERNAL));
                 }
             }
         } catch (Throwable throwable) {
@@ -539,7 +540,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
 
         @Override
         public String toString() {
-            return super.toString().toLowerCase();
+            return super.toString().toLowerCase(StringUtil.LOCALE_INTERNAL);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorMode.java
@@ -18,6 +18,8 @@ package com.hazelcast.internal.networking.nio;
 
 import static java.lang.String.format;
 
+import com.hazelcast.util.StringUtil;
+
 /**
  * Controls the mode in which IO and acceptor thread selectors will be operating
  */
@@ -35,7 +37,7 @@ public enum SelectorMode {
     }
 
     public static String getConfiguredString() {
-        return System.getProperty("hazelcast.io.selectorMode", SELECT_STRING).trim().toLowerCase();
+        return System.getProperty("hazelcast.io.selectorMode", SELECT_STRING).trim().toLowerCase(StringUtil.LOCALE_INTERNAL);
     }
 
     public static SelectorMode fromString(String value) {

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -47,6 +47,7 @@ public final class StringUtil {
      * LOCALE_INTERNAL is the default locale for string operations and number formatting. Initialized to
      * {@code java.util.Locale.US} (US English).
      */
+    //TODO Use java.util.Locale#ROOT value (language neutral) in Hazelcast 4
     public static final Locale LOCALE_INTERNAL = Locale.US;
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapWordCountAggregationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapWordCountAggregationBenchmark.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.StringUtil;
 import com.hazelcast.util.UuidUtil;
 
 import java.io.InputStream;
@@ -172,7 +173,7 @@ public class MapWordCountAggregationBenchmark extends HazelcastTestSupport {
             StringTokenizer tokenizer = new StringTokenizer(value);
 
             while (tokenizer.hasMoreTokens()) {
-                String word = cleanWord(tokenizer.nextToken()).toLowerCase();
+                String word = cleanWord(tokenizer.nextToken()).toLowerCase(StringUtil.LOCALE_INTERNAL);
 
                 MutableInt count = result.get(word);
                 if (count == null) {

--- a/hazelcast/src/test/java/com/hazelcast/config/LoginModuleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LoginModuleConfigTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static org.junit.Assert.assertSame;
+
+import java.util.Locale;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests for {@link LoginModuleConfig} class.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LoginModuleConfigTest {
+
+    @Test
+    public void testLoginModuleUsageSelection() {
+        Locale locale = Locale.getDefault();
+        try {
+            assertSame(LoginModuleUsage.OPTIONAL, LoginModuleUsage.get("optional"));
+            Locale.setDefault(new Locale("tr"));
+            assertSame(LoginModuleUsage.OPTIONAL, LoginModuleUsage.get("optional"));
+        } finally {
+            Locale.setDefault(locale);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static org.junit.Assert.assertSame;
+
+import java.util.Locale;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.MultiMapConfig.ValueCollectionType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests for {@link MultiMapConfig} class.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MultiMapConfigTest {
+
+    @Test
+    public void testValueCollectionTypeSelection() {
+        Locale locale = Locale.getDefault();
+        MultiMapConfig multiMapConfig = new MultiMapConfig();
+        multiMapConfig.setValueCollectionType("list");
+        try {
+            assertSame(ValueCollectionType.LIST, multiMapConfig.getValueCollectionType());
+            Locale.setDefault(new Locale("tr"));
+            assertSame(ValueCollectionType.LIST, multiMapConfig.getValueCollectionType());
+        } finally {
+            Locale.setDefault(locale);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/executor/ScriptCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ScriptCallable.java
@@ -18,6 +18,7 @@ package com.hazelcast.executor;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.util.StringUtil;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -49,7 +50,7 @@ class ScriptCallable implements Callable, Serializable, HazelcastInstanceAware {
         e.put("hazelcast", hazelcastInstance);
         try {
             // for new JavaScript engine called Nashorn we need the compatibility script
-            if (e.getFactory().getEngineName().toLowerCase().contains("nashorn")) {
+            if (e.getFactory().getEngineName().toLowerCase(StringUtil.LOCALE_INTERNAL).contains("nashorn")) {
                 e.eval("load('nashorn:mozilla_compat.js');");
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ScriptRunnable.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ScriptRunnable.java
@@ -18,6 +18,7 @@ package com.hazelcast.executor;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.util.StringUtil;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -48,7 +49,7 @@ class ScriptRunnable implements Runnable, Serializable, HazelcastInstanceAware {
         e.put("hazelcast", hazelcastInstance);
         try {
             // for new JavaScript engine called Nashorn we need the compatibility script
-            if (e.getFactory().getEngineName().toLowerCase().contains("nashorn")) {
+            if (e.getFactory().getEngineName().toLowerCase(StringUtil.LOCALE_INTERNAL).contains("nashorn")) {
                 e.eval("load('nashorn:mozilla_compat.js');");
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EmbeddedMapInterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EmbeddedMapInterceptorTest.java
@@ -25,6 +25,8 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.StringUtil;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -128,9 +130,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = h2.getMap(mapName);
         String key = generateKeyOwnedBy(h1);
         map1.put(key, key);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
     @Test
@@ -142,9 +144,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = h2.getMap(mapName);
         String key = generateKeyOwnedBy(h1);
         map1.putIfAbsent(key, key);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
     @Test
@@ -156,9 +158,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = h2.getMap(mapName);
         String key = generateKeyOwnedBy(h1);
         map1.putTransient(key, key, 1, TimeUnit.MINUTES);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
     @Test
@@ -171,9 +173,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         String key = generateKeyOwnedBy(h1);
         map1.put(key, key);
         map1.replace(key, key);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
     @Test
@@ -186,9 +188,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         String key = generateKeyOwnedBy(h1);
         map1.put(key, key);
         map1.replace(key, key, key);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
     @Test
@@ -200,9 +202,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = h2.getMap(mapName);
         String key = generateKeyOwnedBy(h1);
         map1.set(key, key);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
     @Test
@@ -214,9 +216,9 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = h2.getMap(mapName);
         String key = generateKeyOwnedBy(h1);
         map1.tryPut(key, key, 5, TimeUnit.SECONDS);
-        assertEquals(key.toUpperCase() + "-foo", map1.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
         h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase() + "-foo", map2.get(key));
+        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
     }
 
 
@@ -236,7 +238,7 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
 
         @Override
         public Object interceptPut(Object oldValue, Object newValue) {
-            return newValue.toString().toUpperCase();
+            return newValue.toString().toUpperCase(StringUtil.LOCALE_INTERNAL);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
@@ -29,6 +29,8 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.StringUtil;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -146,7 +148,7 @@ public class InterceptorTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(value.toUpperCase(), listener.value.get());
+                assertEquals(value.toUpperCase(StringUtil.LOCALE_INTERNAL), listener.value.get());
             }
         }, 15);
     }
@@ -166,7 +168,7 @@ public class InterceptorTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(value.toUpperCase(), listener.value.get());
+                assertEquals(value.toUpperCase(StringUtil.LOCALE_INTERNAL), listener.value.get());
             }
         }, 15);
     }
@@ -184,7 +186,7 @@ public class InterceptorTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(value.toUpperCase(), listener.value.get());
+                assertEquals(value.toUpperCase(StringUtil.LOCALE_INTERNAL), listener.value.get());
             }
         }, 15);
     }
@@ -278,7 +280,7 @@ public class InterceptorTest extends HazelcastTestSupport {
 
         @Override
         public Object interceptPut(Object oldValue, Object newValue) {
-            return newValue.toString().toUpperCase();
+            return newValue.toString().toUpperCase(StringUtil.LOCALE_INTERNAL);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionSpecification.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionSpecification.java
@@ -22,6 +22,7 @@ import com.hazelcast.query.impl.extractor.specification.ComplexTestDataStructure
 import com.hazelcast.query.impl.predicates.AbstractPredicate;
 import com.hazelcast.query.impl.predicates.PredicateTestUtils;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -123,7 +124,7 @@ public class AbstractExtractionSpecification extends HazelcastTestSupport {
      */
     protected static String parametrize(String expression, AbstractExtractionTest.Multivalue mv) {
         if (expression != null && !expression.contains("__")) {
-            return expression.replaceAll("_", "_" + mv.name().toLowerCase());
+            return expression.replaceAll("_", "_" + mv.name().toLowerCase(StringUtil.LOCALE_INTERNAL));
         }
         return expression;
     }


### PR DESCRIPTION
This PR replaces Locale-dependent `toLowerCase()` calls with Locale neutral ones.

The original version causes troubles in `tr` based Locales which has non-standard handling of `I`/`i` characters.