### PR TITLE
[forward-port] fix for redundant partition migration when mancenter is configured

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -285,7 +285,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         }
 
         Address thisAddress = nodeEngine.getClusterService().getThisAddress();
-        IPartition partition = nodeEngine.getPartitionService().getPartition(partitionId);
+        IPartition partition = nodeEngine.getPartitionService().getPartition(partitionId, false);
 
         Address owner = partition.getOwnerOrNull();
         if (thisAddress.equals(owner)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -101,14 +101,12 @@ public class LocalMapStatsProvider {
 
         PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
         for (PartitionContainer partitionContainer : partitionContainers) {
-            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
             Collection<RecordStore> allRecordStores = partitionContainer.getAllRecordStores();
-
             for (RecordStore recordStore : allRecordStores) {
                 if (!isStatsCalculationEnabledFor(recordStore)) {
                     continue;
                 }
-
+                IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId(), false);
                 if (partition.isLocal()) {
                     addPrimaryStatsOf(recordStore, getOrCreateOnDemandStats(statsPerMap, recordStore));
                 } else {
@@ -116,7 +114,6 @@ public class LocalMapStatsProvider {
                 }
             }
         }
-
 
         // reuse same HashMap to return calculated LocalMapStats.
         for (Object object : statsPerMap.entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -350,7 +350,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
         Address thisAddress = clusterService.getThisAddress();
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
-            IPartition partition = nodeEngine.getPartitionService().getPartition(i);
+            IPartition partition = nodeEngine.getPartitionService().getPartition(i, false);
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
             MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer(name);
             if (multiMapContainer == null) {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsProviderTest.java
@@ -1,0 +1,40 @@
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalMapStatsProviderTest extends HazelcastTestSupport {
+
+    //https://github.com/hazelcast/hazelcast/issues/11598
+    @Test
+    public void testRedundantPartitionMigrationWhenManCenterConfigured() {
+        Config config = new Config();
+        config.getManagementCenterConfig().setEnabled(true);
+        config.getManagementCenterConfig().setUrl(format("http://localhost:%d%s/", 8085, "/mancenter"));
+
+        //don't need start management center, just configure it
+        final HazelcastInstance instance = createHazelcastInstance(config);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                //check partition migration triggered or not
+                int partitionStateVersion = getNode(instance).getPartitionService().getPartitionStateVersion();
+                assertEquals(0, partitionStateVersion);
+            }
+        }, 5);
+    }
+}


### PR DESCRIPTION
maintenance PR --> https://github.com/hazelcast/hazelcast/pull/11828