### PR TITLE
Operation continuation offload abstraction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -23,8 +23,6 @@ import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.monitor.impl.LocalExecutorStatsImpl;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.ExecutionService;
-import com.hazelcast.spi.LiveOperations;
-import com.hazelcast.spi.LiveOperationsTracker;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -51,7 +49,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 
-public class DistributedExecutorService implements ManagedService, RemoteService, LiveOperationsTracker,
+public class DistributedExecutorService implements ManagedService, RemoteService,
         StatisticsAwareService<LocalExecutorStats>, QuorumAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:executorService";
@@ -201,14 +199,6 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     private void rejectExecution(String name) {
         getLocalExecutorStats(name).rejectExecution();
-    }
-
-    @Override
-    public void populate(LiveOperations liveOperations) {
-        for (CallableProcessor processor : submittedTasks.values()) {
-            Operation op = processor.op;
-            liveOperations.add(op.getCallerAddress(), op.getCallId());
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -20,20 +20,17 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.executor.impl.ExecutorDataSerializerHook;
 import com.hazelcast.executor.impl.RunnableAdapter;
-import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.NamedOperation;
+import com.hazelcast.spi.Offload;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
-
-import static com.hazelcast.spi.CallStatus.OFFLOADED;
 
 abstract class AbstractCallableTaskOperation extends Operation implements NamedOperation, IdentifiedDataSerializable {
 
@@ -52,30 +49,7 @@ abstract class AbstractCallableTaskOperation extends Operation implements NamedO
 
     @Override
     public final CallStatus call() {
-        Callable callable = loadCallable();
-        DistributedExecutorService service = getService();
-        service.execute(name, uuid, callable, this);
-        return OFFLOADED;
-    }
-
-    private Callable loadCallable() {
-        ManagedContext managedContext = getManagedContext();
-
-        Callable callable = getNodeEngine().toObject(callableData);
-        if (callable instanceof RunnableAdapter) {
-            RunnableAdapter adapter = (RunnableAdapter) callable;
-            Runnable runnable = (Runnable) managedContext.initialize(adapter.getRunnable());
-            adapter.setRunnable(runnable);
-        } else {
-            callable = (Callable) managedContext.initialize(callable);
-        }
-        return callable;
-    }
-
-    private ManagedContext getManagedContext() {
-        HazelcastInstanceImpl hazelcastInstance = (HazelcastInstanceImpl) getNodeEngine().getHazelcastInstance();
-        SerializationService serializationService = hazelcastInstance.getSerializationService();
-        return serializationService.getManagedContext();
+        return new OffloadImpl();
     }
 
     @Override
@@ -112,5 +86,32 @@ abstract class AbstractCallableTaskOperation extends Operation implements NamedO
     @Override
     public int getFactoryId() {
         return ExecutorDataSerializerHook.F_ID;
+    }
+
+    private class OffloadImpl extends Offload {
+        OffloadImpl() {
+            super(AbstractCallableTaskOperation.this);
+        }
+
+        @Override
+        public void start() {
+            Callable callable = loadCallable();
+            DistributedExecutorService service = getService();
+            service.execute(name, uuid, callable, AbstractCallableTaskOperation.this);
+        }
+
+        private Callable loadCallable() {
+            ManagedContext managedContext = serializationService.getManagedContext();
+
+            Callable callable = serializationService.toObject(callableData);
+            if (callable instanceof RunnableAdapter) {
+                RunnableAdapter adapter = (RunnableAdapter) callable;
+                Runnable runnable = (Runnable) managedContext.initialize(adapter.getRunnable());
+                adapter.setRunnable(runnable);
+            } else {
+                callable = (Callable) managedContext.initialize(callable);
+            }
+            return callable;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -31,7 +31,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.CallStatus;
-import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.Offload;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationResponseHandler;
@@ -39,25 +39,23 @@ import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.MutatingOperation;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.core.Offloadable.NO_OFFLOADING;
 import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 import static com.hazelcast.spi.CallStatus.DONE_RESPONSE;
-import static com.hazelcast.spi.CallStatus.OFFLOADED;
 import static com.hazelcast.spi.CallStatus.WAIT;
 import static com.hazelcast.spi.ExecutionService.OFFLOADABLE_EXECUTOR;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Contains implementation of the off-loadable contract for EntryProcessor execution on a single key.
@@ -143,7 +141,7 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
 
     private EntryProcessor entryProcessor;
 
-    private transient boolean offloading;
+    private transient boolean offload;
 
     // EntryOperation
     private transient Object response;
@@ -152,8 +150,6 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
     private transient boolean readOnly;
     private transient int setUnlockRetryCount;
     private transient long begin;
-    private transient InternalOperationService ops;
-    private transient ExecutionService exs;
 
     public EntryOperation() {
     }
@@ -166,13 +162,11 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
     @Override
     public void innerBeforeRun() throws Exception {
         super.innerBeforeRun();
-        this.ops = (InternalOperationService) getNodeEngine().getOperationService();
-        this.exs = getNodeEngine().getExecutionService();
         this.begin = Clock.currentTimeMillis();
         this.readOnly = entryProcessor instanceof ReadOnly;
 
-        final SerializationService serializationService = getNodeEngine().getSerializationService();
-        final ManagedContext managedContext = serializationService.getManagedContext();
+        SerializationService serializationService = getNodeEngine().getSerializationService();
+        ManagedContext managedContext = serializationService.getManagedContext();
         managedContext.initialize(entryProcessor);
     }
 
@@ -182,209 +176,15 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
             return WAIT;
         }
 
-        if (offloading) {
-            runOffloaded();
-            return OFFLOADED;
+        if (offload) {
+            return new EntryOperationOffload();
         } else {
-            runVanilla();
+            response = operator(this, entryProcessor)
+                    .operateOnKey(dataKey)
+                    .doPostOperateOps()
+                    .getResult();
             return DONE_RESPONSE;
         }
-    }
-
-    public void runOffloaded() {
-        if (!(entryProcessor instanceof Offloadable)) {
-            throw new HazelcastException("EntryProcessor is expected to implement Offloadable for this operation");
-        }
-        if (readOnly && entryProcessor.getBackupProcessor() != null) {
-            throw new HazelcastException("EntryProcessor.getBackupProcessor() should return null if ReadOnly implemented");
-        }
-
-        boolean shouldCloneForOffloading = OBJECT.equals(mapContainer.getMapConfig().getInMemoryFormat());
-        Object oldValue = recordStore.get(dataKey, false);
-        Object clonedOldValue = shouldCloneForOffloading ? toData(oldValue) : oldValue;
-
-        String executorName = ((Offloadable) entryProcessor).getExecutorName();
-        executorName = executorName.equals(Offloadable.OFFLOADABLE_EXECUTOR) ? OFFLOADABLE_EXECUTOR : executorName;
-
-        if (readOnly) {
-            runOffloadedReadOnlyEntryProcessor(clonedOldValue, executorName);
-        } else {
-            runOffloadedModifyingEntryProcessor(clonedOldValue, executorName);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void runOffloadedReadOnlyEntryProcessor(final Object oldValue, String executorName) {
-        ops.onStartAsyncOperation(this);
-        getNodeEngine().getExecutionService().execute(executorName, new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Data result = operator(EntryOperation.this, entryProcessor)
-                            .operateOnKeyValue(dataKey, oldValue).getResult();
-                    getOperationResponseHandler().sendResponse(EntryOperation.this, result);
-                } catch (Throwable t) {
-                    getOperationResponseHandler().sendResponse(EntryOperation.this, t);
-                } finally {
-                    ops.onCompletionAsyncOperation(EntryOperation.this);
-                }
-            }
-        });
-    }
-
-    @SuppressWarnings("unchecked")
-    private void runOffloadedModifyingEntryProcessor(final Object oldValue, String executorName) {
-        final OperationServiceImpl ops = (OperationServiceImpl) getNodeEngine().getOperationService();
-
-        // callerId is random since the local locks are NOT re-entrant
-        // using a randomID every time prevents from re-entering the already acquired lock
-        final String finalCaller = UuidUtil.newUnsecureUuidString();
-        final Data finalDataKey = dataKey;
-        final long finalThreadId = threadId;
-        final long finalCallId = getCallId();
-        final long finalBegin = begin;
-
-        // The off-loading uses local locks, since the locking is used only on primary-replica.
-        // The locks are not supposed to be migrated on partition migration or partition promotion & downgrade.
-        lock(finalDataKey, finalCaller, finalThreadId, finalCallId);
-
-        try {
-            ops.onStartAsyncOperation(this);
-            getNodeEngine().getExecutionService().execute(executorName, new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        EntryOperator entryOperator = operator(EntryOperation.this, entryProcessor)
-                                .operateOnKeyValue(dataKey, oldValue);
-                        Data result = entryOperator.getResult();
-                        EntryEventType modificationType = entryOperator.getEventType();
-                        if (modificationType != null) {
-                            Data newValue = toData(entryOperator.getNewValue());
-                            updateAndUnlock(toData(oldValue), newValue, modificationType, finalCaller, finalThreadId,
-                                    result, finalBegin);
-                        } else {
-                            unlockOnly(result, finalCaller, finalThreadId, finalBegin);
-                        }
-                    } catch (Throwable t) {
-                        getLogger().severe("Unexpected error on Offloadable execution", t);
-                        unlockOnly(t, finalCaller, finalThreadId, finalBegin);
-                    }
-                }
-            });
-        } catch (Throwable t) {
-            try {
-                unlock(finalDataKey, finalCaller, finalThreadId, finalCallId, t);
-                sneakyThrow(t);
-            } finally {
-                ops.onCompletionAsyncOperation(this);
-            }
-        }
-    }
-
-    private Data toData(Object obj) {
-        return mapServiceContext.toData(obj);
-    }
-
-    private void lock(Data finalDataKey, String finalCaller, long finalThreadId, long finalCallId) {
-        boolean locked = recordStore.localLock(finalDataKey, finalCaller, finalThreadId, finalCallId, -1);
-        if (!locked) {
-            // should not happen since it's a lock-awaiting operation and we are on a partition-thread, but just to make sure
-            throw new IllegalStateException(
-                    String.format("Could not obtain a lock by the caller=%s and threadId=%d", finalCaller, threadId));
-        }
-    }
-
-    private void unlock(Data finalDataKey, String finalCaller, long finalThreadId, long finalCallId, Throwable cause) {
-        boolean unlocked = recordStore.unlock(finalDataKey, finalCaller, finalThreadId, finalCallId);
-        if (!unlocked) {
-            throw new IllegalStateException(
-                    String.format("Could not unlock by the caller=%s and threadId=%d", finalCaller, threadId), cause);
-        }
-    }
-
-    @SuppressWarnings({"unchecked", "checkstyle:methodlength"})
-    private void updateAndUnlock(Data previousValue, Data newValue, EntryEventType modificationType, String caller,
-                                 long threadId, final Object result, long now) {
-        EntryOffloadableSetUnlockOperation updateOperation = new EntryOffloadableSetUnlockOperation(name, modificationType,
-                dataKey, previousValue, newValue, caller, threadId, now, entryProcessor.getBackupProcessor());
-
-        updateOperation.setPartitionId(getPartitionId());
-        updateOperation.setReplicaIndex(0);
-        updateOperation.setNodeEngine(getNodeEngine());
-        updateOperation.setCallerUuid(getCallerUuid());
-        OperationAccessor.setCallerAddress(updateOperation, getCallerAddress());
-        @SuppressWarnings("checkstyle:anoninnerlength")
-        OperationResponseHandler setUnlockResponseHandler = new OperationResponseHandler() {
-            @Override
-            public void sendResponse(Operation op, Object response) {
-                if (isRetryable(response) || isTimeout(response)) {
-                    retry(op);
-                } else {
-                    handleResponse(response);
-                }
-            }
-
-            private void retry(final Operation op) {
-                setUnlockRetryCount++;
-                if (isFastRetryLimitReached()) {
-                    exs.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            ops.execute(op);
-                        }
-                    }, DEFAULT_TRY_PAUSE_MILLIS, TimeUnit.MILLISECONDS);
-                } else {
-                    ops.execute(op);
-                }
-            }
-
-            private void handleResponse(Object response) {
-                if (response instanceof Throwable) {
-                    Throwable t = (Throwable) response;
-                    try {
-                        // EntryOffloadableLockMismatchException is a marker send from the EntryOffloadableSetUnlockOperation
-                        // meaning that the whole invocation of the EntryOffloadableOperation should be retried
-                        if (t instanceof EntryOffloadableLockMismatchException) {
-                            t = new RetryableHazelcastException(t.getMessage(), t);
-                        }
-                        getOperationResponseHandler().sendResponse(EntryOperation.this, t);
-                    } finally {
-                        ops.onCompletionAsyncOperation(EntryOperation.this);
-                    }
-                } else {
-                    try {
-                        getOperationResponseHandler().sendResponse(EntryOperation.this, result);
-                    } finally {
-                        ops.onCompletionAsyncOperation(EntryOperation.this);
-                    }
-                }
-            }
-        };
-        updateOperation.setOperationResponseHandler(setUnlockResponseHandler);
-        ops.execute(updateOperation);
-    }
-
-    private boolean isRetryable(Object response) {
-        return response instanceof RetryableHazelcastException && !(response instanceof WrongTargetException);
-    }
-
-    private boolean isTimeout(Object response) {
-        return response instanceof CallTimeoutResponse;
-    }
-
-    private boolean isFastRetryLimitReached() {
-        return setUnlockRetryCount > SET_UNLOCK_FAST_RETRY_LIMIT;
-    }
-
-    private void unlockOnly(final Object result, String caller, long threadId, long now) {
-        updateAndUnlock(null, null, null, caller, threadId, result, now);
-    }
-
-    private void runVanilla() {
-        response = operator(this, entryProcessor)
-                .operateOnKey(dataKey)
-                .doPostOperateOps()
-                .getResult();
     }
 
     @Override
