### PR TITLE
Return response from SplitBrainMergeValidationOp if any side can merge

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -794,12 +794,12 @@ public class ClusterJoinManager {
 
     @SuppressWarnings({"checkstyle:returncount", "checkstyle:npathcomplexity"})
     public SplitBrainJoinMessage.SplitBrainMergeCheckResult shouldMerge(SplitBrainJoinMessage joinMessage) {
-        if (logger.isFineEnabled()) {
-            logger.fine("Checking if we should merge to: " + joinMessage);
-        }
-
         if (joinMessage == null) {
             return CANNOT_MERGE;
+        }
+
+        if (logger.isFineEnabled()) {
+            logger.fine("Checking if we should merge to: " + joinMessage);
         }
 
         if (!checkValidSplitBrainJoinMessage(joinMessage)) {


### PR DESCRIPTION
Instead of returning response only when the remote node should merge, SplitBrainMergeValidationOp can also return response when the local node should merge to speed up the merge process if MulticastJoiner is being used.