### PR TITLE
Cleanup of Spring XML files

### DIFF
--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -20,9 +20,9 @@
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -56,7 +56,7 @@
             </hz:native-memory>
         </hz:config>
     </hz:hazelcast>
-    
+
     <hz:client id="client" lazy-init="true" scope="prototype">
         <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
         <hz:network connection-attempt-limit="3"

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
@@ -20,11 +20,11 @@
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <cache:annotation-driven cache-manager="cacheManager"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
@@ -20,17 +20,17 @@
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.10.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <cache:annotation-driven cache-manager="cacheManager"/>
 
     <hz:hazelcast id="instance">
         <hz:config>
-            <hz:spring-aware />
+            <hz:spring-aware/>
             <hz:instance-name>named-spring-hz-instance</hz:instance-name>
             <hz:group name="dev" password="dev-pass"/>
             <hz:network port="5701" port-auto-increment="false">
@@ -55,7 +55,7 @@
             <hz:cache name="cacheWithListeners">
                 <hz:cache-entry-listeners>
                     <hz:cache-entry-listener
-                            cache-entry-listener-factory="com.hazelcast.spring.cache.JCacheCacheEntryListenerFactory" />
+                            cache-entry-listener-factory="com.hazelcast.spring.cache.JCacheCacheEntryListenerFactory"/>
                 </hz:cache-entry-listeners>
                 <hz:partition-lost-listeners>
                     <hz:partition-lost-listener class-name="com.hazelcast.spring.cache.JCachePartitionLostListener"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
@@ -20,11 +20,11 @@
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.10.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <cache:annotation-driven cache-manager="cacheManager"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
@@ -21,11 +21,11 @@
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:p="http://jboss.org/xml/ns/javax/validation/mapping"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.10.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
@@ -19,11 +19,11 @@
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns="http://www.springframework.org/schema/beans"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <cache:annotation-driven cache-manager="cacheManager"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
@@ -20,15 +20,15 @@
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd
-		http://www.springframework.org/schema/context
-		http://www.springframework.org/schema/context/spring-context.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
-    <context:property-placeholder location="classpath:timeout.properties" />
+    <context:property-placeholder location="classpath:timeout.properties"/>
 
     <cache:annotation-driven cache-manager="cacheManager"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
@@ -19,11 +19,11 @@
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/cache
+        http://www.springframework.org/schema/cache/spring-cache.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <cache:annotation-driven cache-manager="cacheManager"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
@@ -18,7 +18,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
@@ -18,9 +18,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <hz:hazelcast id="instance"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -20,9 +20,9 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -67,9 +67,8 @@
         </hz:config>
     </hz:hazelcast>
 
-
     <hz:client id="client"
-               credentials-ref="credentials" >
+               credentials-ref="credentials">
         <hz:network connection-attempt-limit="3"
                     connection-attempt-period="3000"
                     connection-timeout="1000"
@@ -126,13 +125,14 @@
                           enable-compression="false"
                           enable-shared-object="false"
                           portable-version="10"
-                          use-native-byte-order="false" >
+                          use-native-byte-order="false">
 
             <hz:data-serializable-factories>
-                <hz:data-serializable-factory factory-id="1" class-name="com.hazelcast.spring.serialization.DummyDataSerializableFactory"/>
+                <hz:data-serializable-factory factory-id="1"
+                                              class-name="com.hazelcast.spring.serialization.DummyDataSerializableFactory"/>
             </hz:data-serializable-factories>
             <hz:portable-factories>
-                <hz:portable-factory factory-id="2" class-name="com.hazelcast.spring.serialization.DummyPortableFactory" />
+                <hz:portable-factory factory-id="2" class-name="com.hazelcast.spring.serialization.DummyPortableFactory"/>
             </hz:portable-factories>
             <hz:serializers>
                 <hz:serializer type-class="com.hazelcast.nio.serialization.CustomSerializationTest$Foo"
@@ -141,12 +141,11 @@
         </hz:serialization>
 
 
-
         <hz:proxy-factories>
