### PR TITLE
Fix lock blocking operations interrupt tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -221,7 +221,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test(timeout = 60000)
     public void testLockInterruption() throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "5000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), String.valueOf(TimeUnit.SECONDS.toMillis(30)));
         final HazelcastInstance hz = createHazelcastInstance(config);
 
         final Lock lock = hz.getLock("testLockInterruption2");
@@ -239,7 +239,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         t.start();
         Thread.sleep(2000);
         t.interrupt();
-        assertOpenEventually("tryLock() is not interrupted!", latch, 30);
+        assertOpenEventually("tryLock() is not interrupted!", latch);
         lock.unlock();
         assertTrue("Could not acquire lock!", lock.tryLock());
     }
@@ -386,7 +386,6 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test
     public void testLockInterruptibly() throws Exception {
         Config config = new Config();
-        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "5000");
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         final HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
         final ILock lock = h1.getLock(randomString());
@@ -404,7 +403,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         t.start();
         sleepMillis(5000);
         t.interrupt();
-        assertOpenEventually(latch, 30);
+        assertOpenEventually(latch);
     }
 
     @Test


### PR DESCRIPTION
The tests were relying on the thread blocking on a lock operation to
throw an InterruptedException when the thread is interrupted. This only
happens if the operation is retried since the retry logic will check for
the interrupt flag. To simulate a retry, the
OPERATION_CALL_TIMEOUT_MILLIS was lowered to 5 seconds but this also
lowers the heartbeat timeout as the two are coupled. If there is a slow
environment, the blocking operation will be completed with a heartbeat
timeout. The fix increases the timeout - this will increase the test
duration but also make it more resilient to slow environments.

Fixes: https://github.com/hazelcast/hazelcast/issues/8645