### PR TITLE
Fix MulticastJoiner split-brain handler message broadcasting

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.internal.cluster.impl.operations.MasterClaimOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -515,7 +516,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         }
         for (Address address : possibleAddresses) {
             SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
-            if (shouldMerge(response)) {
+            if (shouldMerge(response) == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                 logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
                 setTargetAddress(address);
                 startClusterMerge(address);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.Clock;
@@ -130,14 +131,17 @@ public class MulticastJoiner extends AbstractJoiner {
                 }
 
                 SplitBrainJoinMessage response = sendSplitBrainJoinMessage(targetAddress);
-                if (shouldMerge(response)) {
+                SplitBrainMergeCheckResult result = shouldMerge(response);
+                if (result == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                     logger.warning(node.getThisAddress() + " is merging [multicast] to " + targetAddress);
                     startClusterMerge(targetAddress);
                     return;
                 }
 
-                // other side should join to us. broadcast a new SplitBrainJoinMessage.
-                node.multicastService.send(node.createSplitBrainJoinMessage());
+                if (result == SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE) {
+                    // other side should join to us. broadcast a new SplitBrainJoinMessage.
+                    node.multicastService.send(node.createSplitBrainJoinMessage());
+                }
             }
         } catch (InterruptedException e) {
             logger.fine("Interrupted: " + e.getMessage());

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -31,6 +31,21 @@ import java.util.Collection;
  */
 public class SplitBrainJoinMessage extends JoinMessage {
 
+    public enum SplitBrainMergeCheckResult {
+        /**
+         * Denotes that the two endpoints of the SplitBrainJoinMessage cannot merge to each other
+         */
+        CANNOT_MERGE,
+        /**
+         * Denotes that the local node should merge to the other endpoint of the SplitBrainJoinMessage
+         */
+        LOCAL_NODE_SHOULD_MERGE,
+        /**
+         * Denotes that the remote node that sent the SplitBrainJoinMessage should merge
+         */
+        REMOTE_NODE_SHOULD_MERGE
+    }
+
     protected Version clusterVersion;
 
     public SplitBrainJoinMessage() {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -19,6 +19,7 @@ package com.hazelcast.test.mocknetwork;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
 
@@ -152,9 +153,10 @@ class MockJoiner extends AbstractJoiner {
         possibleAddresses.remove(node.getThisAddress());
         possibleAddresses.removeAll(node.getClusterService().getMemberAddresses());
         for (Address address : possibleAddresses) {
-            SplitBrainJoinMessage  response = sendSplitBrainJoinMessage(address);
-            if (shouldMerge(response)) {
+            SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
+            if (shouldMerge(response) == SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE) {
                 startClusterMerge(address);
+                return;
             }
         }
     }


### PR DESCRIPTION
MulticastJoiner split-brain handler should broadcast a new split brain message,
only when it detects other side should join, not on every merge interval.

Otherwise, when clusters are not able to merge, multicast messages are exchanged
between them continuously ignoring the delay.

This problem was introduced by https://github.com/hazelcast/hazelcast/pull/10378

(cherry picked from commit 6ee7c09c7673391b38ce2dc59fbdb2af4436950a)

Backport of https://github.com/hazelcast/hazelcast/pull/11853