### PR TITLE
Fix member missing attributes issue after lite member promotion

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.operations.MemberAttributeChangedOp;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -219,7 +220,7 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
         try {
             for (Member member : nodeEngine.getClusterService().getMembers()) {
                 if (!member.localMember()) {
-                    os.send(operation, member.getAddress());
+                    os.invokeOnTarget(ClusterServiceImpl.SERVICE_NAME, operation, member.getAddress());
                 } else {
                     os.execute(operation);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -621,15 +621,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     public void updateMemberAttribute(String uuid, MemberAttributeOperationType operationType, String key, Object value) {
         lock.lock();
         try {
-            for (MemberImpl member : membershipManager.getMembers()) {
-                if (member.getUuid().equals(uuid)) {
-                    if (!member.equals(getLocalMember())) {
-                        member.updateAttribute(operationType, key, value);
-                    }
-                    sendMemberAttributeEvent(member, operationType, key, value);
-                    break;
-                }
+            MemberImpl member = membershipManager.getMember(uuid);
+            if (!member.equals(getLocalMember())) {
+                member.updateAttribute(operationType, key, value);
             }
+            sendMemberAttributeEvent(member, operationType, key, value);
         } finally {
             lock.unlock();
         }
@@ -1134,12 +1130,20 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 throw new IllegalStateException("Cannot promote to data member! Previous master was: " + master.getAddress()
                     + ", Current master is: " + getMasterAddress());
             }
-
-            localMember = new MemberImpl(member.getAddress(), member.getVersion(), true, member.getUuid(),
-                    member.getAttributes(), false, node.hazelcastInstance);
         } finally {
             lock.unlock();
         }
+    }
+
+    MemberImpl promoteAndGetLocalMember() {
+        MemberImpl member = getLocalMember();
+        assert member.isLiteMember() : "Local member is not lite member!";
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+
+        localMember = new MemberImpl(member.getAddress(), member.getVersion(), true, member.getUuid(),
+                member.getAttributes(), false, node.hazelcastInstance);
+        node.loggingService.setThisMember(localMember);
+        return localMember;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -60,6 +60,7 @@ import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
@@ -327,13 +328,61 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
 
     @Test(expected = UnsupportedOperationException.class)
     // RU_COMPAT_WITH_3_8
-    public void liteMemberPromotion_notSupported_beforeV39()  {
+    public void liteMemberPromotion_notSupported_beforeV39() {
         System.setProperty(BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION, Version.of(3, 8).toString());
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
         HazelcastInstance hz = factory.newHazelcastInstance(new Config().setLiteMember(true));
 
         hz.getCluster().promoteLocalLiteMember();
+    }
+
+    @Test
+    public void masterMemberAttributes_arePreserved_afterPromotion() throws Exception {
+        memberAttributes_arePreserved_afterPromotion(true);
+    }
+
+    @Test
+    public void normalMemberAttributes_arePreserved_afterPromotion() throws Exception {
+        memberAttributes_arePreserved_afterPromotion(false);
+    }
+
+    private void memberAttributes_arePreserved_afterPromotion(boolean isMaster) throws Exception {
+        final String attribute1 = "attr1";
+        final String attribute2 = "attr2";
+        final String attributeValue = "value";
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = new HazelcastInstance[2];
+        instances[0] = factory.newHazelcastInstance(new Config().setLiteMember(isMaster));
+        instances[1] = factory.newHazelcastInstance(new Config().setLiteMember(!isMaster));
+
+        HazelcastInstance hz = instances[isMaster ? 0 : 1];
+
+        // Get local member and SET attribute BEFORE promotion
+        Member localMember = hz.getCluster().getLocalMember();
+        localMember.setStringAttribute(attribute1, attributeValue);
+        assertEquals(attributeValue, localMember.getStringAttribute(attribute1));
+
+        // Promote local Lite member
+        hz.getCluster().promoteLocalLiteMember();
+
+        // Get local member and SET attribute AFTER promotion
+        localMember = hz.getCluster().getLocalMember();
+        localMember.setStringAttribute(attribute2, attributeValue);
+
+        // Check attributes from localMember
+        assertEquals(attributeValue, localMember.getStringAttribute(attribute1));
+        assertEquals(attributeValue, localMember.getStringAttribute(attribute2));
+
+        // Check attributes from member list
+        for (Member member : hz.getCluster().getMembers()) {
+            if (member.localMember()) {
+                assertEquals(attributeValue, member.getStringAttribute(attribute1));
+                assertEquals(attributeValue, member.getStringAttribute(attribute2));
+                break;
+            }
+        }
     }
 
     private void assertPromotionInvocationStarted(HazelcastInstance instance) {


### PR DESCRIPTION
Local member and the member instance from the cluster member-list
should have the same attributes after lite member promotion.

Fixes https://github.com/hazelcast/hazelcast/issues/11720

Backport of https://github.com/hazelcast/hazelcast/pull/11849