### PR TITLE
Refactor split-brain merge check & cluster state change logic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
@@ -51,7 +51,6 @@ public class SplitBrainMergeValidationOp extends AbstractJoinOperation {
 
     @Override
     public void run() {
-        ClusterServiceImpl service = getService();
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         Node node = nodeEngine.getNode();
 
@@ -65,60 +64,13 @@ public class SplitBrainMergeValidationOp extends AbstractJoinOperation {
 
         if (request != null) {
             ILogger logger = getLogger();
-            try {
-                if (service.getClusterJoinManager().validateJoinMessage(request)) {
-                    // Validate other cluster's major.minor version is same as this cluster.
-                    // This way we ensure that all nodes of both clusters will be able to operate normally
-                    // in the unified cluster which will be at the same cluster version as the current subclusters.
-                    // If we only validated node codebase versions of master nodes, then we might end up with a
-                    // unified cluster but some members might be kicked out due to incompatibility. For example
-                    // assuming a 3.8.0 cluster with 2 nodes at codebase versions 3.8.0 & 3.9.0 (master) and another
-                    // cluster with 3x3.9.0 nodes at cluster version 3.9.0: if we only validated on master nodes' codebase
-                    // version, we would find them to be compatible and let the smaller cluster merge towards the bigger one.
-                    // However we would end up with a cluster at cluster version 3.9.0 (including 4x3.9.0 nodes) and the
-                    // 3.8.0-codebase node would be kicked out of the cluster. To enable the kicked-out node to join again
-                    // the cluster, the user would be forced to upgrade the member to 3.9.0 codebase version.
-                    // The implicit change of cluster version ("sneaky upgrade") and the change in membership would be a
-                    // surprise to users and may cause unexpected issues.
-                    if (service.getClusterVersion().equals(request.getClusterVersion())
-                            && (service.getClusterJoinManager().shouldMerge(request) == REMOTE_NODE_SHOULD_MERGE)
-                            && service.getMembershipManager().verifySplitBrainMergeMemberListVersion(request)) {
-                        response = node.createSplitBrainJoinMessage();
-                    } else {
-                        logger.info("Join check from " + getCallerAddress() + " failed validation due to incompatible version,"
-                                + "remote cluster version is " + request.getClusterVersion() + ", this cluster is "
-                                + service.getClusterVersion());
-                    }
-                }
-                if (logger.isFineEnabled()) {
-                    logger.fine("Returning " + response + " to " + getCallerAddress());
-                }
-            } catch (Exception e) {
-                if (logger.isFineEnabled()) {
-                    logger.fine("Could not validate split-brain join message! -> " + e.getMessage());
-                }
+            if (checkSplitBrainJoinMessage()) {
+                response = node.createSplitBrainJoinMessage();
             }
-        }
-    }
 
-    private boolean masterCheck() {
-        ILogger logger = getLogger();
-        ClusterServiceImpl service = getService();
-
-        if (service.isMaster()) {
-            Member existingMember = service.getMembershipManager().getMember(request.getAddress(), request.getUuid());
-            if (existingMember != null) {
-                logger.info("Removing " + suspectedCaller + ", since it thinks it's already split from this cluster "
-                        + "and looking to merge.");
-                suspectedCaller = existingMember;
+            if (logger.isFineEnabled()) {
+                logger.fine("Returning " + response + " to " + getCallerAddress());
             }
-            return true;
-        } else {
-            // ping master to check if it's still valid
-            service.getClusterHeartbeatManager().sendMasterConfirmation();
-            logger.info("Ignoring join check from " + getCallerAddress()
-                    + ", because this node is not master...");
-            return false;
         }
     }
 
@@ -155,6 +107,68 @@ public class SplitBrainMergeValidationOp extends AbstractJoinOperation {
         }
 
         return true;
+    }
+
+    private boolean masterCheck() {
+        ILogger logger = getLogger();
+        ClusterServiceImpl service = getService();
+
+        if (service.isMaster()) {
+            Member existingMember = service.getMembershipManager().getMember(request.getAddress(), request.getUuid());
+            if (existingMember != null) {
+                logger.info("Removing " + suspectedCaller + ", since it thinks it's already split from this cluster "
+                        + "and looking to merge.");
+                suspectedCaller = existingMember;
+            }
+            return true;
+        } else {
+            // ping master to check if it's still valid
+            service.getClusterHeartbeatManager().sendMasterConfirmation();
+            logger.info("Ignoring join check from " + getCallerAddress()
+                    + ", because this node is not master...");
+            return false;
+        }
+    }
+
+    private boolean checkSplitBrainJoinMessage() {
+        ClusterServiceImpl service = getService();
+        ILogger logger = getLogger();
+        try {
+            if (!service.getClusterJoinManager().validateJoinMessage(request)) {
+                // Validate other cluster's major.minor version is same as this cluster.
+                // This way we ensure that all nodes of both clusters will be able to operate normally
+                // in the unified cluster which will be at the same cluster version as the current subclusters.
+                // If we only validated node codebase versions of master nodes, then we might end up with a
+                // unified cluster but some members might be kicked out due to incompatibility. For example
+                // assuming a 3.8.0 cluster with 2 nodes at codebase versions 3.8.0 & 3.9.0 (master) and another
+                // cluster with 3x3.9.0 nodes at cluster version 3.9.0: if we only validated on master nodes' codebase
+                // version, we would find them to be compatible and let the smaller cluster merge towards the bigger one.
+                // However we would end up with a cluster at cluster version 3.9.0 (including 4x3.9.0 nodes) and the
+                // 3.8.0-codebase node would be kicked out of the cluster. To enable the kicked-out node to join again
+                // the cluster, the user would be forced to upgrade the member to 3.9.0 codebase version.
+                // The implicit change of cluster version ("sneaky upgrade") and the change in membership would be a
+                // surprise to users and may cause unexpected issues.
+                return false;
+            }
+
+            if (!service.getClusterVersion().equals(request.getClusterVersion())) {
+                logger.info("Join check from " + getCallerAddress() + " failed validation due to incompatible version,"
+                        + "remote cluster version is " + request.getClusterVersion() + ", this cluster is "
+                        + service.getClusterVersion());
+                return false;
+            }
+
+            if (service.getClusterJoinManager().shouldMerge(request) != REMOTE_NODE_SHOULD_MERGE) {
+                return false;
+            }
+
+            return service.getMembershipManager().verifySplitBrainMergeMemberListVersion(request);
+        } catch (Exception e) {
+            if (logger.isFineEnabled()) {
+                logger.fine("Could not validate split-brain join message! -> " + e.getMessage());
+            }
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
* If the split-brain will not be done because of member list versions, do not print "incompatible cluster version" message
* Eliminate unnecessary 1 second delay after successful cluster state change