@@ -396,17 +196,17 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
     public boolean shouldWait() {
         // optimisation for ReadOnly processors -> they will not wait for the lock
         if (entryProcessor instanceof ReadOnly) {
-            offloading = isOffloadingRequested(entryProcessor);
+            offload = isOffloadingRequested(entryProcessor);
             return false;
         }
-        // mutating offloading -> only if key not locked, since it uses locking too (but on reentrant one)
+        // mutating offload -> only if key not locked, since it uses locking too (but on reentrant one)
         if (!recordStore.isLocked(dataKey) && isOffloadingRequested(entryProcessor)) {
-            offloading = true;
+            offload = true;
             return false;
         }
-        //at this point we cannot offload. the entry is locked or the EP does not support offloading
+        //at this point we cannot offload. the entry is locked or the EP does not support offload
         //if the entry is locked by us then we can still run the EP on the partition thread
-        offloading = false;
+        offload = false;
         return !recordStore.canAcquireLock(dataKey, getCallerUuid(), getThreadId());
     }
 
@@ -452,6 +252,11 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
     }
 
     @Override
+    public int getId() {
+        return MapDataSerializerHook.ENTRY_OPERATION;
+    }
+
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         entryProcessor = in.readObject();
@@ -463,8 +268,182 @@ public class EntryOperation extends KeyBasedMapOperation implements BackupAwareO
         out.writeObject(entryProcessor);
     }
 
