### PR TITLE
 Fix checkMemberListVersionIncrementIsAllowed & MembershipUpdateTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -1018,12 +1018,7 @@ public class MembershipManager {
             throw new IllegalStateException("Cannot increment member list version since mastership claim is in progress!");
         }
 
-        if (!clusterService.getClusterVersion().isEqualTo(V3_10)) {
-            throw new IllegalStateException("Cannot increment member list version for cluster version: "
-                    + clusterService.getClusterVersion());
-        }
-
-        return true;
+        return clusterService.getClusterVersion().isEqualTo(V3_10);
     }
 
     public boolean verifySplitBrainMergeMemberListVersion(SplitBrainJoinMessage joinMessage) {


### PR DESCRIPTION
Fixed MembershipManager.checkMemberListVersionIncrementIsAllowed():
- Do not throw exception when cluster version is not 3.10, but return false instead. Throwing exception was too aggressive.

Fixed MembershipUpdateTest:
 - Registered service names were wrong. 
 - There was a @Repeat leftover.