### PR TITLE
remove redundant code in clientClusterService

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -213,16 +213,13 @@ public class ClientClusterServiceImpl implements ClientClusterService {
     void handleMembershipEvent(MembershipEvent event) {
         synchronized (initialMembershipListenerMutex) {
             Member member = event.getMember();
+            LinkedHashMap<Address, Member> newMap = new LinkedHashMap<Address, Member>(members.get());
             if (event.getEventType() == MembershipEvent.MEMBER_ADDED) {
-                LinkedHashMap<Address, Member> newMap = new LinkedHashMap<Address, Member>(members.get());
                 newMap.put(member.getAddress(), member);
-                members.set(Collections.unmodifiableMap(newMap));
             } else {
-                LinkedHashMap<Address, Member> newMap = new LinkedHashMap<Address, Member>(members.get());
                 newMap.remove(member.getAddress());
-                members.set(Collections.unmodifiableMap(newMap));
             }
-
+            members.set(Collections.unmodifiableMap(newMap));
             fireMembershipEvent(event);
         }
     }


### PR DESCRIPTION
This pr just removes some redundant code, it doesnt change the behavior of the code.