### PR TITLE
Skip migrating partitions when collecting HD query results

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
@@ -108,7 +108,7 @@ public class PartitionAwareCallableBatchingRunnable implements Runnable {
                 break;
             }
             PartitionAwareCallable task = factory.create();
-            if (partition.isLocal()) {
+            if (partition.isLocal() && !partition.isMigrating()) {
                 try {
                     results.add(task.call(currentPartitionId));
                 } catch (Exception ex) {


### PR DESCRIPTION
The results were collected by iterating through all partitions for which
a partition thread is responsible and for which the node was the owner.
This did not check if the migration was still being migrated and the
index may not have been filled with entries yet.
The fix adds the check which makes the query engine get the results
later with a partition operation specific to that partition.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1427