-            <hz:proxy-factory class-name="com.hazelcast.spring.DummyProxyFactory" service="MyService" />
+            <hz:proxy-factory class-name="com.hazelcast.spring.DummyProxyFactory" service="MyService"/>
         </hz:proxy-factories>
 
-        <hz:load-balancer type="round-robin" />
+        <hz:load-balancer type="round-robin"/>
 
         <hz:near-cache name="default"
                        time-to-live-seconds="1"
@@ -156,12 +155,11 @@
                        invalidate-on-change="true"/>
 
 
-
     </hz:client>
 
     <bean id="credentials" class="com.hazelcast.security.UsernamePasswordCredentials">
-        <property name="username" value="spring-group" />
-        <property name="password" value="spring-group-pass" />
+        <property name="username" value="spring-group"/>
+        <property name="password" value="spring-group-pass"/>
     </bean>
 
     <hz:map id="map" instance-ref="client" name="map"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
@@ -17,27 +17,26 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
-      http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/context/spring-context.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+        http://www.springframework.org/schema/tx/spring-tx.xsd
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
-    <tx:annotation-driven transaction-manager="dummyTransactionManager" />
+    <tx:annotation-driven transaction-manager="dummyTransactionManager"/>
 
-    <context:annotation-config />
-    <context:component-scan base-package="com.hazelcast.spring.context" />
+    <context:annotation-config/>
+    <context:component-scan base-package="com.hazelcast.spring.context"/>
 
     <hz:hazelcast id="instance1">
         <hz:config>
-            <hz:spring-aware />
+            <hz:spring-aware/>
             <hz:group name="dev" password="dev-pass"/>
             <hz:network port="5701" port-auto-increment="false">
                 <hz:join>
@@ -56,7 +55,7 @@
 
     <hz:hazelcast id="instance2">
         <hz:config>
-            <hz:spring-aware />
+            <hz:spring-aware/>
             <hz:group name="dev" password="dev-pass"/>
             <hz:network port="5702" port-auto-increment="false">
                 <hz:join>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
@@ -17,23 +17,22 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
-      http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/context/spring-context.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+        http://www.springframework.org/schema/tx/spring-tx.xsd
         http://www.hazelcast.com/schema/spring
         http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
-    <tx:annotation-driven transaction-manager="dummyTransactionManager" />
+    <tx:annotation-driven transaction-manager="dummyTransactionManager"/>
 
-    <context:annotation-config />
-    <context:component-scan base-package="com.hazelcast.spring.context" />
+    <context:annotation-config/>
+    <context:component-scan base-package="com.hazelcast.spring.context"/>
 
     <hz:hazelcast id="instance1">
         <hz:config>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
@@ -20,13 +20,13 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/context/spring-context.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.10.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
-    <context:annotation-config />
+    <context:annotation-config/>
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="locations">
@@ -49,7 +49,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
         <hz:network connection-attempt-limit="${client.connection.attemptLimit}"
                     connection-attempt-period="${client.connection.attemptPeriod}"
                     connection-timeout="1000">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
@@ -21,13 +21,13 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-            http://www.springframework.org/schema/context
-            http://www.springframework.org/schema/context/spring-context-3.0.xsd
-            http://www.springframework.org/schema/tx
-            http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-            http://www.hazelcast.com/schema/spring
-            http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/tx
+        http://www.springframework.org/schema/tx/spring-tx.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <tx:annotation-driven transaction-manager="dummyTransactionManager"/>
 
@@ -64,12 +64,12 @@
                       cache-writer-factory="com.hazelcast.cache.MyCacheWriterFactory"
                       expiry-policy-factory="com.hazelcast.cache.MyExpiryPolicyFactory"
                       in-memory-format="OBJECT">
