### PR TITLE
Added common SplitBrainMergePolicy classes for additional data structures

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -59,6 +59,7 @@ import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
 import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
+import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -362,6 +363,14 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 }
             }
             quorumManagedMap.put(name, beanDefinition);
+        }
+
+        private void handleMergePolicyConfig(Node node, BeanDefinitionBuilder builder) {
+            BeanDefinitionBuilder mergePolicyConfigBuilder = createBeanBuilder(MergePolicyConfig.class);
+            AbstractBeanDefinition beanDefinition = mergePolicyConfigBuilder.getBeanDefinition();
+            fillAttributeValues(node, mergePolicyConfigBuilder);
+            mergePolicyConfigBuilder.addPropertyValue("policy", getTextContent(node).trim());
+            builder.addPropertyValue("mergePolicyConfig", beanDefinition);
         }
 
         private void handleLiteMember(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -2002,6 +2002,34 @@
         <xs:attribute name="discovery-strategy-factory" type="non-space-string" use="optional"/>
     </xs:complexType>
 
+    <xs:complexType name="merge-policy">
+        <xs:annotation>
+            <xs:documentation>
+                While recovering from split-brain (network partitioning), data structure entries in the small cluster
+                merge into the bigger cluster based on the policy set here. When an entry merges into the cluster,
+                an entry with the same key (or value) might already exist in the cluster.
+                The merge policy resolves these conflicts with different out-of-the-box or custom strategies.
+                The out-of-the-box merge polices can be references by their simple class name.
+                For custom merge policies you have to provide a fully qualified class name.
+                <p>
+                    The out-of-the-box policies are:
+                    <br/>DiscardMergePolicy: the entry from the smaller cluster will be discarded.
+                    <br/>HigherHitsMergePolicy: the entry with the higher number of hits wins.
+                    <br/>LatestAccessMergePolicy: the entry with the latest access wins.
+                    <br/>LatestUpdateMergePolicy: the entry with the latest update wins.
+                    <br/>PassThroughMergePolicy: the entry from the smaller cluster wins.
+                    <br/>PutIfAbsentMergePolicy: the entry from the smaller cluster wins if it doesn't exist in the cluster.
+                    <br/>The default policy is: PutIfAbsentMergePolicy
+                </p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="batch-size" default="100" type="xs:positiveInteger" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="merge-policies">
         <xs:sequence>
             <xs:element name="map-merge-policy" type="map-merge-policy" minOccurs="1" maxOccurs="unbounded"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -90,8 +90,9 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int RELIABLE_ID_GENERATOR_CONFIG = 48;
     public static final int ATOMIC_LONG_CONFIG = 49;
     public static final int ATOMIC_REFERENCE_CONFIG = 50;
+    public static final int MERGE_POLICY_CONFIG = 51;
 
-    private static final int LEN = ATOMIC_REFERENCE_CONFIG + 1;
+    private static final int LEN = MERGE_POLICY_CONFIG + 1;
 
     @Override
     public int getFactoryId() {
@@ -413,6 +414,13 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new AtomicReferenceConfig();
+                    }
+                };
+        constructors[MERGE_POLICY_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new MergePolicyConfig();
                     }
                 };
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.Preconditions.checkPositive;
+
+/**
+ * Configuration for {@link com.hazelcast.spi.SplitBrainMergePolicy}.
+ */
+public class MergePolicyConfig implements IdentifiedDataSerializable {
+
+    /**
+     * Default merge policy.
+     */
+    public static final String DEFAULT_MERGE_POLICY = PutIfAbsentMergePolicy.class.getSimpleName();
+
+    /**
+     * Default batch size.
+     */
+    public static final int DEFAULT_BATCH_SIZE = 100;
+
+    protected String policy = DEFAULT_MERGE_POLICY;
+    protected int batchSize = DEFAULT_BATCH_SIZE;
+
+    protected MergePolicyConfig readOnly;
+
+    public MergePolicyConfig() {
+    }
+
+    public MergePolicyConfig(String policy, int batchSize) {
+        setPolicy(policy);
+        setBatchSize(batchSize);
+    }
+
+    public MergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
+        this.policy = mergePolicyConfig.policy;
+        this.batchSize = mergePolicyConfig.batchSize;
+    }
+
+    /**
+     * Returns the classname of the {@link com.hazelcast.spi.SplitBrainMergePolicy}.
+     *
+     * @return the classname of the merge policy
+     */
+    public String getPolicy() {
+        return policy;
+    }
+
+    /**
+     * Sets the classname of your {@link com.hazelcast.spi.SplitBrainMergePolicy}.
+     * <p>
+     * For the out-of-the-box merge policies the simple classname is sufficient, e.g. {@code PutIfAbsentMergePolicy}.
+     * But also the fully qualified classname is fine, e.g. com.hazelcast.spi.merge.PutIfAbsentMergePolicy.
+     * For a custom merge policy the fully qualified classname is needed.
+     * <p>
+     * Must be a non-empty string. The default value is {@code PutIfAbsentMergePolicy}.
+     *
+     * @param policy the classname of the merge policy
+     * @return this {@code MergePolicyConfig} instance
+     */
+    public MergePolicyConfig setPolicy(String policy) {
+        this.policy = checkHasText(policy, "Merge policy must contain text!");
+        return this;
+    }
+
+    /**
+     * Returns the batch size, which will be used to determine the number of entries to be sent in a merge operation.
+     *
+     * @return the batch size
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Sets the batch size, which will be used to determine the number of entries to be sent in a merge operation.
+     * <p>
+     * Must be a positive number. Set to {@code 1} to disable batching. The default value is {@value #DEFAULT_BATCH_SIZE}.
+     *
+     * @param batchSize the batch size
+     * @return this {@code MergePolicyConfig} instance
+     */
+    public MergePolicyConfig setBatchSize(int batchSize) {
+        this.batchSize = checkPositive(batchSize, "batchSize must be a positive number!");
+        return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.MERGE_POLICY_CONFIG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(policy);
+        out.writeInt(batchSize);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        policy = in.readUTF();
+        batchSize = in.readInt();
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MergePolicyConfig)) {
+            return false;
+        }
+
+        MergePolicyConfig that = (MergePolicyConfig) o;
+        if (batchSize != that.batchSize) {
+            return false;
+        }
+        return policy != null ? policy.equals(that.policy) : that.policy == null;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = policy != null ? policy.hashCode() : 0;
+        result = 31 * result + batchSize;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MergePolicyConfig{"
+                + "policy='" + policy + '\''
+                + ", batchSize=" + batchSize
+                + '}';
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return immutable version of this configuration
+     * @deprecated this method will be removed in 4.0; it is meant for internal usage only
+     */
+    public MergePolicyConfig getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new MergePolicyConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    private static class MergePolicyConfigReadOnly extends MergePolicyConfig {
+
+        MergePolicyConfigReadOnly(MergePolicyConfig mergePolicyConfig) {
+            super(mergePolicyConfig);
+        }
+
+        @Override
+        public MergePolicyConfig setPolicy(String policy) {
+            throw new UnsupportedOperationException("This is a read-only configuration");
+        }
+
+        @Override
+        public MergePolicyConfig setBatchSize(int batchSize) {
+            throw new UnsupportedOperationException("This is a read-only configuration");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1750,6 +1750,17 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         return config;
     }
 
+    private MergePolicyConfig createMergePolicyConfig(Node node) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
+        String policyString = getTextContent(node).trim();
+        mergePolicyConfig.setPolicy(policyString);
+        final String att = getAttribute(node, "batch-size");
+        if (att != null) {
+            mergePolicyConfig.setBatchSize(getIntegerValue("batch-size", att));
+        }
+        return mergePolicyConfig;
+    }
+
     private QueueStoreConfig createQueueStoreConfig(Node node) {
         QueueStoreConfig queueStoreConfig = new QueueStoreConfig();
         NamedNodeMap attributes = node.getAttributes();

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
@@ -17,10 +17,10 @@
 package com.hazelcast.core;
 
 /**
- * EntryView represents a readonly view of a map entry.
+ * Represents a read-only view of a data structure entry.
  *
- * @param <K> key
- * @param <V> value
+ * @param <K> the type of the key
+ * @param <V> the type of the value
  */
 public interface EntryView<K, V> {
 
@@ -40,11 +40,8 @@ public interface EntryView<K, V> {
 
     /**
      * Returns the cost (in bytes) of the entry.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method returns -1 if statistics is not enabled.
-     * </p>
+     * <b>Warning:</b> This method returns {@code -1} if statistics are not enabled or not implemented.
      *
      * @return the cost in bytes of the entry
      */
@@ -52,11 +49,8 @@ public interface EntryView<K, V> {
 
     /**
      * Returns the creation time of the entry.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method returns -1 if statistics is not enabled.
-     * </p>
+     * <b>Warning:</b> This method returns {@code -1} if statistics are not enabled or not implemented.
      *
      * @return the creation time of the entry
      */
@@ -71,11 +65,8 @@ public interface EntryView<K, V> {
 
     /**
      * Returns number of hits of the entry.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * <p>                                                                                      ˆ
-     * This method returns -1 if statistics is not enabled.
-     * </p>
+     * <p>
+     * <b>Warning:</b> This method returns {@code -1} if statistics are not enabled or not implemented.
      *
      * @return number of hits of the entry
      */
@@ -83,23 +74,17 @@ public interface EntryView<K, V> {
 
     /**
      * Returns the last access time for the entry.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * <p>                                                                                      ˆ
-     * This method returns -1 if statistics is not enabled.
-     * </p>
+     * <p>
+     * <b>Warning:</b> This method returns {@code -1} if statistics are not enabled or not implemented.
      *
      * @return the last access time for the entry
      */
     long getLastAccessTime();
 
     /**
-     * Returns the last time the value was flushed to mapstore.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * <p>                                                                                      ˆ
-     * This method returns -1 if statistics is not enabled.
-     * </p>
+     * Returns the last time the value was flushed to its store (e.g. {@link MapStore}).
+     * <p>
+     * <b>Warning:</b> This method returns {@code -1} if statistics are not enabled or not implemented.
      *
      * @return the last store time for the value
      */
@@ -107,18 +92,15 @@ public interface EntryView<K, V> {
 
     /**
      * Returns the last time the value was updated.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * <p>                                                                                      ˆ
-     * This method returns -1 if statistics is not enabled.
-     * </p>
+     * <p>
+     * <b>Warning:</b> This method returns {@code -1} if statistics are not enabled or not implemented.
      *
      * @return the last time the value was updated
      */
     long getLastUpdateTime();
 
     /**
-     * Returns the version of the entry
+     * Returns the version of the entry.
      *
      * @return the version of the entry
      */
@@ -127,7 +109,7 @@ public interface EntryView<K, V> {
     /**
      * Returns the last set time to live second.
      *
-     * @return the last set time to live second.
+     * @return the last set time to live second
      */
     long getTtl();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -65,7 +65,6 @@ class ClusterMergeTask implements Runnable {
             resetState();
 
             Collection<Runnable> coreTasks = collectMergeTasks(true);
-
             Collection<Runnable> nonCoreTasks = collectMergeTasks(false);
 
             resetServices();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -143,6 +143,9 @@ public final class FactoryIdHelper {
     public static final String RELIABLE_ID_GENERATOR_DS_FACTORY = "hazelcast.serialization.ds.reliable_id_generator";
     public static final int RELIABLE_ID_GENERATOR_DS_FACTORY_ID = -46;
 
+    public static final String SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY = "hazelcast.serialization.ds.split.brain.merge.policy";
+    public static final int SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY_ID = -47;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -25,6 +25,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.quorum.QuorumService;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -289,4 +290,12 @@ public interface NodeEngine {
      * @since 3.8
      */
     MemberVersion getVersion();
+
+    /**
+     * Returns the {@link SplitBrainMergePolicyProvider} for this instance.
+     *
+     * @return the {@link SplitBrainMergePolicyProvider}
+     * @since 3.10
+     */
+    SplitBrainMergePolicyProvider getSplitBrainMergePolicyProvider();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainAwareDataContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainAwareDataContainer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Interface for split-brain capable data containers of services, which implement {@link SplitBrainHandlerService}.
+ *
+ * @param <K> the type of the record key
+ * @param <V> the type of the record value
+ * @param <T> the type of the merged item
+ * @since 3.10
+ */
+public interface SplitBrainAwareDataContainer<K, V, T> {
+
+    /**
+     * Merges the given {@link SplitBrainMergeEntryView} with an existing entry via the supplied {@link SplitBrainMergePolicy}.
+     * <p>
+     * The existing entry has to be retrieved by the implementing data container, via the key or value of the merging entry.
+     * Both entries are passed to {@link SplitBrainMergePolicy#merge(SplitBrainMergeEntryView, SplitBrainMergeEntryView)},
+     * which decides if one of the entries should be merged.
+     * <p>
+     * The return type of this methods depends on the contract between the calling merge operation and the data container, e.g.
+     * <ul>
+     * <li>the merged entry instance in the data container specific format, to create a backup operation</li>
+     * <li>{@code null} to signal that nothing has been merged</li>
+     * <li>{@code boolean} to signal if the {@code mergingEntry} was merged or not</li>
+     * </ul>
+     *
+     * @param mergingEntry the {@link SplitBrainMergeEntryView} instance that wraps key/value for merging and existing entry
+     * @param mergePolicy  the {@link SplitBrainMergePolicy} instance for handling merge policy
+     * @return the internal item representation to create a backup operation if merge was applied, otherwise {@code null}
+     */
+    T merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergePolicy mergePolicy);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergeEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergeEntryView.java
@@ -16,19 +16,19 @@
 
 package com.hazelcast.spi;
 
-/**
- * An interface that can be implemented by SPI services that want to be able to resolve a split-brain.
- * <p>
- * When the two separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
- * a {@link Runnable}, that will merge the clusters.
- */
-public interface SplitBrainHandlerService {
+import com.hazelcast.core.EntryView;
 
-    /**
-     * When the two separate clusters merge (resolve a split-brain), this method is called to return
-     * a {@link Runnable}, that will merge the clusters.
-     *
-     * @return a {@link Runnable} that will merge the clusters
-     */
-    Runnable prepareMergeRunnable();
+/**
+ * Represents a read-only view of data structure entries for the merging process after a split-brain.
+ * <p>
+ * On key-less data structures like {@link com.hazelcast.core.ISet} or {@link com.hazelcast.ringbuffer.Ringbuffer},
+ * the method {@link #getKey()} will return {@code null}.
+ * <p>
+ * Some methods return {@code -1} if statistics are not enabled or not implemented.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ * @since 3.10
+ */
+public interface SplitBrainMergeEntryView<K, V> extends EntryView<K, V> {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergePolicy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.spi.serialization.SerializationService;
+
+/**
+ * Policy for merging data structure entries after a split-brain has been healed.
+ *
+ * @since 3.10
+ */
+public interface SplitBrainMergePolicy {
+
+    /**
+     * Selects one of the merging and existing data structure entries to be merged.
+     * <p>
+     * Note that as mentioned also in arguments, the {@link SplitBrainMergeEntryView} instance that represents
+     * the existing data structure entry may be {@code null} if there is no existing entry for the specified key
+     * in the {@link SplitBrainMergeEntryView} instance that represents the merging data structure entry.
+     *
+     * @param mergingEntry  {@link SplitBrainMergeEntryView} instance that has the data structure entry to be merged
+     * @param existingEntry {@link SplitBrainMergeEntryView} instance that has the existing data structure entry
+     *                      or {@code null} if there is no existing data structure entry
+     * @param <K>           the type of the key
+     * @param <V>           the type of the value
+     * @return the selected value for merging
+     */
+    <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry);
+
+    /**
+     * Sets the {@link SerializationService} for this merge policy.
+     * <p>
+     * The keys and values of merging and existing {@link SplitBrainMergeEntryView}s are always in the in-memory format of the
+     * backing data structure. This can be a serialized format, so the content cannot be processed without deserialization.
+     * For most merge policies this will be fine, since the key or value are not used. If your implementation needs the
+     * deserialized data, you can use {@link SerializationService#toObject(Object)} of the injected SerializationService.
+     * <p>
+     * The deserialization is not done eagerly for two main reasons:
+     * <ul>
+     * <li>The deserialization is quite expensive and should be avoided, if the result is not needed.</li>
+     * <li>There is no need to locate classes of stored entries on the server side, when the entries are not deserialized.
+     * So you can put entries from a client by using {@link com.hazelcast.config.InMemoryFormat#BINARY} with a different
+     * classpath on client and server. In this case a deserialization could throw a {@link java.lang.ClassNotFoundException}.</li>
+     * </ul>
+     *
+     * @param serializationService the {@link SerializationService}
+     */
+    void setSerializationService(SerializationService serializationService);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -68,6 +68,7 @@ import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.impl.servicemanager.impl.ServiceManagerImpl;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionManagerService;
@@ -113,6 +114,7 @@ public class NodeEngineImpl implements NodeEngine {
     private final PacketHandler packetDispatcher;
     private final QuorumServiceImpl quorumService;
     private final Diagnostics diagnostics;
+    private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     public NodeEngineImpl(Node node) {
@@ -146,6 +148,7 @@ public class NodeEngineImpl implements NodeEngine {
                 new JetPacketHandler());
         this.quorumService = new QuorumServiceImpl(this);
         this.diagnostics = newDiagnostics();
+        this.splitBrainMergePolicyProvider = new SplitBrainMergePolicyProvider(this);
 
         serviceManager.registerService(InternalOperationService.SERVICE_NAME, operationService);
         serviceManager.registerService(OperationParker.SERVICE_NAME, operationParker);
@@ -366,6 +369,11 @@ public class NodeEngineImpl implements NodeEngine {
     @Override
     public MemberVersion getVersion() {
         return node.getVersion();
+    }
+
+    @Override
+    public SplitBrainMergePolicyProvider getSplitBrainMergePolicyProvider() {
+        return splitBrainMergePolicyProvider;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/AbstractMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/AbstractMergePolicy.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.serialization.SerializationService;
+
+/**
+ * Abstract implementation of {@link SplitBrainMergePolicy} for the out-of-the-box merge policies.
+ * <p>
+ * Doesn't save the injected {@link SerializationService}, since it's not needed by any out-of-the-box merge policy.
+ *
+ * @since 3.10
+ */
+abstract class AbstractMergePolicy implements SplitBrainMergePolicy, IdentifiedDataSerializable {
+
+    @Override
+    public void setSerializationService(SerializationService serializationService) {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SplitBrainMergePolicyDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+/**
+ * Merges only entries from the destination data structure and discards all entries from the source data structure.
+ *
+ * @since 3.10
+ */
+public class DiscardMergePolicy extends AbstractMergePolicy {
+
+    DiscardMergePolicy() {
+    }
+
+    @Override
+    public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
+        if (existingEntry == null) {
+            return null;
+        }
+        return existingEntry.getValue();
+    }
+
+    @Override
+    public int getId() {
+        return SplitBrainMergePolicyDataSerializerHook.DISCARD;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+/**
+ * Merges data structure entries from source to destination data structure if the source entry
+ * has more hits than the destination one.
+ *
+ * @since 3.10
+ */
+public class HigherHitsMergePolicy extends AbstractMergePolicy {
+
+    HigherHitsMergePolicy() {
+    }
+
+    @Override
+    public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
+        if (mergingEntry == null) {
+            return existingEntry.getValue();
+        }
+        if (existingEntry == null || mergingEntry.getHits() >= existingEntry.getHits()) {
+            return mergingEntry.getValue();
+        }
+        return existingEntry.getValue();
+    }
+
+    @Override
+    public int getId() {
+        return SplitBrainMergePolicyDataSerializerHook.HIGHER_HITS;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+/**
+ * Merges data structure entries from source to destination data structure if the source entry
+ * has been accessed more recently than the destination entry.
+ * <p>
+ * <b>Note:</b> This policy can only be used if the clocks of the nodes are in sync.
+ *
+ * @since 3.10
+ */
+public class LatestAccessMergePolicy extends AbstractMergePolicy {
+
+    LatestAccessMergePolicy() {
+    }
+
+    @Override
+    public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
+        if (mergingEntry == null) {
+            return existingEntry.getValue();
+        }
+        if (existingEntry == null || mergingEntry.getLastAccessTime() >= existingEntry.getLastAccessTime()) {
+            return mergingEntry.getValue();
+        }
+        return existingEntry.getValue();
+    }
+
+    @Override
+    public int getId() {
+        return SplitBrainMergePolicyDataSerializerHook.LATEST_ACCESS;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+/**
+ * Merges data structure entries from source to destination data structure if the source entry
+ * was updated more frequently than the destination entry.
+ * <p>
+ * <b>Note:</b> This policy can only be used if the clocks of the nodes are in sync.
+ *
+ * @since 3.10
+ */
+public class LatestUpdateMergePolicy extends AbstractMergePolicy {
+
+    LatestUpdateMergePolicy() {
+    }
+
+    @Override
+    public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
+        if (mergingEntry == null) {
+            return existingEntry.getValue();
+        }
+        if (existingEntry == null || mergingEntry.getLastUpdateTime() >= existingEntry.getLastUpdateTime()) {
+            return mergingEntry.getValue();
+        }
+        return existingEntry.getValue();
+    }
+
+    @Override
+    public int getId() {
+        return SplitBrainMergePolicyDataSerializerHook.LATEST_UPDATE;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+/**
+ * Merges data structure entries from source to destination directly unless the merging entry is {@code null}.
+ *
+ * @since 3.10
+ */
+public class PassThroughMergePolicy extends AbstractMergePolicy {
+
+    PassThroughMergePolicy() {
+    }
+
+    @Override
+    public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
+        if (mergingEntry == null) {
+            return existingEntry.getValue();
+        }
+        return mergingEntry.getValue();
+    }
+
+    @Override
+    public int getId() {
+        return SplitBrainMergePolicyDataSerializerHook.PASS_THROUGH;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+/**
+ * Merges data structure entries from source to destination if they don't exist in the destination data structure.
+ *
+ * @since 3.10
+ */
+public class PutIfAbsentMergePolicy extends AbstractMergePolicy {
+
+    PutIfAbsentMergePolicy() {
+    }
+
+    @Override
+    public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
+        if (existingEntry == null) {
+            return mergingEntry.getValue();
+        }
+        return existingEntry.getValue();
+    }
+
+    @Override
+    public int getId() {
+        return SplitBrainMergePolicyDataSerializerHook.PUT_IF_ABSENT;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.collection.impl.collection.CollectionItem;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+
+import java.io.IOException;
+
+/**
+ * Provides static factory methods to create {@link SplitBrainMergeEntryView} instances.
+ *
+ * @since 3.10
+ */
+public final class SplitBrainEntryViews {
+
+    private SplitBrainEntryViews() {
+    }
+
+    public static SplitBrainMergeEntryView<Long, Data> createSplitBrainMergeEntryView(CollectionItem item) {
+        return new SimpleSplitBrainEntryView<Long, Data>()
+                .setKey(item.getItemId())
+                .setValue(item.getValue())
+                .setCreationTime(item.getCreationTime());
+    }
+
+    /**
+     * SimpleSplitBrainEntryView is a mutable implementation of {@link SplitBrainMergeEntryView}.
+     *
+     * @param <K> the type of key
+     * @param <V> the type of value
+     */
+    @SuppressWarnings("checkstyle:methodcount")
+    static class SimpleSplitBrainEntryView<K, V> implements SplitBrainMergeEntryView<K, V>, IdentifiedDataSerializable {
+
+        private K key;
+        private V value;
+        private long cost = -1;
+        private long creationTime = -1;
+        private long expirationTime;
+        private long hits = -1;
+        private long lastAccessTime = -1;
+        private long lastStoredTime = -1;
+        private long lastUpdateTime = -1;
+        private long version;
+        private long ttl;
+
+        SimpleSplitBrainEntryView() {
+        }
+
+        @Override
+        public K getKey() {
+            return key;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setKey(K key) {
+            this.key = key;
+            return this;
+        }
+
+        @Override
+        public V getValue() {
+            return value;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setValue(V value) {
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public long getCost() {
+            return cost;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setCost(long cost) {
+            this.cost = cost;
+            return this;
+        }
+
+        @Override
+        public long getCreationTime() {
+            return creationTime;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setCreationTime(long creationTime) {
+            this.creationTime = creationTime;
+            return this;
+        }
+
+        @Override
+        public long getExpirationTime() {
+            return expirationTime;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setExpirationTime(long expirationTime) {
+            this.expirationTime = expirationTime;
+            return this;
+        }
+
+        @Override
+        public long getHits() {
+            return hits;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setHits(long hits) {
+            this.hits = hits;
+            return this;
+        }
+
+        @Override
+        public long getLastAccessTime() {
+            return lastAccessTime;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setLastAccessTime(long lastAccessTime) {
+            this.lastAccessTime = lastAccessTime;
+            return this;
+        }
+
+        @Override
+        public long getLastStoredTime() {
+            return lastStoredTime;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setLastStoredTime(long lastStoredTime) {
+            this.lastStoredTime = lastStoredTime;
+            return this;
+        }
+
+        @Override
+        public long getLastUpdateTime() {
+            return lastUpdateTime;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setLastUpdateTime(long lastUpdateTime) {
+            this.lastUpdateTime = lastUpdateTime;
+            return this;
+        }
+
+        @Override
+        public long getVersion() {
+            return version;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setVersion(long version) {
+            this.version = version;
+            return this;
+        }
+
+        @Override
+        public long getTtl() {
+            return ttl;
+        }
+
+        SimpleSplitBrainEntryView<K, V> setTtl(long ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            IOUtil.writeObject(out, key);
+            IOUtil.writeObject(out, value);
+            out.writeLong(cost);
+            out.writeLong(creationTime);
+            out.writeLong(expirationTime);
+            out.writeLong(hits);
+            out.writeLong(lastAccessTime);
+            out.writeLong(lastStoredTime);
+            out.writeLong(lastUpdateTime);
+            out.writeLong(version);
+            out.writeLong(ttl);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            key = IOUtil.readObject(in);
+            value = IOUtil.readObject(in);
+            cost = in.readLong();
+            creationTime = in.readLong();
+            expirationTime = in.readLong();
+            hits = in.readLong();
+            lastAccessTime = in.readLong();
+            lastStoredTime = in.readLong();
+            lastUpdateTime = in.readLong();
+            version = in.readLong();
+            ttl = in.readLong();
+        }
+
+        @Override
+        public int getFactoryId() {
+            return SplitBrainMergePolicyDataSerializerHook.F_ID;
+        }
+
+        @Override
+        public int getId() {
+            return SplitBrainMergePolicyDataSerializerHook.ENTRY_VIEW;
+        }
+
+        @Override
+        @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            SimpleSplitBrainEntryView<?, ?> that = (SimpleSplitBrainEntryView<?, ?>) o;
+            if (cost != that.cost) {
+                return false;
+            }
+            if (creationTime != that.creationTime) {
+                return false;
+            }
+            if (expirationTime != that.expirationTime) {
+                return false;
+            }
+            if (hits != that.hits) {
+                return false;
+            }
+            if (lastAccessTime != that.lastAccessTime) {
+                return false;
+            }
+            if (lastStoredTime != that.lastStoredTime) {
+                return false;
+            }
+            if (lastUpdateTime != that.lastUpdateTime) {
+                return false;
+            }
+            if (version != that.version) {
+                return false;
+            }
+            if (ttl != that.ttl) {
+                return false;
+            }
+            if (key != null ? !key.equals(that.key) : that.key != null) {
+                return false;
+            }
+            return value != null ? value.equals(that.value) : that.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key != null ? key.hashCode() : 0;
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            result = 31 * result + (int) (cost ^ (cost >>> 32));
+            result = 31 * result + (int) (creationTime ^ (creationTime >>> 32));
+            result = 31 * result + (int) (expirationTime ^ (expirationTime >>> 32));
+            result = 31 * result + (int) (hits ^ (hits >>> 32));
+            result = 31 * result + (int) (lastAccessTime ^ (lastAccessTime >>> 32));
+            result = 31 * result + (int) (lastStoredTime ^ (lastStoredTime >>> 32));
+            result = 31 * result + (int) (lastUpdateTime ^ (lastUpdateTime >>> 32));
+            result = 31 * result + (int) (version ^ (version >>> 32));
+            result = 31 * result + (int) (ttl ^ (ttl >>> 32));
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "EntryView{"
+                    + "key=" + key
+                    + ", value=" + value
+                    + ", cost=" + cost
+                    + ", creationTime=" + creationTime
+                    + ", expirationTime=" + expirationTime
+                    + ", hits=" + hits
+                    + ", lastAccessTime=" + lastAccessTime
+                    + ", lastStoredTime=" + lastStoredTime
+                    + ", lastUpdateTime=" + lastUpdateTime
+                    + ", version=" + version
+                    + ", ttl=" + ttl
+                    + '}';
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyDataSerializerHook.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY_ID;
+
+/**
+ * Contains all the ID hooks for {@link IdentifiedDataSerializable} classes used by the split-brain framework.
+ * <p>
+ * {@link com.hazelcast.spi.SplitBrainMergePolicy} classes are mapped here. This factory class is used by the
+ * internal serialization system to create {@link IdentifiedDataSerializable} classes without using reflection.
+ *
+ * @since 3.10
+ */
+@SuppressWarnings("checkstyle:javadocvariable")
+public final class SplitBrainMergePolicyDataSerializerHook implements DataSerializerHook {
+
+    public static final int F_ID = FactoryIdHelper.getFactoryId(SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY,
+            SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY_ID);
+
+    public static final int ENTRY_VIEW = 0;
+    public static final int DISCARD = 1;
+    public static final int HIGHER_HITS = 2;
+    public static final int LATEST_ACCESS = 3;
+    public static final int LATEST_UPDATE = 4;
+    public static final int PASS_THROUGH = 5;
+    public static final int PUT_IF_ABSENT = 6;
+
+    private static final int LEN = PUT_IF_ABSENT + 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        //noinspection unchecked
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+        constructors[ENTRY_VIEW] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new SplitBrainEntryViews.SimpleSplitBrainEntryView();
+            }
+        };
+        constructors[DISCARD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DiscardMergePolicy();
+            }
+        };
+        constructors[HIGHER_HITS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new HigherHitsMergePolicy();
+            }
+        };
+        constructors[LATEST_ACCESS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LatestAccessMergePolicy();
+            }
+        };
+        constructors[LATEST_UPDATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LatestUpdateMergePolicy();
+            }
+        };
+        constructors[PASS_THROUGH] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PassThroughMergePolicy();
+            }
+        };
+        constructors[PUT_IF_ABSENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PutIfAbsentMergePolicy();
+            }
+        };
+
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.util.ConstructorFunction;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.nio.ClassLoaderUtil.newInstance;
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+
+/**
+ * A provider for {@link SplitBrainMergePolicy} instances.
+ * <p>
+ * Registers out-of-the-box merge policies by their fully qualified and simple class name.
+ *
+ * @since 3.10
+ */
+public final class SplitBrainMergePolicyProvider {
+
+    private static final Map<String, SplitBrainMergePolicy> OUT_OF_THE_BOX_MERGE_POLICIES;
+
+    static {
+        OUT_OF_THE_BOX_MERGE_POLICIES = new HashMap<String, SplitBrainMergePolicy>();
+        addPolicy(DiscardMergePolicy.class, new DiscardMergePolicy());
+        addPolicy(HigherHitsMergePolicy.class, new HigherHitsMergePolicy());
+        addPolicy(LatestAccessMergePolicy.class, new LatestAccessMergePolicy());
+        addPolicy(LatestUpdateMergePolicy.class, new LatestUpdateMergePolicy());
+        addPolicy(PassThroughMergePolicy.class, new PassThroughMergePolicy());
+        addPolicy(PutIfAbsentMergePolicy.class, new PutIfAbsentMergePolicy());
+    }
+
+    private final NodeEngine nodeEngine;
+
+    private final ConcurrentMap<String, SplitBrainMergePolicy> mergePolicyMap
+            = new ConcurrentHashMap<String, SplitBrainMergePolicy>();
+
+    private final ConstructorFunction<String, SplitBrainMergePolicy> policyConstructorFunction
+            = new ConstructorFunction<String, SplitBrainMergePolicy>() {
+        @Override
+        public SplitBrainMergePolicy createNew(String className) {
+            try {
+                return newInstance(nodeEngine.getConfigClassLoader(), className);
+            } catch (Exception e) {
+                nodeEngine.getLogger(getClass()).severe(e);
+                throw new InvalidConfigurationException("Invalid SplitBrainMergePolicy: " + className, e);
+            }
+        }
+    };
+
+    /**
+     * Constructs a new provider for {@link SplitBrainMergePolicy} classes.
+     *
+     * @param nodeEngine the {@link NodeEngine} to retrieve the classloader from
+     */
+    public SplitBrainMergePolicyProvider(NodeEngine nodeEngine) {
+        this.nodeEngine = nodeEngine;
+        this.mergePolicyMap.putAll(OUT_OF_THE_BOX_MERGE_POLICIES);
+    }
+
+    /**
+     * Resolves the {@link SplitBrainMergePolicy} class by its classname.
+     *
+     * @param className the merge policy classname to resolve
+     * @return the resolved {@link SplitBrainMergePolicy} class
+     * @throws InvalidConfigurationException when the classname could not be resolved
+     */
+    public SplitBrainMergePolicy getMergePolicy(String className) {
+        if (className == null) {
+            throw new InvalidConfigurationException("Class name is mandatory!");
+        }
+        return getOrPutIfAbsent(mergePolicyMap, className, policyConstructorFunction);
+    }
+
+    private static <T extends SplitBrainMergePolicy> void addPolicy(Class<T> clazz, T policy) {
+        OUT_OF_THE_BOX_MERGE_POLICIES.put(clazz.getName(), policy);
+        OUT_OF_THE_BOX_MERGE_POLICIES.put(clazz.getSimpleName(), policy);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/package-info.java
@@ -14,21 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi;
-
 /**
- * An interface that can be implemented by SPI services that want to be able to resolve a split-brain.
- * <p>
- * When the two separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
- * a {@link Runnable}, that will merge the clusters.
+ * This package contains out-of-the-box split brain merge policies.
  */
-public interface SplitBrainHandlerService {
-
-    /**
-     * When the two separate clusters merge (resolve a split-brain), this method is called to return
-     * a {@link Runnable}, that will merge the clusters.
-     *
-     * @return a {@link Runnable} that will merge the clusters
-     */
-    Runnable prepareMergeRunnable();
-}
+package com.hazelcast.spi.merge;

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -32,3 +32,4 @@ com.hazelcast.projection.impl.ProjectionDataSerializerHook
 com.hazelcast.config.ConfigDataSerializerHook
 com.hazelcast.journal.EventJournalDataSerializerHook
 com.hazelcast.reliableidgen.impl.ReliableIdGeneratorDataSerializerHook
+com.hazelcast.spi.merge.SplitBrainMergePolicyDataSerializerHook

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -1323,6 +1323,33 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:complexType name="merge-policy">
+        <xs:annotation>
+            <xs:documentation>
+                While recovering from split-brain (network partitioning), data structure entries in the small cluster
+                merge into the bigger cluster based on the policy set here. When an entry merges into the cluster,
+                an entry with the same key (or value) might already exist in the cluster.
+                The merge policy resolves these conflicts with different out-of-the-box or custom strategies.
+                The out-of-the-box merge polices can be references by their simple class name.
+                For custom merge policies you have to provide a fully qualified class name.
+                <p>
+                    The out-of-the-box policies are:
+                    <br/>DiscardMergePolicy: the entry from the smaller cluster will be discarded.
+                    <br/>HigherHitsMergePolicy: the entry with the higher number of hits wins.
+                    <br/>LatestAccessMergePolicy: the entry with the latest access wins.
+                    <br/>LatestUpdateMergePolicy: the entry with the latest update wins.
+                    <br/>PassThroughMergePolicy: the entry from the smaller cluster wins.
+                    <br/>PutIfAbsentMergePolicy: the entry from the smaller cluster wins if it doesn't exist in the cluster.
+                    <br/>The default policy is: PutIfAbsentMergePolicy
+                </p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="batch-size" default="100" type="xs:positiveInteger" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
     <xs:complexType name="network">
         <xs:all>
             <xs:element name="public-address" type="xs:string" minOccurs="0" maxOccurs="1">

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
@@ -21,8 +21,6 @@ import com.hazelcast.cache.CacheMergePolicy;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -38,7 +36,6 @@ import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
 import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -235,26 +232,6 @@ public class CacheSplitBrainTest extends SplitBrainTestSupport {
                 return mergingEntry.getValue();
             }
             return null;
-        }
-    }
-
-    private static class MergeLifecycleListener implements LifecycleListener {
-
-        private final CountDownLatch latch;
-
-        MergeLifecycleListener(int mergingClusterSize) {
-            latch = new CountDownLatch(mergingClusterSize);
-        }
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            if (event.getState() == LifecycleEvent.LifecycleState.MERGED) {
-                latch.countDown();
-            }
-        }
-
-        void await() {
-            assertOpenEventually(latch);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -182,6 +182,12 @@ class ConfigCompatibilityChecker {
         return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null && nullSafeEqual(c1.isFsync(), c2.isFsync()));
     }
 
+    private static boolean isCompatible(MergePolicyConfig c1, MergePolicyConfig c2) {
+        return c1 == c2 || !(c1 == null || c2 == null)
+                && c1.getBatchSize() == c2.getBatchSize()
+                && nullSafeEqual(c1.getPolicy(), c2.getPolicy());
+    }
+
     private abstract static class ConfigChecker<T> {
 
         abstract boolean check(T t1, T t2);

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+import com.hazelcast.spi.serialization.SerializationService;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class MergePolicyConfigTest {
+
+    private MergePolicyConfig config = new MergePolicyConfig();
+
+    @Test
+    public void testConstructor_withParameters() {
+        new MergePolicyConfig(DiscardMergePolicy.class.getName(), 100);
+        new MergePolicyConfig(PassThroughMergePolicy.class.getName(), 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructor_withParameters_withNullPolicy() {
+        new MergePolicyConfig(null, 100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructor_withParameters_withEmptyPolicy() {
+        new MergePolicyConfig("", 100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructor_withParameters_withZeroBatchSize() {
+        new MergePolicyConfig(DiscardMergePolicy.class.getName(), 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructor_withParameters_withNegativeBatchSize() {
+        new MergePolicyConfig(DiscardMergePolicy.class.getName(), -1);
+    }
+
+    @Test
+    public void setPolicy() {
+        config.setPolicy(DiscardMergePolicy.class.getName());
+
+        assertEquals(DiscardMergePolicy.class.getName(), config.getPolicy());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setPolicy_withNull() {
+        config.setPolicy(null);
+    }
+
+    @Test
+    public void setBatchSize() {
+        config.setBatchSize(1234);
+
+        assertEquals(1234, config.getBatchSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setBatchSize_withZero() {
+        config.setBatchSize(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setBatchSize_withNegative() {
+        config.setBatchSize(-1);
+    }
+
+    @Test
+    public void testToString() {
+        config.setPolicy(HigherHitsMergePolicy.class.getName());
+        config.setBatchSize(2342);
+
+        String configString = config.toString();
+        assertThat(configString, containsString("MergePolicyConfig"));
+        assertThat(configString, containsString("policy='" + HigherHitsMergePolicy.class.getName() + "'"));
+        assertThat(configString, containsString("batchSize=2342"));
+    }
+
+    @Test
+    public void getAsReadOnly() {
+        config.setPolicy(HigherHitsMergePolicy.class.getName());
+        config.setBatchSize(2342);
+
+        MergePolicyConfig readOnly = config.getAsReadOnly();
+
+        assertEquals(config.getPolicy(), readOnly.getPolicy());
+        assertEquals(config.getBatchSize(), readOnly.getBatchSize());
+    }
+
+    @Test
+    public void testSerialization() {
+        config.setPolicy(DiscardMergePolicy.class.getName());
+        config.setBatchSize(1234);
+
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+        Data serialized = serializationService.toData(config);
+        MergePolicyConfig deserialized = serializationService.toObject(serialized);
+
+        assertEquals(config.getPolicy(), deserialized.getPolicy());
+        assertEquals(config.getBatchSize(), deserialized.getBatchSize());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MergePolicyConfig.class)
+                .allFieldsShouldBeUsedExcept("readOnly")
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withPrefabValues(MergePolicyConfig.class,
+                        new MergePolicyConfig(PutIfAbsentMergePolicy.class.getName(), 1000),
+                        new MergePolicyConfig(DiscardMergePolicy.class.getName(), 300))
+                .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyReadOnlyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyReadOnlyConfigTest.java
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi;
+package com.hazelcast.config;
 
-/**
- * An interface that can be implemented by SPI services that want to be able to resolve a split-brain.
- * <p>
- * When the two separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
- * a {@link Runnable}, that will merge the clusters.
- */
-public interface SplitBrainHandlerService {
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import org.junit.Test;
 
-    /**
-     * When the two separate clusters merge (resolve a split-brain), this method is called to return
-     * a {@link Runnable}, that will merge the clusters.
-     *
-     * @return a {@link Runnable} that will merge the clusters
-     */
-    Runnable prepareMergeRunnable();
+public class MergePolicyReadOnlyConfigTest {
+
+    private MergePolicyConfig getReadOnlyConfig() {
+        return new MergePolicyConfig().getAsReadOnly();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setPolicy() {
+        getReadOnlyConfig().setPolicy(DiscardMergePolicy.class.getName());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setBatchSize() {
+        getReadOnlyConfig().setBatchSize(1234);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
@@ -18,8 +18,6 @@ package com.hazelcast.replicatedmap.merge;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
@@ -34,7 +32,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -237,26 +234,6 @@ public class ReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
                 return mergingEntry.getValue();
             }
             return null;
-        }
-    }
-
-    private static class MergeLifecycleListener implements LifecycleListener {
-
-        private final CountDownLatch latch;
-
-        MergeLifecycleListener(int mergingClusterSize) {
-            latch = new CountDownLatch(mergingClusterSize);
-        }
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            if (event.getState() == LifecycleEvent.LifecycleState.MERGED) {
-                latch.countDown();
-            }
-        }
-
-        void await() {
-            assertOpenEventually(latch);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.serialization.SerializationService;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractSplitBrainMergePolicyTest {
+
+    private static final String EXISTING = "EXISTING";
+    private static final String MERGING = "MERGING";
+
+    protected SerializationService serializationService;
+    protected SplitBrainMergePolicy policy;
+
+    @Before
+    public void setup() {
+        serializationService = mock(InternalSerializationService.class);
+
+        policy = createMergePolicy();
+        policy.setSerializationService(serializationService);
+    }
+
+    protected abstract SplitBrainMergePolicy createMergePolicy();
+
+    @Test
+    public void merge_mergingWins() {
+        SplitBrainMergeEntryView existing = entryWithGivenPropertyAndValue(1, EXISTING);
+        SplitBrainMergeEntryView merging = entryWithGivenPropertyAndValue(333, MERGING);
+
+        assertEquals(MERGING, policy.merge(merging, existing));
+    }
+
+    @Test
+    public void merge_existingWins() {
+        SplitBrainMergeEntryView existing = entryWithGivenPropertyAndValue(333, EXISTING);
+        SplitBrainMergeEntryView merging = entryWithGivenPropertyAndValue(1, MERGING);
+
+        assertEquals(EXISTING, policy.merge(merging, existing));
+    }
+
+    @Test
+    public void merge_draw_mergingWins() {
+        SplitBrainMergeEntryView existing = entryWithGivenPropertyAndValue(1, EXISTING);
+        SplitBrainMergeEntryView merging = entryWithGivenPropertyAndValue(1, MERGING);
+
+        assertEquals(MERGING, policy.merge(merging, existing));
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void merge_mergingWins_sinceExistingIsNotExist() {
+        SplitBrainMergeEntryView existing = null;
+        SplitBrainMergeEntryView merging = entryWithGivenPropertyAndValue(1, MERGING);
+
+        assertEquals(MERGING, policy.merge(merging, existing));
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void merge_existingWins_sinceMergingIsNotExist() {
+        SplitBrainMergeEntryView existing = entryWithGivenPropertyAndValue(1, EXISTING);
+        SplitBrainMergeEntryView merging = null;
+
+        assertEquals(EXISTING, policy.merge(merging, existing));
+    }
+
+    private SplitBrainMergeEntryView entryWithGivenPropertyAndValue(long testedProperty, String value) {
+        SplitBrainMergeEntryView entryView = mock(SplitBrainMergeEntryView.class);
+        try {
+            if (policy instanceof HigherHitsMergePolicy) {
+                when(entryView.getHits()).thenReturn(testedProperty);
+            } else if (policy instanceof LatestAccessMergePolicy) {
+                when(entryView.getLastAccessTime()).thenReturn(testedProperty);
+            } else if (policy instanceof LatestUpdateMergePolicy) {
+                when(entryView.getLastUpdateTime()).thenReturn(testedProperty);
+            }
+            when(entryView.getValue()).thenReturn(value);
+            return entryView;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DiscardMergePolicyTest {
+
+    private static final String EXISTING = "EXISTING";
+    private static final String MERGING = "MERGING";
+
+    protected SplitBrainMergePolicy policy;
+
+    @Before
+    public void setup() {
+        policy = new DiscardMergePolicy();
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void merge_existingValueAbsent() {
+        SplitBrainMergeEntryView existing = null;
+        SplitBrainMergeEntryView merging = entryWithGivenValue(MERGING);
+
+        assertNull(policy.merge(merging, existing));
+    }
+
+    @Test
+    public void merge_existingValuePresent() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(EXISTING);
+        SplitBrainMergeEntryView merging = entryWithGivenValue(MERGING);
+
+        assertEquals(EXISTING, policy.merge(merging, existing));
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void merge_mergingNull() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(EXISTING);
+        SplitBrainMergeEntryView merging = null;
+
+        assertEquals(EXISTING, policy.merge(merging, existing));
+    }
+
+    @Test
+    public void merge_bothValuesNull() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(null);
+        SplitBrainMergeEntryView merging = entryWithGivenValue(null);
+
+        assertNull(policy.merge(merging, existing));
+    }
+
+    private SplitBrainMergeEntryView entryWithGivenValue(String value) {
+        SplitBrainMergeEntryView entryView = mock(SplitBrainMergeEntryView.class);
+        try {
+            when(entryView.getValue()).thenReturn(value);
+            return entryView;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi;
+package com.hazelcast.spi.merge;
 
-/**
- * An interface that can be implemented by SPI services that want to be able to resolve a split-brain.
- * <p>
- * When the two separate clusters merge, the {@link #prepareMergeRunnable()} method is called to return
- * a {@link Runnable}, that will merge the clusters.
- */
-public interface SplitBrainHandlerService {
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
-    /**
-     * When the two separate clusters merge (resolve a split-brain), this method is called to return
-     * a {@link Runnable}, that will merge the clusters.
-     *
-     * @return a {@link Runnable} that will merge the clusters
-     */
-    Runnable prepareMergeRunnable();
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class HigherHitsSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
+
+    @Override
+    protected SplitBrainMergePolicy createMergePolicy() {
+        return new HigherHitsMergePolicy();
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatestAccessSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
+
+    @Override
+    protected SplitBrainMergePolicy createMergePolicy() {
+        return new LatestAccessMergePolicy();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatestUpdateSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
+
+    @Override
+    protected SplitBrainMergePolicy createMergePolicy() {
+        return new LatestUpdateMergePolicy();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PassThroughMergePolicyTest {
+
+    private static final String EXISTING = "EXISTING";
+    private static final String MERGING = "MERGING";
+
+    protected SplitBrainMergePolicy policy;
+
+    @Before
+    public void setup() {
+        policy = new PassThroughMergePolicy();
+    }
+
+    @Test
+    public void merge_mergingNotNull() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(EXISTING);
+        SplitBrainMergeEntryView merging = entryWithGivenValue(MERGING);
+
+        assertEquals(MERGING, policy.merge(merging, existing));
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void merge_mergingNull() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(EXISTING);
+        SplitBrainMergeEntryView merging = null;
+
+        assertEquals(EXISTING, policy.merge(merging, existing));
+    }
+
+    private SplitBrainMergeEntryView entryWithGivenValue(String value) {
+        SplitBrainMergeEntryView entryView = mock(SplitBrainMergeEntryView.class);
+        try {
+            when(entryView.getValue()).thenReturn(value);
+            return entryView;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PutIfAbsentMergePolicyTest {
+
+    private static final String EXISTING = "EXISTING";
+    private static final String MERGING = "MERGING";
+
+    protected SplitBrainMergePolicy policy;
+
+    @Before
+    public void setup() {
+        policy = new PutIfAbsentMergePolicy();
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void merge_existingValueAbsent() {
+        SplitBrainMergeEntryView existing = null;
+        SplitBrainMergeEntryView merging = entryWithGivenValue(MERGING);
+
+        assertEquals(MERGING, policy.merge(merging, existing));
+    }
+
+    @Test
+    public void merge_existingValuePresent() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(EXISTING);
+        SplitBrainMergeEntryView merging = entryWithGivenValue(MERGING);
+
+        assertEquals(EXISTING, policy.merge(merging, existing));
+    }
+
+    @Test
+    public void merge_bothValuesNull() {
+        SplitBrainMergeEntryView existing = entryWithGivenValue(null);
+        SplitBrainMergeEntryView merging = entryWithGivenValue(null);
+
+        assertNull(policy.merge(merging, existing));
+    }
+
+    private SplitBrainMergeEntryView entryWithGivenValue(String value) {
+        SplitBrainMergeEntryView entryView = mock(SplitBrainMergeEntryView.class);
+        try {
+            when(entryView.getValue()).thenReturn(value);
+            return entryView;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProviderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SplitBrainMergePolicyProviderTest extends HazelcastTestSupport {
+
+    private SplitBrainMergePolicyProvider mergePolicyProvider;
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        mergePolicyProvider = new SplitBrainMergePolicyProvider(getNode(createHazelcastInstance()).getNodeEngine());
+    }
+
+    @Test
+    public void getMergePolicy_NotExistingMergePolicy() {
+        expected.expect(InvalidConfigurationException.class);
+        expected.expectCause(IsInstanceOf.any(ClassNotFoundException.class));
+        mergePolicyProvider.getMergePolicy("No such policy!");
+    }
+
+    @Test
+    public void getMergePolicy_NullPolicy() {
+        expected.expect(InvalidConfigurationException.class);
+        mergePolicyProvider.getMergePolicy(null);
+    }
+
+    @Test
+    public void getMergePolicy_HigherHitsMapCachePolicy_byFullyQualifiedName() {
+        assertMergePolicyCorrectlyInitialised(HigherHitsMergePolicy.class.getName(), HigherHitsMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_HigherHitsMapCachePolicy_bySimpleName() {
+        assertMergePolicyCorrectlyInitialised(HigherHitsMergePolicy.class.getSimpleName(), HigherHitsMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_LatestAccessCacheMergePolicy_byFullyQualifiedName() {
+        assertMergePolicyCorrectlyInitialised(LatestAccessMergePolicy.class.getName(), LatestAccessMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_LatestAccessCacheMergePolicy_bySimpleName() {
+        assertMergePolicyCorrectlyInitialised(LatestAccessMergePolicy.class.getSimpleName(), LatestAccessMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_LatestUpdateMergePolicy_byFullyQualifiedName() {
+        assertMergePolicyCorrectlyInitialised(LatestUpdateMergePolicy.class.getName(), LatestUpdateMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_LatestUpdateMergePolicy_bySimpleName() {
+        assertMergePolicyCorrectlyInitialised(LatestUpdateMergePolicy.class.getSimpleName(), LatestUpdateMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_PassThroughCachePolicy_byFullyQualifiedName() {
+        assertMergePolicyCorrectlyInitialised(PassThroughMergePolicy.class.getName(), PassThroughMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_PassThroughCachePolicy_bySimpleName() {
+        assertMergePolicyCorrectlyInitialised(PassThroughMergePolicy.class.getSimpleName(), PassThroughMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_PutIfAbsentCacheMergePolicy_byFullyQualifiedName() {
+        assertMergePolicyCorrectlyInitialised(PutIfAbsentMergePolicy.class.getName(), PutIfAbsentMergePolicy.class);
+    }
+
+    @Test
+    public void getMergePolicy_PutIfAbsentCacheMergePolicy_bySimpleName() {
+        assertMergePolicyCorrectlyInitialised(PutIfAbsentMergePolicy.class.getSimpleName(), PutIfAbsentMergePolicy.class);
+    }
+
+    private void assertMergePolicyCorrectlyInitialised(String mergePolicyName,
+                                                       Class<? extends SplitBrainMergePolicy> expectedMergePolicyClass) {
+        SplitBrainMergePolicy mergePolicy = mergePolicyProvider.getMergePolicy(mergePolicyName);
+
+        assertNotNull(mergePolicy);
+        assertEquals(expectedMergePolicyClass, mergePolicy.getClass());
+    }
+}


### PR DESCRIPTION
These are all split-brain healing related interfaces. They are in the `com.hazelcast.spi` package (without the `StatisticsAwareService` of course):
![screenshot from 2017-12-15 12-14-08](https://user-images.githubusercontent.com/4196298/34040373-ad968460-e193-11e7-83c8-5a4800b09582.png)

These are some common implementations. They are in the `com.hazelcast.spi.merge` package:
![screenshot from 2017-12-15 12-11-41](https://user-images.githubusercontent.com/4196298/34040375-afc16f98-e193-11e7-8fb0-7f3286a7419c.png)
