### PR TITLE
Bug fix for ConsoleApp being called as MainClass instead of StartServer

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -89,7 +89,7 @@
                             <transformers>
                                 <transformer
                                         implementation="com.hazelcast.buildutils.HazelcastManifestTransformer">
-                                    <mainClass>com.hazelcast.console.ConsoleApp</mainClass>
+                                    <mainClass>com.hazelcast.core.server.StartServer</mainClass>
                                     <overrideInstructions>
                                         <Import-Package>
                                             sun.misc;resolution:=optional,


### PR DESCRIPTION
Fixed the value of MainClass in hazelcast-all/pom.xml. Hence, after the maven installation is done and jar is generated. When you run the jar, StartServer class is called instead of ConsoleApp. 

Fixes: https://github.com/hazelcast/hazelcast/issues/11655