-                    <hz:eviction size="50" max-size-policy="ENTRY_COUNT" eviction-policy="LRU"/>
-                    <hz:cache-entry-listeners>
-                        <hz:cache-entry-listener cache-entry-event-filter-factory="com.hazelcast.cache.MyCacheFilterFactory"
-                                                 cache-entry-listener-factory="com.hazelcast.cache.MyCacheListenerFactory"
-                                                 old-value-required="false" synchronous="false"/>
-                    </hz:cache-entry-listeners>
+                <hz:eviction size="50" max-size-policy="ENTRY_COUNT" eviction-policy="LRU"/>
+                <hz:cache-entry-listeners>
+                    <hz:cache-entry-listener cache-entry-event-filter-factory="com.hazelcast.cache.MyCacheFilterFactory"
+                                             cache-entry-listener-factory="com.hazelcast.cache.MyCacheListenerFactory"
+                                             old-value-required="false" synchronous="false"/>
+                </hz:cache-entry-listeners>
             </hz:cache>
             <hz:cache name="cacheWithTimedCreatedExpiryPolicyFactory">
                 <hz:expiry-policy-factory>
@@ -105,9 +105,9 @@
                 </hz:expiry-policy-factory>
             </hz:cache>
             <hz:cache name="cacheWithPartitionLostListener">
-              <hz:partition-lost-listeners>
-                  <hz:partition-lost-listener class-name="DummyCachePartitionLostListenerImpl"/>
-              </hz:partition-lost-listeners>
+                <hz:partition-lost-listeners>
+                    <hz:partition-lost-listener class-name="DummyCachePartitionLostListenerImpl"/>
+                </hz:partition-lost-listeners>
             </hz:cache>
             <hz:cache name="cacheWithQuorumRef">
                 <hz:quorum-ref>cacheQuorumRefString</hz:quorum-ref>
@@ -117,7 +117,8 @@
                 <hz:merge-policy>MyDummyMergePolicy</hz:merge-policy>
             </hz:cache>
             <hz:cache name="cacheWithComparatorClassName">
-                <hz:eviction size="50" max-size-policy="ENTRY_COUNT" comparator-class-name="com.mycompany.MyEvictionPolicyComparator"/>
+                <hz:eviction size="50" max-size-policy="ENTRY_COUNT"
+                             comparator-class-name="com.mycompany.MyEvictionPolicyComparator"/>
             </hz:cache>
             <hz:cache name="cacheWithComparatorBean">
                 <hz:eviction size="50" max-size-policy="ENTRY_COUNT" comparator-bean="myEvictionPolicyComparator"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
@@ -19,9 +19,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-            http://www.hazelcast.com/schema/spring
-            http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <hz:hazelcast id="instance">
         <hz:config>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -20,13 +20,11 @@
        xmlns:s="http://www.hazelcast.com/schema/sample"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		hazelcast-spring-3.10.xsd
-		http://www.hazelcast.com/schema/sample
-		hazelcast-sample-service.xsd">
-
-    <!--xmlns="http://www.hazelcast.com/schema/config"-->
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/sample
+        hazelcast-sample-service.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
@@ -20,9 +20,9 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -55,15 +55,15 @@
             <hz:executor-service name="testExec"
                                  pool-size="2"
                                  queue-capacity="100"
-                                 />
+            />
         </hz:config>
     </hz:hazelcast>
 
     <hz:hibernate-region-factory id="regionFactory" instance-ref="instance"/>
-    <hz:hibernate-region-factory id="localRegionFactory" instance-ref="instance" mode="LOCAL" />
+    <hz:hibernate-region-factory id="localRegionFactory" instance-ref="instance" mode="LOCAL"/>
 
     <bean id="localRegionFactory2" class="com.hazelcast.hibernate.HazelcastLocalCacheRegionFactory">
-        <constructor-arg ref="instance" />
+        <constructor-arg ref="instance"/>
     </bean>
 
 </beans>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -20,10 +20,9 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.hazelcast.com/schema/spring
-		hazelcast-spring-3.10.xsd
-		">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -157,13 +156,13 @@
                        serialize-keys="false"
                        local-update-policy="CACHE_ON_UPDATE"/>
 
-        <hz:near-cache name="lfuNearCacheEviction" eviction-policy="LFU" />
+        <hz:near-cache name="lfuNearCacheEviction" eviction-policy="LFU"/>
         <hz:near-cache name="lruNearCacheEviction"
-                       eviction-policy="LRU" />
+                       eviction-policy="LRU"/>
         <hz:near-cache name="noneNearCacheEviction"
