### PR TITLE
Cleanup of Spring related classes

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -29,6 +29,7 @@ import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.spring.context.SpringManagedContext;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanReference;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -36,16 +37,17 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.util.Assert;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 
 import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
 import static com.hazelcast.util.StringUtil.upperCaseInternal;
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+import static org.springframework.util.Assert.isTrue;
 
 /**
  * Base class of all Hazelcast BeanDefinitionParser implementations.
@@ -57,6 +59,7 @@ import static com.hazelcast.util.StringUtil.upperCaseInternal;
  * <li>{@link HazelcastTypeBeanDefinitionParser}</li>
  * </ul>
  */
+@SuppressWarnings("WeakerAccess")
 public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBeanDefinitionParser {
 
     /**
@@ -67,7 +70,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
         protected BeanDefinitionBuilder configBuilder;
 
         protected void handleCommonBeanAttributes(Node node, BeanDefinitionBuilder builder, ParserContext parserContext) {
-            final NamedNodeMap attributes = node.getAttributes();
+            NamedNodeMap attributes = node.getAttributes();
             if (attributes != null) {
                 Node lazyInitAttr = attributes.getNamedItem("lazy-init");
                 if (lazyInitAttr != null) {
@@ -95,33 +98,29 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             }
         }
 
-        protected BeanDefinitionBuilder createBeanBuilder(final Class clazz) {
+        protected BeanDefinitionBuilder createBeanBuilder(Class clazz) {
             BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(clazz);
             builder.setScope(configBuilder.getBeanDefinition().getScope());
             builder.setLazyInit(configBuilder.getBeanDefinition().isLazyInit());
             return builder;
         }
 
-        protected BeanDefinitionBuilder createAndFillBeanBuilder(Node node, final Class clazz,
-                                                                 final String propertyName,
-                                                                 final BeanDefinitionBuilder parent,
-                                                                 final String... exceptPropertyNames) {
+        protected BeanDefinitionBuilder createAndFillBeanBuilder(Node node, Class clazz, String propertyName,
+                                                                 BeanDefinitionBuilder parent, String... exceptPropertyNames) {
             BeanDefinitionBuilder builder = createBeanBuilder(clazz);
-            final AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
             fillValues(node, builder, exceptPropertyNames);
             parent.addPropertyValue(propertyName, beanDefinition);
             return builder;
         }
 
-        protected void createAndFillListedBean(final Node node,
-                                               final Class clazz,
-                                               final String propertyName,
-                                               final ManagedMap<String, AbstractBeanDefinition> managedMap,
-                                               final String... excludeNames) {
-            final BeanDefinitionBuilder builder = createBeanBuilder(clazz);
-            final AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
-            //"name"
-            final String name = getAttribute(node, propertyName);
+        @SuppressWarnings("SameParameterValue")
+        protected void createAndFillListedBean(Node node, Class clazz, String propertyName,
+                                               ManagedMap<String, AbstractBeanDefinition> managedMap, String... excludeNames) {
+            BeanDefinitionBuilder builder = createBeanBuilder(clazz);
+            AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
+            // "name"
+            String name = getAttribute(node, propertyName);
             builder.addPropertyValue("name", name);
             fillValues(node, builder, excludeNames);
             managedMap.put(name, beanDefinition);
@@ -129,7 +128,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
 
         protected void fillValues(Node node, BeanDefinitionBuilder builder, String... excludeNames) {
             Collection<String> epn = excludeNames != null && excludeNames.length > 0
-                    ? new HashSet<String>(Arrays.asList(excludeNames)) : null;
+                    ? new HashSet<String>(asList(excludeNames)) : null;
             fillAttributeValues(node, builder, epn);
             for (Node n : childElements(node)) {
                 String name = xmlToJavaName(cleanNodeName(n));
@@ -143,30 +142,30 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
 
         protected void fillAttributeValues(Node node, BeanDefinitionBuilder builder, String... excludeNames) {
             Collection<String> epn = excludeNames != null && excludeNames.length > 0
-                    ? new HashSet<String>(Arrays.asList(excludeNames)) : null;
+                    ? new HashSet<String>(asList(excludeNames)) : null;
             fillAttributeValues(node, builder, epn);
         }
 
         protected void fillAttributeValues(Node node, BeanDefinitionBuilder builder, Collection<String> epn) {
-            final NamedNodeMap atts = node.getAttributes();
-            if (atts != null) {
-                for (int a = 0; a < atts.getLength(); a++) {
-                    final Node att = atts.item(a);
-                    final String name = xmlToJavaName(att.getNodeName());
+            NamedNodeMap attributes = node.getAttributes();
+            if (attributes != null) {
+                for (int a = 0; a < attributes.getLength(); a++) {
+                    Node attribute = attributes.item(a);
+                    String name = xmlToJavaName(attribute.getNodeName());
                     if (epn != null && epn.contains(name)) {
                         continue;
                     }
-                    final String value = att.getNodeValue();
+                    String value = attribute.getNodeValue();
                     builder.addPropertyValue(name, value);
                 }
             }
         }
 
         protected ManagedList parseListeners(Node node, Class listenerConfigClass) {
-            ManagedList listeners = new ManagedList();
-            final String implementationAttr = "implementation";
+            ManagedList<BeanDefinition> listeners = new ManagedList<BeanDefinition>();
+            String implementationAttr = "implementation";
             for (Node listenerNode : childElements(node)) {
-                final BeanDefinitionBuilder listenerConfBuilder = createBeanBuilder(listenerConfigClass);
+                BeanDefinitionBuilder listenerConfBuilder = createBeanBuilder(listenerConfigClass);
                 fillAttributeValues(listenerNode, listenerConfBuilder, implementationAttr);
                 Node implementationNode = listenerNode.getAttributes().getNamedItem(implementationAttr);
                 if (implementationNode != null) {
@@ -178,32 +177,30 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
         }
 
         protected ManagedList parseProxyFactories(Node node, Class proxyFactoryConfigClass) {
-            ManagedList list = new ManagedList();
+            ManagedList<BeanDefinition> list = new ManagedList<BeanDefinition>();
             for (Node instanceNode : childElements(node)) {
-                final BeanDefinitionBuilder confBuilder = createBeanBuilder(proxyFactoryConfigClass);
+                BeanDefinitionBuilder confBuilder = createBeanBuilder(proxyFactoryConfigClass);
                 fillAttributeValues(instanceNode, confBuilder);
                 list.add(confBuilder.getBeanDefinition());
             }
             return list;
         }
 
-
-        protected void handleDataSerializableFactories(final Node node, final BeanDefinitionBuilder serializationConfigBuilder) {
-            ManagedMap factories = new ManagedMap();
+        protected void handleDataSerializableFactories(Node node, BeanDefinitionBuilder serializationConfigBuilder) {
+            ManagedMap<Integer, BeanReference> factories = new ManagedMap<Integer, BeanReference>();
             ManagedMap<Integer, String> classNames = new ManagedMap<Integer, String>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("data-serializable-factory".equals(name)) {
-                    final NamedNodeMap attrs = child.getAttributes();
-                    final Node implRef = attrs.getNamedItem("implementation");
-                    final Node classNode = attrs.getNamedItem("class-name");
-                    final Node fidNode = attrs.getNamedItem("factory-id");
+                    NamedNodeMap attributes = child.getAttributes();
+                    Node implRef = attributes.getNamedItem("implementation");
+                    Node classNode = attributes.getNamedItem("class-name");
+                    Node fidNode = attributes.getNamedItem("factory-id");
                     if (implRef != null) {
-                        factories.put(Integer.parseInt(getTextContent(fidNode))
-                                , new RuntimeBeanReference(getTextContent(implRef)));
+                        factories.put(parseInt(getTextContent(fidNode)), new RuntimeBeanReference(getTextContent(implRef)));
                     }
                     if (classNode != null) {
-                        classNames.put(Integer.parseInt(getTextContent(fidNode)), getTextContent(classNode));
+                        classNames.put(parseInt(getTextContent(fidNode)), getTextContent(classNode));
                     }
                 }
             }
@@ -211,16 +208,16 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             serializationConfigBuilder.addPropertyValue("dataSerializableFactories", factories);
         }
 
-        protected void handleSerializers(final Node node, final BeanDefinitionBuilder serializationConfigBuilder) {
+        protected void handleSerializers(Node node, BeanDefinitionBuilder serializationConfigBuilder) {
             BeanDefinitionBuilder globalSerializerConfigBuilder = null;
             String implementation = "implementation";
             String className = "class-name";
             String typeClassName = "type-class";
             String overrideJavaSerializationName = "override-java-serialization";
 
-            ManagedList serializers = new ManagedList();
+            ManagedList<BeanDefinition> serializers = new ManagedList<BeanDefinition>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("global-serializer".equals(name)) {
                     globalSerializerConfigBuilder = createGSConfigBuilder(GlobalSerializerConfig.class, child, implementation,
                             className, overrideJavaSerializationName);
@@ -228,16 +225,14 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                 if ("serializer".equals(name)) {
                     BeanDefinitionBuilder serializerConfigBuilder = createBeanBuilder(SerializerConfig.class);
                     fillAttributeValues(child, serializerConfigBuilder);
-                    final NamedNodeMap attrs = child.getAttributes();
-                    final Node implRef = attrs.getNamedItem(implementation);
-                    final Node classNode = attrs.getNamedItem(className);
-
-                    final Node typeClass = attrs.getNamedItem(typeClassName);
+                    NamedNodeMap attributes = child.getAttributes();
+                    Node implRef = attributes.getNamedItem(implementation);
+                    Node classNode = attributes.getNamedItem(className);
+                    Node typeClass = attributes.getNamedItem(typeClassName);
 
                     if (typeClass != null) {
                         serializerConfigBuilder.addPropertyValue("typeClassName", getTextContent(typeClass));
                     }
-
                     if (implRef != null) {
                         serializerConfigBuilder.addPropertyReference(xmlToJavaName(implementation), getTextContent(implRef));
                     }
@@ -248,8 +243,8 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                 }
             }
             if (globalSerializerConfigBuilder != null) {
-                serializationConfigBuilder.addPropertyValue("globalSerializerConfig"
-                        , globalSerializerConfigBuilder.getBeanDefinition());
+                serializationConfigBuilder.addPropertyValue("globalSerializerConfig",
+                        globalSerializerConfigBuilder.getBeanDefinition());
             }
             serializationConfigBuilder.addPropertyValue("serializerConfigs", serializers);
         }
@@ -258,10 +253,10 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                                                             String implementation, String className,
                                                             String overrideJavaSerializationName) {
             BeanDefinitionBuilder globalSerializerConfigBuilder = createBeanBuilder(globalSerializerConfigClass);
-            final NamedNodeMap attrs = child.getAttributes();
-            final Node implRef = attrs.getNamedItem(implementation);
-            final Node classNode = attrs.getNamedItem(className);
-            final Node overrideJavaSerializationNode = attrs.getNamedItem(overrideJavaSerializationName);
+            NamedNodeMap attributes = child.getAttributes();
+            Node implRef = attributes.getNamedItem(implementation);
+            Node classNode = attributes.getNamedItem(className);
+            Node overrideJavaSerializationNode = attributes.getNamedItem(overrideJavaSerializationName);
             if (implRef != null) {
                 globalSerializerConfigBuilder.addPropertyReference(xmlToJavaName(implementation), getTextContent(implRef));
             }
@@ -275,22 +270,21 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             return globalSerializerConfigBuilder;
         }
 
-        protected void handlePortableFactories(final Node node, final BeanDefinitionBuilder serializationConfigBuilder) {
-            ManagedMap factories = new ManagedMap();
+        protected void handlePortableFactories(Node node, BeanDefinitionBuilder serializationConfigBuilder) {
+            ManagedMap<Integer, BeanReference> factories = new ManagedMap<Integer, BeanReference>();
             ManagedMap<Integer, String> classNames = new ManagedMap<Integer, String>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("portable-factory".equals(name)) {
-                    final NamedNodeMap attrs = child.getAttributes();
-                    final Node implRef = attrs.getNamedItem("implementation");
-                    final Node classNode = attrs.getNamedItem("class-name");
-                    final Node fidNode = attrs.getNamedItem("factory-id");
+                    NamedNodeMap attributes = child.getAttributes();
+                    Node implRef = attributes.getNamedItem("implementation");
+                    Node classNode = attributes.getNamedItem("class-name");
+                    Node fidNode = attributes.getNamedItem("factory-id");
                     if (implRef != null) {
-                        factories.put(Integer.parseInt(getTextContent(fidNode))
-                                , new RuntimeBeanReference(getTextContent(implRef)));
+                        factories.put(parseInt(getTextContent(fidNode)), new RuntimeBeanReference(getTextContent(implRef)));
                     }
                     if (classNode != null) {
-                        classNames.put(Integer.parseInt(getTextContent(fidNode)), getTextContent(classNode));
+                        classNames.put(parseInt(getTextContent(fidNode)), getTextContent(classNode));
                     }
                 }
             }
@@ -298,12 +292,12 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             serializationConfigBuilder.addPropertyValue("portableFactories", factories);
         }
 
-        protected void handleSerialization(final Node node) {
-            final BeanDefinitionBuilder serializationConfigBuilder = createBeanBuilder(SerializationConfig.class);
-            final AbstractBeanDefinition beanDefinition = serializationConfigBuilder.getBeanDefinition();
+        protected void handleSerialization(Node node) {
+            BeanDefinitionBuilder serializationConfigBuilder = createBeanBuilder(SerializationConfig.class);
+            AbstractBeanDefinition beanDefinition = serializationConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, serializationConfigBuilder);
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("data-serializable-factories".equals(nodeName)) {
                     handleDataSerializableFactories(child, serializationConfigBuilder);
                 } else if ("portable-factories".equals(nodeName)) {
@@ -315,9 +309,9 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             configBuilder.addPropertyValue("serializationConfig", beanDefinition);
         }
 
-        protected void handleSocketInterceptorConfig(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
+        protected void handleSocketInterceptorConfig(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             BeanDefinitionBuilder socketInterceptorConfigBuilder = createBeanBuilder(SocketInterceptorConfig.class);
-            final String implAttribute = "implementation";
+            String implAttribute = "implementation";
             fillAttributeValues(node, socketInterceptorConfigBuilder, implAttribute);
             Node implNode = node.getAttributes().getNamedItem(implAttribute);
             String implementation = implNode != null ? getTextContent(implNode) : null;
@@ -325,7 +319,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                 socketInterceptorConfigBuilder.addPropertyReference(xmlToJavaName(implAttribute), implementation);
             }
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, socketInterceptorConfigBuilder);
                 }
@@ -334,21 +328,21 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                     socketInterceptorConfigBuilder.getBeanDefinition());
         }
 
-        protected void handleProperties(final Node node, BeanDefinitionBuilder beanDefinitionBuilder) {
+        protected void handleProperties(Node node, BeanDefinitionBuilder beanDefinitionBuilder) {
             ManagedMap properties = parseProperties(node);
             beanDefinitionBuilder.addPropertyValue("properties", properties);
         }
 
-        protected ManagedMap parseProperties(final Node node) {
-            ManagedMap properties = new ManagedMap();
+        protected ManagedMap parseProperties(Node node) {
+            ManagedMap<String, String> properties = new ManagedMap<String, String>();
             for (Node n : childElements(node)) {
-                final String name = cleanNodeName(n);
-                final String propertyName;
+                String name = cleanNodeName(n);
+                String propertyName;
                 if (!"property".equals(name)) {
                     continue;
                 }
                 propertyName = getTextContent(n.getAttributes().getNamedItem("name")).trim();
-                final String value = getTextContent(n);
+                String value = getTextContent(n);
                 properties.put(propertyName, value);
             }
             return properties;
@@ -360,7 +354,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
         }
 
         @SuppressWarnings("checkstyle:npathcomplexity")
-        protected BeanDefinition getEvictionConfig(final Node node) {
+        protected BeanDefinition getEvictionConfig(Node node) {
             Node size = node.getAttributes().getNamedItem("size");
             Node maxSizePolicy = node.getAttributes().getNamedItem("max-size-policy");
             Node evictionPolicy = node.getAttributes().getNamedItem("eviction-policy");
@@ -368,7 +362,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             Node comparatorBean = node.getAttributes().getNamedItem("comparator-bean");
             if (comparatorClassName != null && comparatorBean != null) {
                 throw new InvalidConfigurationException("Only one of the `comparator-class-name` and `comparator-bean`"
-                    + " attributes can be configured inside eviction configuration!");
+                        + " attributes can be configured inside eviction configuration!");
             }
 
             BeanDefinitionBuilder evictionConfigBuilder = createBeanBuilder(EvictionConfig.class);
@@ -380,10 +374,10 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             String comparatorBeanValue = null;
 
             if (size != null) {
-                sizeValue = Integer.parseInt(getTextContent(size));
+                sizeValue = parseInt(getTextContent(size));
             }
             if (maxSizePolicy != null) {
-                maxSizePolicyValue =  EvictionConfig.MaxSizePolicy.valueOf(
+                maxSizePolicyValue = EvictionConfig.MaxSizePolicy.valueOf(
                         upperCaseInternal(getTextContent(maxSizePolicy)));
             }
             if (evictionPolicy != null) {
@@ -416,7 +410,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             return evictionConfigBuilder.getBeanDefinition();
         }
 
-        protected BeanDefinition getPreloaderConfig(final Node node) {
+        protected BeanDefinition getPreloaderConfig(Node node) {
             Node enabled = node.getAttributes().getNamedItem("enabled");
             Node directory = node.getAttributes().getNamedItem("directory");
             Node storeInitialDelaySeconds = node.getAttributes().getNamedItem("store-initial-delay-seconds");
@@ -433,13 +427,13 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                 enabledValue = Boolean.parseBoolean(getTextContent(enabled));
             }
             if (directory != null) {
-                directoryValue =  getTextContent(directory);
+                directoryValue = getTextContent(directory);
             }
             if (storeInitialDelaySeconds != null) {
-                storeInitialDelaySecondsValue = Integer.parseInt(getTextContent(storeInitialDelaySeconds));
+                storeInitialDelaySecondsValue = parseInt(getTextContent(storeInitialDelaySeconds));
             }
             if (storeIntervalSeconds != null) {
-                storeIntervalSecondsValue = Integer.parseInt(getTextContent(storeIntervalSeconds));
+                storeIntervalSecondsValue = parseInt(getTextContent(storeIntervalSeconds));
             }
 
             nearCachePreloaderConfigBuilder.addPropertyValue("enabled", enabledValue);
@@ -451,11 +445,10 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
         }
 
         protected void handleDiscoveryStrategies(Node node, BeanDefinitionBuilder joinConfigBuilder) {
-            final BeanDefinitionBuilder discoveryConfigBuilder =
-                    createBeanBuilder(DiscoveryConfig.class);
-            final ManagedList discoveryStrategyConfigs = new ManagedList();
+            BeanDefinitionBuilder discoveryConfigBuilder = createBeanBuilder(DiscoveryConfig.class);
+            ManagedList<BeanDefinition> discoveryStrategyConfigs = new ManagedList<BeanDefinition>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("discovery-strategy".equals(name)) {
                     handleDiscoveryStrategy(child, discoveryStrategyConfigs);
                 } else if ("node-filter".equals(name)) {
@@ -468,50 +461,45 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             joinConfigBuilder.addPropertyValue("discoveryConfig", discoveryConfigBuilder.getBeanDefinition());
         }
 
-        private void handleDiscoveryServiceProvider(Node node, BeanDefinitionBuilder discoveyConfigBuilder) {
-            final NamedNodeMap attrs = node.getAttributes();
-            Node implNode = attrs.getNamedItem("implementation");
-            String implementation = implNode != null ? getTextContent(implNode) : null;
-            Assert.isTrue(implementation != null,
-                    "`implementation' attribute is required "
-                            + "to create DiscoveryServiceProvider!");
-            discoveyConfigBuilder.addPropertyReference("discoveryServiceProvider", implementation);
+        private void handleDiscoveryServiceProvider(Node node, BeanDefinitionBuilder discoveryConfigBuilder) {
+            NamedNodeMap attributes = node.getAttributes();
+            Node implNode = attributes.getNamedItem("implementation");
+            String implementation = getTextContent(implNode).trim();
+            isTrue(!implementation.isEmpty(), "'implementation' attribute is required to create DiscoveryServiceProvider!");
+            discoveryConfigBuilder.addPropertyReference("discoveryServiceProvider", implementation);
         }
 
         private void handleDiscoveryNodeFilter(Node node, BeanDefinitionBuilder discoveryConfigBuilder) {
-            final NamedNodeMap attrs = node.getAttributes();
-            Node classNameNode = attrs.getNamedItem("class-name");
-            String className = classNameNode != null ? getTextContent(classNameNode) : null;
-            Node implNode = attrs.getNamedItem("implementation");
-            String implementation = implNode != null ? getTextContent(implNode) : null;
-            Assert.isTrue(className != null || implementation != null,
-                    "One of 'class-name' or 'implementation' attributes is required "
-                            + "to create NodeFilter!");
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
+            String className = getTextContent(classNameNode).trim();
+            Node implNode = attributes.getNamedItem("implementation");
+            String implementation = getTextContent(implNode).trim();
+            isTrue(!className.isEmpty() || !implementation.isEmpty(),
+                    "One of 'class-name' or 'implementation' attributes is required to create NodeFilter!");
             discoveryConfigBuilder.addPropertyValue("nodeFilterClass", className);
-            if (implementation != null) {
+            if (!implementation.isEmpty()) {
                 discoveryConfigBuilder.addPropertyReference("nodeFilter", implementation);
             }
         }
 
-        private void handleDiscoveryStrategy(Node node, ManagedList discoveryStrategyConfigs) {
-            final BeanDefinitionBuilder discoveryStrategyConfigBuilder =
-                    createBeanBuilder(DiscoveryStrategyConfig.class);
-            final NamedNodeMap attrs = node.getAttributes();
-            Node classNameNode = attrs.getNamedItem("class-name");
-            String className = classNameNode != null ? getTextContent(classNameNode) : null;
-            Node implNode = attrs.getNamedItem("discovery-strategy-factory");
-            String implementation = implNode != null ? getTextContent(implNode) : null;
-            Assert.isTrue(className != null || implementation != null,
-                    "One of 'class-name' or 'implementation' attributes is required "
-                            + "to create DiscoveryStrategyConfig!");
-            if (implementation != null) {
+        private void handleDiscoveryStrategy(Node node, ManagedList<BeanDefinition> discoveryStrategyConfigs) {
+            BeanDefinitionBuilder discoveryStrategyConfigBuilder = createBeanBuilder(DiscoveryStrategyConfig.class);
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
+            String className = getTextContent(classNameNode).trim();
+            Node implNode = attributes.getNamedItem("discovery-strategy-factory");
+            String implementation = getTextContent(implNode).trim();
+            isTrue(!className.isEmpty() || !implementation.isEmpty(),
+                    "One of 'class-name' or 'implementation' attributes is required to create DiscoveryStrategyConfig!");
+            if (!implementation.isEmpty()) {
                 discoveryStrategyConfigBuilder.addConstructorArgReference(implementation);
-            } else if (className != null) {
+            } else {
                 discoveryStrategyConfigBuilder.addConstructorArgValue(className);
             }
 
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     ManagedMap properties = parseProperties(child);
                     if (!properties.isEmpty()) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/CacheManagerBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/CacheManagerBeanDefinitionParser.java
@@ -31,47 +31,45 @@ import java.util.Properties;
  * <p>
  * <b>Sample bean</b>
  * <pre>
- * &lt;hz:cache-manager id="cacheManager" instance-ref="instance" name="cacheManager" /&gt;
+ * &lt;hz:cache-manager id="cacheManager" instance-ref="instance" name="cacheManager"/&gt;
  * </pre>
  */
-public class CacheManagerBeanDefinitionParser
-        extends AbstractHazelcastBeanDefinitionParser {
+public class CacheManagerBeanDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
 
     @Override
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-        final SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(SpringHazelcastCachingProvider.class, parserContext);
+        SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(SpringHazelcastCachingProvider.class, parserContext);
         springXmlBuilder.handle(element);
-        final BeanDefinitionBuilder builder = springXmlBuilder.getBuilder();
+        BeanDefinitionBuilder builder = springXmlBuilder.getBuilder();
         return builder.getBeanDefinition();
     }
 
     private class SpringXmlBuilder extends AbstractHazelcastBeanDefinitionParser.SpringXmlBuilderHelper {
 
         private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
 
-        private BeanDefinitionBuilder builder;
-
-        public SpringXmlBuilder(Class providerClass, ParserContext parserContext) {
+        SpringXmlBuilder(Class providerClass, ParserContext parserContext) {
             this.parserContext = parserContext;
             this.builder = BeanDefinitionBuilder.rootBeanDefinition(providerClass);
         }
 
-        public BeanDefinitionBuilder getBuilder() {
+        BeanDefinitionBuilder getBuilder() {
             return this.builder;
         }
 
         public void handle(Element element) {
             handleCommonBeanAttributes(element, builder, parserContext);
-            final NamedNodeMap attrs = element.getAttributes();
+            NamedNodeMap attributes = element.getAttributes();
 
             String uri = null;
             String instanceRef = null;
-            if (attrs != null) {
-                Node instanceRefNode = attrs.getNamedItem("instance-ref");
+            if (attributes != null) {
+                Node instanceRefNode = attributes.getNamedItem("instance-ref");
                 if (instanceRefNode != null) {
                     instanceRef = getTextContent(instanceRefNode);
                 }
-                Node uriNode = attrs.getNamedItem("uri");
+                Node uriNode = attributes.getNamedItem("uri");
                 if (uriNode != null) {
                     uri = getTextContent(uriNode);
                 }
@@ -79,16 +77,16 @@ public class CacheManagerBeanDefinitionParser
 
             Properties properties = new Properties();
             for (Node n : childElements(element)) {
-                final String nodeName = cleanNodeName(n);
+                String nodeName = cleanNodeName(n);
                 if ("properties".equals(nodeName)) {
                     for (Node propNode : childElements(n)) {
-                        final String name = cleanNodeName(propNode);
-                        final String propertyName;
+                        String name = cleanNodeName(propNode);
+                        String propertyName;
                         if (!"property".equals(name)) {
                             continue;
                         }
                         propertyName = getTextContent(propNode.getAttributes().getNamedItem("name")).trim();
-                        final String value = getTextContent(propNode);
+                        String value = getTextContent(propNode);
                         properties.setProperty(propertyName, value);
                     }
                 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -74,7 +74,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
 
     @Override
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-        final SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
+        SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
         springXmlBuilder.handleClient(element);
         return springXmlBuilder.getBeanDefinition();
     }
@@ -82,12 +82,10 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
     private class SpringXmlBuilder extends SpringXmlBuilderHelper {
 
         private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
+        private final ManagedMap<String, BeanDefinition> nearCacheConfigMap;
 
-        private BeanDefinitionBuilder builder;
-
-        private ManagedMap<String, BeanDefinition> nearCacheConfigMap;
-
-        public SpringXmlBuilder(ParserContext parserContext) {
+        SpringXmlBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
             this.builder = BeanDefinitionBuilder.rootBeanDefinition(HazelcastClient.class);
             this.builder.setFactoryMethod("newHazelcastClient");
@@ -98,16 +96,16 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("nearCacheConfigMap", nearCacheConfigMap);
         }
 
-        public AbstractBeanDefinition getBeanDefinition() {
+        AbstractBeanDefinition getBeanDefinition() {
             return builder.getBeanDefinition();
         }
 
         @SuppressWarnings("checkstyle:cyclomaticcomplexity")
-        public void handleClient(Element element) {
+        void handleClient(Element element) {
             handleCommonBeanAttributes(element, builder, parserContext);
             handleClientAttributes(element);
             for (Node node : childElements(element)) {
-                final String nodeName = cleanNodeName(node);
+                String nodeName = cleanNodeName(node);
                 if ("group".equals(nodeName)) {
                     createAndFillBeanBuilder(node, GroupConfig.class, "groupConfig", configBuilder);
                 } else if ("properties".equals(nodeName)) {
@@ -115,12 +113,12 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                 } else if ("network".equals(nodeName)) {
                     handleNetwork(node);
                 } else if ("listeners".equals(nodeName)) {
-                    final List listeners = parseListeners(node, ListenerConfig.class);
+                    List listeners = parseListeners(node, ListenerConfig.class);
                     configBuilder.addPropertyValue("listenerConfigs", listeners);
                 } else if ("serialization".equals(nodeName)) {
                     handleSerialization(node);
                 } else if ("proxy-factories".equals(nodeName)) {
-                    final List list = parseProxyFactories(node, ProxyFactoryConfig.class);
+                    List list = parseProxyFactories(node, ProxyFactoryConfig.class);
                     configBuilder.addPropertyValue("proxyFactoryConfigs", list);
                 } else if ("load-balancer".equals(nodeName)) {
                     handleLoadBalancer(node);
@@ -147,17 +145,17 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             List<String> classNames = new ArrayList<String>(INITIAL_CAPACITY);
             fillAttributeValues(node, userCodeDeploymentConfig);
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("jarpaths".equals(nodeName)) {
                     for (Node child1 : childElements(child)) {
-                        final String nodeName1 = cleanNodeName(child1);
+                        String nodeName1 = cleanNodeName(child1);
                         if ("jarpath".equals(nodeName1)) {
                             jarPaths.add(getTextContent(child1));
                         }
                     }
                 } else if ("classnames".equals(nodeName)) {
                     for (Node child1 : childElements(child)) {
-                        final String nodeName1 = cleanNodeName(child1);
+                        String nodeName1 = cleanNodeName(child1);
                         if ("classname".equals(nodeName1)) {
                             classNames.add(getTextContent(child1));
                         }
@@ -171,12 +169,12 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleClientAttributes(Element element) {
-            final NamedNodeMap attrs = element.getAttributes();
-            if (attrs != null) {
-                for (int a = 0; a < attrs.getLength(); a++) {
-                    final Node att = attrs.item(a);
-                    final String name = att.getNodeName();
-                    final String value = att.getNodeValue();
+            NamedNodeMap attributes = element.getAttributes();
+            if (attributes != null) {
+                for (int a = 0; a < attributes.getLength(); a++) {
+                    Node att = attributes.item(a);
+                    String name = att.getNodeName();
+                    String value = att.getNodeValue();
                     if ("executor-pool-size".equals(name)) {
                         configBuilder.addPropertyValue("executorPoolSize", value);
                     } else if ("credentials-ref".equals(name)) {
@@ -187,11 +185,11 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleNetwork(Node node) {
-            final BeanDefinitionBuilder clientNetworkConfig = createBeanBuilder(ClientNetworkConfig.class);
+            BeanDefinitionBuilder clientNetworkConfig = createBeanBuilder(ClientNetworkConfig.class);
             List<String> members = new ArrayList<String>(INITIAL_CAPACITY);
             fillAttributeValues(node, clientNetworkConfig);
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("member".equals(nodeName)) {
                     members.add(getTextContent(child));
                 } else if ("socket-options".equals(nodeName)) {
@@ -217,9 +215,9 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             createAndFillBeanBuilder(node, ClientAwsConfig.class, "awsConfig", clientNetworkConfig);
         }
 
-        private void handleSSLConfig(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
+        private void handleSSLConfig(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             BeanDefinitionBuilder sslConfigBuilder = createBeanBuilder(SSLConfig.class);
-            final String implAttribute = "factory-implementation";
+            String implAttribute = "factory-implementation";
             fillAttributeValues(node, sslConfigBuilder, implAttribute);
             Node implNode = node.getAttributes().getNamedItem(implAttribute);
             String implementation = implNode != null ? getTextContent(implNode) : null;
@@ -227,7 +225,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                 sslConfigBuilder.addPropertyReference(xmlToJavaName(implAttribute), implementation);
             }
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, sslConfigBuilder);
                 }
@@ -236,7 +234,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleLoadBalancer(Node node) {
-            final String type = getAttribute(node, "type");
+            String type = getAttribute(node, "type");
             if ("random".equals(type)) {
                 configBuilder.addPropertyValue("loadBalancer", new RandomLB());
             } else if ("round-robin".equals(type)) {
@@ -248,7 +246,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder nearCacheConfigBuilder = createBeanBuilder(NearCacheConfig.class);
             fillAttributeValues(node, nearCacheConfigBuilder);
             for (Node childNode : childElements(node)) {
-                final String nodeName = cleanNodeName(childNode);
+                String nodeName = cleanNodeName(childNode);
                 if ("eviction".equals(nodeName)) {
                     handleEvictionConfig(childNode, nearCacheConfigBuilder);
                 } else if ("preloader".equals(nodeName)) {
@@ -277,7 +275,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void parseQueryCache(ManagedMap<String, ManagedMap<String, BeanDefinition>> queryCaches, Node queryCacheNode) {
-            final BeanDefinitionBuilder builder = createBeanBuilder(QueryCacheConfig.class);
+            BeanDefinitionBuilder builder = createBeanBuilder(QueryCacheConfig.class);
 
             NamedNodeMap attributes = queryCacheNode.getAttributes();
             String mapName = getTextContent(attributes.getNamedItem("map-name"));
@@ -351,7 +349,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedList<BeanDefinition> getIndexes(Node node) {
             ManagedList<BeanDefinition> indexes = new ManagedList<BeanDefinition>();
             for (Node indexNode : childElements(node)) {
-                final BeanDefinitionBuilder indexConfBuilder = createBeanBuilder(MapIndexConfig.class);
+                BeanDefinitionBuilder indexConfBuilder = createBeanBuilder(MapIndexConfig.class);
                 fillAttributeValues(indexNode, indexConfBuilder);
                 indexes.add(indexConfBuilder.getBeanDefinition());
             }
@@ -360,7 +358,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private ManagedList<BeanDefinition> getEntryListeners(Node node) {
             ManagedList<BeanDefinition> listeners = new ManagedList<BeanDefinition>();
-            final String implementationAttr = "implementation";
+            String implementationAttr = "implementation";
             for (Node listenerNode : childElements(node)) {
                 BeanDefinitionBuilder listenerConfBuilder = createBeanBuilder(EntryListenerConfig.class);
                 fillAttributeValues(listenerNode, listenerConfBuilder, implementationAttr);
@@ -373,10 +371,10 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             return listeners;
         }
 
-        private void handleOutboundPorts(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
-            ManagedList outboundPorts = new ManagedList();
+        private void handleOutboundPorts(Node node, BeanDefinitionBuilder networkConfigBuilder) {
+            ManagedList<String> outboundPorts = new ManagedList<String>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("ports".equals(name)) {
                     String value = getTextContent(child);
                     outboundPorts.add(value);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spring;
 
-import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -52,7 +51,10 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
+import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -97,14 +99,13 @@ import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.spi.ServiceConfigurationParser;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.util.StringUtil;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.support.ManagedSet;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.util.Assert;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -115,8 +116,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.util.StringUtil.upperCaseInternal;
+import static org.springframework.util.Assert.isTrue;
 
 /**
  * BeanDefinitionParser for Hazelcast Config Configuration.
@@ -140,11 +144,12 @@ import static com.hazelcast.util.StringUtil.upperCaseInternal;
  * &lt;/hz:config&gt;
  * </pre>
  */
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:executablestatementcount", "checkstyle:cyclomaticcomplexity"})
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:executablestatementcount", "checkstyle:cyclomaticcomplexity",
+        "WeakerAccess"})
 public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
 
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-        final SpringXmlConfigBuilder springXmlConfigBuilder = new SpringXmlConfigBuilder(parserContext);
+        SpringXmlConfigBuilder springXmlConfigBuilder = new SpringXmlConfigBuilder(parserContext);
         springXmlConfigBuilder.handleConfig(element);
         return springXmlConfigBuilder.getBeanDefinition();
     }
@@ -212,11 +217,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         @SuppressWarnings("checkstyle:methodlength")
-        public void handleConfig(final Element element) {
+        public void handleConfig(Element element) {
             if (element != null) {
                 handleCommonBeanAttributes(element, configBuilder, parserContext);
                 for (Node node : childElements(element)) {
-                    final String nodeName = cleanNodeName(node);
+                    String nodeName = cleanNodeName(node);
                     if ("network".equals(nodeName)) {
                         handleNetwork(node);
                     } else if ("group".equals(nodeName)) {
@@ -274,7 +279,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     } else if ("instance-name".equals(nodeName)) {
                         configBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(node));
                     } else if ("listeners".equals(nodeName)) {
-                        final List listeners = parseListeners(node, ListenerConfig.class);
+                        List listeners = parseListeners(node, ListenerConfig.class);
                         configBuilder.addPropertyValue("listenerConfigs", listeners);
                     } else if ("lite-member".equals(nodeName)) {
                         handleLiteMember(node);
@@ -296,13 +301,13 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleHotRestartPersistence(Node node) {
-            final BeanDefinitionBuilder hotRestartConfigBuilder = createBeanBuilder(HotRestartPersistenceConfig.class);
+            BeanDefinitionBuilder hotRestartConfigBuilder = createBeanBuilder(HotRestartPersistenceConfig.class);
             fillAttributeValues(node, hotRestartConfigBuilder);
 
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("base-dir".equals(name)) {
-                    final String value = getTextContent(child);
+                    String value = getTextContent(child);
                     hotRestartConfigBuilder.addPropertyValue("baseDir", value);
                 } else if ("backup-dir".equals(name)) {
                     hotRestartConfigBuilder.addPropertyValue("backupDir", getTextContent(child));
@@ -311,17 +316,17 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("hotRestartPersistenceConfig", hotRestartConfigBuilder.getBeanDefinition());
         }
 
-        private void handleQuorum(final org.w3c.dom.Node node) {
+        private void handleQuorum(Node node) {
             BeanDefinitionBuilder quorumConfigBuilder = createBeanBuilder(QuorumConfig.class);
-            final AbstractBeanDefinition beanDefinition = quorumConfigBuilder.getBeanDefinition();
-            final String name = getAttribute(node, "name");
+            AbstractBeanDefinition beanDefinition = quorumConfigBuilder.getBeanDefinition();
+            String name = getAttribute(node, "name");
             quorumConfigBuilder.addPropertyValue("name", name);
             Node attrEnabled = node.getAttributes().getNamedItem("enabled");
-            final boolean enabled = attrEnabled != null ? getBooleanValue(getTextContent(attrEnabled)) : false;
+            boolean enabled = attrEnabled != null && getBooleanValue(getTextContent(attrEnabled));
             quorumConfigBuilder.addPropertyValue("enabled", enabled);
-            for (org.w3c.dom.Node n : childElements(node)) {
-                final String value = getTextContent(n).trim();
-                final String nodeName = cleanNodeName(n);
+            for (Node n : childElements(node)) {
+                String value = getTextContent(n).trim();
+                String nodeName = cleanNodeName(n);
                 if ("quorum-size".equals(nodeName)) {
                     quorumConfigBuilder.addPropertyValue("size", getIntegerValue("quorum-size", value));
                 } else if ("quorum-listeners".equals(nodeName)) {
@@ -343,15 +348,14 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleServices(Node node) {
             BeanDefinitionBuilder servicesConfigBuilder = createBeanBuilder(ServicesConfig.class);
-            final AbstractBeanDefinition beanDefinition = servicesConfigBuilder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = servicesConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, servicesConfigBuilder);
             ManagedList<AbstractBeanDefinition> serviceConfigManagedList = new ManagedList<AbstractBeanDefinition>();
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("service".equals(nodeName)) {
                     serviceConfigManagedList.add(handleService(child));
                 }
-
             }
             servicesConfigBuilder.addPropertyValue("serviceConfigs", serviceConfigManagedList);
             configBuilder.addPropertyValue("servicesConfig", beanDefinition);
@@ -359,11 +363,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private AbstractBeanDefinition handleService(Node node) {
             BeanDefinitionBuilder serviceConfigBuilder = createBeanBuilder(ServiceConfig.class);
-            final AbstractBeanDefinition beanDefinition = serviceConfigBuilder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = serviceConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, serviceConfigBuilder);
             boolean classNameSet = false;
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("name".equals(nodeName)) {
                     serviceConfigBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
                 } else if ("class-name".equals(nodeName)) {
@@ -373,8 +377,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 } else if ("properties".equals(nodeName)) {
                     handleProperties(child, serviceConfigBuilder);
                 } else if ("configuration".equals(nodeName)) {
-                    final Node parser = child.getAttributes().getNamedItem("parser");
-                    final String name = getTextContent(parser);
+                    Node parser = child.getAttributes().getNamedItem("parser");
+                    String name = getTextContent(parser);
                     try {
                         ServiceConfigurationParser serviceConfigurationParser =
                                 ClassLoaderUtil.newInstance(getClass().getClassLoader(), name);
@@ -386,24 +390,24 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 }
             }
 
-            final NamedNodeMap attrs = node.getAttributes();
-            Node classNameNode = attrs.getNamedItem("class-name");
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
             if (classNameNode != null) {
                 serviceConfigBuilder.addPropertyValue("className", getTextContent(classNameNode));
             }
-            Node implNode = attrs.getNamedItem("implementation");
+            Node implNode = attributes.getNamedItem("implementation");
             if (implNode != null) {
                 serviceConfigBuilder.addPropertyReference("implementation", getTextContent(implNode));
             }
-            Assert.isTrue(classNameSet || classNameNode != null || implNode != null, "One of 'class-name' or 'implementation' "
-                    + "attributes is required to create ServiceConfig!");
+            isTrue(classNameSet || classNameNode != null || implNode != null, "One of 'class-name' or 'implementation'"
+                    + " attributes is required to create ServiceConfig!");
             return beanDefinition;
         }
 
         public void handleReplicatedMap(Node node) {
             BeanDefinitionBuilder replicatedMapConfigBuilder = createBeanBuilder(ReplicatedMapConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, replicatedMapConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("entry-listeners".equals(cleanNodeName(childNode))) {
@@ -416,10 +420,10 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleNetwork(Node node) {
             BeanDefinitionBuilder networkConfigBuilder = createBeanBuilder(NetworkConfig.class);
-            final AbstractBeanDefinition beanDefinition = networkConfigBuilder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = networkConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, networkConfigBuilder);
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("join".equals(nodeName)) {
                     handleJoin(child, networkConfigBuilder);
                 } else if ("interfaces".equals(nodeName)) {
@@ -449,19 +453,19 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             handleProperties(node, configBuilder);
         }
 
-        public void handleInterfaces(Node node, final BeanDefinitionBuilder networkConfigBuilder) {
+        public void handleInterfaces(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             BeanDefinitionBuilder builder = createBeanBuilder(InterfacesConfig.class);
-            final AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
-            final NamedNodeMap atts = node.getAttributes();
-            if (atts != null) {
-                for (int a = 0; a < atts.getLength(); a++) {
-                    final Node att = atts.item(a);
-                    final String name = xmlToJavaName(att.getNodeName());
-                    final String value = att.getNodeValue();
+            AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
+            NamedNodeMap attributes = node.getAttributes();
+            if (attributes != null) {
+                for (int a = 0; a < attributes.getLength(); a++) {
+                    Node att = attributes.item(a);
+                    String name = xmlToJavaName(att.getNodeName());
+                    String value = att.getNodeValue();
                     builder.addPropertyValue(name, value);
                 }
             }
-            ManagedList interfacesSet = new ManagedList();
+            ManagedList<String> interfacesSet = new ManagedList<String>();
             for (Node n : childElements(node)) {
                 String name = xmlToJavaName(cleanNodeName(n));
                 String value = getTextContent(n);
@@ -475,9 +479,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleJoin(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             BeanDefinitionBuilder joinConfigBuilder = createBeanBuilder(JoinConfig.class);
-            final AbstractBeanDefinition beanDefinition = joinConfigBuilder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = joinConfigBuilder.getBeanDefinition();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("multicast".equals(name)) {
                     handleMulticast(child, joinConfigBuilder);
                 } else if ("tcp-ip".equals(name)) {
@@ -491,11 +495,10 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             networkConfigBuilder.addPropertyValue("join", beanDefinition);
         }
 
-
-        private void handleOutboundPorts(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
-            ManagedList outboundPorts = new ManagedList();
+        private void handleOutboundPorts(Node node, BeanDefinitionBuilder networkConfigBuilder) {
+            ManagedList<String> outboundPorts = new ManagedList<String>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("ports".equals(name)) {
                     String value = getTextContent(child);
                     outboundPorts.add(value);
@@ -504,33 +507,32 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             networkConfigBuilder.addPropertyValue("outboundPortDefinitions", outboundPorts);
         }
 
-        private void handleReuseAddress(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
+        private void handleReuseAddress(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             String value = node.getTextContent();
             networkConfigBuilder.addPropertyValue("reuseAddress", value);
         }
 
-        private void handleMemberAddressProvider(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
-            final BeanDefinitionBuilder memberAddressProviderConfigBuilder = createBeanBuilder(MemberAddressProviderConfig.class);
+        private void handleMemberAddressProvider(Node node, BeanDefinitionBuilder networkConfigBuilder) {
+            BeanDefinitionBuilder memberAddressProviderConfigBuilder = createBeanBuilder(MemberAddressProviderConfig.class);
             for (Node child : childElements(node)) {
                 if ("properties".equals(cleanNodeName(child))) {
                     handleProperties(child, memberAddressProviderConfigBuilder);
                     break;
                 }
             }
-            final String implementationAttr = "implementation";
-            final String classNameAttr = "class-name";
-            final String implementationValue = getAttribute(node, implementationAttr);
-            final String classNameValue = getAttribute(node, classNameAttr);
+            String implementationAttr = "implementation";
+            String classNameAttr = "class-name";
+            String implementationValue = getAttribute(node, implementationAttr);
+            String classNameValue = getAttribute(node, classNameAttr);
 
             memberAddressProviderConfigBuilder.addPropertyValue("enabled", getBooleanValue(getAttribute(node, "enabled")));
 
-            if (!StringUtil.isNullOrEmpty(implementationValue)) {
+            if (!isNullOrEmpty(implementationValue)) {
                 memberAddressProviderConfigBuilder.addPropertyReference(implementationAttr, implementationValue);
             } else {
-                if (StringUtil.isNullOrEmpty(classNameValue)) {
-                    throw new InvalidConfigurationException(
-                            "One of the \"class-name\" or \"implementation\" configuration "
-                                    + "is needed for member address provider configuration");
+                if (isNullOrEmpty(classNameValue)) {
+                    throw new InvalidConfigurationException("One of the \"class-name\" or \"implementation\" configuration"
+                            + " is needed for member address provider configuration");
                 }
                 memberAddressProviderConfigBuilder.addPropertyValue("className", classNameValue);
             }
@@ -538,9 +540,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     memberAddressProviderConfigBuilder.getBeanDefinition());
         }
 
-        private void handleSSLConfig(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
+        private void handleSSLConfig(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             BeanDefinitionBuilder sslConfigBuilder = createBeanBuilder(SSLConfig.class);
-            final String implAttribute = "factory-implementation";
+            String implAttribute = "factory-implementation";
             fillAttributeValues(node, sslConfigBuilder, implAttribute);
             Node implNode = node.getAttributes().getNamedItem(implAttribute);
             String implementation = implNode != null ? getTextContent(implNode) : null;
@@ -548,7 +550,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 sslConfigBuilder.addPropertyReference(xmlToJavaName(implAttribute), implementation);
             }
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, sslConfigBuilder);
                 }
@@ -577,9 +579,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleMulticast(Node node, BeanDefinitionBuilder joinConfigBuilder) {
-            final BeanDefinitionBuilder builder = createAndFillBeanBuilder(node, MulticastConfig.class,
-                    "multicastConfig", joinConfigBuilder, "trusted-interfaces", "interface");
-            final ManagedList<String> interfaces = new ManagedList<String>();
+            BeanDefinitionBuilder builder = createAndFillBeanBuilder(node, MulticastConfig.class, "multicastConfig",
+                    joinConfigBuilder, "trusted-interfaces", "interface");
+            ManagedList<String> interfaces = new ManagedList<String>();
             for (Node n : childElements(node)) {
                 String name = cleanNodeName(n);
                 if ("trusted-interfaces".equals(name)) {
@@ -596,12 +598,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleTcpIp(Node node, BeanDefinitionBuilder joinConfigBuilder) {
-            final BeanDefinitionBuilder builder =
-                    createAndFillBeanBuilder(node, TcpIpConfig.class,
-                            "tcpIpConfig",
-                            joinConfigBuilder,
-                            "interface", "member", "members");
-            final ManagedList members = new ManagedList();
+            BeanDefinitionBuilder builder = createAndFillBeanBuilder(node, TcpIpConfig.class, "tcpIpConfig", joinConfigBuilder,
+                    "interface", "member", "members");
+            ManagedList<String> members = new ManagedList<String>();
             for (Node n : childElements(node)) {
                 String name = cleanNodeName(n);
                 if ("member".equals(name) || "members".equals(name) || "interface".equals(name)) {
@@ -617,7 +616,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleReliableTopic(Node node) {
-            final BeanDefinitionBuilder builder = createBeanBuilder(ReliableTopicConfig.class);
+            BeanDefinitionBuilder builder = createBeanBuilder(ReliableTopicConfig.class);
             fillAttributeValues(node, builder);
             for (Node childNode : childElements(node)) {
                 if ("message-listeners".equals(cleanNodeName(childNode))) {
@@ -629,16 +628,16 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleSemaphore(Node node) {
-            final BeanDefinitionBuilder builder = createBeanBuilder(SemaphoreConfig.class);
+            BeanDefinitionBuilder builder = createBeanBuilder(SemaphoreConfig.class);
             fillAttributeValues(node, builder);
             semaphoreManagedMap.put(getAttribute(node, "name"), builder.getBeanDefinition());
         }
 
         public void handleLock(Node node) {
-            final BeanDefinitionBuilder lockConfigBuilder = createBeanBuilder(LockConfig.class);
+            BeanDefinitionBuilder lockConfigBuilder = createBeanBuilder(LockConfig.class);
             fillAttributeValues(node, lockConfigBuilder);
             for (Node childNode : childElements(node)) {
-                final String nodeName = cleanNodeName(childNode);
+                String nodeName = cleanNodeName(childNode);
                 if ("quorum-ref".equals(nodeName)) {
                     lockConfigBuilder.addPropertyValue("quorumName", getTextContent(childNode));
                 }
@@ -647,20 +646,20 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleEventJournal(Node node) {
-            final BeanDefinitionBuilder eventJournalBuilder = createBeanBuilder(EventJournalConfig.class);
+            BeanDefinitionBuilder eventJournalBuilder = createBeanBuilder(EventJournalConfig.class);
             fillAttributeValues(node, eventJournalBuilder);
-            final String mapName = getAttribute(node, "map-name");
-            final String cacheName = getAttribute(node, "cache-name");
-            if (!StringUtil.isNullOrEmpty(mapName)) {
+            String mapName = getAttribute(node, "map-name");
+            String cacheName = getAttribute(node, "cache-name");
+            if (!isNullOrEmpty(mapName)) {
                 mapEventJournalManagedMap.put(mapName, eventJournalBuilder.getBeanDefinition());
             }
-            if (!StringUtil.isNullOrEmpty(cacheName)) {
+            if (!isNullOrEmpty(cacheName)) {
                 cacheEventJournalManagedMap.put(cacheName, eventJournalBuilder.getBeanDefinition());
             }
         }
 
         public void handleRingbuffer(Node node) {
-            final BeanDefinitionBuilder ringbufferConfigBuilder = createBeanBuilder(RingbufferConfig.class);
+            BeanDefinitionBuilder ringbufferConfigBuilder = createBeanBuilder(RingbufferConfig.class);
             fillAttributeValues(node, ringbufferConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("ringbuffer-store".equals(cleanNodeName(childNode))) {
@@ -671,7 +670,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleRingbufferStoreConfig(Node node, BeanDefinitionBuilder ringbufferConfigBuilder) {
-            final BeanDefinitionBuilder builder = createBeanBuilder(RingbufferStoreConfig.class);
+            BeanDefinitionBuilder builder = createBeanBuilder(RingbufferStoreConfig.class);
             for (Node child : childElements(node)) {
                 if ("properties".equals(cleanNodeName(child))) {
                     handleProperties(child, builder);
@@ -684,11 +683,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleQueue(Node node) {
             BeanDefinitionBuilder queueConfigBuilder = createBeanBuilder(QueueConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, queueConfigBuilder);
             for (Node childNode : childElements(node)) {
-                final String nodeName = cleanNodeName(childNode);
+                String nodeName = cleanNodeName(childNode);
                 if ("item-listeners".equals(nodeName)) {
                     ManagedList listeners = parseListeners(childNode, ItemListenerConfig.class);
                     queueConfigBuilder.addPropertyValue("itemListenerConfigs", listeners);
@@ -703,19 +702,19 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleQueueStoreConfig(Node node, BeanDefinitionBuilder queueConfigBuilder) {
             BeanDefinitionBuilder queueStoreConfigBuilder = createBeanBuilder(QueueStoreConfig.class);
-            final AbstractBeanDefinition beanDefinition = queueStoreConfigBuilder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = queueStoreConfigBuilder.getBeanDefinition();
             for (Node child : childElements(node)) {
                 if ("properties".equals(cleanNodeName(child))) {
                     handleProperties(child, queueStoreConfigBuilder);
                     break;
                 }
             }
-            final String storeImplAttrName = "store-implementation";
-            final String factoryImplAttrName = "factory-implementation";
+            String storeImplAttrName = "store-implementation";
+            String factoryImplAttrName = "factory-implementation";
             fillAttributeValues(node, queueStoreConfigBuilder, storeImplAttrName, factoryImplAttrName);
-            final NamedNodeMap attributes = node.getAttributes();
-            final Node implRef = attributes.getNamedItem(storeImplAttrName);
-            final Node factoryImplRef = attributes.getNamedItem(factoryImplAttrName);
+            NamedNodeMap attributes = node.getAttributes();
+            Node implRef = attributes.getNamedItem(storeImplAttrName);
+            Node factoryImplRef = attributes.getNamedItem(factoryImplAttrName);
             if (factoryImplRef != null) {
                 queueStoreConfigBuilder.addPropertyReference(xmlToJavaName(factoryImplAttrName), getTextContent(factoryImplRef));
             }
@@ -725,26 +724,24 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             queueConfigBuilder.addPropertyValue("queueStoreConfig", beanDefinition);
         }
 
-        private BeanDefinitionBuilder extractBasicStoreConfig(Node node,
-                                                              BeanDefinitionBuilder builder) {
-            final String storeImplAttrName = "implementation";
-            final String factoryImplAttrName = "factory-implementation";
+        private void extractBasicStoreConfig(Node node, BeanDefinitionBuilder builder) {
+            String storeImplAttrName = "implementation";
+            String factoryImplAttrName = "factory-implementation";
             fillAttributeValues(node, builder, storeImplAttrName, factoryImplAttrName);
-            final String implRef = getAttribute(node, storeImplAttrName);
-            final String factoryImplRef = getAttribute(node, factoryImplAttrName);
+            String implRef = getAttribute(node, storeImplAttrName);
+            String factoryImplRef = getAttribute(node, factoryImplAttrName);
             if (factoryImplRef != null) {
                 builder.addPropertyReference(xmlToJavaName(factoryImplAttrName), factoryImplRef);
             }
             if (implRef != null) {
                 builder.addPropertyReference(xmlToJavaName("store-implementation"), implRef);
             }
-            return builder;
         }
 
         public void handleList(Node node) {
             BeanDefinitionBuilder listConfigBuilder = createBeanBuilder(ListConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, listConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("item-listeners".equals(cleanNodeName(childNode))) {
@@ -757,8 +754,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleSet(Node node) {
             BeanDefinitionBuilder setConfigBuilder = createBeanBuilder(SetConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, setConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("item-listeners".equals(cleanNodeName(childNode))) {
@@ -772,31 +769,30 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         @SuppressWarnings({"checkstyle:methodlength", "checkstyle:npathcomplexity"})
         public void handleMap(Node node) {
             BeanDefinitionBuilder mapConfigBuilder = createBeanBuilder(MapConfig.class);
-            final AbstractBeanDefinition beanDefinition = mapConfigBuilder.getBeanDefinition();
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            AbstractBeanDefinition beanDefinition = mapConfigBuilder.getBeanDefinition();
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             mapConfigBuilder.addPropertyValue("name", name);
             fillAttributeValues(node, mapConfigBuilder, "maxSize", "maxSizePolicy");
-            final BeanDefinitionBuilder maxSizeConfigBuilder = createBeanBuilder(MaxSizeConfig.class);
-            final AbstractBeanDefinition maxSizeConfigBeanDefinition = maxSizeConfigBuilder.getBeanDefinition();
+            BeanDefinitionBuilder maxSizeConfigBuilder = createBeanBuilder(MaxSizeConfig.class);
+            AbstractBeanDefinition maxSizeConfigBeanDefinition = maxSizeConfigBuilder.getBeanDefinition();
             mapConfigBuilder.addPropertyValue("maxSizeConfig", maxSizeConfigBeanDefinition);
-            final Node maxSizeNode = node.getAttributes().getNamedItem("max-size");
+            Node maxSizeNode = node.getAttributes().getNamedItem("max-size");
             if (maxSizeNode != null) {
                 maxSizeConfigBuilder.addPropertyValue("size", getTextContent(maxSizeNode));
             }
-            final Node maxSizePolicyNode = node.getAttributes().getNamedItem("max-size-policy");
+            Node maxSizePolicyNode = node.getAttributes().getNamedItem("max-size-policy");
             if (maxSizePolicyNode != null) {
-                maxSizeConfigBuilder
-                        .addPropertyValue(xmlToJavaName(cleanNodeName(maxSizePolicyNode))
-                                , MaxSizeConfig.MaxSizePolicy.valueOf(getTextContent(maxSizePolicyNode)));
+                maxSizeConfigBuilder.addPropertyValue(xmlToJavaName(cleanNodeName(maxSizePolicyNode)),
+                        MaxSizePolicy.valueOf(getTextContent(maxSizePolicyNode)));
             }
-            final Node cacheDeserializedValueNode = node.getAttributes().getNamedItem("cache-deserialized-values");
+            Node cacheDeserializedValueNode = node.getAttributes().getNamedItem("cache-deserialized-values");
             if (cacheDeserializedValueNode != null) {
                 mapConfigBuilder.addPropertyValue("cacheDeserializedValues", getTextContent(cacheDeserializedValueNode));
             }
 
             for (Node childNode : childElements(node)) {
-                final String nodeName = cleanNodeName(childNode);
+                String nodeName = cleanNodeName(childNode);
                 if ("map-store".equals(nodeName)) {
                     handleMapStoreConfig(childNode, mapConfigBuilder);
                 } else if ("near-cache".equals(nodeName)) {
@@ -804,17 +800,17 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 } else if ("wan-replication-ref".equals(nodeName)) {
                     handleWanReplicationRef(mapConfigBuilder, childNode);
                 } else if ("indexes".equals(nodeName)) {
-                    ManagedList indexes = new ManagedList();
+                    ManagedList<BeanDefinition> indexes = new ManagedList<BeanDefinition>();
                     for (Node indexNode : childElements(childNode)) {
-                        final BeanDefinitionBuilder indexConfBuilder = createBeanBuilder(MapIndexConfig.class);
+                        BeanDefinitionBuilder indexConfBuilder = createBeanBuilder(MapIndexConfig.class);
                         fillAttributeValues(indexNode, indexConfBuilder);
                         indexes.add(indexConfBuilder.getBeanDefinition());
                     }
                     mapConfigBuilder.addPropertyValue("mapIndexConfigs", indexes);
                 } else if ("attributes".equals(nodeName)) {
-                    ManagedList attributes = new ManagedList();
+                    ManagedList<BeanDefinition> attributes = new ManagedList<BeanDefinition>();
                     for (Node attributeNode : childElements(childNode)) {
-                        final BeanDefinitionBuilder attributeConfBuilder = createBeanBuilder(MapAttributeConfig.class);
+                        BeanDefinitionBuilder attributeConfBuilder = createBeanBuilder(MapAttributeConfig.class);
                         fillAttributeValues(attributeNode, attributeConfBuilder);
                         attributes.add(attributeConfBuilder.getBeanDefinition());
                     }
@@ -859,7 +855,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     mapConfigBuilder.addPropertyValue("mapEvictionPolicy", mapEvictionPolicy);
 
                 } catch (Exception e) {
-                    throw ExceptionUtil.rethrow(e);
+                    throw rethrow(e);
                 }
             } else {
                 throw new IllegalArgumentException("One of `className` or `implementation`"
@@ -874,7 +870,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private ManagedList getQueryCaches(Node childNode) {
-            ManagedList queryCaches = new ManagedList();
+            ManagedList<BeanDefinition> queryCaches = new ManagedList<BeanDefinition>();
             for (Node queryCacheNode : childElements(childNode)) {
                 BeanDefinitionBuilder beanDefinitionBuilder = parseQueryCaches(queryCacheNode);
                 queryCaches.add(beanDefinitionBuilder.getBeanDefinition());
@@ -884,13 +880,13 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         @SuppressWarnings("checkstyle:methodlength")
         private BeanDefinitionBuilder parseQueryCaches(Node queryCacheNode) {
-            final BeanDefinitionBuilder builder = createBeanBuilder(QueryCacheConfig.class);
+            BeanDefinitionBuilder builder = createBeanBuilder(QueryCacheConfig.class);
 
             for (Node node : childElements(queryCacheNode)) {
                 String nodeName = cleanNodeName(node);
                 String textContent = getTextContent(node);
-                NamedNodeMap attrs = queryCacheNode.getAttributes();
-                String cacheName = getTextContent(attrs.getNamedItem("name"));
+                NamedNodeMap attributes = queryCacheNode.getAttributes();
+                String cacheName = getTextContent(attributes.getNamedItem("name"));
                 builder.addPropertyValue("name", cacheName);
 
                 if ("predicate".equals(nodeName)) {
@@ -903,8 +899,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     }
                     builder.addPropertyValue("predicateConfig", predicateBuilder.getBeanDefinition());
                 } else if ("entry-listeners".equals(nodeName)) {
-                    ManagedList listeners = new ManagedList();
-                    final String implementationAttr = "implementation";
+                    ManagedList<BeanDefinition> listeners = new ManagedList<BeanDefinition>();
+                    String implementationAttr = "implementation";
                     for (Node listenerNode : childElements(node)) {
                         BeanDefinitionBuilder listenerConfBuilder = createBeanBuilder(EntryListenerConfig.class);
                         fillAttributeValues(listenerNode, listenerConfBuilder, implementationAttr);
@@ -940,9 +936,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     boolean populate = getBooleanValue(textContent);
                     builder.addPropertyValue("populate", populate);
                 } else if ("indexes".equals(nodeName)) {
-                    ManagedList indexes = new ManagedList();
+                    ManagedList<BeanDefinition> indexes = new ManagedList<BeanDefinition>();
                     for (Node indexNode : childElements(node)) {
-                        final BeanDefinitionBuilder indexConfBuilder = createBeanBuilder(MapIndexConfig.class);
+                        BeanDefinitionBuilder indexConfBuilder = createBeanBuilder(MapIndexConfig.class);
                         fillAttributeValues(indexNode, indexConfBuilder);
                         indexes.add(indexConfBuilder.getBeanDefinition());
                     }
@@ -956,8 +952,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleCache(Node node) {
             BeanDefinitionBuilder cacheConfigBuilder = createBeanBuilder(CacheSimpleConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, cacheConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("eviction".equals(cleanNodeName(childNode))) {
@@ -965,9 +961,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 } else if ("expiry-policy-factory".equals(cleanNodeName(childNode))) {
                     cacheConfigBuilder.addPropertyValue("expiryPolicyFactoryConfig", getExpiryPolicyFactoryConfig(childNode));
                 } else if ("cache-entry-listeners".equals(cleanNodeName(childNode))) {
-                    ManagedList listeners = new ManagedList();
+                    ManagedList<BeanDefinition> listeners = new ManagedList<BeanDefinition>();
                     for (Node listenerNode : childElements(childNode)) {
-                        final BeanDefinitionBuilder listenerConfBuilder = createBeanBuilder(CacheSimpleEntryListenerConfig.class);
+                        BeanDefinitionBuilder listenerConfBuilder = createBeanBuilder(CacheSimpleEntryListenerConfig.class);
                         fillAttributeValues(listenerNode, listenerConfBuilder);
                         listeners.add(listenerConfBuilder.getBeanDefinition());
                     }
@@ -992,30 +988,30 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         public void handleWanReplication(Node node) {
-            final BeanDefinitionBuilder replicationConfigBuilder = createBeanBuilder(WanReplicationConfig.class);
-            final String name = getAttribute(node, "name");
+            BeanDefinitionBuilder replicationConfigBuilder = createBeanBuilder(WanReplicationConfig.class);
+            String name = getAttribute(node, "name");
             replicationConfigBuilder.addPropertyValue("name", name);
 
-            final ManagedList<AbstractBeanDefinition> wanPublishers = new ManagedList<AbstractBeanDefinition>();
+            ManagedList<AbstractBeanDefinition> wanPublishers = new ManagedList<AbstractBeanDefinition>();
             for (Node n : childElements(node)) {
-                final String nName = cleanNodeName(n);
+                String nName = cleanNodeName(n);
                 if ("wan-publisher".equals(nName)) {
-                    final BeanDefinitionBuilder publisherBuilder = createBeanBuilder(WanPublisherConfig.class);
-                    final AbstractBeanDefinition childBeanDefinition = publisherBuilder.getBeanDefinition();
+                    BeanDefinitionBuilder publisherBuilder = createBeanBuilder(WanPublisherConfig.class);
+                    AbstractBeanDefinition childBeanDefinition = publisherBuilder.getBeanDefinition();
                     fillAttributeValues(n, publisherBuilder, Collections.<String>emptyList());
 
-                    final String className = getAttribute(n, "class-name");
-                    final String implementation = getAttribute(n, "implementation");
+                    String className = getAttribute(n, "class-name");
+                    String implementation = getAttribute(n, "implementation");
 
                     publisherBuilder.addPropertyValue("className", className);
                     if (implementation != null) {
                         publisherBuilder.addPropertyReference("implementation", implementation);
                     }
-                    Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
-                            + "attributes is required to create WanPublisherConfig!");
+                    isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                            + " attributes is required to create WanPublisherConfig!");
                     for (Node child : childElements(n)) {
 
-                        final String nodeName = cleanNodeName(child);
+                        String nodeName = cleanNodeName(child);
                         if ("properties".equals(nodeName)) {
                             handleProperties(child, publisherBuilder);
                         } else if ("queue-full-behavior".equals(nodeName)) {
@@ -1030,17 +1026,17 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     }
                     wanPublishers.add(childBeanDefinition);
                 } else if ("wan-consumer".equals(nName)) {
-                    final BeanDefinitionBuilder consumerConfigBuilder = createBeanBuilder(WanConsumerConfig.class);
-                    final String className = getAttribute(n, "class-name");
-                    final String implementation = getAttribute(n, "implementation");
+                    BeanDefinitionBuilder consumerConfigBuilder = createBeanBuilder(WanConsumerConfig.class);
+                    String className = getAttribute(n, "class-name");
+                    String implementation = getAttribute(n, "implementation");
                     consumerConfigBuilder.addPropertyValue("className", className);
                     if (implementation != null) {
                         consumerConfigBuilder.addPropertyReference("implementation", implementation);
                     }
-                    Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
-                            + "attributes is required to create WanConsumerConfig!");
+                    isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                            + " attributes is required to create WanConsumerConfig!");
                     for (Node child : childElements(n)) {
-                        final String nodeName = cleanNodeName(child);
+                        String nodeName = cleanNodeName(child);
                         if ("properties".equals(nodeName)) {
                             handleProperties(child, consumerConfigBuilder);
                         }
@@ -1052,16 +1048,16 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             wanReplicationManagedMap.put(name, replicationConfigBuilder.getBeanDefinition());
         }
 
-        private void handlePartitionGroup(final Node node) {
-            final BeanDefinitionBuilder partitionConfigBuilder = createBeanBuilder(PartitionGroupConfig.class);
+        private void handlePartitionGroup(Node node) {
+            BeanDefinitionBuilder partitionConfigBuilder = createBeanBuilder(PartitionGroupConfig.class);
             fillAttributeValues(node, partitionConfigBuilder);
 
-            ManagedList memberGroups = new ManagedList();
+            ManagedList<BeanDefinition> memberGroups = new ManagedList<BeanDefinition>();
             for (Node child : childElements(node)) {
-                final String name = cleanNodeName(child);
+                String name = cleanNodeName(child);
                 if ("member-group".equals(name)) {
                     BeanDefinitionBuilder memberGroupBuilder = createBeanBuilder(MemberGroupConfig.class);
-                    ManagedList interfaces = new ManagedList();
+                    ManagedList<String> interfaces = new ManagedList<String>();
                     for (Node n : childElements(child)) {
                         if ("interface".equals(cleanNodeName(n))) {
                             interfaces.add(getTextContent(n));
@@ -1075,8 +1071,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("partitionGroupConfig", partitionConfigBuilder.getBeanDefinition());
         }
 
-        private void handleManagementCenter(final Node node) {
-            final BeanDefinitionBuilder managementCenterConfigBuilder = createBeanBuilder(ManagementCenterConfig.class);
+        private void handleManagementCenter(Node node) {
+            BeanDefinitionBuilder managementCenterConfigBuilder = createBeanBuilder(ManagementCenterConfig.class);
             fillAttributeValues(node, managementCenterConfigBuilder);
             // < 3.9 - Backwards compatibility
             boolean isComplexType = false;
@@ -1102,7 +1098,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private BeanDefinitionBuilder handleMcMutualAuthConfig(Node node) {
-            final BeanDefinitionBuilder mcMutualAuthConfigBuilder = createBeanBuilder(MCMutualAuthConfig.class);
+            BeanDefinitionBuilder mcMutualAuthConfigBuilder = createBeanBuilder(MCMutualAuthConfig.class);
             fillAttributeValues(node, mcMutualAuthConfigBuilder);
             for (Node n : childElements(node)) {
                 String nodeName = cleanNodeName(n);
@@ -1119,7 +1115,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder nearCacheConfigBuilder = createBeanBuilder(NearCacheConfig.class);
             fillAttributeValues(node, nearCacheConfigBuilder);
             for (Node childNode : childElements(node)) {
-                final String nodeName = cleanNodeName(childNode);
+                String nodeName = cleanNodeName(childNode);
                 if ("eviction".equals(nodeName)) {
                     handleEvictionConfig(childNode, nearCacheConfigBuilder);
                 }
@@ -1132,43 +1128,38 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private ExpiryPolicyFactoryConfig getExpiryPolicyFactoryConfig(Node node) {
-            final String className = getAttribute(node, "class-name");
-            if (!StringUtil.isNullOrEmpty(className)) {
+            String className = getAttribute(node, "class-name");
+            if (!isNullOrEmpty(className)) {
                 return new ExpiryPolicyFactoryConfig(className);
             } else {
                 TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig = null;
-                for (org.w3c.dom.Node n : childElements(node)) {
-                    final String nodeName = cleanNodeName(n);
+                for (Node n : childElements(node)) {
+                    String nodeName = cleanNodeName(n);
                     if ("timed-expiry-policy-factory".equals(nodeName)) {
-                        final String expiryPolicyTypeStr = getAttribute(n, "expiry-policy-type");
-                        final String durationAmountStr = getAttribute(n, "duration-amount");
-                        final String timeUnitStr = getAttribute(n, "time-unit");
-                        final ExpiryPolicyType expiryPolicyType =
-                                ExpiryPolicyType.valueOf(upperCaseInternal(expiryPolicyTypeStr));
+                        String expiryPolicyTypeStr = getAttribute(n, "expiry-policy-type");
+                        String durationAmountStr = getAttribute(n, "duration-amount");
+                        String timeUnitStr = getAttribute(n, "time-unit");
+                        ExpiryPolicyType expiryPolicyType = ExpiryPolicyType.valueOf(upperCaseInternal(expiryPolicyTypeStr));
                         if (expiryPolicyType != ExpiryPolicyType.ETERNAL
-                                && (StringUtil.isNullOrEmpty(durationAmountStr)
-                                || StringUtil.isNullOrEmpty(timeUnitStr))) {
-                            throw new InvalidConfigurationException(
-                                    "Both of the \"duration-amount\" or \"time-unit\" attributes "
-                                            + "are required for expiry policy factory configuration "
-                                            + "(except \"ETERNAL\" expiry policy type)");
+                                && (isNullOrEmpty(durationAmountStr)
+                                || isNullOrEmpty(timeUnitStr))) {
+                            throw new InvalidConfigurationException("Both of the \"duration-amount\" or \"time-unit\" attributes"
+                                    + " are required for expiry policy factory configuration"
+                                    + " (except \"ETERNAL\" expiry policy type)");
                         }
                         DurationConfig durationConfig = null;
                         if (expiryPolicyType != ExpiryPolicyType.ETERNAL) {
-                            final long durationAmount =
-                                    Long.parseLong(durationAmountStr);
-                            final TimeUnit timeUnit =
-                                    TimeUnit.valueOf(upperCaseInternal(timeUnitStr));
+                            long durationAmount = Long.parseLong(durationAmountStr);
+                            TimeUnit timeUnit = TimeUnit.valueOf(upperCaseInternal(timeUnitStr));
                             durationConfig = new DurationConfig(durationAmount, timeUnit);
                         }
-                        timedExpiryPolicyFactoryConfig =
-                                new TimedExpiryPolicyFactoryConfig(expiryPolicyType, durationConfig);
+                        timedExpiryPolicyFactoryConfig = new TimedExpiryPolicyFactoryConfig(expiryPolicyType, durationConfig);
                     }
                 }
                 if (timedExpiryPolicyFactoryConfig == null) {
                     throw new InvalidConfigurationException(
-                            "One of the \"class-name\" or \"timed-expire-policy-factory\" configuration "
-                                    + "is needed for expiry policy factory configuration");
+                            "One of the \"class-name\" or \"timed-expire-policy-factory\" configuration"
+                                    + " is needed for expiry policy factory configuration");
                 } else {
                     return new ExpiryPolicyFactoryConfig(timedExpiryPolicyFactoryConfig);
                 }
@@ -1177,21 +1168,21 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleMapStoreConfig(Node node, BeanDefinitionBuilder mapConfigBuilder) {
             BeanDefinitionBuilder mapStoreConfigBuilder = createBeanBuilder(MapStoreConfig.class);
-            final AbstractBeanDefinition beanDefinition = mapStoreConfigBuilder.getBeanDefinition();
+            AbstractBeanDefinition beanDefinition = mapStoreConfigBuilder.getBeanDefinition();
             for (Node child : childElements(node)) {
                 if ("properties".equals(cleanNodeName(child))) {
                     handleProperties(child, mapStoreConfigBuilder);
                     break;
                 }
             }
-            final String implAttrName = "implementation";
-            final String factoryImplAttrName = "factory-implementation";
-            final String initialModeAttrName = "initial-mode";
+            String implAttrName = "implementation";
+            String factoryImplAttrName = "factory-implementation";
+            String initialModeAttrName = "initial-mode";
             fillAttributeValues(node, mapStoreConfigBuilder, implAttrName, factoryImplAttrName, "initialMode");
-            final NamedNodeMap attrs = node.getAttributes();
-            final Node implRef = attrs.getNamedItem(implAttrName);
-            final Node factoryImplRef = attrs.getNamedItem(factoryImplAttrName);
-            final Node initialMode = attrs.getNamedItem(initialModeAttrName);
+            NamedNodeMap attributes = node.getAttributes();
+            Node implRef = attributes.getNamedItem(implAttrName);
+            Node factoryImplRef = attributes.getNamedItem(factoryImplAttrName);
+            Node initialMode = attributes.getNamedItem(initialModeAttrName);
             if (factoryImplRef != null) {
                 mapStoreConfigBuilder
                         .addPropertyReference(xmlToJavaName(factoryImplAttrName), getTextContent(factoryImplRef));
@@ -1200,8 +1191,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 mapStoreConfigBuilder.addPropertyReference(xmlToJavaName(implAttrName), getTextContent(implRef));
             }
             if (initialMode != null) {
-                final MapStoreConfig.InitialLoadMode mode
-                        = MapStoreConfig.InitialLoadMode.valueOf(upperCaseInternal(getTextContent(initialMode)));
+                InitialLoadMode mode = InitialLoadMode.valueOf(upperCaseInternal(getTextContent(initialMode)));
                 mapStoreConfigBuilder.addPropertyValue("initialLoadMode", mode);
             }
             mapConfigBuilder.addPropertyValue("mapStoreConfig", beanDefinition);
@@ -1209,8 +1199,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleMultiMap(Node node) {
             BeanDefinitionBuilder multiMapConfigBuilder = createBeanBuilder(MultiMapConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, multiMapConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("entry-listeners".equals(cleanNodeName(childNode))) {
@@ -1223,21 +1213,21 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleTopic(Node node) {
             BeanDefinitionBuilder topicConfigBuilder = createBeanBuilder(TopicConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, topicConfigBuilder);
             for (Node childNode : childElements(node)) {
                 if ("message-listeners".equals(cleanNodeName(childNode))) {
                     ManagedList listeners = parseListeners(childNode, ListenerConfig.class);
                     topicConfigBuilder.addPropertyValue("messageListenerConfigs", listeners);
                 } else if ("statistics-enabled".equals(cleanNodeName(childNode))) {
-                    final String statisticsEnabled = getTextContent(childNode);
+                    String statisticsEnabled = getTextContent(childNode);
                     topicConfigBuilder.addPropertyValue("statisticsEnabled", statisticsEnabled);
                 } else if ("global-ordering-enabled".equals(cleanNodeName(childNode))) {
-                    final String globalOrderingEnabled = getTextContent(childNode);
+                    String globalOrderingEnabled = getTextContent(childNode);
                     topicConfigBuilder.addPropertyValue("globalOrderingEnabled", globalOrderingEnabled);
                 } else if ("multi-threading-enabled".equals(cleanNodeName(childNode))) {
-                    final String multiThreadingEnabled = getTextContent(childNode);
+                    String multiThreadingEnabled = getTextContent(childNode);
                     topicConfigBuilder.addPropertyValue("multiThreadingEnabled", multiThreadingEnabled);
                 }
             }
@@ -1246,18 +1236,18 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleJobTracker(Node node) {
             BeanDefinitionBuilder jobTrackerConfigBuilder = createBeanBuilder(JobTrackerConfig.class);
-            final Node attName = node.getAttributes().getNamedItem("name");
-            final String name = getTextContent(attName);
+            Node attName = node.getAttributes().getNamedItem("name");
+            String name = getTextContent(attName);
             fillAttributeValues(node, jobTrackerConfigBuilder);
             jobTrackerManagedMap.put(name, jobTrackerConfigBuilder.getBeanDefinition());
         }
 
-        private void handleSecurity(final Node node) {
-            final BeanDefinitionBuilder securityConfigBuilder = createBeanBuilder(SecurityConfig.class);
-            final AbstractBeanDefinition beanDefinition = securityConfigBuilder.getBeanDefinition();
+        private void handleSecurity(Node node) {
+            BeanDefinitionBuilder securityConfigBuilder = createBeanBuilder(SecurityConfig.class);
+            AbstractBeanDefinition beanDefinition = securityConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, securityConfigBuilder);
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("member-credentials-factory".equals(nodeName)) {
                     handleCredentialsFactory(child, securityConfigBuilder);
                 } else if ("member-login-modules".equals(nodeName)) {
@@ -1275,19 +1265,19 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("securityConfig", beanDefinition);
         }
 
-        private void handleMemberAttributes(final Node node) {
-            final BeanDefinitionBuilder memberAttributeConfigBuilder = createBeanBuilder(MemberAttributeConfig.class);
-            final AbstractBeanDefinition beanDefinition = memberAttributeConfigBuilder.getBeanDefinition();
+        private void handleMemberAttributes(Node node) {
+            BeanDefinitionBuilder memberAttributeConfigBuilder = createBeanBuilder(MemberAttributeConfig.class);
+            AbstractBeanDefinition beanDefinition = memberAttributeConfigBuilder.getBeanDefinition();
             ManagedMap<String, Object> attributes = new ManagedMap<String, Object>();
             for (Node n : childElements(node)) {
-                final String name = cleanNodeName(n);
+                String name = cleanNodeName(n);
                 if (!"attribute".equals(name)) {
                     continue;
                 }
-                final String attributeName = getTextContent(n.getAttributes().getNamedItem("name")).trim();
-                final String attributeType = getTextContent(n.getAttributes().getNamedItem("type")).trim();
-                final String value = getTextContent(n);
-                final Object oValue;
+                String attributeName = getTextContent(n.getAttributes().getNamedItem("name")).trim();
+                String attributeType = getTextContent(n.getAttributes().getNamedItem("type")).trim();
+                String value = getTextContent(n);
+                Object oValue;
                 if ("string".equals(attributeType)) {
                     oValue = value;
                 } else if ("boolean".equals(attributeType)) {
@@ -1313,12 +1303,12 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("memberAttributeConfig", beanDefinition);
         }
 
-        private void handleNativeMemory(final Node node) {
-            final BeanDefinitionBuilder nativeMemoryConfigBuilder = createBeanBuilder(NativeMemoryConfig.class);
-            final AbstractBeanDefinition beanDefinition = nativeMemoryConfigBuilder.getBeanDefinition();
+        private void handleNativeMemory(Node node) {
+            BeanDefinitionBuilder nativeMemoryConfigBuilder = createBeanBuilder(NativeMemoryConfig.class);
+            AbstractBeanDefinition beanDefinition = nativeMemoryConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, nativeMemoryConfigBuilder);
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("size".equals(nodeName)) {
                     handleMemorySizeConfig(child, nativeMemoryConfigBuilder);
                 }
@@ -1328,29 +1318,29 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleMemorySizeConfig(Node node, BeanDefinitionBuilder nativeMemoryConfigBuilder) {
             BeanDefinitionBuilder memorySizeConfigBuilder = createBeanBuilder(MemorySize.class);
-            final NamedNodeMap attrs = node.getAttributes();
-            final Node value = attrs.getNamedItem("value");
-            final Node unit = attrs.getNamedItem("unit");
+            NamedNodeMap attributes = node.getAttributes();
+            Node value = attributes.getNamedItem("value");
+            Node unit = attributes.getNamedItem("unit");
             memorySizeConfigBuilder.addConstructorArgValue(getTextContent(value));
             memorySizeConfigBuilder.addConstructorArgValue(MemoryUnit.valueOf(getTextContent(unit)));
             nativeMemoryConfigBuilder.addPropertyValue("size", memorySizeConfigBuilder.getBeanDefinition());
         }
 
-        private void handleSecurityInterceptors(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {
-            final List lms = new ManagedList();
+        private void handleSecurityInterceptors(Node node, BeanDefinitionBuilder securityConfigBuilder) {
+            List<BeanDefinition> lms = new ManagedList<BeanDefinition>();
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("interceptor".equals(nodeName)) {
-                    final BeanDefinitionBuilder siConfigBuilder = createBeanBuilder(SecurityInterceptorConfig.class);
-                    final AbstractBeanDefinition beanDefinition = siConfigBuilder.getBeanDefinition();
-                    final NamedNodeMap attrs = child.getAttributes();
-                    Node classNameNode = attrs.getNamedItem("class-name");
+                    BeanDefinitionBuilder siConfigBuilder = createBeanBuilder(SecurityInterceptorConfig.class);
+                    AbstractBeanDefinition beanDefinition = siConfigBuilder.getBeanDefinition();
+                    NamedNodeMap attributes = child.getAttributes();
+                    Node classNameNode = attributes.getNamedItem("class-name");
                     String className = classNameNode != null ? getTextContent(classNameNode) : null;
-                    Node implNode = attrs.getNamedItem("implementation");
+                    Node implNode = attributes.getNamedItem("implementation");
                     String implementation = implNode != null ? getTextContent(implNode) : null;
-                    Assert.isTrue(className != null || implementation != null,
-                            "One of 'class-name' or 'implementation' attributes is required "
-                                    + "to create SecurityInterceptorConfig!");
+                    isTrue(className != null || implementation != null,
+                            "One of 'class-name' or 'implementation' attributes is required"
+                                    + " to create SecurityInterceptorConfig!");
                     siConfigBuilder.addPropertyValue("className", className);
                     if (implementation != null) {
                         siConfigBuilder.addPropertyReference("implementation", implementation);
@@ -1361,22 +1351,22 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             securityConfigBuilder.addPropertyValue("securityInterceptorConfigs", lms);
         }
 
-        private void handleCredentialsFactory(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {
-            final BeanDefinitionBuilder credentialsConfigBuilder = createBeanBuilder(CredentialsFactoryConfig.class);
-            final AbstractBeanDefinition beanDefinition = credentialsConfigBuilder.getBeanDefinition();
-            final NamedNodeMap attrs = node.getAttributes();
-            Node classNameNode = attrs.getNamedItem("class-name");
+        private void handleCredentialsFactory(Node node, BeanDefinitionBuilder securityConfigBuilder) {
+            BeanDefinitionBuilder credentialsConfigBuilder = createBeanBuilder(CredentialsFactoryConfig.class);
+            AbstractBeanDefinition beanDefinition = credentialsConfigBuilder.getBeanDefinition();
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
             String className = classNameNode != null ? getTextContent(classNameNode) : null;
-            Node implNode = attrs.getNamedItem("implementation");
+            Node implNode = attributes.getNamedItem("implementation");
             String implementation = implNode != null ? getTextContent(implNode) : null;
             credentialsConfigBuilder.addPropertyValue("className", className);
             if (implementation != null) {
                 credentialsConfigBuilder.addPropertyReference("implementation", implementation);
             }
-            Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
-                    + "attributes is required to create CredentialsFactory!");
+            isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                    + " attributes is required to create CredentialsFactory!");
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("properties".equals(nodeName)) {
                     handleProperties(child, credentialsConfigBuilder);
                     break;
@@ -1385,10 +1375,10 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             securityConfigBuilder.addPropertyValue("memberCredentialsConfig", beanDefinition);
         }
 
-        private void handleLoginModules(final Node node, final BeanDefinitionBuilder securityConfigBuilder, boolean member) {
-            final List lms = new ManagedList();
+        private void handleLoginModules(Node node, BeanDefinitionBuilder securityConfigBuilder, boolean member) {
+            List<BeanDefinition> lms = new ManagedList<BeanDefinition>();
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("login-module".equals(nodeName)) {
                     handleLoginModule(child, lms);
                 }
@@ -1400,23 +1390,23 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
         }
 
-        private void handleLoginModule(final Node node, List list) {
-            final BeanDefinitionBuilder lmConfigBuilder = createBeanBuilder(LoginModuleConfig.class);
-            final AbstractBeanDefinition beanDefinition = lmConfigBuilder.getBeanDefinition();
+        private void handleLoginModule(Node node, List<BeanDefinition> list) {
+            BeanDefinitionBuilder lmConfigBuilder = createBeanBuilder(LoginModuleConfig.class);
+            AbstractBeanDefinition beanDefinition = lmConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, lmConfigBuilder, "class-name", "implementation");
-            final NamedNodeMap attrs = node.getAttributes();
-            Node classNameNode = attrs.getNamedItem("class-name");
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
             String className = classNameNode != null ? getTextContent(classNameNode) : null;
-            Node implNode = attrs.getNamedItem("implementation");
+            Node implNode = attributes.getNamedItem("implementation");
             String implementation = implNode != null ? getTextContent(implNode) : null;
             lmConfigBuilder.addPropertyValue("className", className);
             if (implementation != null) {
                 lmConfigBuilder.addPropertyReference("implementation", implementation);
             }
-            Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
-                    + "attributes is required to create LoginModule!");
+            isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                    + " attributes is required to create LoginModule!");
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("properties".equals(nodeName)) {
                     handleProperties(child, lmConfigBuilder);
                     break;
@@ -1425,22 +1415,22 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             list.add(beanDefinition);
         }
 
-        private void handlePermissionPolicy(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {
-            final BeanDefinitionBuilder permPolicyConfigBuilder = createBeanBuilder(PermissionPolicyConfig.class);
-            final AbstractBeanDefinition beanDefinition = permPolicyConfigBuilder.getBeanDefinition();
-            final NamedNodeMap attrs = node.getAttributes();
-            Node classNameNode = attrs.getNamedItem("class-name");
+        private void handlePermissionPolicy(Node node, BeanDefinitionBuilder securityConfigBuilder) {
+            BeanDefinitionBuilder permPolicyConfigBuilder = createBeanBuilder(PermissionPolicyConfig.class);
+            AbstractBeanDefinition beanDefinition = permPolicyConfigBuilder.getBeanDefinition();
+            NamedNodeMap attributes = node.getAttributes();
+            Node classNameNode = attributes.getNamedItem("class-name");
             String className = classNameNode != null ? getTextContent(classNameNode) : null;
-            Node implNode = attrs.getNamedItem("implementation");
+            Node implNode = attributes.getNamedItem("implementation");
             String implementation = implNode != null ? getTextContent(implNode) : null;
             permPolicyConfigBuilder.addPropertyValue("className", className);
             if (implementation != null) {
                 permPolicyConfigBuilder.addPropertyReference("implementation", implementation);
             }
-            Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
-                    + "attributes is required to create PermissionPolicy!");
+            isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                    + " attributes is required to create PermissionPolicy!");
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("properties".equals(nodeName)) {
                     handleProperties(child, permPolicyConfigBuilder);
                     break;
@@ -1449,12 +1439,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             securityConfigBuilder.addPropertyValue("clientPolicyConfig", beanDefinition);
         }
 
-        private void handleSecurityPermissions(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {
-            final Set permissions = new ManagedSet();
+        private void handleSecurityPermissions(Node node, BeanDefinitionBuilder securityConfigBuilder) {
+            Set<BeanDefinition> permissions = new ManagedSet<BeanDefinition>();
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 PermissionType type = PermissionType.getType(nodeName);
-
                 if (type == null) {
                     continue;
                 }
@@ -1464,21 +1453,21 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             securityConfigBuilder.addPropertyValue("clientPermissionConfigs", permissions);
         }
 
-        private void handleSecurityPermission(final Node node, final Set permissions, PermissionType type) {
-            final BeanDefinitionBuilder permissionConfigBuilder = createBeanBuilder(PermissionConfig.class);
-            final AbstractBeanDefinition beanDefinition = permissionConfigBuilder.getBeanDefinition();
+        private void handleSecurityPermission(Node node, Set<BeanDefinition> permissions, PermissionType type) {
+            BeanDefinitionBuilder permissionConfigBuilder = createBeanBuilder(PermissionConfig.class);
+            AbstractBeanDefinition beanDefinition = permissionConfigBuilder.getBeanDefinition();
             permissionConfigBuilder.addPropertyValue("type", type);
-            final NamedNodeMap attrs = node.getAttributes();
-            Node nameNode = attrs.getNamedItem("name");
+            NamedNodeMap attributes = node.getAttributes();
+            Node nameNode = attributes.getNamedItem("name");
             String name = nameNode != null ? getTextContent(nameNode) : "*";
             permissionConfigBuilder.addPropertyValue("name", name);
-            Node principalNode = attrs.getNamedItem("principal");
+            Node principalNode = attributes.getNamedItem("principal");
             String principal = principalNode != null ? getTextContent(principalNode) : "*";
             permissionConfigBuilder.addPropertyValue("principal", principal);
-            final List endpoints = new ManagedList();
-            final List actions = new ManagedList();
+            List<String> endpoints = new ManagedList<String>();
+            List<String> actions = new ManagedList<String>();
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("endpoints".equals(nodeName)) {
                     handleSecurityPermissionEndpoints(child, endpoints);
                 } else if ("actions".equals(nodeName)) {
@@ -1490,18 +1479,18 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             permissions.add(beanDefinition);
         }
 
-        private void handleSecurityPermissionEndpoints(final Node node, final List endpoints) {
+        private void handleSecurityPermissionEndpoints(Node node, List<String> endpoints) {
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("endpoint".equals(nodeName)) {
                     endpoints.add(getTextContent(child));
                 }
             }
         }
 
-        private void handleSecurityPermissionActions(final Node node, final List actions) {
+        private void handleSecurityPermissionActions(Node node, List<String> actions) {
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("action".equals(nodeName)) {
                     actions.add(getTextContent(child));
                 }
@@ -1509,14 +1498,13 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleWanReplicationRef(BeanDefinitionBuilder beanDefinitionBuilder, Node childNode) {
-            final BeanDefinitionBuilder wanReplicationRefBuilder = createBeanBuilder(WanReplicationRef.class);
-            final AbstractBeanDefinition wanReplicationRefBeanDefinition = wanReplicationRefBuilder
-                    .getBeanDefinition();
+            BeanDefinitionBuilder wanReplicationRefBuilder = createBeanBuilder(WanReplicationRef.class);
+            AbstractBeanDefinition wanReplicationRefBeanDefinition = wanReplicationRefBuilder.getBeanDefinition();
             fillValues(childNode, wanReplicationRefBuilder);
             for (Node node : childElements(childNode)) {
-                final String nodeName = cleanNodeName(node);
+                String nodeName = cleanNodeName(node);
                 if (nodeName.equals("filters")) {
-                    final List filters = new ManagedList();
+                    List<String> filters = new ManagedList<String>();
                     handleFilters(node, filters);
                     wanReplicationRefBuilder.addPropertyValue("filters", filters);
                 }
@@ -1524,9 +1512,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             beanDefinitionBuilder.addPropertyValue("wanReplicationRef", wanReplicationRefBeanDefinition);
         }
 
-        private void handleFilters(Node node, List filters) {
+        private void handleFilters(Node node, List<String> filters) {
             for (Node child : childElements(node)) {
-                final String nodeName = cleanNodeName(child);
+                String nodeName = cleanNodeName(child);
                 if ("filter-impl".equals(nodeName)) {
                     filters.add(getTextContent(child));
                 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
@@ -50,7 +50,7 @@ public class HazelcastInstanceDefinitionParser extends AbstractHazelcastBeanDefi
 
     @Override
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-        final SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
+        SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
         springXmlBuilder.handle(element);
         return springXmlBuilder.getBeanDefinition();
     }
@@ -58,17 +58,16 @@ public class HazelcastInstanceDefinitionParser extends AbstractHazelcastBeanDefi
     private class SpringXmlBuilder extends SpringXmlBuilderHelper {
 
         private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
 
-        private BeanDefinitionBuilder builder;
-
-        public SpringXmlBuilder(ParserContext parserContext) {
+        SpringXmlBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
             this.builder = BeanDefinitionBuilder.rootBeanDefinition(HazelcastInstanceFactory.class);
             this.builder.setFactoryMethod("newHazelcastInstance");
             this.builder.setDestroyMethodName("shutdown");
         }
 
-        public AbstractBeanDefinition getBeanDefinition() {
+        AbstractBeanDefinition getBeanDefinition() {
             return builder.getBeanDefinition();
         }
 
@@ -76,14 +75,14 @@ public class HazelcastInstanceDefinitionParser extends AbstractHazelcastBeanDefi
             handleCommonBeanAttributes(element, builder, parserContext);
             Element config = null;
             for (Node node : childElements(element)) {
-                final String nodeName = cleanNodeName(node);
+                String nodeName = cleanNodeName(node);
                 if ("config".equals(nodeName)) {
                     config = (Element) node;
                 }
             }
-            final HazelcastConfigBeanDefinitionParser configParser = new HazelcastConfigBeanDefinitionParser();
-            final AbstractBeanDefinition configBeanDef = configParser.parseInternal(config, parserContext);
-            this.builder.addConstructorArgValue(configBeanDef);
+            HazelcastConfigBeanDefinitionParser configParser = new HazelcastConfigBeanDefinitionParser();
+            AbstractBeanDefinition configBeanDef = configParser.parseInternal(config, parserContext);
+            builder.addConstructorArgValue(configBeanDef);
         }
     }
 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
@@ -31,7 +31,7 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("client", new HazelcastClientBeanDefinitionParser());
         registerBeanDefinitionParser("hibernate-region-factory", new RegionFactoryBeanDefinitionParser());
         registerBeanDefinitionParser("cache-manager", new CacheManagerBeanDefinitionParser());
-        final String[] types = {
+        String[] types = {
                 "map",
                 "multiMap",
                 "replicatedMap",
@@ -47,9 +47,8 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
                 "semaphore",
                 "lock",
         };
-        for (final String type : types) {
+        for (String type : types) {
             registerBeanDefinitionParser(type, new HazelcastTypeBeanDefinitionParser(type));
         }
     }
 }
-

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastTypeBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastTypeBeanDefinitionParser.java
@@ -32,16 +32,16 @@ public class HazelcastTypeBeanDefinitionParser extends AbstractHazelcastBeanDefi
     private final String type;
     private final String methodName;
 
-    public HazelcastTypeBeanDefinitionParser(final String type) {
+    public HazelcastTypeBeanDefinitionParser(String type) {
         this.type = type;
         this.methodName = "get" + Character.toUpperCase(type.charAt(0)) + type.substring(1);
     }
 
     @Override
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-        final SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
+        SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
         springXmlBuilder.handle(element);
-        final BeanDefinitionBuilder builder = springXmlBuilder.getBuilder();
+        BeanDefinitionBuilder builder = springXmlBuilder.getBuilder();
         builder.setFactoryMethod(methodName);
         return builder.getBeanDefinition();
     }
@@ -49,34 +49,32 @@ public class HazelcastTypeBeanDefinitionParser extends AbstractHazelcastBeanDefi
     private class SpringXmlBuilder extends SpringXmlBuilderHelper {
 
         private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
 
-        private BeanDefinitionBuilder builder;
-
-        public SpringXmlBuilder(ParserContext parserContext) {
+        SpringXmlBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
             this.builder = BeanDefinitionBuilder.rootBeanDefinition(HazelcastInstance.class);
         }
 
-        public BeanDefinitionBuilder getBuilder() {
+        BeanDefinitionBuilder getBuilder() {
             return this.builder;
         }
 
         public void handle(Element element) {
             handleCommonBeanAttributes(element, builder, parserContext);
-            final NamedNodeMap attrs = element.getAttributes();
-            if (attrs != null) {
-                Node instanceRefNode = attrs.getNamedItem("instance-ref");
+            NamedNodeMap attributes = element.getAttributes();
+            if (attributes != null) {
+                Node instanceRefNode = attributes.getNamedItem("instance-ref");
                 if (instanceRefNode == null) {
-                    throw new IllegalStateException("'instance-ref' attribute is required for creating"
-                            + " Hazelcast " + type);
+                    throw new IllegalStateException("'instance-ref' attribute is required for creating Hazelcast " + type);
                 }
-                final String instanceRef = getTextContent(instanceRefNode);
+                String instanceRef = getTextContent(instanceRefNode);
                 builder.getRawBeanDefinition().setFactoryBeanName(instanceRef);
                 builder.addDependsOn(instanceRef);
 
-                Node nameNode = attrs.getNamedItem("name");
+                Node nameNode = attributes.getNamedItem("name");
                 if (nameNode == null) {
-                    nameNode = attrs.getNamedItem("id");
+                    nameNode = attributes.getNamedItem("id");
                 }
                 builder.addConstructorArgValue(getTextContent(nameNode));
             }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -25,13 +25,12 @@ import com.hazelcast.util.ExceptionUtil;
 import org.springframework.cache.Cache;
 import org.springframework.cache.support.SimpleValueWrapper;
 
-import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * @author mdogan 4/3/12
+ * Sprint related {@link Cache} implementation for Hazelcast.
  */
 public class HazelcastCache implements Cache {
 
@@ -40,13 +39,13 @@ public class HazelcastCache implements Cache {
     private final IMap<Object, Object> map;
 
     /**
-     * read timeout for cache value retrieval operations.
-     * if 0 or negative, get operations block, otherwise uses getAsync with defined
-     * timeout
+     * Read timeout for cache value retrieval operations.
+     * <p>
+     * If {@code 0} or negative, get() operations block, otherwise uses getAsync() with defined timeout.
      */
     private long readTimeout;
 
-    public HazelcastCache(final IMap<Object, Object> map) {
+    public HazelcastCache(IMap<Object, Object> map) {
         this.map = map;
     }
 
@@ -61,14 +60,15 @@ public class HazelcastCache implements Cache {
     }
 
     @Override
-    public ValueWrapper get(final Object key) {
+    public ValueWrapper get(Object key) {
         if (key == null) {
             return null;
         }
-        final Object value = lookup(key);
+        Object value = lookup(key);
         return value != null ? new SimpleValueWrapper(fromStoreValue(value)) : null;
     }
 
+    @SuppressWarnings("unchecked")
     public <T> T get(Object key, Class<T> type) {
         Object value = fromStoreValue(lookup(key));
         if (type != null && value != null && !type.isInstance(value)) {
@@ -109,20 +109,20 @@ public class HazelcastCache implements Cache {
     }
 
     @Override
-    public void put(final Object key, final Object value) {
+    public void put(Object key, Object value) {
         if (key != null) {
             map.set(key, toStoreValue(value));
         }
     }
 
-    protected Object toStoreValue(final Object value) {
+    protected Object toStoreValue(Object value) {
         if (value == null) {
             return NULL;
         }
         return value;
     }
 
-    protected Object fromStoreValue(final Object value) {
+    protected Object fromStoreValue(Object value) {
         if (NULL.equals(value)) {
             return null;
         }
@@ -130,7 +130,7 @@ public class HazelcastCache implements Cache {
     }
 
     @Override
-    public void evict(final Object key) {
+    public void evict(Object key) {
         if (key != null) {
             map.delete(key);
         }
@@ -163,12 +163,13 @@ public class HazelcastCache implements Cache {
     }
 
     static final class NullDataSerializable implements DataSerializable {
+
         @Override
-        public void writeData(final ObjectDataOutput out) throws IOException {
+        public void writeData(ObjectDataOutput out) {
         }
 
         @Override
-        public void readData(final ObjectDataInput in) throws IOException {
+        public void readData(ObjectDataInput in) {
         }
 
         @Override
@@ -185,13 +186,14 @@ public class HazelcastCache implements Cache {
     private static class ValueRetrievalExceptionResolver {
 
         static RuntimeException resolveException(Object key, Callable<?> valueLoader,
-                Throwable ex) {
+                                                 Throwable ex) {
             return new ValueRetrievalException(key, valueLoader, ex);
         }
     }
 
     /**
      * Set cache value retrieval timeout
+     *
      * @param readTimeout cache value retrieval timeout in milliseconds. 0 or negative values disable timeout
      */
     public void setReadTimeout(long readTimeout) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringAware.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringAware.java
@@ -25,10 +25,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotates a class for injection of Spring dependencies.
- *
- * @author mdogan 4/6/12
  */
-
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
@@ -36,5 +33,4 @@ import java.lang.annotation.Target;
 public @interface SpringAware {
 
     String beanName() default "";
-
 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringManagedContext.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringManagedContext.java
@@ -24,7 +24,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 /**
- * @author mdogan 4/6/12
+ * {@link ManagedContext} implementation for Hazelcast.
  */
 public class SpringManagedContext implements ManagedContext, ApplicationContextAware {
 
@@ -54,8 +54,8 @@ public class SpringManagedContext implements ManagedContext, ApplicationContextA
         SpringAware s = (SpringAware) clazz.getAnnotation(SpringAware.class);
         Object resultObject = obj;
         if (s != null) {
-            String name = s.beanName();
-            if (name == null || name.length() == 0) {
+            String name = s.beanName().trim();
+            if (name.isEmpty()) {
                 name = clazz.getName();
             }
             beanFactory.autowireBean(obj);
@@ -65,7 +65,7 @@ public class SpringManagedContext implements ManagedContext, ApplicationContextA
     }
 
     @Override
-    public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.beanFactory = applicationContext.getAutowireCapableBeanFactory();
     }
 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/hibernate/RegionFactoryBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/hibernate/RegionFactoryBeanDefinitionParser.java
@@ -44,13 +44,13 @@ public class RegionFactoryBeanDefinitionParser extends AbstractBeanDefinitionPar
 
     @Override
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-        final NamedNodeMap atts = element.getAttributes();
+         NamedNodeMap attributes = element.getAttributes();
         String instanceRefName = "instance";
         String mode = "DISTRIBUTED";
-        if (atts != null) {
-            for (int a = 0; a < atts.getLength(); a++) {
-                final Node att = atts.item(a);
-                final String name = att.getNodeName();
+        if (attributes != null) {
+            for (int a = 0; a < attributes.getLength(); a++) {
+                 Node att = attributes.item(a);
+                 String name = att.getNodeName();
                 if ("instance-ref".equals(name)) {
                     instanceRefName = att.getTextContent();
                 } else if ("mode".equals(name)) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -183,25 +183,25 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
         private boolean newTransactionContextHolder;
         private boolean rollbackOnly;
 
-        public void setRollbackOnly(boolean rollbackOnly) {
+        void setRollbackOnly(boolean rollbackOnly) {
             this.rollbackOnly = rollbackOnly;
         }
 
-        public void setTransactionContextHolder(TransactionContextHolder transactionContextHolder,
-                                                boolean newTransactionContextHolder) {
+        void setTransactionContextHolder(TransactionContextHolder transactionContextHolder,
+                                         boolean newTransactionContextHolder) {
             this.transactionContextHolder = transactionContextHolder;
             this.newTransactionContextHolder = newTransactionContextHolder;
         }
 
-        public TransactionContextHolder getTransactionContextHolder() {
+        TransactionContextHolder getTransactionContextHolder() {
             return transactionContextHolder;
         }
 
-        public boolean isNewTransactionContextHolder() {
+        boolean isNewTransactionContextHolder() {
             return newTransactionContextHolder;
         }
 
-        public boolean hasTransaction() {
+        boolean hasTransaction() {
             return this.transactionContextHolder != null && this.transactionContextHolder.isTransactionActive();
         }
 
@@ -212,7 +212,7 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
 
         @Override
         public void flush() {
-            //Do nothing here.
+            // do nothing here
         }
     }
 }


### PR DESCRIPTION
Just the usual stuff of removing warnings and aligning the code style. I unified `atts` and `attrs` to `attributes`, since it's the most readable and also the default suggestion of IDEA.

The line coverage on the Spring module is ~92%, so I'm quite confident that a green PR builder is a good indicator that everything is still working.

Sorry @mmedenjak :(