### PR TITLE
fix testClientListener_withShuttingDownOwnerMember

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -501,7 +501,7 @@ public class ClientServiceTest extends ClientTestSupport {
     }
 
     @Test
-    public void testClientListener_withShuttingDownOwnerMember() {
+    public void testClientListener_withShuttingDownOwnerMember() throws InterruptedException {
         Config config = new Config();
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger atomicInteger = new AtomicInteger();
@@ -514,6 +514,7 @@ public class ClientServiceTest extends ClientTestSupport {
 
             @Override
             public void clientDisconnected(Client client) {
+                atomicInteger.incrementAndGet();
             }
         });
 
@@ -522,6 +523,7 @@ public class ClientServiceTest extends ClientTestSupport {
         //first member is owner connection
         hazelcastFactory.newHazelcastClient();
 
+        config.setProperty(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
         hazelcastFactory.newHazelcastInstance(config);
         //make sure connected to second one before proceeding
         assertOpenEventually(latch);


### PR DESCRIPTION
Delay client endpoint removal so that test will not fail
in a slow environment.

fixes https://github.com/hazelcast/hazelcast/issues/11737