### PR TITLE
Small cleanup of NodeEngine and NodeEngineImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -34,7 +34,7 @@ import com.hazelcast.wan.WanReplicationService;
 
 /**
  * The NodeEngine is the 'umbrella' of services/service-method that gets injected into a {@link ManagedService}.
- * <p/>
+ * <p>
  * So if you are writing a custom SPI service, such as a stack-service, this service should probably implement
  * the {@link ManagedService} so you can get access to the services within the system.
  */
@@ -43,118 +43,118 @@ public interface NodeEngine {
     /**
      * Gets the OperationService.
      *
-     * @return the OperationService.
+     * @return the OperationService
      */
     OperationService getOperationService();
 
     /**
      * Gets the ExecutionService.
      *
-     * @return the ExecutionService.
+     * @return the ExecutionService
      */
     ExecutionService getExecutionService();
 
     /**
      * Gets the ClusterService.
      *
-     * @return the ClusterService.
+     * @return the ClusterService
      */
     ClusterService getClusterService();
 
     /**
      * Gets the IPartitionService.
      *
-     * @return the IPartitionService.
+     * @return the IPartitionService
      */
     IPartitionService getPartitionService();
 
     /**
      * Gets the EventService.
      *
-     * @return the EventService.
+     * @return the EventService
      */
     EventService getEventService();
 
     /**
      * Gets the SerializationService.
      *
-     * @return the SerializationService.
+     * @return the SerializationService
      */
     SerializationService getSerializationService();
 
     /**
      * Gets the ProxyService.
      *
-     * @return the ProxyService.
+     * @return the ProxyService
      */
     ProxyService getProxyService();
 
     /**
      * Gets the WanReplicationService.
      *
-     * @return the WanReplicationService.
+     * @return the WanReplicationService
      */
     WanReplicationService getWanReplicationService();
 
     /**
      * Gets the QuorumService.
      *
-     * @return the QuorumService.
+     * @return the QuorumService
      */
     QuorumService getQuorumService();
 
     /**
      * Gets the TransactionManagerService.
      *
-     * @return the TransactionManagerService.
+     * @return the TransactionManagerService
      */
     TransactionManagerService getTransactionManagerService();
 
     /**
      * Gets the address of the master member.
-     * <p/>
+     * <p>
      * This value can be null if no master is elected yet.
-     * <p/>
+     * <p>
      * The value can change over time.
      *
-     * @return the address of the master member.
+     * @return the address of the master member
      */
     Address getMasterAddress();
 
     /**
      * Get the address of this member.
-     * <p/>
-     * The returned value will never change and will never be null.
+     * <p>
+     * The returned value will never change and will never be {@code null}.
      *
-     * @return the address of this member.
+     * @return the address of this member
      */
     Address getThisAddress();
 
     /**
      * Returns the local member.
-     * <p/>
+     * <p>
      * The returned value will never be null but it may change when local lite member is promoted to a data member
      * or when this member merges to a new cluster after split-brain detected. Returned value should not be
      * cached but instead this method should be called each time when local member is needed.
      *
-     * @return the local member.
+     * @return the local member
      */
     Member getLocalMember();
 
     /**
      * Returns the Config that was used to create the HazelcastInstance.
-     * <p/>
-     * The returned value will never change and will never be null.
+     * <p>
+     * The returned value will never change and will never be {@code null}.
      *
-     * @return the config.
+     * @return the config
      */
     Config getConfig();
 
     /**
      * Returns the Config ClassLoader. This class loader will be used for instantiation of all classes defined by the
-     * configuration (e.g. listeners, policies, stores, partitioning strategies, quorum functions, ...)
-     * <p/>
-     * todo: add more documentation what the purpose is of the config classloader.
+     * configuration (e.g. listeners, policies, stores, partitioning strategies, quorum functions, ...).
+     * <p>
+     * TODO: add more documentation what the purpose is of the config classloader
      *
      * @return the config ClassLoader.
      */
@@ -162,8 +162,8 @@ public interface NodeEngine {
 
     /**
      * Returns the HazelcastProperties.
-     * <p/>
-     * The returned value will never change and will never be null.
+     * <p>
+     * The returned value will never change and will never be {@code null}.
      *
      * @return the HazelcastProperties
      */
@@ -171,75 +171,77 @@ public interface NodeEngine {
 
     /**
      * Gets the logger for a given name.
-     * <p/>
-     * It is best to get an ILogger through this method instead of doing
+     * <p>
+     * It is best to get an ILogger through this method instead of calling {@link com.hazelcast.logging.Logger#getLogger(String)}.
      *
-     * @param name the name of the logger.
-     * @return the ILogger.
-     * @throws NullPointerException if name is null.
-     * @see #getLogger(Class)
+     * @param name the name of the logger
+     * @return the ILogger
+     * @throws NullPointerException if name is {@code null}
+     * @see #getLogger(String)
      */
     ILogger getLogger(String name);
 
     /**
      * Gets the logger for a given class.
+     * <p>
+     * It is best to get an ILogger through this method instead of calling {@link com.hazelcast.logging.Logger#getLogger(Class)}.
      *
-     * @param clazz the class of the logger.
-     * @return the ILogger.
-     * @throws NullPointerException if clazz is null.
-     * @see #getLogger(String)
+     * @param clazz the class of the logger
+     * @return the ILogger
+     * @throws NullPointerException if clazz is {@code null}
+     * @see #getLogger(Class)
      */
     ILogger getLogger(Class clazz);
 
     /**
      * Serializes an object to a {@link Data}.
-     * <p/>
+     * <p>
      * This method can safely be called with a {@link Data} instance. In that case, that instance is returned.
-     * <p/>
-     * If this method is called with null, null is returned.
+     * <p>
+     * If this method is called with {@code null}, {@code null} is returned.
      *
-     * @param object the object to serialize.
-     * @return the serialized object.
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException when serialization fails.
+     * @param object the object to serialize
+     * @return the serialized object
+     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException when serialization fails
      */
     Data toData(Object object);
 
     /**
      * Deserializes an object.
-     * <p/>
+     * <p>
      * This method can safely be called on an object that is already deserialized. In that case, that instance
      * is returned.
-     * <p/>
-     * If this method is called with null, null is returned.
+     * <p>
+     * If this method is called with {@code null}, {@code null} is returned.
      *
-     * @param object the object to deserialize.
-     * @return the deserialized object.
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException when deserialization fails.
+     * @param object the object to deserialize
+     * @return the deserialized object
+     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException when deserialization fails
      */
     <T> T toObject(Object object);
 
     /**
      * Deserializes an object.
-     * <p/>
+     * <p>
      * This method can safely be called on an object that is already deserialized. In that case, that instance
      * is returned.
-     * <p/>
-     * If this method is called with null, null is returned.
+     * <p>
+     * If this method is called with {@code null}, {@code null} is returned.
      *
-     * @param object the object to deserialize.
-     * @param klazz The class to instantiate when deserializing the object.
-     * @return the deserialized object.
-     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException when deserialization fails.
+     * @param object the object to deserialize
+     * @param klazz  The class to instantiate when deserializing the object
+     * @return the deserialized object
+     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException when deserialization fails
      */
     <T> T toObject(Object object, Class klazz);
 
     /**
      * Checks if the HazelcastInstance that this {@link NodeEngine} belongs to is still active.
-     * <p/>
+     * <p>
      * A HazelcastInstance is not active when it is shutting down or already shut down.
-     * * Also see {@link NodeEngine#isRunning()}
+     * Also see {@link NodeEngine#isRunning()}.
      *
-     * @return true if active, false otherwise.
+     * @return {@code true} if active, {@code false} otherwise
      */
     @Deprecated
     boolean isActive();
@@ -247,7 +249,7 @@ public interface NodeEngine {
     /**
      * Indicates that node is not shutting down or it has not already shut down
      *
-     * @return true if node is not shutting down or it has not already shut down
+     * @return {@code true} if node is not shutting down or it has not already shut down, {@code false} otherwise
      */
     boolean isRunning();
 
@@ -262,19 +264,19 @@ public interface NodeEngine {
      * Gets the service with the given name.
      *
      * @param serviceName the name of the service
-     * @param <T> the type of the service.
-     * @return the found service, or HazelcastException in case of failure. Null will not be returned.
+     * @param <T>         the type of the service
+     * @return the found service, or HazelcastException in case of failure ({@code null} will never be returned)
      */
     <T> T getService(String serviceName);
 
     /**
      * Gets the {@link SharedService} for the given serviceName.
      *
-     * @param serviceName the name of the shared service to get.
-     * @param <T>
-     * @return the found service, or null if the service was not found.
-     * @throws NullPointerException if the serviceName is null.
-     * @deprecated since 3.7. Use {@link #getService(String)} instead.
+     * @param serviceName the name of the shared service to get
+     * @param <T>         the type of the service
+     * @return the found service, or null if the service was not found
+     * @throws NullPointerException if the serviceName is {@code null}
+     * @deprecated since 3.7, please use {@link #getService(String)} instead
      */
     <T extends SharedService> T getSharedService(String serviceName);
 
@@ -282,10 +284,9 @@ public interface NodeEngine {
      * Returns the codebase version of the node. For example, when running on hazelcast-3.8.jar, this would resolve
      * to {@code Version.of(3,8,0)}. A node's codebase version may be different than cluster version.
      *
-     * @return codebase version of the node.
+     * @return codebase version of the node
      * @see Cluster#getClusterVersion()
      * @since 3.8
      */
     MemberVersion getVersion();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -87,7 +87,7 @@ import static java.lang.System.currentTimeMillis;
  * compared to a Spring ApplicationContext. It is fine that we refer to concrete types, and it is fine
  * that we cast to a concrete type within this class (e.g. to call shutdown). In an application context
  * you get exactly the same behavior.
- * <p/>
+ * <p>
  * But the crucial thing is that we don't want to leak concrete dependencies to the outside. For example
  * we don't leak {@link com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl} to the outside.
  */
@@ -97,29 +97,28 @@ public class NodeEngineImpl implements NodeEngine {
     private static final String JET_SERVICE_NAME = "hz:impl:jetService";
 
     private final Node node;
+    private final SerializationService serializationService;
+    private final LoggingServiceImpl loggingService;
     private final ILogger logger;
-    private final EventServiceImpl eventService;
-    private final OperationServiceImpl operationService;
-    private final ExecutionServiceImpl executionService;
-    private final OperationParkerImpl operationParker;
-    private final ServiceManagerImpl serviceManager;
-    private final TransactionManagerServiceImpl transactionManagerService;
+    private final MetricsRegistryImpl metricsRegistry;
     private final ProxyServiceImpl proxyService;
+    private final ServiceManagerImpl serviceManager;
+    private final ExecutionServiceImpl executionService;
+    private final OperationServiceImpl operationService;
+    private final EventServiceImpl eventService;
+    private final OperationParkerImpl operationParker;
+    private final ClusterWideConfigurationService configurationService;
+    private final TransactionManagerServiceImpl transactionManagerService;
     private final WanReplicationService wanReplicationService;
     private final PacketHandler packetDispatcher;
     private final QuorumServiceImpl quorumService;
-    private final MetricsRegistryImpl metricsRegistry;
-    private final SerializationService serializationService;
-    private final LoggingServiceImpl loggingService;
     private final Diagnostics diagnostics;
-    private final UserCodeDeploymentService userCodeDeploymentService;
-    private final ClusterWideConfigurationService configurationService;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
-    public NodeEngineImpl(final Node node) {
+    public NodeEngineImpl(Node node) {
         this.node = node;
-        this.loggingService = node.loggingService;
         this.serializationService = node.getSerializationService();
+        this.loggingService = node.loggingService;
         this.logger = node.getLogger(NodeEngine.class.getName());
         this.metricsRegistry = newMetricRegistry(node);
         this.proxyService = new ProxyServiceImpl(this);
@@ -128,7 +127,7 @@ public class NodeEngineImpl implements NodeEngine {
         this.operationService = new OperationServiceImpl(this);
         this.eventService = new EventServiceImpl(this);
         this.operationParker = new OperationParkerImpl(this);
-        this.userCodeDeploymentService = new UserCodeDeploymentService();
+        UserCodeDeploymentService userCodeDeploymentService = new UserCodeDeploymentService();
         DynamicConfigListener dynamicConfigListener = node.getNodeExtension().createDynamicConfigListener();
         this.configurationService = new ClusterWideConfigurationService(this, dynamicConfigListener);
         ClassLoader configClassLoader = node.getConfigClassLoader();
@@ -144,7 +143,7 @@ public class NodeEngineImpl implements NodeEngine {
                 operationService.getInvocationMonitor(),
                 eventService,
                 new ConnectionManagerPacketHandler(),
-                newJetPacketHandler());
+                new JetPacketHandler());
         this.quorumService = new QuorumServiceImpl(this);
         this.diagnostics = newDiagnostics();
 
@@ -152,26 +151,6 @@ public class NodeEngineImpl implements NodeEngine {
         serviceManager.registerService(OperationParker.SERVICE_NAME, operationParker);
         serviceManager.registerService(UserCodeDeploymentService.SERVICE_NAME, userCodeDeploymentService);
         serviceManager.registerService(ClusterWideConfigurationService.SERVICE_NAME, configurationService);
-    }
-
-    private PacketHandler newJetPacketHandler() {
-        // currently service registration is done after the creation of the packet dispatcher, hence
-        // we need to lazily initialize the jet packet handler
-        return new PacketHandler() {
-
-            private volatile PacketHandler handler;
-
-            @Override
-            public void handle(Packet packet) throws Exception {
-                if (handler == null) {
-                    handler = serviceManager.getService(JET_SERVICE_NAME);
-                    if (handler == null) {
-                        throw new UnsupportedOperationException("Jet is not registered on this node");
-                    }
-                }
-                handler.handle(packet);
-            }
-        };
     }
 
     private MetricsRegistryImpl newMetricRegistry(Node node) {
@@ -191,25 +170,12 @@ public class NodeEngineImpl implements NodeEngine {
                 node.getProperties());
     }
 
-    class ConnectionManagerPacketHandler implements PacketHandler {
-        // ConnectionManager is only available after the NodeEngineImpl is available.
-        @Override
-        public void handle(Packet packet) throws Exception {
-            PacketHandler packetHandler = (PacketHandler) node.getConnectionManager();
-            packetHandler.handle(packet);
-        }
-    }
-
     public LoggingService getLoggingService() {
         return loggingService;
     }
 
     public MetricsRegistry getMetricsRegistry() {
         return metricsRegistry;
-    }
-
-    public PacketHandler getPacketDispatcher() {
-        return packetDispatcher;
     }
 
     public void start() {
@@ -232,6 +198,10 @@ public class NodeEngineImpl implements NodeEngine {
         diagnostics.start();
 
         node.getNodeExtension().registerPlugins(diagnostics);
+    }
+
+    public PacketHandler getPacketDispatcher() {
+        return packetDispatcher;
     }
 
     public Diagnostics getDiagnostics() {
@@ -335,7 +305,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
-    public Object toObject(Object object) {
+    public <T> T toObject(Object object) {
         return serializationService.toObject(object);
     }
 
@@ -382,8 +352,7 @@ public class NodeEngineImpl implements NodeEngine {
                 throw new HazelcastException("Service with name '" + serviceName + "' not found!",
                         new ServiceNotFoundException("Service with name '" + serviceName + "' not found!"));
             } else {
-                throw new RetryableHazelcastException("HazelcastInstance[" + getThisAddress()
-                        + "] is not active!");
+                throw new RetryableHazelcastException("HazelcastInstance[" + getThisAddress() + "] is not active!");
             }
         }
         return service;
@@ -401,8 +370,8 @@ public class NodeEngineImpl implements NodeEngine {
 
     /**
      * Returns a list of services matching provides service class/interface.
-     * <br></br>
-     * <b>CoreServices will be placed at the beginning of the list.</b>
+     * <p>
+     * <b>Note:</b> CoreServices will be placed at the beginning of the list.
      */
     public <S> Collection<S> getServices(Class<S> serviceClass) {
         return serviceManager.getServices(serviceClass);
@@ -435,7 +404,7 @@ public class NodeEngineImpl implements NodeEngine {
      * <p>
      * Post join operations should return response, at least a {@code null} response.
      * <p>
-     * <b>NOTE</b>: Post join operations must be lock free, meaning no locks at all:
+     * <b>Note</b>: Post join operations must be lock free, meaning no locks at all:
      * no partition locks, no key-based locks, no service level locks, no database interaction!
      * The {@link Operation#getPartitionId()} method should return a negative value.
      * This means that the operations should not implement {@link PartitionAwareOperation}.
@@ -443,16 +412,15 @@ public class NodeEngineImpl implements NodeEngine {
      * @return the operations to be executed at the end of a finalized join
      */
     public Operation[] getPostJoinOperations() {
-        final Collection<Operation> postJoinOps = new LinkedList<Operation>();
+        Collection<Operation> postJoinOps = new LinkedList<Operation>();
         Collection<PostJoinAwareService> services = getServices(PostJoinAwareService.class);
         for (PostJoinAwareService service : services) {
             Operation postJoinOperation = service.getPostJoinOperation();
             if (postJoinOperation != null) {
                 if (postJoinOperation.getPartitionId() >= 0) {
-                    logger.severe(
-                            "Post-join operations should not have partition ID set! Service: "
-                                    + service + ", Operation: "
-                                    + postJoinOperation);
+                    logger.severe("Post-join operations should not have partition ID set! Service: "
+                            + service + ", Operation: "
+                            + postJoinOperation);
                     continue;
                 }
                 postJoinOps.add(postJoinOperation);
@@ -462,16 +430,15 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     public Operation[] getPreJoinOperations() {
-        final Collection<Operation> preJoinOps = new LinkedList<Operation>();
+        Collection<Operation> preJoinOps = new LinkedList<Operation>();
         Collection<PreJoinAwareService> services = getServices(PreJoinAwareService.class);
         for (PreJoinAwareService service : services) {
-            final Operation preJoinOperation = service.getPreJoinOperation();
+            Operation preJoinOperation = service.getPreJoinOperation();
             if (preJoinOperation != null) {
                 if (preJoinOperation.getPartitionId() >= 0) {
-                    logger.severe(
-                            "Pre-join operations operations should not have partition ID set! Service: "
-                                    + service + ", Operation: "
-                                    + preJoinOperation);
+                    logger.severe("Pre-join operations operations should not have partition ID set! Service: "
+                            + service + ", Operation: "
+                            + preJoinOperation);
                     continue;
                 }
                 preJoinOps.add(preJoinOperation);
@@ -485,7 +452,7 @@ public class NodeEngineImpl implements NodeEngine {
         operationService.reset();
     }
 
-    public void shutdown(final boolean terminate) {
+    public void shutdown(boolean terminate) {
         logger.finest("Shutting down services...");
         operationParker.shutdown();
         operationService.shutdownInvocations();
@@ -497,5 +464,33 @@ public class NodeEngineImpl implements NodeEngine {
         executionService.shutdown();
         metricsRegistry.shutdown();
         diagnostics.shutdown();
+    }
+
+    private class ConnectionManagerPacketHandler implements PacketHandler {
+
+        @Override
+        public void handle(Packet packet) throws Exception {
+            // ConnectionManager is only available after the NodeEngineImpl is available
+            PacketHandler packetHandler = (PacketHandler) node.getConnectionManager();
+            packetHandler.handle(packet);
+        }
+    }
+
+    private class JetPacketHandler implements PacketHandler {
+
+        private volatile PacketHandler handler;
+
+        @Override
+        public void handle(Packet packet) throws Exception {
+            // currently service registration is done after the creation of the packet dispatcher,
+            // hence we need to lazily initialize the JetPacketHandler
+            if (handler == null) {
+                handler = serviceManager.getService(JET_SERVICE_NAME);
+                if (handler == null) {
+                    throw new UnsupportedOperationException("Jet is not registered on this node");
+                }
+            }
+            handler.handle(packet);
+        }
     }
 }


### PR DESCRIPTION
* fixed JavaDoc
* fixed return type of `toObject(Object object)`
* sorted fields in `NodeEngineImpl` and its constructor
* pulled out `JetPacketHandler` as inner class
* moved inner classes to bottom
* removed superfluous final keywords