### PR TITLE
Map stats fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MultiMapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MultiMapMBean.java
@@ -189,4 +189,10 @@ public class MultiMapMBean extends HazelcastMBean<MultiMap> {
     public int getSize() {
         return managedObject.size();
     }
+
+    @ManagedAnnotation("config")
+    @ManagedDescription("MultiMapConfig")
+    public String getConfig() {
+        return service.instance.getConfig().findMultiMapConfig(managedObject.getName()).toString();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -267,10 +267,6 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         increaseHits();
     }
 
-    protected void updateStatsOnRemove(long hits) {
-        decreaseHits(hits);
-    }
-
     protected void resetStats() {
         this.hits = 0;
         this.lastAccess = 0;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -498,7 +498,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
                     record.getKey(), record.getValue());
             storage.removeRecord(record);
-            updateStatsOnRemove(record.getHits());
             iterator.remove();
         }
         return removalSize;
@@ -547,7 +546,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             eventJournal.writeEvictEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
                     key, value);
             storage.removeRecord(record);
-            updateStatsOnRemove(record.getHits());
             if (!backup) {
                 mapServiceContext.interceptRemove(name, value);
             }
@@ -576,7 +574,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
                 record.getKey(), record.getValue());
         storage.removeRecord(record);
-        updateStatsOnRemove(record.getHits());
         mapDataStore.removeBackup(key, now);
     }
 
@@ -622,7 +619,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
                     key, oldValue);
             storage.removeRecord(record);
-            updateStatsOnRemove(record.getHits());
             removed = true;
         }
         return removed;
@@ -853,7 +849,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 eventJournal.writeUpdateEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(),
                         partitionId, key, oldValue, null);
                 storage.removeRecord(record);
-                updateStatsOnRemove(record.getHits());
                 return true;
             }
             if (newValue == mergingEntry.getValue()) {
@@ -1059,7 +1054,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         eventJournal.writeRemoveEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
                 record.getKey(), record.getValue());
         storage.removeRecord(record);
