### PR TITLE
Remove redundant multicast join workaround

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.RandomPicker;
@@ -122,12 +121,6 @@ public class MulticastJoiner extends AbstractJoiner {
                         logger.fine("Ignoring merge join response, since " + targetAddress + " is already a member.");
                     }
                     continue;
-                }
-
-                if (splitBrainMsg.getMemberCount() == 1) {
-                    // if the other cluster has just single member, that may be a newly starting node instead of a split node
-                    // wait 2 times 'WAIT_SECONDS_BEFORE_JOIN' seconds before processing merge JoinRequest
-                    Thread.sleep(2 * node.getProperties().getMillis(GroupProperty.WAIT_SECONDS_BEFORE_JOIN));
                 }
 
                 SplitBrainJoinMessage response = sendSplitBrainJoinMessage(targetAddress);


### PR DESCRIPTION
While split-brain merge process running, there was a workaround to avoid
a newly joining member to be considered as a merging member.
(See commit 0fb2f8e13ad13a7dd2807d99d997413d690aaa33)

Since 3.8, this is not needed anymore, because split-brain join messages
are a sub-type of join messages. See https://github.com/hazelcast/hazelcast/pull/9325

Backport of https://github.com/hazelcast/hazelcast/pull/11896