### PR TITLE
Added configuration for IAtomicLong and IAtomicReference

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spring;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -165,6 +167,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> queueManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> lockManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> ringbufferManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> atomicLongManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> atomicReferenceManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> reliableTopicManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> semaphoreManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> listManagedMap;
@@ -191,6 +195,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.queueManagedMap = createManagedMap("queueConfigs");
             this.lockManagedMap = createManagedMap("lockConfigs");
             this.ringbufferManagedMap = createManagedMap("ringbufferConfigs");
+            this.atomicLongManagedMap = createManagedMap("atomicLongConfigs");
+            this.atomicReferenceManagedMap = createManagedMap("atomicReferenceConfigs");
             this.reliableTopicManagedMap = createManagedMap("reliableTopicConfigs");
             this.semaphoreManagedMap = createManagedMap("semaphoreConfigs");
             this.listManagedMap = createManagedMap("listConfigs");
@@ -248,6 +254,10 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleLock(node);
                     } else if ("ringbuffer".equals(nodeName)) {
                         handleRingbuffer(node);
+                    } else if ("atomic-long".equals(nodeName)) {
+                        handleAtomicLong(node);
+                    } else if ("atomic-reference".equals(nodeName)) {
+                        handleAtomicReference(node);
                     } else if ("reliable-topic".equals(nodeName)) {
                         handleReliableTopic(node);
                     } else if ("semaphore".equals(nodeName)) {
@@ -692,6 +702,18 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
             extractBasicStoreConfig(node, builder);
             ringbufferConfigBuilder.addPropertyValue("ringbufferStoreConfig", builder.getBeanDefinition());
+        }
+
+        public void handleAtomicLong(Node node) {
+            BeanDefinitionBuilder atomicLongConfigBuilder = createBeanBuilder(AtomicLongConfig.class);
+            fillAttributeValues(node, atomicLongConfigBuilder);
+            atomicLongManagedMap.put(getAttribute(node, "name"), atomicLongConfigBuilder.getBeanDefinition());
+        }
+
+        public void handleAtomicReference(Node node) {
+            BeanDefinitionBuilder atomicReferenceConfigBuilder = createBeanBuilder(AtomicReferenceConfig.class);
+            fillAttributeValues(node, atomicReferenceConfigBuilder);
+            atomicReferenceManagedMap.put(getAttribute(node, "name"), atomicReferenceConfigBuilder.getBeanDefinition());
         }
 
         public void handleQueue(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -316,6 +316,16 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element name="atomic-long" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="atomic-reference" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="semaphore" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:attribute name="name" use="required" type="xs:string"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spring;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -502,6 +504,20 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     }
 
     @Test
+    public void testAtomicLongConfig() {
+        AtomicLongConfig testAtomicLong = config.getAtomicLongConfig("testAtomicLong");
+        assertNotNull(testAtomicLong);
+        assertEquals("testAtomicLong", testAtomicLong.getName());
+    }
+
+    @Test
+    public void testAtomicReferenceConfig() {
+        AtomicReferenceConfig testAtomicReference = config.getAtomicReferenceConfig("testAtomicReference");
+        assertNotNull(testAtomicReference);
+        assertEquals("testAtomicReference", testAtomicReference.getName());
+    }
+
+    @Test
     public void testSemaphoreConfig() {
         SemaphoreConfig testSemaphore = config.getSemaphoreConfig("testSemaphore");
         assertNotNull(testSemaphore);
@@ -772,8 +788,8 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("list", list.getName());
         assertEquals("idGenerator", idGenerator.getName());
         assertEquals("reliableIdGenerator", reliableIdGenerator.getName());
-        assertEquals("atomicLong", atomicLong.getName());
-        assertEquals("atomicReference", atomicReference.getName());
+        assertEquals("testAtomicLong", atomicLong.getName());
+        assertEquals("testAtomicReference", atomicReference.getName());
         assertEquals("countDownLatch", countDownLatch.getName());
         assertEquals("semaphore", semaphore.getName());
     }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -266,6 +266,10 @@
                 <hz:ringbuffer-store enabled="true" factory-implementation="dummyRingbufferStoreFactory"/>
             </hz:ringbuffer>
 
+            <hz:atomic-long name="testAtomicLong"/>
+
+            <hz:atomic-reference name="testAtomicReference"/>
+
             <hz:semaphore name="testSemaphore" async-backup-count="1" backup-count="1" initial-permits="10"/>
 
             <hz:reliable-topic name="testReliableTopic" topic-overload-policy="BLOCK" read-batch-size="10"
@@ -576,8 +580,8 @@
     <hz:executorService id="executorService" instance-ref="instance" name="executorService"/>
     <hz:idGenerator id="idGenerator" instance-ref="instance" name="idGenerator"/>
     <hz:reliableIdGenerator id="reliableIdGenerator" instance-ref="instance" name="reliableIdGenerator"/>
-    <hz:atomicLong id="atomicLong" instance-ref="instance" name="atomicLong"/>
-    <hz:atomicReference id="atomicReference" instance-ref="instance" name="atomicReference"/>
+    <hz:atomicLong id="atomicLong" instance-ref="instance" name="testAtomicLong"/>
+    <hz:atomicReference id="atomicReference" instance-ref="instance" name="testAtomicReference"/>
     <hz:countDownLatch id="countDownLatch" instance-ref="instance" name="countDownLatch"/>
     <hz:semaphore id="semaphore" instance-ref="instance" name="semaphore"/>
     <hz:lock id="lock" instance-ref="instance" name="lock"/>

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
@@ -16,9 +16,21 @@
 
 package com.hazelcast.concurrent.atomiclong;
 