-        updateStatsOnRemove(record.getHits());
         return oldValue;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -17,10 +17,10 @@
 package com.hazelcast.monitor;
 
 /**
- * Local map statistics. As everything is partitioned in Hazelcast,
- * each member owns 1/N (N being the number of members in the cluster)
- * entries of a distributed map. Each member also holds backup entries
- * of other members. LocalMapStats tells you the count of owned and backup
+ * Local map statistics. As {@link com.hazelcast.core.IMap} is a partitioned data structure
+ * in Hazelcast, each member owns a fraction of the total number of entries of a distributed map.
+ * Depending on the {@link com.hazelcast.core.IMap}'s configuration, each member may also hold backup
+ * entries of other members. LocalMapStats provides the count of owned and backup
  * entries besides their size in memory.
  */
 public interface LocalMapStats extends LocalInstanceStats {
@@ -82,7 +82,11 @@ public interface LocalMapStats extends LocalInstanceStats {
     long getLastUpdateTime();
 
     /**
-     * Returns the number of hits (reads) of the locally owned entries.
+     * Returns the number of hits (reads) of locally owned entries, including those
+     * which are no longer in the map (for example, may have been evicted).
+     *
+     * The number of hits may be inaccurate after a partition is migrated to a new
+     * owner member.
      *
      * @return number of hits (reads) of the locally owned entries.
      */

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MultiMapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MultiMapMBeanTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.jmx;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MultiMapMBeanTest extends HazelcastTestSupport {
+
+    private static final String TYPE_NAME = "MultiMap";
+
+    private TestHazelcastInstanceFactory factory;
+    private MBeanDataHolder holder;
+    private MultiMap<String, String> multiMap;
+    private String mapName = randomString();
+    private long startTime = System.currentTimeMillis();
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory();
+        holder = new MBeanDataHolder(factory);
+        multiMap = holder.getHz().getMultiMap(mapName);
+        holder.assertMBeanExistEventually(TYPE_NAME, mapName);
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testName() throws Exception {
+        String name = getStringAttribute("name");
+
+        assertEquals(mapName, name);
+    }
+
+    @Test
+    public void testConfig() throws Exception {
+        String config = getStringAttribute("config");
+
+        assertTrue("configuration string should start with 'MultiMapConfig{'", config.startsWith("MultiMapConfig{"));
+    }
+
+    @Test
+    public void testStats() throws Exception {
+
+        int iterations = 100;
+        for (int i = 0; i < iterations; i++) {
+            multiMap.put("Ubuntu", "Artful Aardvark");
+            multiMap.put("Ubuntu", "Zesty Zapus");
+            multiMap.put("Fedora", "Heisenbug");
+            multiMap.put("Fedora", "Schrodinger's Cat");
+
+            multiMap.get("Windows");
+            multiMap.get("Ubuntu");
+            multiMap.remove("Fedora", "Heisenbug");
+            multiMap.localKeySet();
+        }
+
+        long localEntryCount = getLongAttribute("localOwnedEntryCount");
+        long localBackupEntryCount = getLongAttribute("localBackupEntryCount");
+        int localBackupCount = getIntegerAttribute("localBackupCount");
+
+        long localCreationTime = getLongAttribute("localCreationTime");
+        long localLastAccessTime = getLongAttribute("localLastAccessTime");
+        long localLastUpdateTime = getLongAttribute("localLastUpdateTime");
+        long localHits = getLongAttribute("localHits");
+        long localLockedEntryCount = getLongAttribute("localLockedEntryCount");
+        long localDirtyEntryCount = getLongAttribute("localDirtyEntryCount");
+
+        long localPutOperationCount = getLongAttribute("localPutOperationCount");
+        long localGetOperationCount = getLongAttribute("localGetOperationCount");
+        long localRemoveOperationCount = getLongAttribute("localRemoveOperationCount");
+
+        long localTotalPutLatency = getLongAttribute("localTotalPutLatency");
+        long localTotalGetLatency = getLongAttribute("localTotalGetLatency");
+        long localTotalRemoveLatency = getLongAttribute("localTotalRemoveLatency");
+        long localMaxPutLatency = getLongAttribute("localMaxPutLatency");
+        long localMaxGetLatency = getLongAttribute("localMaxGetLatency");
+        long localMaxRemoveLatency = getLongAttribute("localMaxRemoveLatency");
+
+        long localEventOperationCount = getLongAttribute("localEventOperationCount");
+        long localOtherOperationCount = getLongAttribute("localOtherOperationCount");
+        long localTotal = getLongAttribute("localTotal");
+        int size = getIntegerAttribute("size");
+
+        assertEquals(iterations, localHits);
+        assertEquals(3, localEntryCount);
+        assertEquals(0, localBackupEntryCount);
+        assertEquals(1, localBackupCount);
+        assertEquals(2 * iterations, localGetOperationCount);
+        assertEquals(4 * iterations, localPutOperationCount);
+        assertEquals(iterations, localRemoveOperationCount);
+        assertEquals(0, localLockedEntryCount);
+        assertEquals(0, localDirtyEntryCount);
+
+        assertTrue("Creation time should be > start time", localCreationTime > startTime);
+        assertTrue("Last access time should be > start time", localLastAccessTime > startTime);
+        assertTrue("Last update time should be > start time", localLastUpdateTime > startTime);
+        assertTrue("Total put latency should be >= 0", localTotalPutLatency >= 0);
+        assertTrue("Total get latency should be >= 0", localTotalGetLatency >= 0);
+        assertTrue("Total remove latency should be >= 0", localTotalRemoveLatency >= 0);
+        assertTrue("Max put latency should be >= 0", localMaxPutLatency >= 0);
+        assertTrue("Max get latency should be >= 0", localMaxGetLatency >= 0);
+        assertTrue("Max remove latency should be >= 0", localMaxRemoveLatency >= 0);
+
+        assertEquals(0, localEventOperationCount);
+        assertEquals(iterations, localOtherOperationCount);
+        assertTrue("Total operation count should be > 0", localTotal > 0);
+        assertEquals(3, size);
+    }
+
+    private String getStringAttribute(String name) throws Exception {
+        return (String) holder.getMBeanAttribute(TYPE_NAME, mapName, name);
+    }
+
+    private Long getLongAttribute(String name) throws Exception {
+        return (Long) holder.getMBeanAttribute(TYPE_NAME, mapName, name);
+    }
+
+    private Integer getIntegerAttribute(String name) throws Exception {
+        return (Integer) holder.getMBeanAttribute(TYPE_NAME, mapName, name);
+    }
+
+}


### PR DESCRIPTION
* Fixes hits count so it reflects the entire history per record store (not just entries currently in the record store).
* Introduces test & fixes in `MultiMap` statistics

Fixes #4321 