### PR TITLE
Fix MulticastJoiner split-brain handler message broadcasting

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.internal.cluster.impl.operations.JoinMastershipClaimOp;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -515,7 +516,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         }
         for (Address address : possibleAddresses) {
             SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
-            if (shouldMerge(response)) {
+            if (shouldMerge(response) == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                 logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
                 setTargetAddress(address);
                 startClusterMerge(address);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.internal.cluster.impl.operations.MergeClustersOp;
 import com.hazelcast.internal.cluster.impl.operations.SplitBrainMergeValidationOp;
 import com.hazelcast.logging.ILogger;
@@ -215,34 +216,38 @@ public abstract class AbstractJoiner implements Joiner {
                 + node.getProperties().getMillis(GroupProperty.MAX_WAIT_SECONDS_BEFORE_JOIN);
     }
 
+    /**
+     * Checks split-brain join response and returns the merge check result whether or not this node should
+     * join to the target.
+     */
     @SuppressWarnings({"checkstyle:returncount", "checkstyle:npathcomplexity"})
-    protected boolean shouldMerge(SplitBrainJoinMessage joinMessage) {
+    protected SplitBrainMergeCheckResult shouldMerge(SplitBrainJoinMessage joinMessage) {
         if (logger.isFineEnabled()) {
             logger.fine("Should merge to: " + joinMessage);
         }
 
         if (joinMessage == null) {
-            return false;
+            return SplitBrainMergeCheckResult.CANNOT_MERGE;
         }
 
         if (!checkValidSplitBrainJoinMessage(joinMessage)) {
-            return false;
+            return SplitBrainMergeCheckResult.CANNOT_MERGE;
         }
 
         if (!checkCompatibleSplitBrainJoinMessage(joinMessage)) {
-            return false;
+            return SplitBrainMergeCheckResult.CANNOT_MERGE;
         }
 
         if (!checkMergeTargetIsNotMember(joinMessage)) {
-            return false;
+            return SplitBrainMergeCheckResult.CANNOT_MERGE;
         }
 
         if (!checkClusterStateAllowsJoinBeforeMerge(joinMessage)) {
-            return false;
+            return SplitBrainMergeCheckResult.CANNOT_MERGE;
         }
 
         if (!checkMembershipIntersectionSetEmpty(joinMessage)) {
-            return false;
+            return SplitBrainMergeCheckResult.CANNOT_MERGE;
         }
 
         int targetDataMemberCount = joinMessage.getDataMemberCount();
@@ -252,26 +257,26 @@ public abstract class AbstractJoiner implements Joiner {
             logger.info("We are merging to " + joinMessage.getAddress()
                     + ", because their data member count is bigger than ours ["
                     + (targetDataMemberCount + " > " + currentDataMemberCount) + ']');
-            return true;
+            return SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE;
         }
 
         if (targetDataMemberCount < currentDataMemberCount) {
             logger.info(joinMessage.getAddress() + " should merge to us "
                     + ", because our data member count is bigger than theirs ["
                     + (currentDataMemberCount + " > " + targetDataMemberCount) + ']');
-            return false;
+            return SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
         }
 
         // targetDataMemberCount == currentDataMemberCount
         if (shouldMergeTo(node.getThisAddress(), joinMessage.getAddress())) {
             logger.info("We are merging to " + joinMessage.getAddress()
                     + ", both have the same data member count: " + currentDataMemberCount);
-            return true;
+            return SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE;
         }
 
         logger.info(joinMessage.getAddress() + " should merge to us "
                 + ", both have the same data member count: " + currentDataMemberCount);
-        return false;
+        return SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
     }
 
     private boolean checkValidSplitBrainJoinMessage(SplitBrainJoinMessage joinMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -34,6 +34,21 @@ import static com.hazelcast.internal.cluster.Versions.V3_9;
  */
 public class SplitBrainJoinMessage extends JoinMessage implements Versioned {
 
+    public enum SplitBrainMergeCheckResult {
+        /**
+         * Denotes that the two endpoints of the SplitBrainJoinMessage cannot merge to each other
+         */
+        CANNOT_MERGE,
+        /**
+         * Denotes that the local node should merge to the other endpoint of the SplitBrainJoinMessage
+         */
+        LOCAL_NODE_SHOULD_MERGE,
+        /**
+         * Denotes that the remote node that sent the SplitBrainJoinMessage should merge
+         */
+        REMOTE_NODE_SHOULD_MERGE
+    }
+
     private Version clusterVersion;
 
     private int memberListVersion;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -19,6 +19,7 @@ package com.hazelcast.test.mocknetwork;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
 
@@ -153,8 +154,9 @@ class MockJoiner extends AbstractJoiner {
         possibleAddresses.removeAll(node.getClusterService().getMemberAddresses());
         for (Address address : possibleAddresses) {
             SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
-            if (shouldMerge(response)) {
+            if (shouldMerge(response) == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                 startClusterMerge(address);
+                return;
             }
         }
     }


### PR DESCRIPTION
MulticastJoiner split-brain handler should broadcast a new split brain message,
only when it detects other side should join, not on every merge interval.

Otherwise, when clusters are not able to merge, multicast messages are exchanged
between them continuously ignoring the delay.

This problem was introduced by https://github.com/hazelcast/hazelcast/pull/10378

Backport of https://github.com/hazelcast/hazelcast/pull/11852

Fixes https://github.com/hazelcast/hazelcast/issues/11836