-                       eviction-policy="NONE" />
+                       eviction-policy="NONE"/>
         <hz:near-cache name="randomNearCacheEviction"
-                       eviction-policy="RANDOM" />
+                       eviction-policy="RANDOM"/>
 
         <hz:near-cache name="preloader">
             <hz:preloader enabled="true" directory="/tmp/preloader"

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
@@ -18,13 +18,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
-       xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/cache
-		http://www.springframework.org/schema/cache/spring-cache.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <hz:hazelcast id="instance">
         <hz:config>
@@ -40,10 +37,11 @@
                     <hz:interface>127.0.0.1</hz:interface>
                 </hz:interfaces>
             </hz:network>
-            <hz:replicatedmap name="replicatedMap" concurrency-level="3" in-memory-format="OBJECT" async-fillup="true" statistics-enabled="false" replication-delay-millis="10">
-                    <hz:entry-listeners>
-                        <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener"/>
-                    </hz:entry-listeners>
+            <hz:replicatedmap name="replicatedMap" concurrency-level="3" in-memory-format="OBJECT" async-fillup="true"
+                              statistics-enabled="false" replication-delay-millis="10">
+                <hz:entry-listeners>
+                    <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener"/>
+                </hz:entry-listeners>
             </hz:replicatedmap>
         </hz:config>
     </hz:hazelcast>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
@@ -20,9 +20,9 @@
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -19,9 +19,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
         <hz:config>
@@ -42,7 +42,7 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
         <hz:network connection-attempt-limit="3"
                     connection-attempt-period="3000"
                     connection-timeout="1000"

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -19,13 +19,13 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
         <hz:config>
-            <hz:spring-aware />
+            <hz:spring-aware/>
             <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
             <hz:network port="5701" port-auto-increment="false">
                 <hz:join>
@@ -43,8 +43,8 @@
     </hz:hazelcast>
 
     <hz:client id="client" lazy-init="true" scope="prototype">
-        <hz:spring-aware />
-        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:spring-aware/>
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
         <hz:network connection-attempt-limit="3"
                     connection-attempt-period="3000"
                     connection-timeout="1000"

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -20,10 +20,11 @@
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/tx
+        http://www.springframework.org/schema/tx/spring-tx.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <tx:annotation-driven transaction-manager="transactionManager"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/withoutconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/withoutconfig-applicationContext-hazelcast.xml
@@ -18,9 +18,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:hz="http://www.hazelcast.com/schema/spring"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <hz:hazelcast id="instance"/>
 

--- a/hazelcast-spring/src/test/resources/hazelcast-sample-service.xsd
+++ b/hazelcast-spring/src/test/resources/hazelcast-sample-service.xsd
@@ -22,16 +22,16 @@
     <xs:element name="my-service">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="string-prop" minOccurs="0" maxOccurs="1" />
-                <xs:element ref="int-prop" minOccurs="0" maxOccurs="1" />
-                <xs:element ref="bool-prop" minOccurs="0" maxOccurs="1" />
+                <xs:element ref="string-prop" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="int-prop" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="bool-prop" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="string-prop" type="xs:string" />
-    <xs:element name="int-prop" type="xs:int" />
-    <xs:element name="bool-prop" type="xs:boolean" />
+    <xs:element name="string-prop" type="xs:string"/>
+    <xs:element name="int-prop" type="xs:int"/>
+    <xs:element name="bool-prop" type="xs:boolean"/>
 
 </xs:schema>


### PR DESCRIPTION
* removed Spring version numbers, so the latest XSD is used
  (currently 3.2 instead of 2.5 or 3.0)
* removed Hazelcast version numbers, so the latest XSD is used

I don't understand why `http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd` isn't working properly on a default IDEA. It's resolving to the 3.2 XSD, not the 3.10 one. The `http://www.springframework.org/schema/beans/spring-beans.xsd` is correctly resolved to the latest 3.2 version.

Since I didn't configure anything in IDEA I think I'm not the only one with that issue. So I'm pinning the HZ version to 3.10, which resolves some XSD validation errors.