### PR TITLE
Fix GetCacheEntryRequest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
@@ -183,6 +184,21 @@ abstract class AbstractInternalCacheProxy<K, V>
             if (completionOperation) {
                 deregisterCompletionLatch(completionId);
             }
+        }
+    }
+
+    public CacheEntryView<K, V> getEntryViewInternal(K key) {
+        ensureOpen();
+        validateNotNull(key);
+
+        Data keyData = serializationService.toData(key);
+        Operation operation = operationProvider.createGetEntryViewOperation(serializationService.toData(key));
+
+        try {
+            InternalCompletableFuture<CacheEntryView<K, V>> future = invoke(operation, keyData, false);
+            return future.get();
+        } catch (Throwable e) {
+            throw rethrowAllowedTypeFirst(e, CacheException.class);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -38,6 +38,7 @@ import com.hazelcast.cache.impl.operation.CacheGetAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheGetAndRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheGetAndReplaceOperation;
 import com.hazelcast.cache.impl.operation.CacheGetConfigOperation;
+import com.hazelcast.cache.impl.operation.CacheGetEntryViewOperation;
 import com.hazelcast.cache.impl.operation.CacheGetInvalidationMetaDataOperation;
 import com.hazelcast.cache.impl.operation.CacheGetOperation;
 import com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation;
@@ -148,8 +149,9 @@ public final class CacheDataSerializerHook
     public static final short EVENT_JOURNAL_INTERNAL_CACHE_EVENT = 59;
     public static final short EVENT_JOURNAL_READ_RESULT_SET = 60;
     public static final int PRE_JOIN_CACHE_CONFIG = 61;
+    public static final int GET_ENTRY_VIEW = 62;
 
-    private static final int LEN = PRE_JOIN_CACHE_CONFIG + 1;
+    private static final int LEN = GET_ENTRY_VIEW + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -455,6 +457,13 @@ public final class CacheDataSerializerHook
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new PreJoinCacheConfig();
+                    }
+                };
+        constructors[GET_ENTRY_VIEW] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new CacheGetEntryViewOperation();
                     }
                 };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -55,6 +55,8 @@ public interface CacheOperationProvider {
 
     Operation createEntryIteratorOperation(int lastTableIndex, int fetchSize);
 
+    Operation createGetEntryViewOperation(Data key);
+
     OperationFactory createGetAllOperationFactory(Set<Data> keySet, ExpiryPolicy policy);
 
     OperationFactory createLoadAllOperationFactory(Set<Data> keySet, boolean replaceExistingValues);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -23,6 +23,7 @@ import com.hazelcast.cache.impl.operation.CacheEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheGetAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheGetAndRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheGetAndReplaceOperation;
+import com.hazelcast.cache.impl.operation.CacheGetEntryViewOperation;
 import com.hazelcast.cache.impl.operation.CacheGetOperation;
 import com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation;
 import com.hazelcast.cache.impl.operation.CacheLoadAllOperationFactory;
@@ -114,6 +115,11 @@ public class DefaultOperationProvider implements CacheOperationProvider {
     @Override
     public Operation createEntryIteratorOperation(int lastTableIndex, int fetchSize) {
         return new CacheEntryIteratorOperation(nameWithPrefix, lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public Operation createGetEntryViewOperation(Data key) {
+        return new CacheGetEntryViewOperation(nameWithPrefix, key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetEntryViewOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheEntryViews;
+import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ReadonlyOperation;
+
+public class CacheGetEntryViewOperation extends AbstractCacheOperation implements ReadonlyOperation {
+    public CacheGetEntryViewOperation() {
+    }
+
+    public CacheGetEntryViewOperation(String name, Data key) {
+        super(name, key);
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.GET_ENTRY_VIEW;
+    }
+
+    @Override
+    public void run() throws Exception {
+        CacheRecord record = cache.getRecord(key);
+        if (record != null) {
+            response = CacheEntryViews.createDefaultEntryView(key,
+                    getNodeEngine().getSerializationService().toData(record.getValue()),
+                    record);
+        }
+    }
+}


### PR DESCRIPTION
GetCacheEntry request is used by MC to browse cache entries. Currently,
the EntryProcessor it uses is not serializable and doesn't work for
keys on remote members, causing deserialization failure on the member
when it tries to get the entry from another member.

A new operation is being introduced. Since it's intended for internal
usage only and not needed by client, a new method for triggering the
operation is added to AbstractInternalCacheProxy class directly.