### PR TITLE
Fix client endpoint update when promoting to owner

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientTypes;
 import com.hazelcast.client.impl.ClientEndpointImpl;
 import com.hazelcast.client.impl.ReAuthenticationOperationSupplier;
@@ -95,6 +96,10 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
 
     @Override
     protected ClientEndpointImpl getEndpoint() {
+        ClientEndpoint endpoint = endpointManager.getEndpoint(connection);
+        if (endpoint != null) {
+            return (ClientEndpointImpl) endpoint;
+        }
         return new ClientEndpointImpl(clientEngine, nodeEngine, connection);
     }
 


### PR DESCRIPTION
When a client connection is promoted to be the owner connection,
we were failing to update the existing endpoint on server side.
This results in no clientEndpoint being the owner. Therefore,
when endpoints are removed, none of them will result in
`client disconnected operation` and resources of the client will
leak.

Issue is found when investigating :
https://github.com/hazelcast/hazelcast/issues/8777