### PR TITLE
Simplified Operation Continuation : Basic Infrastructure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -24,29 +24,21 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
+
+import static com.hazelcast.spi.CallStatus.OFFLOADED;
 
 abstract class AbstractCallableTaskOperation extends Operation implements IdentifiedDataSerializable {
 
     protected String name;
     protected String uuid;
-    protected transient Callable callable;
     private Data callableData;
-
-    // transient.
-    // We are cheating a bit here. The idea is the following. An AbstractCallableTaskOperation is always going to be send to a
-    // partition, but the operation doesn't send a response directly and therefor when a WrongTargetException is thronw (e.g.
-    // partition has moved) the operation is not retried. To prevent this from happening, we say that we return a response until
-    // the before-run method is called. Then we know we are going to be offloaded to a different thread and we are not returning
-    // a response immediately. So then we switch to 'returnsResponse = false'.
-    private boolean returnsResponse = true;
 
     public AbstractCallableTaskOperation() {
     }
@@ -58,12 +50,17 @@ abstract class AbstractCallableTaskOperation extends Operation implements Identi
     }
 
     @Override
-    public final void beforeRun() throws Exception {
-        returnsResponse = false;
+    public final CallStatus call() {
+        Callable callable = loadCallable();
+        DistributedExecutorService service = getService();
+        service.execute(name, uuid, callable, this);
+        return OFFLOADED;
+    }
 
-        callable = getCallable();
+    private Callable loadCallable() {
         ManagedContext managedContext = getManagedContext();
 
+        Callable callable = getNodeEngine().toObject(callableData);
         if (callable instanceof RunnableAdapter) {
             RunnableAdapter adapter = (RunnableAdapter) callable;
             Runnable runnable = (Runnable) managedContext.initialize(adapter.getRunnable());
@@ -71,36 +68,13 @@ abstract class AbstractCallableTaskOperation extends Operation implements Identi
         } else {
             callable = (Callable) managedContext.initialize(callable);
         }
-    }
-
-    /**
-     * since this operation handles responses in an async way, we need to handle serialization exceptions too
-     * @return
-     */
-    private Callable getCallable() {
-        try {
-            return getNodeEngine().toObject(callableData);
-        } catch (HazelcastSerializationException e) {
-            sendResponse(e);
-            throw ExceptionUtil.rethrow(e);
-        }
+        return callable;
     }
 
     private ManagedContext getManagedContext() {
         HazelcastInstanceImpl hazelcastInstance = (HazelcastInstanceImpl) getNodeEngine().getHazelcastInstance();
         SerializationService serializationService = hazelcastInstance.getSerializationService();
         return serializationService.getManagedContext();
-    }
-
-    @Override
-    public final void run() throws Exception {
-        DistributedExecutorService service = getService();
-        service.execute(name, uuid, callable, this);
-    }
-
-    @Override
-    public final boolean returnsResponse() {
-        return returnsResponse;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.BlockingOperation;
+import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
@@ -49,6 +50,9 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.core.Offloadable.NO_OFFLOADING;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
+import static com.hazelcast.spi.CallStatus.DONE_RESPONSE;
+import static com.hazelcast.spi.CallStatus.OFFLOADED;
+import static com.hazelcast.spi.CallStatus.WAIT;
 import static com.hazelcast.spi.ExecutionService.OFFLOADABLE_EXECUTOR;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
@@ -170,11 +174,17 @@ public class EntryOperation extends MutatingKeyBasedMapOperation implements Back
     }
 
     @Override
-    public void run() {
+    public CallStatus call() {
+        if (shouldWait()) {
+            return WAIT;
+        }
+
         if (offloading) {
             runOffloaded();
+            return OFFLOADED;
         } else {
             runVanilla();
+            return DONE_RESPONSE;
         }
     }
 
@@ -367,29 +377,6 @@ public class EntryOperation extends MutatingKeyBasedMapOperation implements Back
         updateAndUnlock(null, null, null, caller, threadId, result, now);
     }
 
-    @Override
-    public void onExecutionFailure(Throwable e) {
-        if (offloading) {
-            // This is required since if the returnsResponse() method returns false there won't be any response sent
-            // to the invoking party - this means that the operation won't be retried if the exception is instanceof
-            // HazelcastRetryableException
-            sendResponse(e);
-        } else {
-            super.onExecutionFailure(e);
-        }
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        if (offloading) {
-            // This has to be false, since the operation uses the deferred-response mechanism.
-            // This method returns false, but the response will be send later on using the response handler
-            return false;
-        } else {
-            return super.returnsResponse();
-        }
-    }
-
     private void runVanilla() {
         response = operator(this, entryProcessor)
                 .operateOnKey(dataKey)
@@ -437,26 +424,17 @@ public class EntryOperation extends MutatingKeyBasedMapOperation implements Back
 
     @Override
     public Object getResponse() {
-        if (offloading) {
-            return null;
-        }
         return response;
     }
 
     @Override
     public Operation getBackupOperation() {
-        if (offloading) {
-            return null;
-        }
         EntryBackupProcessor backupProcessor = entryProcessor.getBackupProcessor();
         return backupProcessor != null ? new EntryBackupOperation(name, dataKey, backupProcessor) : null;
     }
 
     @Override
     public boolean shouldBackup() {
-        if (offloading) {
-            return false;
-        }
         return mapContainer.getTotalBackupCount() > 0 && entryProcessor.getBackupProcessor() != null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/CallStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CallStatus.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * The result of an {@link Operation#call()}.
+ *
+ * Using the CallStatus the operation can control how the system will deal with the operation after it is executed. For example
+ * when the CallStatus is {@link CallStatus#DONE_RESPONSE}, a response can be send to the caller. But it also allows for
+ * different behavior where no response is available yet e.g. when an operation gets offloaded.
+ *
+ * <h1>CallStatus doesn't need ot be enum</h1>
+ * CallStatus is currently an enumeration. But if for whatever reason state needs to be returned, we can easily convert this
+ * enumeration to a regular object like e.g. java https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html.
+ *
+ * So you can have a call status class and if e.g. an operation that requires interleaving, a new Interleaving (subclass of
+ * CallStatus) can be returned containing all the state for that interleaving.
+ *
+ * The same can be done for Blocking operations. Currently we just return WAIT, but this can easily be modified by creating a new
+ * Wait (subclass of CallStatus) containing the wait key or whatever else is needed.
+ *
+ * It is very likely that the CallStatus is going to be converted to regular classes/object with the introduction of the
+ * 'Offloaded' which is part of phase 2 for the Operation continuations.
+ *
+ * <h1>Future additions</h1>
+ * In the future we can add more values to this enumeration, for example 'YIELD' for batching operations that wants to
+ * release the operation thread so that other operations can be interleaved.
+ */
+public enum CallStatus {
+
+    /**
+     * Signals that the Operation is done running and that a response is ready to be returned. Most of the normal operations
+     * like IAtomicLong.get will fall in this category.
+     */
+    DONE_RESPONSE,
+
+    /**
+     * Signals that the Operation is done running, but no response will be returned. Most of the regular operations like map.get
+     * will return a response, but there are also fire and forget operations (lot of cluster operations) that don't return a
+     * response.
+     */
+    DONE_VOID,
+
+    /**
+     * Indicates that the call could not complete because waiting is required. E.g. a queue.take on an empty queue. This can
+     * only be returned by BlockingOperations.
+     */
+    WAIT,
+
+    /**
+     * Signals that the Operation has been offloaded e.g. an EntryProcessor. And therefor no response is available when the
+     * operation is executed. Only at a later time a response is ready and it is up to the offload functionality to determine
+     * how to deal with that. It could be that a response is send using the original operation handler, but it could also
+     * be that the operation will be rescheduled on an operation thread (a real continuation).
+     */
+    OFFLOADED
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -31,9 +31,13 @@ import com.hazelcast.spi.properties.GroupProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.logging.Level;
 
+import static com.hazelcast.spi.CallStatus.DONE_RESPONSE;
+import static com.hazelcast.spi.CallStatus.DONE_VOID;
+import static com.hazelcast.spi.CallStatus.WAIT;
 import static com.hazelcast.spi.ExceptionAction.RETRY_INVOCATION;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.util.EmptyStatement.ignore;
@@ -97,7 +101,46 @@ public abstract class Operation implements DataSerializable {
     }
 
     // runs after wait-support, supposed to do actual operation
-    public abstract void run() throws Exception;
+    public void run() throws Exception {
+    }
+
+    /**
+     * Call the operation and returns the CallStatus.
+     *
+     * An Operation should either implement call or run; not both. If run is implemented, then the system remains backwards
+     * compatible to prevent making massive code changes while adding this feature.
+     *
+     * In the future all {@link #run()} methods will be replaced by call methods.
+     *
+     * The call method looks very much like the {@link #run()} method and it is very close to {@link Runnable#run()} and
+     * {@link Callable#call()}.
+     *
+     * The main difference between a run and call, is that the returned CallStatus from the call can tell something about the
+     * actual execution. For example it could tell that some waiting is required in case of a {@link BlockingOperation}.
+     * Or that the actual execution the work is offloaded to some executor in case of an {@link com.hazelcast.core.Offloadable}
+     * {@link com.hazelcast.map.impl.operation.EntryOperation}.
+     *
+     * In the future new types of CallStatus are expected to be added, e.g. for interleaving.
+     *
+     * In the future it is very likely that for regular Operation that want to return a concrete response, the
+     * actual response can be returned directly. In this case we'll change the return type to {@link Object} to
+     * prevent forcing the response to be wrapped in a {@link CallStatus#DONE_RESPONSE}  monad since that would force additional
+     * litter to be created.
+     *
+     * @return the CallStatus.
+     * @throws Exception if something failed while executing 'call'.
+     */
+    public CallStatus call() throws Exception {
+        if (this instanceof BlockingOperation) {
+            BlockingOperation blockingOperation = (BlockingOperation) this;
+            if (blockingOperation.shouldWait()) {
+                return WAIT;
+            }
+        }
+
+        run();
+        return returnsResponse() ? DONE_RESPONSE : DONE_VOID;
+    }
 
     // runs after backups, before wait-notify
     public void afterRun() throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -39,6 +39,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.spi.BlockingOperation;
+import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
@@ -187,19 +188,50 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
             op.beforeRun();
 
-            if (waitingNeeded(op)) {
-                return;
-            }
-
-            op.run();
-            handleResponse(op);
-            afterRun(op);
+            call(op);
         } catch (Throwable e) {
             handleOperationError(op, e);
         } finally {
             if (publishCurrentTask) {
                 currentTask = null;
             }
+        }
+    }
+
+    private void call(Operation op) throws Exception {
+        CallStatus callStatus = op.call();
+
+        switch (callStatus) {
+            case DONE_RESPONSE:
+                handleResponse(op);
+                afterRun(op);
+                break;
+            case DONE_VOID:
+                // todo: currently there is no difference between DONE_VOID and OFFLOADED
+                op.afterRun();
+                break;
+            case OFFLOADED:
+                op.afterRun();
+                break;
+            case WAIT:
+                nodeEngine.getOperationParker().park((BlockingOperation) op);
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    private void handleResponse(Operation op) throws Exception {
+        int backupAcks = backupHandler.sendBackups(op);
+
+        try {
+            Object response = op.getResponse();
+            if (backupAcks > 0) {
+                response = new NormalResponse(response, op.getCallId(), backupAcks, op.isUrgent());
+            }
+            op.sendResponse(response);
+        } catch (ResponseAlreadySentException e) {
+            logOperationError(op, e);
         }
     }
 
@@ -245,19 +277,6 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         quorumService.ensureQuorumPresent(op);
     }
 
-    private boolean waitingNeeded(Operation op) {
-        if (!(op instanceof BlockingOperation)) {
-            return false;
-        }
-
-        BlockingOperation blockingOperation = (BlockingOperation) op;
-        if (blockingOperation.shouldWait()) {
-            nodeEngine.getOperationParker().park(blockingOperation);
-            return true;
-        }
-        return false;
-    }
-
     private boolean timeout(Operation op) {
         if (!operationService.isCallTimedOut(op)) {
             return false;
@@ -267,28 +286,6 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         return true;
     }
 
-    private void handleResponse(Operation op) throws Exception {
-        boolean returnsResponse = op.returnsResponse();
-        int backupAcks = backupHandler.sendBackups(op);
-
-        if (!returnsResponse) {
-            return;
-        }
-
-        sendResponse(op, backupAcks);
-    }
-
-    private void sendResponse(Operation op, int backupAcks) {
-        try {
-            Object response = op.getResponse();
-            if (backupAcks > 0) {
-                response = new NormalResponse(response, op.getCallId(), backupAcks, op.isUrgent());
-            }
-            op.sendResponse(response);
-        } catch (ResponseAlreadySentException e) {
-            logOperationError(op, e);
-        }
-    }
 
     private void afterRun(Operation op) {
         try {


### PR DESCRIPTION
Goal of this PR is to introduce the 'operation continuation' with the minimum number of changed files.

Introducing Operation continuation requires returning some information about the state of the execution e.g. if blocking is needed or the operation is offloaded. This would require a massive number of changes since the signature of the Operation.run needs to be modified. 

This PR introduces a new Operation.call method that can be overridden en can return this state. However, if this method isn't implemented, it forwards the call to the original Operation.run. This means that all the old code will keep working without modification and the new more advanced call method can be used when needed. 

The old methods will be deprecated so that in the future we'll get rid of this duplicate behavior. But for the time being makes integration of the operation continuation with the minimum number of changes possible.