+import com.hazelcast.config.AtomicLongConfig;
+
 public class AtomicLongContainer {
 
+    private final AtomicLongConfig config;
+
     private long value;
+
+    public AtomicLongContainer(AtomicLongConfig config) {
+        this.config = config;
+    }
+
+    public AtomicLongConfig getConfig() {
+        return config;
+    }
 
     public long get() {
         return value;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.concurrent.atomiclong;
 
 import com.hazelcast.concurrent.atomiclong.operations.AtomicLongReplicationOperation;
+import com.hazelcast.config.AtomicLongConfig;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -47,7 +48,8 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
     private final ConstructorFunction<String, AtomicLongContainer> atomicLongConstructorFunction =
             new ConstructorFunction<String, AtomicLongContainer>() {
                 public AtomicLongContainer createNew(String key) {
-                    return new AtomicLongContainer();
+                    AtomicLongConfig config = nodeEngine.getConfig().findAtomicLongConfig(key);
+                    return new AtomicLongContainer(config);
                 }
             };
 
@@ -58,7 +60,7 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
         return getOrPutIfAbsent(containers, name, atomicLongConstructorFunction);
     }
 
-    // need for testing..
+    // need for testing
     public boolean containsAtomicLong(String name) {
         return containers.containsKey(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
@@ -16,11 +16,22 @@
 
 package com.hazelcast.concurrent.atomicreference;
 
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.nio.serialization.Data;
 
 public class AtomicReferenceContainer {
 
+    private final AtomicReferenceConfig config;
+
     private Data value;
+
+    public AtomicReferenceContainer(AtomicReferenceConfig config) {
+        this.config = config;
+    }
+
+    public AtomicReferenceConfig getConfig() {
+        return config;
+    }
 
     public Data get() {
         return value;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.concurrent.atomicreference;
 
 import com.hazelcast.concurrent.atomicreference.operations.AtomicReferenceReplicationOperation;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.ManagedService;
@@ -49,7 +50,8 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
     private final ConstructorFunction<String, AtomicReferenceContainer> atomicReferenceConstructorFunction =
             new ConstructorFunction<String, AtomicReferenceContainer>() {
                 public AtomicReferenceContainer createNew(String key) {
-                    return new AtomicReferenceContainer();
+                    AtomicReferenceConfig config = nodeEngine.getConfig().findAtomicReferenceConfig(key);
+                    return new AtomicReferenceContainer(config);
                 }
             };
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Provides a basic configuration.
+ *
+ * @param <T> type of the config
+ */
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractBasicConfig<T extends AbstractBasicConfig> implements IdentifiedDataSerializable {
+
+    private String name;
+
+    protected AbstractBasicConfig() {
+    }
+
+    protected AbstractBasicConfig(AbstractBasicConfig config) {
+        this.name = config.name;
+    }
+
+    abstract T getAsReadOnly();
+
+    /**
+     * Gets the name of this collection.
+     *
+     * @return the name of this collection
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of this collection.
+     *
+     * @param name the name of this collection
+     * @return the updated collection configuration
+     */
+    public T setName(String name) {
+        this.name = checkNotNull(name, "name cannot be null");
+        //noinspection unchecked
+        return (T) this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+    }
+
+    @Override
+    @SuppressWarnings("SimplifiableIfStatement")
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AbstractBasicConfig)) {
+            return false;
+        }
+
+        AbstractBasicConfig<?> that = (AbstractBasicConfig<?>) o;
+        return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+
+    /**
+     * Returns field names with values as concatenated String so it can be used in child classes' toString() methods.
+     */
+    protected String fieldsToString() {
+        return "name='" + name + "'";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AtomicLongConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AtomicLongConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Contains the configuration for an {@link java.util.concurrent.atomic.AtomicLong}.
+ */
+public class AtomicLongConfig extends AbstractBasicConfig<AtomicLongConfig> {
+
+    private transient AtomicLongConfigReadOnly readOnly;
+
+    public AtomicLongConfig() {
+    }
+
+    public AtomicLongConfig(String name) {
+        setName(name);
+    }
+
+    public AtomicLongConfig(AtomicLongConfig config) {
+        super(config);
+    }
+
+    @Override
+    public String toString() {
+        return "AtomicLongConfig{"
+                + fieldsToString()
+                + "}";
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.ATOMIC_LONG_CONFIG;
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return immutable version of this configuration
+     * @deprecated this method will be removed in 4.0; it is meant for internal usage only
+     */
+    @Override
+    public AtomicLongConfig getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new AtomicLongConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    static class AtomicLongConfigReadOnly extends AtomicLongConfig {
+
+        AtomicLongConfigReadOnly(AtomicLongConfig config) {
+            super(config);
+        }
+
+        @Override
+        public AtomicLongConfig setName(String name) {
+            throw new UnsupportedOperationException("This is a read-only config!");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AtomicReferenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AtomicReferenceConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Contains the configuration for an {@link java.util.concurrent.atomic.AtomicReference}.
+ */
+public class AtomicReferenceConfig extends AbstractBasicConfig<AtomicReferenceConfig> {
+
+    private transient AtomicReferenceConfigReadOnly readOnly;
+
+    public AtomicReferenceConfig() {
+    }
+
+    public AtomicReferenceConfig(String name) {
+        setName(name);
+    }
+
+    public AtomicReferenceConfig(AtomicReferenceConfig config) {
+        super(config);
+    }
+
+    @Override
+    public String toString() {
+        return "AtomicReferenceConfig{"
+                + fieldsToString()
+                + "}";
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.ATOMIC_REFERENCE_CONFIG;
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return immutable version of this configuration
+     * @deprecated this method will be removed in 4.0; it is meant for internal usage only
+     */
+    @Override
+    public AtomicReferenceConfig getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new AtomicReferenceConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    static class AtomicReferenceConfigReadOnly extends AtomicReferenceConfig {
+
+        AtomicReferenceConfigReadOnly(AtomicReferenceConfig config) {
+            super(config);
+        }
+
+        @Override
+        public AtomicReferenceConfig setName(String name) {
+            throw new UnsupportedOperationException("This is a read-only config!");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -120,6 +120,11 @@ public class Config {
     private final Map<String, ReliableIdGeneratorConfig> reliableIdGeneratorConfigMap =
             new ConcurrentHashMap<String, ReliableIdGeneratorConfig>();
 
+    private final Map<String, AtomicLongConfig> atomicLongConfigs = new ConcurrentHashMap<String, AtomicLongConfig>();
+
+    private final Map<String, AtomicReferenceConfig> atomicReferenceConfigs
+            = new ConcurrentHashMap<String, AtomicReferenceConfig>();
+
     private ServicesConfig servicesConfig = new ServicesConfig();
 
     private SecurityConfig securityConfig = new SecurityConfig();
@@ -1393,6 +1398,222 @@ public class Config {
         this.ringbufferConfigs.clear();
         this.ringbufferConfigs.putAll(ringbufferConfigs);
         for (Entry<String, RingbufferConfig> entry : ringbufferConfigs.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
+        return this;
+    }
+
+    /**
+     * Returns a read-only AtomicLong configuration for the given name.
+     * <p>
+     * The name is matched by pattern to the configuration and by stripping the
+     * partition ID qualifier from the given {@code name}.
+     * If there is no config found by the name, it will return the configuration
+     * with the name {@code default}.
+     *
+     * @param name name of the AtomicLong config
+     * @return the AtomicLong configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public AtomicLongConfig findAtomicLongConfig(String name) {
+        name = getBaseName(name);
+        AtomicLongConfig config = lookupByPattern(configPatternMatcher, atomicLongConfigs, name);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getAtomicLongConfig("default").getAsReadOnly();
+    }
+
+    /**
+     * Returns the AtomicLongConfig for the given name, creating one
+     * if necessary and adding it to the collection of known configurations.
+     * <p>
+     * The configuration is found by matching the the configuration name
+     * pattern to the provided {@code name} without the partition qualifier
+     * (the part of the name after {@code '@'}).
+     * If no configuration matches, it will create one by cloning the
+     * {@code "default"} configuration and add it to the configuration
+     * collection.
+     * <p>
+     * This method is intended to easily and fluently create and add
+     * configurations more specific than the default configuration without
+     * explicitly adding it by invoking {@link #addAtomicLongConfig(AtomicLongConfig)}.
+     * <p>
+     * Because it adds new configurations if they are not already present,
+     * this method is intended to be used before this config is used to
+     * create a hazelcast instance. Afterwards, newly added configurations
+     * may be ignored.
+     *
+     * @param name name of the AtomicLong config
+     * @return the AtomicLong configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public AtomicLongConfig getAtomicLongConfig(String name) {
+        name = getBaseName(name);
+        AtomicLongConfig config = lookupByPattern(configPatternMatcher, atomicLongConfigs, name);
+        if (config != null) {
+            return config;
+        }
+        AtomicLongConfig defConfig = atomicLongConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new AtomicLongConfig();
+            defConfig.setName("default");
+            addAtomicLongConfig(defConfig);
+        }
+        config = new AtomicLongConfig(defConfig);
+        config.setName(name);
+        addAtomicLongConfig(config);
+        return config;
+    }
+
+    /**
+     * Adds the AtomicLong configuration. The configuration is saved under the config
+     * name, which may be a pattern with which the configuration will be
+     * obtained in the future.
+     *
+     * @param atomicLongConfig the AtomicLong configuration
+     * @return this config instance
+     */
+    public Config addAtomicLongConfig(AtomicLongConfig atomicLongConfig) {
+        atomicLongConfigs.put(atomicLongConfig.getName(), atomicLongConfig);
+        return this;
+    }
+
+    /**
+     * Returns the map of AtomicLong configurations, mapped by config name.
+     * The config name may be a pattern with which the configuration was initially obtained.
+     *
+     * @return the AtomicLong configurations mapped by config name
+     */
+    public Map<String, AtomicLongConfig> getAtomicLongConfigs() {
+        return atomicLongConfigs;
+    }
+
+    /**
+     * Sets the map of AtomicLong configurations, mapped by config name.
+     * The config name may be a pattern with which the configuration will be obtained in the future.
+     *
+     * @param atomicLongConfigs the AtomicLong configuration map to set
+     * @return this config instance
+     */
+    public Config setAtomicLongConfigs(Map<String, AtomicLongConfig> atomicLongConfigs) {
+        this.atomicLongConfigs.clear();
+        this.atomicLongConfigs.putAll(atomicLongConfigs);
+        for (Entry<String, AtomicLongConfig> entry : atomicLongConfigs.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
+        return this;
+    }
+
+    /**
+     * Returns a read-only AtomicReference configuration for the given name.
+     * <p>
+     * The name is matched by pattern to the configuration and by stripping the
+     * partition ID qualifier from the given {@code name}.
+     * If there is no config found by the name, it will return the configuration
+     * with the name {@code default}.
+     *
+     * @param name name of the AtomicReference config
+     * @return the AtomicReference configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public AtomicReferenceConfig findAtomicReferenceConfig(String name) {
+        name = getBaseName(name);
+        AtomicReferenceConfig config = lookupByPattern(configPatternMatcher, atomicReferenceConfigs, name);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getAtomicReferenceConfig("default").getAsReadOnly();
+    }
+
+    /**
+     * Returns the AtomicReferenceConfig for the given name, creating one
+     * if necessary and adding it to the collection of known configurations.
+     * <p>
+     * The configuration is found by matching the the configuration name
+     * pattern to the provided {@code name} without the partition qualifier
+     * (the part of the name after {@code '@'}).
+     * If no configuration matches, it will create one by cloning the
+     * {@code "default"} configuration and add it to the configuration
+     * collection.
+     * <p>
+     * This method is intended to easily and fluently create and add
+     * configurations more specific than the default configuration without
+     * explicitly adding it by invoking {@link #addAtomicReferenceConfig(AtomicReferenceConfig)}.
+     * <p>
+     * Because it adds new configurations if they are not already present,
+     * this method is intended to be used before this config is used to
+     * create a hazelcast instance. Afterwards, newly added configurations
+     * may be ignored.
+     *
+     * @param name name of the AtomicReference config
+     * @return the AtomicReference configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public AtomicReferenceConfig getAtomicReferenceConfig(String name) {
+        name = getBaseName(name);
+        AtomicReferenceConfig config = lookupByPattern(configPatternMatcher, atomicReferenceConfigs, name);
+        if (config != null) {
+            return config;
+        }
+        AtomicReferenceConfig defConfig = atomicReferenceConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new AtomicReferenceConfig();
+            defConfig.setName("default");
+            addAtomicReferenceConfig(defConfig);
+        }
+        config = new AtomicReferenceConfig(defConfig);
+        config.setName(name);
+        addAtomicReferenceConfig(config);
+        return config;
+    }
+
+    /**
+     * Adds the AtomicReference configuration. The configuration is saved under the config
+     * name, which may be a pattern with which the configuration will be
+     * obtained in the future.
+     *
+     * @param atomicReferenceConfig the AtomicReference configuration
+     * @return this config instance
+     */
+    public Config addAtomicReferenceConfig(AtomicReferenceConfig atomicReferenceConfig) {
+        atomicReferenceConfigs.put(atomicReferenceConfig.getName(), atomicReferenceConfig);
+        return this;
+    }
+
+    /**
+     * Returns the map of AtomicReference configurations, mapped by config name.
+     * The config name may be a pattern with which the configuration was initially obtained.
+     *
+     * @return the AtomicReference configurations mapped by config name
+     */
+    public Map<String, AtomicReferenceConfig> getAtomicReferenceConfigs() {
+        return atomicReferenceConfigs;
+    }
+
+    /**
+     * Sets the map of AtomicReference configurations, mapped by config name.
+     * The config name may be a pattern with which the configuration will be obtained in the future.
+     *
+     * @param atomicReferenceConfigs the AtomicReference configuration map to set
+     * @return this config instance
+     */
+    public Config setAtomicReferenceConfigs(Map<String, AtomicReferenceConfig> atomicReferenceConfigs) {
+        this.atomicReferenceConfigs.clear();
+        this.atomicReferenceConfigs.putAll(atomicReferenceConfigs);
+        for (Entry<String, AtomicReferenceConfig> entry : atomicReferenceConfigs.entrySet()) {
             entry.getValue().setName(entry.getKey());
         }
         return this;
@@ -3183,6 +3404,8 @@ public class Config {
                 + ", executorConfigs=" + executorConfigs
                 + ", semaphoreConfigs=" + semaphoreConfigs
                 + ", ringbufferConfigs=" + ringbufferConfigs
+                + ", atomicLongConfigs=" + atomicLongConfigs
+                + ", atomicReferenceConfigs=" + atomicReferenceConfigs
                 + ", wanReplicationConfigs=" + wanReplicationConfigs
                 + ", listenerConfigs=" + listenerConfigs
                 + ", mapEventJournalConfigs=" + mapEventJournalConfigs

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -88,8 +88,10 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int CACHE_PARTITION_LOST_LISTENER_CONFIG = 46;
     public static final int SIMPLE_CACHE_ENTRY_LISTENER_CONFIG = 47;
     public static final int RELIABLE_ID_GENERATOR_CONFIG = 48;
+    public static final int ATOMIC_LONG_CONFIG = 49;
+    public static final int ATOMIC_REFERENCE_CONFIG = 50;
 
-    private static final int LEN = RELIABLE_ID_GENERATOR_CONFIG + 1;
+    private static final int LEN = ATOMIC_REFERENCE_CONFIG + 1;
 
     @Override
     public int getFactoryId() {
@@ -397,6 +399,20 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new ReliableIdGeneratorConfig();
+                    }
+                };
+        constructors[ATOMIC_LONG_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new AtomicLongConfig();
+                    }
+                };
+        constructors[ATOMIC_REFERENCE_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new AtomicReferenceConfig();
                     }
                 };
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -115,6 +115,8 @@ public class ConfigXmlGenerator {
         semaphoreXmlGenerator(gen, config);
         lockXmlGenerator(gen, config);
         ringbufferXmlGenerator(gen, config);
+        atomicLongXmlGenerator(gen, config);
+        atomicReferenceXmlGenerator(gen, config);
         executorXmlGenerator(gen, config);
         durableExecutorXmlGenerator(gen, config);
         scheduledExecutorXmlGenerator(gen, config);
@@ -462,6 +464,24 @@ public class ConfigXmlGenerator {
                         .appendProperties(storeConfig.getProperties());
                 gen.close();
             }
+            gen.close();
+        }
+    }
+
+    private static void atomicLongXmlGenerator(XmlGenerator gen, Config config) {
+        Collection<AtomicLongConfig> configs = config.getAtomicLongConfigs().values();
+        for (AtomicLongConfig atomicLongConfig : configs) {
+            gen.open("atomic-long", "name", atomicLongConfig.getName());
+
+            gen.close();
+        }
+    }
+
+    private static void atomicReferenceXmlGenerator(XmlGenerator gen, Config config) {
+        Collection<AtomicReferenceConfig> configs = config.getAtomicReferenceConfigs().values();
+        for (AtomicReferenceConfig atomicReferenceConfig : configs) {
+            gen.open("atomic-reference", "name", atomicReferenceConfig.getName());
+
             gen.close();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -62,6 +62,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.JobTrackerConfig.DEFAULT_COMMUNICATE_STATS;
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode;
+import static com.hazelcast.config.XmlElements.ATOMIC_LONG;
+import static com.hazelcast.config.XmlElements.ATOMIC_REFERENCE;
 import static com.hazelcast.config.XmlElements.CACHE;
 import static com.hazelcast.config.XmlElements.CARDINALITY_ESTIMATOR;
 import static com.hazelcast.config.XmlElements.DURABLE_EXECUTOR_SERVICE;
@@ -354,6 +356,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleLock(node);
         } else if (RINGBUFFER.isEqual(nodeName)) {
             handleRingbuffer(node);
+        } else if (ATOMIC_LONG.isEqual(nodeName)) {
+            handleAtomicLong(node);
+        } else if (ATOMIC_REFERENCE.isEqual(nodeName)) {
+            handleAtomicReference(node);
         } else if (LISTENERS.isEqual(nodeName)) {
             handleListeners(node);
         } else if (PARTITION_GROUP.isEqual(nodeName)) {
@@ -1961,6 +1967,20 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             }
         }
         config.addRingBufferConfig(rbConfig);
+    }
+
+    private void handleAtomicLong(Node node) {
+        Node attName = node.getAttributes().getNamedItem("name");
+        String name = getTextContent(attName);
+        AtomicLongConfig atomicLongConfig = new AtomicLongConfig(name);
+        config.addAtomicLongConfig(atomicLongConfig);
+    }
+
+    private void handleAtomicReference(Node node) {
+        Node attName = node.getAttributes().getNamedItem("name");
+        String name = getTextContent(attName);
+        AtomicReferenceConfig atomicReferenceConfig = new AtomicReferenceConfig(name);
+        config.addAtomicReferenceConfig(atomicReferenceConfig);
     }
 
     private void handleListeners(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -44,6 +44,8 @@ enum XmlElements {
     SEMAPHORE("semaphore", true),
     LOCK("lock", true),
     RINGBUFFER("ringbuffer", true),
+    ATOMIC_LONG("atomic-long", true),
+    ATOMIC_REFERENCE("atomic-reference", true),
     LISTENERS("listeners", false),
     SERIALIZATION("serialization", false),
     SERVICES("services", false),

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.ConfigPatternMatcher;
@@ -75,6 +77,7 @@ import static java.util.Collections.singleton;
 @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class ClusterWideConfigurationService implements PreJoinAwareService,
         CoreService, ClusterVersionListener, ManagedService, ConfigurationService, SplitBrainHandlerService {
+
     public static final String SERVICE_NAME = "configuration-service";
     public static final int CONFIG_PUBLISH_MAX_ATTEMPT_COUNT = 100;
 
@@ -91,6 +94,9 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
     private final ConcurrentMap<String, CardinalityEstimatorConfig> cardinalityEstimatorConfigs =
             new ConcurrentHashMap<String, CardinalityEstimatorConfig>();
     private final ConcurrentMap<String, RingbufferConfig> ringbufferConfigs = new ConcurrentHashMap<String, RingbufferConfig>();
+    private final ConcurrentMap<String, AtomicLongConfig> atomicLongConfigs = new ConcurrentHashMap<String, AtomicLongConfig>();
+    private final ConcurrentMap<String, AtomicReferenceConfig> atomicReferenceConfigs
+            = new ConcurrentHashMap<String, AtomicReferenceConfig>();
     private final ConcurrentMap<String, LockConfig> lockConfigs = new ConcurrentHashMap<String, LockConfig>();
     private final ConcurrentMap<String, ListConfig> listConfigs = new ConcurrentHashMap<String, ListConfig>();
     private final ConcurrentMap<String, SetConfig> setConfigs = new ConcurrentHashMap<String, SetConfig>();
@@ -237,10 +243,10 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
      * Register a dynamic configuration in a local member. When a dynamic configuration with the same name already
      * exists then this call has no effect.
      *
-     * @param newConfig Configuration to register.
+     * @param newConfig       Configuration to register.
      * @param configCheckMode behaviour when a config is detected
      * @throws UnsupportedOperationException when given configuration type is not supported
-     * @throws ConfigurationException when conflict is detected and configCheckMode is on THROW_EXCEPTION
+     * @throws ConfigurationException        when conflict is detected and configCheckMode is on THROW_EXCEPTION
      */
     @SuppressWarnings("checkstyle:methodlength")
     public void registerConfigLocally(IdentifiedDataSerializable newConfig,
@@ -453,6 +459,26 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
     @Override
     public ConcurrentMap<String, RingbufferConfig> getRingbufferConfigs() {
         return ringbufferConfigs;
+    }
+
+    @Override
+    public AtomicLongConfig findAtomicLongConfig(String name) {
+        return lookupByPattern(configPatternMatcher, atomicLongConfigs, name);
+    }
+
+    @Override
+    public Map<String, AtomicLongConfig> getAtomicLongConfigs() {
+        return atomicLongConfigs;
+    }
+
+    @Override
+    public AtomicReferenceConfig findAtomicReferenceConfig(String name) {
+        return lookupByPattern(configPatternMatcher, atomicReferenceConfigs, name);
+    }
+
+    @Override
+    public Map<String, AtomicReferenceConfig> getAtomicReferenceConfigs() {
+        return atomicReferenceConfigs;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -73,7 +75,6 @@ public interface ConfigurationService {
      */
     MapConfig findMapConfig(String name);
 
-
     /**
      * Finds existing Topic config.
      *
@@ -129,6 +130,20 @@ public interface ConfigurationService {
      * @return Ringbuffer config or {@code null} when requested Ringbuffer configuration does not exist
      */
     RingbufferConfig findRingbufferConfig(String name);
+
+    /**
+     * Finds existing AtomicLong config.
+     *
+     * @return AtomicLong Config or {@code null} when requested AtomicLong configuration does not exist
+     */
+    AtomicLongConfig findAtomicLongConfig(String name);
+
+    /**
+     * Finds existing AtomicReference config.
+     *
+     * @return AtomicReference Config or {@code null} when requested AtomicReference configuration does not exist
+     */
+    AtomicReferenceConfig findAtomicReferenceConfig(String name);
 
     /**
      * Finds existing Lock config.
@@ -265,6 +280,20 @@ public interface ConfigurationService {
      * @return registered ringbuffer configurations
      */
     Map<String, RingbufferConfig> getRingbufferConfigs();
+
+    /**
+     * Returns all registered AtomicLong configurations.
+     *
+     * @return registered AtomicLong configurations
+     */
+    Map<String, AtomicLongConfig> getAtomicLongConfigs();
+
+    /**
+     * Returns all registered AtomicReference configurations.
+     *
+     * @return registered AtomicReference configurations
+     */
+    Map<String, AtomicReferenceConfig> getAtomicReferenceConfigs();
 
     /**
      * Returns all registered topic configurations.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.Config;
@@ -72,6 +74,7 @@ import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBas
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class DynamicConfigurationAwareConfig extends Config {
+
     private final Config staticConfig;
     private final ConfigPatternMatcher configPatternMatcher;
 
@@ -595,6 +598,93 @@ public class DynamicConfigurationAwareConfig extends Config {
     @Override
     public Config setRingbufferConfigs(Map<String, RingbufferConfig> ringbufferConfigs) {
         throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public AtomicLongConfig findAtomicLongConfig(String name) {
+        return getAtomicLongConfigInternal(name, "default").getAsReadOnly();
+    }
+
+    @Override
+    public AtomicLongConfig getAtomicLongConfig(String name) {
+        return getAtomicLongConfigInternal(name, name);
+    }
+
+    @Override
+    public Config addAtomicLongConfig(AtomicLongConfig atomicLongConfig) {
+        checkStaticConfigurationDoesNotExist(staticConfig.getAtomicLongConfigs(), atomicLongConfig.getName(), atomicLongConfig);
+        configurationService.broadcastConfig(atomicLongConfig);
+        return this;
+    }
+
+    @Override
+    public Map<String, AtomicLongConfig> getAtomicLongConfigs() {
+        Map<String, AtomicLongConfig> staticConfigs = staticConfig.getAtomicLongConfigs();
+        Map<String, AtomicLongConfig> dynamicConfigs = configurationService.getAtomicLongConfigs();
+
+        return aggregate(staticConfigs, dynamicConfigs);
+    }
+
+    @Override
+    public Config setAtomicLongConfigs(Map<String, AtomicLongConfig> atomicLongConfigs) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    private AtomicLongConfig getAtomicLongConfigInternal(String name, String fallbackName) {
+        String baseName = getBaseName(name);
+        Map<String, AtomicLongConfig> atomicLongConfigs = staticConfig.getAtomicLongConfigs();
+        AtomicLongConfig atomicLongConfig = lookupByPattern(configPatternMatcher, atomicLongConfigs, baseName);
+        if (atomicLongConfig == null) {
+            atomicLongConfig = configurationService.findAtomicLongConfig(baseName);
+        }
+        if (atomicLongConfig == null) {
+            atomicLongConfig = staticConfig.getAtomicLongConfig(fallbackName);
+        }
+        return atomicLongConfig;
+    }
+
+    @Override
+    public AtomicReferenceConfig findAtomicReferenceConfig(String name) {
+        return getAtomicReferenceConfigInternal(name, "default").getAsReadOnly();
+    }
+
+    @Override
+    public AtomicReferenceConfig getAtomicReferenceConfig(String name) {
+        return getAtomicReferenceConfigInternal(name, name);
+    }
+
+    @Override
+    public Config addAtomicReferenceConfig(AtomicReferenceConfig atomicReferenceConfig) {
+        checkStaticConfigurationDoesNotExist(staticConfig.getAtomicReferenceConfigs(), atomicReferenceConfig.getName(),
+                atomicReferenceConfig);
+        configurationService.broadcastConfig(atomicReferenceConfig);
+        return this;
+    }
+
+    @Override
+    public Map<String, AtomicReferenceConfig> getAtomicReferenceConfigs() {
+        Map<String, AtomicReferenceConfig> staticConfigs = staticConfig.getAtomicReferenceConfigs();
+        Map<String, AtomicReferenceConfig> dynamicConfigs = configurationService.getAtomicReferenceConfigs();
+
+        return aggregate(staticConfigs, dynamicConfigs);
+    }
+
+    @Override
+    public Config setAtomicReferenceConfigs(Map<String, AtomicReferenceConfig> atomicReferenceConfigs) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    private AtomicReferenceConfig getAtomicReferenceConfigInternal(String name, String fallbackName) {
+        String baseName = getBaseName(name);
+        Map<String, AtomicReferenceConfig> atomicReferenceConfigs = staticConfig.getAtomicReferenceConfigs();
+        AtomicReferenceConfig atomicReferenceConfig = lookupByPattern(configPatternMatcher, atomicReferenceConfigs, baseName);
+        if (atomicReferenceConfig == null) {
+            atomicReferenceConfig = configurationService.findAtomicReferenceConfig(baseName);
+        }
+        if (atomicReferenceConfig == null) {
+            atomicReferenceConfig = staticConfig.getAtomicReferenceConfig(fallbackName);
+        }
+        return atomicReferenceConfig;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -88,6 +90,16 @@ class EmptyConfigurationService implements ConfigurationService {
 
     @Override
     public RingbufferConfig findRingbufferConfig(String name) {
+        return null;
+    }
+
+    @Override
+    public AtomicLongConfig findAtomicLongConfig(String name) {
+        return null;
+    }
+
+    @Override
+    public AtomicReferenceConfig findAtomicReferenceConfig(String name) {
         return null;
     }
 
@@ -188,6 +200,16 @@ class EmptyConfigurationService implements ConfigurationService {
 
     @Override
     public Map<String, RingbufferConfig> getRingbufferConfigs() {
+        return emptyMap();
+    }
+
+    @Override
+    public Map<String, AtomicLongConfig> getAtomicLongConfigs() {
+        return emptyMap();
+    }
+
+    @Override
+    public Map<String, AtomicReferenceConfig> getAtomicReferenceConfigs() {
         return emptyMap();
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -57,6 +57,8 @@
                 <xs:element name="semaphore" type="semaphore" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="lock" type="lock" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="ringbuffer" type="ringbuffer" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="atomic-long" type="atomic-long" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="atomic-reference" type="atomic-reference" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="native-memory" type="native-memory" minOccurs="0" maxOccurs="1"/>
@@ -1290,6 +1292,30 @@
             <xs:annotation>
                 <xs:documentation>
                     The name of the ringbuffer. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="atomic-long">
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the IAtomicLong. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="atomic-reference">
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the IAtomicReference. Required.
                 </xs:documentation>
             </xs:annotation>
             <xs:simpleType>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -272,6 +272,10 @@
         <prefetch-validity-millis>10000</prefetch-validity-millis>
     </reliable-id-generator>
 
+    <atomic-long name="default"/>
+
+    <atomic-reference name="default"/>
+
     <serialization>
         <portable-version>0</portable-version>
     </serialization>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1526,7 +1526,6 @@ https://hazelcast.org/documentation/.
         Includes the Ringbuffer store factory class name and property configurations. The store format is the same as the
             in-memory-format for the Ringbuffer.
     -->
-
     <ringbuffer name="default">
         <capacity>10000</capacity>
         <time-to-live-seconds>0</time-to-live-seconds>
@@ -1563,6 +1562,22 @@ https://hazelcast.org/documentation/.
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>10000</prefetch-validity-millis>
     </reliable-id-generator>
+
+    <!--
+        ===== HAZELCAST ATOMIC LONG CONFIGURATION =====
+
+        Configuration element's name is <atomic-long>. It has the required attribute "name" with which you
+        can specify the name of your IAtomicLong. This attribute's default value is "default".
+    -->
+    <atomic-long name="default"/>
+
+    <!--
+        ===== HAZELCAST ATOMIC REFERENCE CONFIGURATION =====
+
+        Configuration element's name is <atomic-reference>. It has the required attribute "name" with which you
+        can specify the name of your IAtomicReference. This attribute's default value is "default".
+    -->
+    <atomic-reference name="default"/>
 
     <!--
         ===== HAZELCAST LISTENER CONFIGURATIONS =====

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigReadOnlyTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractBasicConfigReadOnlyTest<T extends AbstractBasicConfig> extends HazelcastTestSupport {
+
+    protected T config;
+
+    @Before
+    public final void setUpConfig() {
+        config = createConfig();
+    }
+
+    protected abstract T createConfig();
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setName() {
+        config.setName("myAtomicLong");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractBasicConfigTest<T extends AbstractBasicConfig> extends HazelcastTestSupport {
+
+    protected T config;
+
+    @Before
+    public final void setUpConfig() {
+        config = createConfig();
+    }
+
+    protected abstract T createConfig();
+
+    @Test
+    public void setName() {
+        config.setName("myAtomicLong");
+
+        assertEquals("myAtomicLong", config.getName());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setName_withNull() {
+        config.setName(null);
+    }
+
+    @Test
+    public void testToString() {
+        String configString = config.toString();
+        assertNotNull("toString() should be implemented", configString);
+        assertTrue("toString() should contain name field", configString.contains("name='" + config.getName() + "'"));
+    }
+
+    @Test
+    public void testSerialization() {
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+        Data data = serializationService.toData(config);
+        T clone = serializationService.toObject(data);
+
+        assertEquals(clone, config);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigReadOnlyTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AtomicLongConfigReadOnlyTest extends AbstractBasicConfigReadOnlyTest<AtomicLongConfig> {
+
+    @Override
+    protected AtomicLongConfig createConfig() {
+        return new AtomicLongConfig().getAsReadOnly();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.AtomicLongConfig.AtomicLongConfigReadOnly;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AtomicLongConfigTest extends AbstractBasicConfigTest<AtomicLongConfig> {
+
+    @Override
+    protected AtomicLongConfig createConfig() {
+        return new AtomicLongConfig();
+    }
+
+    @Test
+    public void testConstructor_withName() {
+        config = new AtomicLongConfig("myAtomicLong");
+
+        assertEquals("myAtomicLong", config.getName());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(AtomicLongConfig.class)
+                .allFieldsShouldBeUsedExcept("readOnly")
+                .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .withPrefabValues(AtomicLongConfigReadOnly.class,
+                        new AtomicLongConfigReadOnly(new AtomicLongConfig("red")),
+                        new AtomicLongConfigReadOnly(new AtomicLongConfig("black")))
+                .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigReadOnlyTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AtomicReferenceConfigReadOnlyTest extends AbstractBasicConfigReadOnlyTest<AtomicReferenceConfig> {
+
+    @Override
+    protected AtomicReferenceConfig createConfig() {
+        return new AtomicReferenceConfig().getAsReadOnly();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.AtomicReferenceConfig.AtomicReferenceConfigReadOnly;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AtomicReferenceConfigTest extends AbstractBasicConfigTest<AtomicReferenceConfig> {
+
+    @Override
+    protected AtomicReferenceConfig createConfig() {
+        return new AtomicReferenceConfig();
+    }
+
+    @Test
+    public void testConstructor_withName() {
+        config = new AtomicReferenceConfig("myAtomicReference");
+
+        assertEquals("myAtomicReference", config.getName());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(AtomicReferenceConfig.class)
+                .allFieldsShouldBeUsedExcept("readOnly")
+                .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .withPrefabValues(AtomicReferenceConfigReadOnly.class,
+                        new AtomicReferenceConfigReadOnly(new AtomicReferenceConfig("red")),
+                        new AtomicReferenceConfigReadOnly(new AtomicReferenceConfig("black")))
+                .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -76,6 +76,8 @@ class ConfigCompatibilityChecker {
         checkCompatibleConfigs("network", c1.getNetworkConfig(), c2.getNetworkConfig(), new NetworkConfigChecker());
         checkCompatibleConfigs("map", c1, c2, c1.getMapConfigs(), c2.getMapConfigs(), new MapConfigChecker());
         checkCompatibleConfigs("ringbuffer", c1, c2, c1.getRingbufferConfigs(), c2.getRingbufferConfigs(), new RingbufferConfigChecker());
+        checkCompatibleConfigs("atomic-long", c1, c2, c1.getAtomicLongConfigs(), c2.getAtomicLongConfigs(), new AtomicLongConfigChecker());
+        checkCompatibleConfigs("atomic-reference", c1, c2, c1.getAtomicReferenceConfigs(), c2.getAtomicReferenceConfigs(), new AtomicReferenceConfigChecker());
         checkCompatibleConfigs("queue", c1, c2, c1.getQueueConfigs(), c2.getQueueConfigs(), new QueueConfigChecker());
         checkCompatibleConfigs("semaphore", c1, c2, getSemaphoreConfigsByName(c1), getSemaphoreConfigsByName(c2), new SemaphoreConfigChecker());
         checkCompatibleConfigs("lock", c1, c2, c1.getLockConfigs(), c2.getLockConfigs(), new LockConfigChecker());
@@ -241,6 +243,32 @@ class ConfigCompatibilityChecker {
         @Override
         EventJournalConfig getDefault(Config c) {
             return c.getCacheEventJournalConfig("default");
+        }
+    }
+
+    private static class AtomicLongConfigChecker extends ConfigChecker<AtomicLongConfig> {
+        @Override
+        boolean check(AtomicLongConfig c1, AtomicLongConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName());
+        }
+
+        @Override
+        AtomicLongConfig getDefault(Config c) {
+            return c.getAtomicLongConfig("default");
+        }
+    }
+
+    private static class AtomicReferenceConfigChecker extends ConfigChecker<AtomicReferenceConfig> {
+        @Override
+        boolean check(AtomicReferenceConfig c1, AtomicReferenceConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName());
+        }
+
+        @Override
+        AtomicReferenceConfig getDefault(Config c) {
+            return c.getAtomicReferenceConfig("default");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -193,6 +193,32 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
+    public void testAtomicLong() {
+        AtomicLongConfig expectedConfig = new AtomicLongConfig("testAtomicLongConfig");
+
+        Config config = new Config()
+                .addAtomicLongConfig(expectedConfig);
+
+        Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        AtomicLongConfig actualConfig = xmlConfig.getAtomicLongConfig(expectedConfig.getName());
+        assertEquals(expectedConfig, actualConfig);
+    }
+
+    @Test
+    public void testAtomicReference() {
+        AtomicReferenceConfig expectedConfig = new AtomicReferenceConfig("testAtomicReferenceConfig");
+
+        Config config = new Config()
+                .addAtomicReferenceConfig(expectedConfig);
+
+        Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        AtomicReferenceConfig actualConfig = xmlConfig.getAtomicReferenceConfig(expectedConfig.getName());
+        assertEquals(expectedConfig, actualConfig);
+    }
+
+    @Test
     public void testCacheMergePolicy() {
         CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
         cacheConfig.setName("testCache");

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -425,6 +425,26 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void readAtomicLong() {
+        String xml = HAZELCAST_START_TAG
+                + "    <atomic-long name=\"custom\"/>"
+                + HAZELCAST_END_TAG;
+        Config config = buildConfig(xml);
+        AtomicLongConfig atomicLongConfig = config.getAtomicLongConfig("custom");
+        assertEquals("custom", atomicLongConfig.getName());
+    }
+
+    @Test
+    public void readAtomicReference() {
+        String xml = HAZELCAST_START_TAG
+                + "    <atomic-reference name=\"custom\"/>"
+                + HAZELCAST_END_TAG;
+        Config config = buildConfig(xml);
+        AtomicReferenceConfig atomicReferenceConfig = config.getAtomicReferenceConfig("custom");
+        assertEquals("custom", atomicReferenceConfig.getName());
+    }
+
+    @Test
     public void testConfig2Xml2DefaultConfig() {
         testConfig2Xml2Config("hazelcast-default.xml");
     }


### PR DESCRIPTION
* added `AbstractBasicConfig` class
* added `AtomicLongConfig` and `AtomicReferenceConfig` implementations
* added configuration to XSD and XML parser and generator classes
* added configuration to `DynamicConfig` classes
* added configuration to Spring classes
* added configuration to `AtomicLongService` and `AtomicLongContainer`
* added configuration to `AtomicReferenceService` and `AtomicReferenceContainer`

We need configuration classes for the `com.hazelcast.concurrent` data structures, since we need to add configuration for the following 3.10 features:
* split-brain protection (aka quorum)
* split-brain healing (aka merge policies)