### PR TITLE
Separate ParallelTest from parallel method

### DIFF
--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -43,7 +43,7 @@
                 <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
                 <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
             </hz:properties>
-            <hz:network port="${cluster.port}" port-auto-increment="false">
+            <hz:network port="${cluster.port}" port-auto-increment="true">
                 <hz:join>
                     <hz:multicast enabled="false"
                                   multicast-group="224.2.2.3"

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -412,7 +412,7 @@ public class ClusterHeartbeatManager {
 
     /**
      * Checks the elapsed time from the last local heartbeat and compares it to the expected {@code intervalMillis}.
-     * The method will correct a number of clocks and timestamps based on this difference :
+     * The method will correct a number of clocks and timestamps based on this difference:
      * <ul>
      * <li>
      * set the local cluster time diff if the absolute diff is larger than {@link #CLOCK_JUMP_THRESHOLD} and

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -25,10 +25,9 @@ import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,8 +70,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class})
 public class MembershipFailureTest extends HazelcastTestSupport {
 
     @Parameterized.Parameters(name = "fd:{0}")
@@ -300,7 +299,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
                 .setProperty(HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
         HazelcastInstance master = newHazelcastInstance(config);
         HazelcastInstance slave1 = newHazelcastInstance(config);
-        final HazelcastInstance slave2 = newHazelcastInstance(config);
+        HazelcastInstance slave2 = newHazelcastInstance(config);
 
         assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelParametersRunnerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelParametersRunnerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import org.junit.runners.parameterized.ParametersRunnerFactory;
+
+/**
+ * {@link ParametersRunnerFactory} implementation which creates {@link HazelcastParallelClassRunner}
+ * to run test methods in parallel.
+ * <p>
+ * See {@link com.hazelcast.test package documentation} for runners overview.
+ */
+public class HazelcastParallelParametersRunnerFactory extends HazelcastParametersRunnerFactory {
+
+    @Override
+    protected boolean isParallel(Class<?> testClass) {
+        return true;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParametersRunnerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParametersRunnerFactory.java
@@ -24,12 +24,10 @@ import org.junit.runners.parameterized.ParametersRunnerFactory;
 import org.junit.runners.parameterized.TestWithParameters;
 
 /**
- * ParametersRunnerFactory implementation which creates either {@link HazelcastSerialClassRunner}
- * or {@link HazelcastParallelClassRunner}, depending on existence of {@link ParallelTest} category.
- *
- * When {@link ParallelTest} category is used, test class will be run with parallel method execution
- * either on a single JVM or on multiple JVMs depending on the maven profile selected.
- * Otherwise it will be run in full isolation (single JVM, serial method execution).
+ * {@link ParametersRunnerFactory} implementation which creates either {@link HazelcastSerialClassRunner}
+ * or {@link HazelcastParallelClassRunner}, depending on the presence of the {@link ParallelTest} category.
+ * <p>
+ * See {@link com.hazelcast.test package documentation} for runners overview.
  */
 public class HazelcastParametersRunnerFactory implements ParametersRunnerFactory {
 
@@ -46,7 +44,7 @@ public class HazelcastParametersRunnerFactory implements ParametersRunnerFactory
         return getSerialClassRunner(testClass, parameters, testName);
     }
 
-    private boolean isParallel(Class<?> testClass) {
+    protected boolean isParallel(Class<?> testClass) {
         Category category = testClass.getAnnotation(Category.class);
         if (category == null) {
             return false;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialParametersRunnerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialParametersRunnerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import org.junit.runners.parameterized.ParametersRunnerFactory;
+
+/**
+ * {@link ParametersRunnerFactory} implementation which creates {@link HazelcastSerialClassRunner}
+ * to run test methods serially.
+ * <p>
+ * See {@link com.hazelcast.test package documentation} for runners overview.
+ */
+public class HazelcastSerialParametersRunnerFactory extends HazelcastParametersRunnerFactory {
+
+    @Override
+    protected boolean isParallel(Class<?> testClass) {
+        return false;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -935,10 +935,10 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void assertClusterSize(int expectedSize, HazelcastInstance... instances) {
-        for (HazelcastInstance instance : instances) {
-            int clusterSize = getClusterSize(instance);
+        for (int i = 0; i < instances.length; i++) {
+            int clusterSize = getClusterSize(instances[i]);
             if (expectedSize != clusterSize) {
-                fail(format("Cluster size is not correct. Expected: %d Actual: %d", expectedSize, clusterSize));
+                fail(format("Cluster size is not correct. Expected: %d, actual: %d, instance index: %d", expectedSize, clusterSize, i));
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/package-info.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/package-info.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <h4>Hazelcast Test Runners overview</h4>
+ * <table>
+ *     <tr><th>Class</th><th>Parametric</th><th>Parallel method execution</th></tr>
+ *     <tr>
+ *         <td>{@link com.hazelcast.test.HazelcastSerialClassRunner}</td>
+ *         <td>No</td>
+ *         <td>No</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link com.hazelcast.test.HazelcastParallelClassRunner}</td>
+ *         <td>No</td>
+ *         <td>Yes</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link com.hazelcast.test.HazelcastParametersRunnerFactory}</td>
+ *         <td>Yes</td>
+ *         <td>Based presence of the {@link com.hazelcast.test.annotation.ParallelTest} category</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link com.hazelcast.test.HazelcastSerialParametersRunnerFactory}</td>
+ *         <td>Yes</td>
+ *         <td>No</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link com.hazelcast.test.HazelcastParallelParametersRunnerFactory}</td>
+ *         <td>Yes</td>
+ *         <td>Yes</td>
+ *     </tr>
+ * </table>
+ */
+package com.hazelcast.test;


### PR DESCRIPTION
In HazelcastParametersRunnerFactory, the `@ParallelTest` annotation was
used to determine whether test methods will be run in parallel. However,
in some cases we wanted to run methods in parallel, but still avoid
running the entire test class in parallel with other tests in multiple
JVMs.

This PR introduces `HazelcastParallelParametersRunnerFactory` and
`HazelcastSerialParametersRunnerFactory` which allow enabling/disabling
of parallel method execution separately from using `ParallelTest`
annotation.