### PR TITLE
Fix MulticastJoiner split-brain handler message broadcasting

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.internal.cluster.impl.operations.JoinMastershipClaimOp;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -513,9 +514,10 @@ public class TcpIpJoiner extends AbstractJoiner {
         if (possibleAddresses.isEmpty()) {
             return;
         }
+        SplitBrainJoinMessage request = node.createSplitBrainJoinMessage();
         for (Address address : possibleAddresses) {
-            SplitBrainJoinMessage request = sendSplitBrainJoinMessageAndCheckResponse(address);
-            if (request != null) {
+            SplitBrainMergeCheckResult result = sendSplitBrainJoinMessageAndCheckResponse(address, request);
+            if (result == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                 logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
                 setTargetAddress(address);
                 startClusterMerge(address, request.getMemberListVersion());


### PR DESCRIPTION
MulticastJoiner split-brain handler should broadcast a new split brain message,
only when it detects other side should join, not on every merge interval.

Otherwise, when clusters are not able to merge, multicast messages are exchanged
between them continuously ignoring the delay.

This problem was introduced by https://github.com/hazelcast/hazelcast/pull/10378

Fixes https://github.com/hazelcast/hazelcast/issues/11836