-    @Override
-    public int getId() {
-        return MapDataSerializerHook.ENTRY_OPERATION;
+    private final class EntryOperationOffload extends Offload {
+        private EntryOperationOffload() {
+            super(EntryOperation.this);
+        }
+
+        @Override
+        public void start() {
+            verifyEntryProcessor();
+
+            boolean shouldCloneForOffloading = OBJECT.equals(mapContainer.getMapConfig().getInMemoryFormat());
+            Object oldValue = recordStore.get(dataKey, false);
+            Object clonedOldValue = shouldCloneForOffloading ? serializationService.toData(oldValue) : oldValue;
+
+            String executorName = ((Offloadable) entryProcessor).getExecutorName();
+            executorName = executorName.equals(Offloadable.OFFLOADABLE_EXECUTOR) ? OFFLOADABLE_EXECUTOR : executorName;
+
+            if (readOnly) {
+                executeReadOnlyEntryProcessor(clonedOldValue, executorName);
+            } else {
+                executeMutatingEntryProcessor(clonedOldValue, executorName);
+            }
+        }
+
+        private void verifyEntryProcessor() {
+            if (!(entryProcessor instanceof Offloadable)) {
+                throw new HazelcastException("EntryProcessor is expected to implement Offloadable for this operation");
+            }
+            if (readOnly && entryProcessor.getBackupProcessor() != null) {
+                throw new HazelcastException("EntryProcessor.getBackupProcessor() should return null if ReadOnly implemented");
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void executeReadOnlyEntryProcessor(final Object oldValue, String executorName) {
+            executionService.execute(executorName, new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Data result = operator(EntryOperation.this, entryProcessor)
+                                .operateOnKeyValue(dataKey, oldValue).getResult();
+                        sendResponse(result);
+                    } catch (Throwable t) {
+                        sendResponse(t);
+                    }
+                }
+            });
+        }
+
+        @SuppressWarnings("unchecked")
+        private void executeMutatingEntryProcessor(final Object oldValue, String executorName) {
+            // callerId is random since the local locks are NOT re-entrant
+            // using a randomID every time prevents from re-entering the already acquired lock
+            final String finalCaller = UuidUtil.newUnsecureUuidString();
+            final Data finalDataKey = dataKey;
+            final long finalThreadId = threadId;
+            final long finalCallId = getCallId();
+            final long finalBegin = begin;
+
+            // The off-loading uses local locks, since the locking is used only on primary-replica.
+            // The locks are not supposed to be migrated on partition migration or partition promotion & downgrade.
+            lock(finalDataKey, finalCaller, finalThreadId, finalCallId);
+
+            try {
+                executionService.execute(executorName, new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            EntryOperator entryOperator = operator(EntryOperation.this, entryProcessor)
+                                    .operateOnKeyValue(dataKey, oldValue);
+                            Data result = entryOperator.getResult();
+                            EntryEventType modificationType = entryOperator.getEventType();
+                            if (modificationType != null) {
+                                Data newValue = serializationService.toData(entryOperator.getNewValue());
+                                updateAndUnlock(serializationService.toData(oldValue),
+                                        newValue, modificationType, finalCaller, finalThreadId, result, finalBegin);
+                            } else {
+                                unlockOnly(result, finalCaller, finalThreadId, finalBegin);
+                            }
+                        } catch (Throwable t) {
+                            getLogger().severe("Unexpected error on Offloadable execution", t);
+                            unlockOnly(t, finalCaller, finalThreadId, finalBegin);
+                        }
+                    }
+                });
+            } catch (Throwable t) {
+                unlock(finalDataKey, finalCaller, finalThreadId, finalCallId, t);
+                sneakyThrow(t);
+            }
+        }
+
+        private void lock(Data finalDataKey, String finalCaller, long finalThreadId, long finalCallId) {
+            boolean locked = recordStore.localLock(finalDataKey, finalCaller, finalThreadId, finalCallId, -1);
+            if (!locked) {
+                // should not happen since it's a lock-awaiting operation and we are on a partition-thread, but just to make sure
+                throw new IllegalStateException(
+                        format("Could not obtain a lock by the caller=%s and threadId=%d", finalCaller, threadId));
+            }
+        }
+
+        private void unlock(Data finalDataKey, String finalCaller, long finalThreadId, long finalCallId, Throwable cause) {
+            boolean unlocked = recordStore.unlock(finalDataKey, finalCaller, finalThreadId, finalCallId);
+            if (!unlocked) {
+                throw new IllegalStateException(
+                        format("Could not unlock by the caller=%s and threadId=%d", finalCaller, threadId), cause);
+            }
+        }
+
+        private void unlockOnly(final Object result, String caller, long threadId, long now) {
+            updateAndUnlock(null, null, null, caller, threadId, result, now);
+        }
+
+        @SuppressWarnings({"unchecked", "checkstyle:methodlength"})
+        private void updateAndUnlock(Data previousValue, Data newValue, EntryEventType modificationType, String caller,
+                                     long threadId, final Object result, long now) {
+            EntryOffloadableSetUnlockOperation updateOperation = new EntryOffloadableSetUnlockOperation(name, modificationType,
+                    dataKey, previousValue, newValue, caller, threadId, now, entryProcessor.getBackupProcessor());
+
+            updateOperation.setPartitionId(getPartitionId());
+            updateOperation.setReplicaIndex(0);
+            updateOperation.setNodeEngine(nodeEngine);
+            updateOperation.setCallerUuid(getCallerUuid());
+            OperationAccessor.setCallerAddress(updateOperation, getCallerAddress());
+            @SuppressWarnings("checkstyle:anoninnerlength")
+            OperationResponseHandler setUnlockResponseHandler = new OperationResponseHandler() {
+                @Override
+                public void sendResponse(Operation op, Object response) {
+                    if (isRetryable(response) || isTimeout(response)) {
+                        retry(op);
+                    } else {
+                        EntryOperation.this.sendResponse(toResponse(response));
+                    }
+                }
+
+                private void retry(final Operation op) {
+                    setUnlockRetryCount++;
+                    if (isFastRetryLimitReached()) {
+                        executionService.schedule(new Runnable() {
+                            @Override
+                            public void run() {
+                                operationService.execute(op);
+                            }
+                        }, DEFAULT_TRY_PAUSE_MILLIS, MILLISECONDS);
+                    } else {
+                        operationService.execute(op);
+                    }
+                }
+
+                private Object toResponse(Object response) {
+                    if (response instanceof Throwable) {
+                        Throwable t = (Throwable) response;
+                        // EntryOffloadableLockMismatchException is a marker send from the EntryOffloadableSetUnlockOperation
+                        // meaning that the whole invocation of the EntryOffloadableOperation should be retried
+                        if (t instanceof EntryOffloadableLockMismatchException) {
+                            t = new RetryableHazelcastException(t.getMessage(), t);
+                        }
+                        return t;
+                    } else {
+                        return result;
+                    }
+                }
+            };
+
+            updateOperation.setOperationResponseHandler(setUnlockResponseHandler);
+            operationService.execute(updateOperation);
+        }
+
+        private boolean isRetryable(Object response) {
+            return response instanceof RetryableHazelcastException && !(response instanceof WrongTargetException);
+        }
+
+        private boolean isTimeout(Object response) {
+            return response instanceof CallTimeoutResponse;
+        }
+
+        private boolean isFastRetryLimitReached() {
+            return setUnlockRetryCount > SET_UNLOCK_FAST_RETRY_LIMIT;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/CallStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CallStatus.java
@@ -19,53 +19,76 @@ package com.hazelcast.spi;
 /**
  * The result of an {@link Operation#call()}.
  *
- * Using the CallStatus the operation can control how the system will deal with the operation after it is executed. For example
- * when the CallStatus is {@link CallStatus#DONE_RESPONSE}, a response can be send to the caller. But it also allows for
- * different behavior where no response is available yet e.g. when an operation gets offloaded.
- *
- * <h1>CallStatus doesn't need ot be enum</h1>
- * CallStatus is currently an enumeration. But if for whatever reason state needs to be returned, we can easily convert this
- * enumeration to a regular object like e.g. java https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html.
- *
- * So you can have a call status class and if e.g. an operation that requires interleaving, a new Interleaving (subclass of
- * CallStatus) can be returned containing all the state for that interleaving.
- *
- * The same can be done for Blocking operations. Currently we just return WAIT, but this can easily be modified by creating a new
- * Wait (subclass of CallStatus) containing the wait key or whatever else is needed.
- *
- * It is very likely that the CallStatus is going to be converted to regular classes/object with the introduction of the
- * 'Offloaded' which is part of phase 2 for the Operation continuations.
+ * Using the CallStatus the operation can control how the system will deal with
+ * the operation after it is executed. For example when the CallStatus is
+ * {@link CallStatus#DONE_RESPONSE}, a response can be send to the caller. But
+ * it also allows for different behavior where no response is available yet e.g.
+ * when an operation gets offloaded.
  *
  * <h1>Future additions</h1>
- * In the future we can add more values to this enumeration, for example 'YIELD' for batching operations that wants to
- * release the operation thread so that other operations can be interleaved.
+ * In the future we can add more values to this enumeration, for example 'YIELD'
+ * for batching operations that wants to release the operation thread so that
+ * other operations can be interleaved.
  */
-public enum CallStatus {
+public class CallStatus {
 
     /**
-     * Signals that the Operation is done running and that a response is ready to be returned. Most of the normal operations
-     * like IAtomicLong.get will fall in this category.
+     * The ordinal value for a {@link #DONE_RESPONSE}.
      */
-    DONE_RESPONSE,
+    public static final int DONE_RESPONSE_ORDINAL = 0;
 
     /**
-     * Signals that the Operation is done running, but no response will be returned. Most of the regular operations like map.get
-     * will return a response, but there are also fire and forget operations (lot of cluster operations) that don't return a
-     * response.
+     * The ordinal value for a {@link #DONE_VOID}.
      */
-    DONE_VOID,
+    public static final int DONE_VOID_ORDINAL = 1;
 
     /**
-     * Indicates that the call could not complete because waiting is required. E.g. a queue.take on an empty queue. This can
-     * only be returned by BlockingOperations.
+     * The ordinal value for a {@link #WAIT}.
      */
-    WAIT,
+    public static final int WAIT_ORDINAL = 2;
 
     /**
-     * Signals that the Operation has been offloaded e.g. an EntryProcessor. And therefor no response is available when the
-     * operation is executed. Only at a later time a response is ready and it is up to the offload functionality to determine
-     * how to deal with that. It could be that a response is send using the original operation handler, but it could also
-     * be that the operation will be rescheduled on an operation thread (a real continuation).
+     * The ordinal value for an {@link Offload}.
      */
-    OFFLOADED
+    public static final int OFFLOAD_ORDINAL = 3;
+
+    /**
+     * Signals that the Operation is done running and that a response is ready
+     * to be returned. Most of the normal operations like IAtomicLong.get will
+     * fall in this category.
+     */
+    public static final CallStatus DONE_RESPONSE = new CallStatus(DONE_RESPONSE_ORDINAL);
+
+    /**
+     * Signals that the Operation is done running, but no response will be
+     * returned. Most of the regular operations like map.get will return a
+     * response, but there are also fire and forget operations (lot of
+     * cluster operations) that don't return a response.
+     */
+    public static final CallStatus DONE_VOID = new CallStatus(DONE_VOID_ORDINAL);
+
+    /**
+     * Indicates that the call could not complete because waiting is required.
+     * E.g. a queue.take on an empty queue. This can only be returned by
+     * BlockingOperations.
+     */
+    public static final CallStatus WAIT = new CallStatus(WAIT_ORDINAL);
+
+    private final int ordinal;
+
+    protected CallStatus(int ordinal) {
+        this.ordinal = ordinal;
+    }
+
+    /**
+     * Returns the ordinal value (useful for doing a switch case based on the
+     * type of CallStatus).
+     *
+     * @return the ordinal value.
+     */
+    public int ordinal() {
+        return ordinal;
+    }
 }
+
+

--- a/hazelcast/src/main/java/com/hazelcast/spi/Offload.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Offload.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.util.Set;
+
+/**
+ * This is an internal class. So if you are a regular Hazelcast user, you don't
+ * want to use this class. You probably want to use
+ * {@link com.hazelcast.core.Offloadable}.
+ *
+ * The Offload is a {@link CallStatus} designed when an offloaded operation
+ * needs to offload the processing of the operation to a different system, e.g
+ * a different thread and at some point in the future a response will be ready.
+ * Offload instance can be created by Operations that require offloading, for
+ * more information see the {@link Operation#call()}.
+ *
+ * If the operation 'offloads' some work, but doesn't send a response ever,
+ * {@link CallStatus#DONE_VOID} should be used instead.
+ *
+ * <h1>Response handling</h1>
+ * When the {@link Offload#init(NodeEngineImpl, Set)} is called, the original
+ * {@link OperationResponseHandler} of the offloaded operation is decorated with
+ * one of designed for the offloading (see heartbeats for more info). This means
+ * that sending a response for an offloaded operation, can be done using the
+ * regular response handling mechanism
+ * (see {@link Operation#sendResponse(Object)} or
+ * {@link Operation#getOperationResponseHandler()}. But one should not modify
+ * the response handler of an offloaded Operation because otherwise one could
+ * e.g. run into a memory leak (the offloaded operation will not be removed
+ * from the asynchronous operations).
+ *
+ * There is an important difference with exception handling. With regular
+ * operation when an exception is thrown, first the
+ * {@link Operation#onExecutionFailure(Throwable)} is called before the
+ * {@link Operation#sendResponse(Object)} is called. But with an offloaded
+ * operation, typically the {@link Operation#sendResponse(Object)} is called by
+ * the implementation of the offloading logic. So if you need the
+ * {@link Operation#onExecutionFailure(Throwable)} to be executed, just as the
+ * sendResponse call, the onExecuteFailure call is your own concern.
+ *
+ * <h1>Heartbeats</h1>
+ * The Offload functionality automatically registers the offloaded operation for
+ * operation heartbeats. The registration is done when the
+ * {@link Offload#init(NodeEngineImpl, Set)} is called. And it is unregistered,
+ * as soon as a response is send to the offloaded operation. This is done by
+ * decorating updating the original response handler of the operation by wrapping
+ * it in a decorating response handler that automatically deregisters on completion.
+ */
+public abstract class Offload extends CallStatus {
+
+    protected InternalOperationService operationService;
+    protected NodeEngine nodeEngine;
+    protected ExecutionService executionService;
+    protected SerializationService serializationService;
+    private final Operation offloadedOperation;
+    private Set<Operation> asyncOperations;
+
+    /**
+     * Creates a new Offload instance.
+     *
+     * @param offloadedOperation the Operation that is offloaded
+     */
+    public Offload(final Operation offloadedOperation) {
+        super(OFFLOAD_ORDINAL);
+        this.offloadedOperation = offloadedOperation;
+    }
+
+    /**
+     * Returns the Operation that created this Offload. Returned operation
+     * should not be null.
+     *
+     * Currently this is used to automatically register the operation for the
+     * sake of heartbeats.
+     *
+     * @return the Operation.
+     */
+    public final Operation offloadedOperation() {
+        return offloadedOperation;
+    }
+
+    /**
+     * Initializes the Offload.
+     *
+     * As part of the initialization, the {@link OperationResponseHandler} of
+     * the offloaded {@link Operation} is replaced by a decorated version that
+     * takes care of automatic deregistration of the operation on completion.
+     *
+     * This method is called before the {@link #start()} is called by the
+     * Operation infrastructure. An implementor of the {@link Offload} doesn't
+     * need to deal with this method.
+     *
+     * @param nodeEngine the {@link NodeEngineImpl}
+     */
+    public final void init(NodeEngineImpl nodeEngine, Set<Operation> asyncOperations) {
+        this.nodeEngine = nodeEngine;
+        this.operationService = nodeEngine.getOperationService();
+        this.serializationService = nodeEngine.getSerializationService();
+        this.asyncOperations = asyncOperations;
+        this.executionService = nodeEngine.getExecutionService();
+
+        asyncOperations.add(offloadedOperation);
+        offloadedOperation.setOperationResponseHandler(newOperationResponseHandler());
+    }
+
+    private OperationResponseHandler newOperationResponseHandler() {
+        OperationResponseHandler delegate = offloadedOperation.getOperationResponseHandler();
+
+        // we need to peel of the OperationResponseHandlerImpl
+        if (delegate instanceof OffloadedOperationResponseHandler) {
+            delegate = ((OffloadedOperationResponseHandler) delegate).delegate;
+        }
+
+        return new OffloadedOperationResponseHandler(delegate);
+    }
+
+    /**
+     * Starts the actual offloading.
+     *
+     * This method is still called on the same thread that called the
+     * {@link Operation#call()} where this Offload instance was returned. So in
+     * most cases you want to schedule some work and then return from this method ASAP so
+     * that the thread is released.
+     *
+     * This method is called after the {@link Operation#afterRun()} is called.
+     *
+     * It is allowed to call {@link Operation#sendResponse(Object)} in the start
+     * method if there is nothing to offload.
+     *
+     * @throws Exception if something fails. If this happens, regular Operation
+     *                   exception handling is triggered and normally the
+     *                   exception is returned to the caller.
+     */
+    public abstract void start() throws Exception;
+
+    private class OffloadedOperationResponseHandler implements OperationResponseHandler {
+        private final OperationResponseHandler delegate;
+
+        OffloadedOperationResponseHandler(OperationResponseHandler delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void sendResponse(Operation op, Object response) {
+            asyncOperations.remove(offloadedOperation);
+            delegate.sendResponse(offloadedOperation, response);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -103,11 +103,23 @@ public abstract class Operation implements DataSerializable {
         return this instanceof UrgentSystemOperation;
     }
 
-    // runs before wait-support
+    /**
+     * The beforeRun is called before either the {@link #run()} or the {@link #call()} method is called.
+     *
+     *  runs before wait-support
+     */
     public void beforeRun() throws Exception {
     }
 
-    // runs after wait-support, supposed to do actual operation
+    /**
+     * Runs the operation.
+     *
+     * Either the {@link #run()} or {@link #call()} method should be implemented; not both.
+     *
+     * Runs after wait-support, supposed to do actual operation
+     *
+     * @see #call()
+     */
     public void run() throws Exception {
     }
 
@@ -136,6 +148,7 @@ public abstract class Operation implements DataSerializable {
      *
      * @return the CallStatus.
      * @throws Exception if something failed while executing 'call'.
+     * @see #run()
      */
     public CallStatus call() throws Exception {
         if (this instanceof BlockingOperation) {
@@ -149,7 +162,12 @@ public abstract class Operation implements DataSerializable {
         return returnsResponse() ? DONE_RESPONSE : DONE_VOID;
     }
 
-    // runs after backups, before wait-notify
+    /**
+     * Is executed called after {@link #run()} or {@link #call()} method completes normally and the operation is not
+     * blocked, see {@link CallStatus#WAIT}.
+     *
+     * Runs after backups, before wait-notify.
+     */
     public void afterRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -41,6 +41,7 @@ import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.Notifier;
+import com.hazelcast.spi.Offload;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.ReadonlyOperation;
@@ -65,6 +66,10 @@ import java.util.logging.Level;
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.spi.CallStatus.DONE_RESPONSE_ORDINAL;
+import static com.hazelcast.spi.CallStatus.DONE_VOID_ORDINAL;
+import static com.hazelcast.spi.CallStatus.OFFLOAD_ORDINAL;
+import static com.hazelcast.spi.CallStatus.WAIT_ORDINAL;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.OperationAccessor.setConnection;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
@@ -201,19 +206,21 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
     private void call(Operation op) throws Exception {
         CallStatus callStatus = op.call();
 
-        switch (callStatus) {
-            case DONE_RESPONSE:
+        switch (callStatus.ordinal()) {
+            case DONE_RESPONSE_ORDINAL:
                 handleResponse(op);
                 afterRun(op);
                 break;
-            case DONE_VOID:
-                // todo: currently there is no difference between DONE_VOID and OFFLOADED
+            case DONE_VOID_ORDINAL:
                 op.afterRun();
                 break;
-            case OFFLOADED:
+            case OFFLOAD_ORDINAL:
                 op.afterRun();
+                Offload offload = (Offload) callStatus;
+                offload.init(nodeEngine, operationService.asyncOperations);
+                offload.start();
                 break;
-            case WAIT:
+            case WAIT_ORDINAL:
                 nodeEngine.getOperationParker().park((BlockingOperation) op);
                 break;
             default:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -99,6 +99,11 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     private static final int ASYNC_QUEUE_CAPACITY = 100000;
     private static final long TERMINATION_TIMEOUT_MILLIS = SECONDS.toMillis(10);
 
+    // contains the current executing asyncOperations. This information is needed for the operation-heartbeats.
+    // operations are added/removed using the {@link Offload} functionality.
+    @Probe
+    final Set<Operation> asyncOperations = newSetFromMap(new ConcurrentHashMap<Operation, Boolean>());
+
     final InvocationRegistry invocationRegistry;
     final OperationExecutor operationExecutor;
 
@@ -130,12 +135,6 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     private final int invocationMaxRetryCount;
     private final long invocationRetryPauseMillis;
     private final boolean failOnIndeterminateOperationState;
-
-    // contains the current executing asyncOperations. This information is needed for the operation-ping.
-    // this is a temporary solution till we found a better async operation abstraction
-    @Probe
-    private final Set<Operation> asyncOperations
-            = newSetFromMap(new ConcurrentHashMap<Operation, Boolean>());
 
     public OperationServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -20,7 +20,9 @@ import com.hazelcast.client.impl.operations.OperationFactoryWrapper;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.CallStatus;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Offload;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationFactory;
@@ -80,117 +82,19 @@ public final class PartitionIteratingOperation extends Operation implements Iden
     }
 
     @Override
-    public boolean returnsResponse() {
-        // since this call is non blocking, we don't have a response. The response is send when the actual operations complete.
-        return false;
-    }
-
-    @Override
-    public void run() throws Exception {
-        // partitions may be empty if the node has joined and didn't get any partitions yet
-        // a generic operation may already execute on it.
-        if (partitions.length == 0) {
-            this.sendResponse(EMPTY_RESPONSE);
-            return;
-        }
-
-        getOperationService().onStartAsyncOperation(this);
-        PartitionAwareOperationFactory partitionAwareFactory = extractPartitionAware(operationFactory);
-        if (partitionAwareFactory != null) {
-            executePartitionAwareOperations(partitionAwareFactory);
-        } else {
-            executeOperations();
-        }
+    public CallStatus call() {
+        return new OffloadImpl();
     }
 
     @Override
     public void onExecutionFailure(Throwable cause) {
-        try {
-            // we also send a response so that the caller doesn't wait indefinitely.
-            sendResponse(new ErrorResponse(cause, getCallId(), isUrgent()));
-        } finally {
-            // in case of an error, we need to de-register to prevent leaks.
-            getOperationService().onCompletionAsyncOperation(this);
-        }
+        // we also send a response so that the caller doesn't wait indefinitely.
+        sendResponse(new ErrorResponse(cause, getCallId(), isUrgent()));
         getLogger().severe(cause);
-    }
-
-    private void executeOperations() {
-        PartitionTaskFactory f = new PartitionTaskFactory() {
-            private final NodeEngine nodeEngine = getNodeEngine();
-            private final OperationResponseHandler responseHandler = new OperationResponseHandlerImpl(partitions);
-            private final Object service = getServiceName() == null ? null : getService();
-
-            @Override
-            public Operation create(int partitionId) {
-                Operation op = operationFactory.createOperation()
-                        .setNodeEngine(nodeEngine)
-                        .setPartitionId(partitionId)
-                        .setReplicaIndex(getReplicaIndex())
-                        .setOperationResponseHandler(responseHandler)
-                        .setServiceName(getServiceName())
-                        .setService(service)
-                        .setCallerUuid(extractCallerUuid());
-
-                OperationAccessor.setCallerAddress(op, getCallerAddress());
-                return op;
-            }
-        };
-
-        getOperationService().executeOnPartitions(f, toPartitionBitSet());
-    }
-
-    private BitSet toPartitionBitSet() {
-        BitSet bitSet = new BitSet(getNodeEngine().getPartitionService().getPartitionCount());
-        for (int partition : partitions) {
-            bitSet.set(partition);
-        }
-        return bitSet;
-    }
-
-    private void executePartitionAwareOperations(PartitionAwareOperationFactory givenFactory) {
-        final NodeEngine nodeEngine = getNodeEngine();
-
-        final PartitionAwareOperationFactory factory = givenFactory.createFactoryOnRunner(nodeEngine);
-
-        int[] operationFactoryPartitions = factory.getPartitions();
-        partitions = operationFactoryPartitions == null ? partitions : operationFactoryPartitions;
-
-        final OperationResponseHandler responseHandler = new OperationResponseHandlerImpl(partitions);
-        final Object service = getServiceName() == null ? null : getService();
-
-        PartitionTaskFactory f = new PartitionTaskFactory() {
-            @Override
-            public Operation create(int partitionId) {
-                Operation op = factory.createPartitionOperation(partitionId)
-                        .setNodeEngine(nodeEngine)
-                        .setPartitionId(partitionId)
-                        .setReplicaIndex(getReplicaIndex())
-                        .setOperationResponseHandler(responseHandler)
-                        .setServiceName(getServiceName())
-                        .setService(service)
-                        .setCallerUuid(extractCallerUuid());
-
-                OperationAccessor.setCallerAddress(op, getCallerAddress());
-                return op;
-            }
-        };
-
-        getOperationService().executeOnPartitions(f, toPartitionBitSet());
     }
 
     private InternalOperationService getOperationService() {
         return (InternalOperationService) getNodeEngine().getOperationService();
-    }
-
-    private String extractCallerUuid() {
-        // Clients callerUUID can be set already. See OperationFactoryWrapper usage.
-        if (operationFactory instanceof OperationFactoryWrapper) {
-            return ((OperationFactoryWrapper) operationFactory).getUuid();
-        }
-
-        // Members UUID
-        return getCallerUuid();
     }
 
     @Override
@@ -224,6 +128,104 @@ public final class PartitionIteratingOperation extends Operation implements Iden
         super.toString(sb);
 
         sb.append(", operationFactory=").append(operationFactory);
+    }
+
+    private final class OffloadImpl extends Offload {
+        private OffloadImpl() {
+            super(PartitionIteratingOperation.this);
+        }
+
+        @Override
+        public void start() {
+            if (partitions.length == 0) {
+                // partitions may be empty if the node has joined and didn't get any partitions yet
+                // a generic operation may already execute on it.
+                sendResponse(EMPTY_RESPONSE);
+                return;
+            }
+
+            PartitionAwareOperationFactory partitionAwareFactory = extractPartitionAware(operationFactory);
+            if (partitionAwareFactory == null) {
+                executeOperations();
+            } else {
+                executeOperations(partitionAwareFactory);
+            }
+        }
+
+        private void executeOperations() {
+            PartitionTaskFactory f = new PartitionTaskFactory() {
+                private final NodeEngine nodeEngine = getNodeEngine();
+                private final OperationResponseHandler responseHandler = new OperationResponseHandlerImpl(partitions);
+                private final Object service = getServiceName() == null ? null : getService();
+
+                @Override
+                public Operation create(int partitionId) {
+                    Operation op = operationFactory.createOperation()
+                            .setNodeEngine(nodeEngine)
+                            .setPartitionId(partitionId)
+                            .setReplicaIndex(getReplicaIndex())
+                            .setOperationResponseHandler(responseHandler)
+                            .setServiceName(getServiceName())
+                            .setService(service)
+                            .setCallerUuid(extractCallerUuid());
+
+                    OperationAccessor.setCallerAddress(op, getCallerAddress());
+                    return op;
+                }
+            };
+
+            getOperationService().executeOnPartitions(f, toPartitionBitSet());
+        }
+
+        private void executeOperations(PartitionAwareOperationFactory givenFactory) {
+            final NodeEngine nodeEngine = getNodeEngine();
+
+            final PartitionAwareOperationFactory factory = givenFactory.createFactoryOnRunner(nodeEngine);
+
+            int[] operationFactoryPartitions = factory.getPartitions();
+            partitions = operationFactoryPartitions == null ? partitions : operationFactoryPartitions;
+
+            final OperationResponseHandler responseHandler = new OperationResponseHandlerImpl(partitions);
+            final Object service = getServiceName() == null ? null : getService();
+
+
+            PartitionTaskFactory f = new PartitionTaskFactory() {
+                @Override
+                public Operation create(int partitionId) {
+                    Operation op = factory.createPartitionOperation(partitionId)
+                            .setNodeEngine(nodeEngine)
+                            .setPartitionId(partitionId)
+                            .setReplicaIndex(getReplicaIndex())
+                            .setOperationResponseHandler(responseHandler)
+                            .setServiceName(getServiceName())
+                            .setService(service)
+                            .setCallerUuid(extractCallerUuid());
+
+                    OperationAccessor.setCallerAddress(op, getCallerAddress());
+                    return op;
+                }
+            };
+
+            getOperationService().executeOnPartitions(f, toPartitionBitSet());
+        }
+
+        private BitSet toPartitionBitSet() {
+            BitSet bitSet = new BitSet(getNodeEngine().getPartitionService().getPartitionCount());
+            for (int partition : partitions) {
+                bitSet.set(partition);
+            }
+            return bitSet;
+        }
+
+        private String extractCallerUuid() {
+            // Clients callerUUID can be set already. See OperationFactoryWrapper usage.
+            if (operationFactory instanceof OperationFactoryWrapper) {
+                return ((OperationFactoryWrapper) operationFactory).getUuid();
+            }
+
+            // Members UUID
+            return getCallerUuid();
+        }
     }
 
     private class OperationResponseHandlerImpl implements OperationResponseHandler {
@@ -261,11 +263,7 @@ public final class PartitionIteratingOperation extends Operation implements Iden
 
             // if it is the last response we are waiting for, we can send the final response to the caller.
             if (pendingOperations.decrementAndGet() == 0) {
-                try {
-                    sendResponse();
-                } finally {
-                    getOperationService().onCompletionAsyncOperation(PartitionIteratingOperation.this);
-                }
+                sendResponse();
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OffloadedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OffloadedTest.java
@@ -1,0 +1,151 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.CallStatus;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Offload;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Invocation_OffloadedTest extends HazelcastTestSupport {
+
+    private OperationServiceImpl localOperationService;
+    private TestHazelcastInstanceFactory instanceFactory;
+
+    @Before
+    public void setup() {
+        instanceFactory = createHazelcastInstanceFactory();
+        Config config = new Config();
+        config.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+
+        HazelcastInstance[] cluster = instanceFactory.newInstances(config, 1);
+
+        localOperationService = getOperationServiceImpl(cluster[0]);
+    }
+
+    @Test(expected = ExpectedRuntimeException.class)
+    public void whenStartThrowsException_thenExceptionPropagated() {
+        InternalCompletableFuture f = localOperationService.invokeOnPartition(new OffloadingOperation(new OffloadFactory() {
+            @Override
+            public Offload create(Operation op) {
+                return new Offload(op) {
+                    @Override
+                    public void start() {
+                        throw new ExpectedRuntimeException();
+                    }
+                };
+            }
+        }));
+
+        assertCompletesEventually(f);
+        f.join();
+    }
+
+    @Test
+    public void whenCompletesInStart() throws Exception {
+        final String response = "someresponse";
+        OffloadingOperation source = new OffloadingOperation(new OffloadFactory() {
+            @Override
+            public Offload create(Operation op) {
+                return new Offload(op) {
+                    @Override
+                    public void start() {
+                        offloadedOperation().sendResponse("someresponse");
+                    }
+                };
+            }
+        });
+
+        InternalCompletableFuture<String> f = localOperationService.invokeOnPartition(source);
+
+        assertCompletesEventually(f);
+        assertEquals(response, f.get());
+        // make sure the source operation isn't registered anymore
+        assertFalse(localOperationService.asyncOperations.contains(source));
+    }
+
+    @Test
+    public void whenCompletesEventually() throws Exception {
+        final String response = "someresponse";
+
+        InternalCompletableFuture<String> f = localOperationService.invokeOnPartition(new OffloadingOperation(new OffloadFactory() {
+            @Override
+            public Offload create(Operation op) {
+                return new Offload(op) {
+                    @Override
+                    public void start() {
+                        new Thread() {
+                            @Override
+                            public void run() {
+                                sleepSeconds(5);
+                                offloadedOperation().sendResponse(response);
+                            }
+                        }.start();
+                    }
+                };
+            }
+        }));
+
+        assertCompletesEventually(f);
+        assertEquals(response, f.get());
+    }
+
+    @Test
+    public void whenOffloaded_thenAsyncOperationRegisteredOnStart_andUnregisteredOnCompletion() {
+        OffloadingOperation source = new OffloadingOperation(new OffloadFactory() {
+            @Override
+            public Offload create(Operation op) {
+                return new Offload(op) {
+                    @Override
+                    public void start() {
+                        // we make sure that the operation is registered
+                        assertTrue(localOperationService.asyncOperations.contains(offloadedOperation()));
+                        offloadedOperation().sendResponse("someresponse");
+                    }
+                };
+            }
+        });
+
+        InternalCompletableFuture<String> f = localOperationService.invokeOnPartition(source);
+
+        assertCompletesEventually(f);
+        // make sure the source operation isn't registered anymore
+        assertFalse(localOperationService.asyncOperations.contains(source));
+    }
+
+    private interface OffloadFactory {
+        Offload create(Operation op);
+    }
+
+    public static class OffloadingOperation extends Operation {
+        private final OffloadFactory offloadFactory;
+
+        public OffloadingOperation(OffloadFactory offloadFactory) {
+            this.offloadFactory = offloadFactory;
+            setPartitionId(0);
+        }
+
+        @Override
+        public CallStatus call() throws Exception {
+            return offloadFactory.create(this);
+        }
+    }
+}
+


### PR DESCRIPTION
The Offloaded functionality is a CallStatus implementation tailored for
offloaded operations.

One of the features it provides is automatic registration of the operations
for the purpose of heartbeats.

The following operations have been refactored to make use of this new functionality
-  EntryOperation 
- AbstractCallableTaskOperation 
- QueryOperation
- PartitionIteratingOperation

For enterprise PR see https://github.com/hazelcast/hazelcast-enterprise/pull/2103
