### PR TITLE
Added TLS host verification support.

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
@@ -581,8 +581,26 @@
         <xs:all>
             <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="host-verification" type="host-verification" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+    <xs:complexType name="host-verification">
+        <xs:annotation>
+            <xs:documentation>
+                Configures additional TLS host verification (based on com.hazelcast.nio.ssl.TlsHostVerifier interface)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="policy-class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Fully qualified class name implementing com.hazelcast.nio.ssl.TlsHostVerifier 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="user-code-deployment">
         <xs:all>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -64,6 +64,12 @@
 
         <ssl enabled="false">
             <factory-class-name>com.hazelcast.examples.MySslFactory</factory-class-name>
+            <properties>
+                <property name="protocol">TLS</property>
+            </properties>
+            <host-verification policy-class-name="com.hazelcast.nio.ssl.BasicHostVerifier">
+                <properties/>
+            </host-verification>
         </ssl>
         <aws enabled="true" connection-timeout-seconds="11">
             <inside-aws>true</inside-aws>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -22,12 +22,14 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.HostVerificationConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
@@ -258,6 +260,23 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(nearCacheConfig.isInvalidateOnChange());
         assertTrue(nearCacheConfig.isSerializeKeys());
         assertEquals(InMemoryFormat.OBJECT, nearCacheConfig.getInMemoryFormat());
+    }
+
+    @Test
+    public void testSSLConfigs() {
+        SSLConfig sslConfig = clientConfig.getNetworkConfig().getSSLConfig();
+        assertNotNull(sslConfig);
+        assertFalse(sslConfig.isEnabled());
+
+        assertEquals("com.hazelcast.examples.MySslFactory", sslConfig.getFactoryClassName());
+        assertEquals(1, sslConfig.getProperties().size());
+        assertEquals("TLS", sslConfig.getProperties().get("protocol"));
+
+        HostVerificationConfig hostVerification = sslConfig.getHostVerificationConfig();
+        assertNotNull(hostVerification);
+        assertEquals("com.hazelcast.nio.ssl.BasicHostVerifier", hostVerification.getPolicyClassName());
+        assertFalse(hostVerification.isEnabledOnServer());
+        assertTrue(hostVerification.getProperties().isEmpty());
     }
 
     @Test

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.GlobalSerializerConfig;
+import com.hazelcast.config.HostVerificationConfig;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.config.SerializationConfig;
@@ -509,5 +510,25 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             }
             discoveryStrategyConfigs.add(discoveryStrategyConfigBuilder.getBeanDefinition());
         }
+
+        protected void handleHostVerification(Node node, BeanDefinitionBuilder sslConfigBuilder) {
+            BeanDefinitionBuilder hostVerificationBuilder = createBeanBuilder(HostVerificationConfig.class);
+            NamedNodeMap attributes = node.getAttributes();
+            hostVerificationBuilder.addPropertyValue("policyClassName",
+                    getTextContent(attributes.getNamedItem("policy-class-name")));
+            Node attributeNode = attributes.getNamedItem("enabled-on-server");
+            if (attributeNode != null) {
+                hostVerificationBuilder.addPropertyValue("enabledOnServer", getBooleanValue(getTextContent(attributeNode)));
+            }
+
+            for (Node child : childElements(node)) {
+                String name = cleanNodeName(child);
+                if ("properties".equals(name)) {
+                    handleProperties(child, hostVerificationBuilder);
+                }
+            }
+            sslConfigBuilder.addPropertyValue("hostVerificationConfig", hostVerificationBuilder.getBeanDefinition());
+        }
+
     }
 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -234,6 +234,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                 String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, sslConfigBuilder);
+                } else if ("host-verification".equals(name)) {
+                    handleHostVerification(child, sslConfigBuilder);
                 }
             }
             networkConfigBuilder.addPropertyValue("SSLConfig", sslConfigBuilder.getBeanDefinition());

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -576,6 +576,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, sslConfigBuilder);
+                } else if ("host-verification".equals(name)) {
+                    handleHostVerification(child, sslConfigBuilder);
                 }
             }
             networkConfigBuilder.addPropertyValue("SSLConfig", sslConfigBuilder.getBeanDefinition());

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -2186,11 +2186,21 @@
     <xs:complexType name="ssl">
         <xs:sequence>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="host-verification" type="host-verification" minOccurs="0" maxOccurs="1"/>            
         </xs:sequence>
         <xs:attribute name="enabled" default="false" type="xs:string"/>
         <xs:attribute name="factory-class-name" type="xs:string" use="optional"/>
         <xs:attribute name="factory-implementation" type="xs:string" use="optional"/>
     </xs:complexType>
+
+    <xs:complexType name="host-verification">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="policy-class-name"  type="xs:string" use="required"/>
+        <xs:attribute name="enabled-on-server" default="false" type="xs:string"/>
+    </xs:complexType>
+
 
     <xs:complexType name="socket-interceptor">
         <xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.nio.ssl.TestKeyStoreUtil;
@@ -38,6 +39,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -87,8 +89,9 @@ public class TestClientNetworkConfig {
     @Test
     public void smokeSSLConfig() {
         ClientConfig config = client.getClientConfig();
-        assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory",
-                config.getNetworkConfig().getSSLConfig().getFactoryClassName());
+        SSLConfig sslConfig = config.getNetworkConfig().getSSLConfig();
+        assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory", sslConfig.getFactoryClassName());
+        assertEquals("com.hazelcast.nio.ssl.BasicHostVerifier", sslConfig.getHostVerificationConfig().getPolicyClassName());
     }
 
     @Test

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -33,6 +33,7 @@ import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.HostVerificationConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ItemListenerConfig;
@@ -872,6 +873,15 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertFalse(sslConfig.isEnabled());
         assertEquals(DummySSLContextFactory.class.getName(), sslConfig.getFactoryClassName());
         assertEquals(sslContextFactory, sslConfig.getFactoryImplementation());
+    }
+
+    @Test
+    public void testHostVerification() {
+        HostVerificationConfig hostVerification = config.getNetworkConfig().getSSLConfig().getHostVerificationConfig();
+        assertNotNull(hostVerification);
+        assertEquals("com.hazelcast.nio.ssl.BasicHostVerifier", hostVerification.getPolicyClassName());
+        assertTrue(hostVerification.isEnabledOnServer());
+        assertEquals(1, hostVerification.getProperties().size());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -90,6 +90,7 @@
                     <hz:property name="javax.net.ssl.trustStorePassword">123456</hz:property>
                     <hz:property name="javax.net.ssl.protocol">TLS</hz:property>
                 </hz:properties>
+                <hz:host-verification policy-class-name="com.hazelcast.nio.ssl.BasicHostVerifier"/>
             </hz:ssl>
             <hz:discovery-strategies>
                 <hz:node-filter implementation="dummyNodeFilter"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -166,7 +166,13 @@
 
 
                 <hz:ssl enabled="false" factory-class-name="com.hazelcast.spring.DummySSLContextFactory"
-                        factory-implementation="dummySSLContextFactory"/>
+                        factory-implementation="dummySSLContextFactory">
+                    <hz:host-verification policy-class-name="com.hazelcast.nio.ssl.BasicHostVerifier" enabled-on-server="true">
+                        <hz:properties>
+                            <hz:property name="testProperty">testValue</hz:property>
+                        </hz:properties>
+                    </hz:host-verification>
+                </hz:ssl>
                 <hz:socket-interceptor enabled="false" class-name="com.hazelcast.spring.DummySocketInterceptor"
                                        implementation="dummySocketInterceptor"/>
                 <hz:symmetric-encryption enabled="true"

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -908,6 +908,15 @@ public class ConfigXmlGenerator {
             gen.node("factory-class-name",
                     classNameOrImplClass(ssl.getFactoryClassName(), ssl.getFactoryImplementation()))
                     .appendProperties(props);
+
+            HostVerificationConfig hostVerification = ssl.getHostVerificationConfig();
+            if (hostVerification != null) {
+                gen.open("host-verification",
+                        "policy-class-name", hostVerification.getPolicyClassName(),
+                        "enabled-on-server", hostVerification.isEnabledOnServer());
+                gen.appendProperties(hostVerification.getProperties());
+                gen.close();
+            }
         }
         gen.close();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/HostVerificationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HostVerificationConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Properties;
+
+import com.hazelcast.nio.ssl.TlsHostVerifier;
+
+/**
+ * TLS host verification configuration holder.
+ */
+public class HostVerificationConfig {
+
+    private String policyClassName;
+    private TlsHostVerifier implementation;
+    private boolean enabledOnServer;
+    private Properties properties = new Properties();
+
+    /**
+     * Returns a class name implementing {@link com.hazelcast.nio.ssl.TlsHostVerifier} interface.
+     * @return TLS host verifier class name
+     */
+    public String getPolicyClassName() {
+        return policyClassName;
+    }
+
+    /**
+     * Sets a class name implementing {@link com.hazelcast.nio.ssl.TlsHostVerifier} interface.
+     * @return this instance
+     */
+    public HostVerificationConfig setPolicyClassName(String policyClassName) {
+        this.policyClassName = policyClassName;
+        return this;
+    }
+
+    /**
+     * Returns if TLS host verification should also proceed on the server side of TLS connection.
+     */
+    public boolean isEnabledOnServer() {
+        return enabledOnServer;
+    }
+
+    /**
+     * Sets if TLS host verification should also proceed on the server side of TLS connection. By default only the client side
+     * is checked.
+     * @return this instance
+     */
+    public HostVerificationConfig setEnabledOnServer(boolean enabledOnServer) {
+        this.enabledOnServer = enabledOnServer;
+        return this;
+    }
+
+    /**
+     * Returns TLS host verifier properties.
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    /**
+     * Sets TLS host verifier properties. They are provided to {@link com.hazelcast.nio.ssl.TlsHostVerifier#init(Properties)}
+     * method during verifier initialization.
+     */
+    public HostVerificationConfig setProperties(Properties properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    /**
+     * Adds a single property to {@link Properties} object used for TLS host verifier initialization.
+     */
+    public HostVerificationConfig setProperty(String name, String value) {
+        properties.put(name, value);
+        return this;
+    }
+
+    /**
+     * Returns the implementation object.
+     * @return the implementation
+     */
+    public TlsHostVerifier getImplementation() {
+        return implementation;
+    }
+
+    /**
+     * Sets the implementation object. If the implementation is configured, then it takes precedence over the
+     * {@codepolicyClassName}.
+     *
+     * @param implementation the implementation to set
+     * @return this instance
+     */
+    public HostVerificationConfig setImplementation(TlsHostVerifier implementation) {
+        this.implementation = implementation;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "HostVerification{policyClassName=" + policyClassName
+                + ", implementation=" + implementation
+                + ", enabledOnServer=" + enabledOnServer
+                + ", properties=" + properties + "}";
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
@@ -27,6 +27,7 @@ public final class SSLConfig {
     private String factoryClassName;
     private Object factoryImplementation;
     private Properties properties = new Properties();
+    private HostVerificationConfig hostVerificationConfig;
 
     /**
      * Returns the name of the implementation class.
@@ -95,6 +96,26 @@ public final class SSLConfig {
         return factoryImplementation;
     }
 
+
+    /**
+     * Returns the TLS host verification config object.
+     *
+     * @return the hostVerification
+     */
+    public HostVerificationConfig getHostVerificationConfig() {
+        return hostVerificationConfig;
+    }
+
+    /**
+     * Sets the TLS host verification config object.
+     *
+     * @param hostVerification the hostVerification to set
+     */
+    public SSLConfig setHostVerificationConfig(HostVerificationConfig hostVerification) {
+        this.hostVerificationConfig = hostVerification;
+        return this;
+    }
+
     /**
      * Sets a property.
      *
@@ -150,6 +171,7 @@ public final class SSLConfig {
                 + ", enabled=" + enabled
                 + ", implementation=" + factoryImplementation
                 + ", properties=" + properties
+                + ", hostVerification=" + hostVerificationConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1786,9 +1786,32 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 sslConfig.setFactoryClassName(getTextContent(n).trim());
             } else if ("properties".equals(nodeName)) {
                 fillProperties(n, sslConfig.getProperties());
+            } else if ("host-verification".equals(nodeName)) {
+                handleTlsHostVerificationConfig(n, sslConfig);
             }
         }
         config.getNetworkConfig().setSSLConfig(sslConfig);
+    }
+
+    private void handleTlsHostVerificationConfig(Node node, SSLConfig sslConfig) {
+        HostVerificationConfig hostVerification = new HostVerificationConfig();
+        NamedNodeMap attributes = node.getAttributes();
+        Node classNameNode = attributes.getNamedItem("policy-class-name");
+        if (classNameNode == null) {
+            throw new InvalidConfigurationException(
+                    "The 'policy-class-name' attribute has to be provided in ssl/host-verification");
+        }
+        hostVerification.setPolicyClassName(getTextContent(classNameNode).trim());
+        Node enabledNode = attributes.getNamedItem("enabled-on-server");
+        hostVerification.setEnabledOnServer(enabledNode != null && getBooleanValue(getTextContent(enabledNode).trim()));
+
+        for (Node n : childElements(node)) {
+            String nodeName = cleanNodeName(n);
+            if ("properties".equals(nodeName)) {
+                fillProperties(n, hostVerification.getProperties());
+            }
+        }
+        sslConfig.setHostVerificationConfig(hostVerification);
     }
 
     private void handleMcMutualAuthConfig(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -488,7 +488,7 @@ public final class IOUtil {
      */
     public static void copy(InputStream source, File target) {
         if (!target.exists()) {
-            throw new HazelcastException("The target directory doesn't exist " + target);
+            throw new HazelcastException("The target file doesn't exist " + target);
         }
 
         FileOutputStream out = null;

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/TlsHostVerifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/TlsHostVerifier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ssl;
+
+import java.net.InetAddress;
+import java.security.cert.Certificate;
+import java.util.Properties;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+/**
+ * Interface for additional host validation in SSL/TLS connections. The implementing classes have to provide a public no-args
+ * constructor.
+ */
+public interface TlsHostVerifier {
+
+    /**
+     * Inits the verifier instance after creation with properties.
+     *
+     * @param properties verifier properties (may be {@code null})
+     */
+    void init(Properties properties);
+
+    /**
+     * Verifies the given host address and its list of {@link Certificate}s are valid combination for this
+     * {@link TlsHostVerifier} implementation. If the verification fails, the {@link SSLPeerUnverifiedException} is thrown.
+     *
+     * @param hostAddress Peer address.
+     * @param hostCertificates Peer certificates. May be {@code null} if checking is enabled on the server side of TLS connection
+     *        and a TLS client comes without authentication.
+     * @throws SSLPeerUnverifiedException if the host was not verified.
+     */
+    void verifyHost(InetAddress hostAddress, Certificate[] hostCertificates) throws SSLPeerUnverifiedException;
+}

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -2133,11 +2133,37 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="host-verification" type="host-verification" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="enabled" default="false" type="xs:boolean">
             <xs:annotation>
                 <xs:documentation>
                     True to enable this ssl configuration, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="host-verification">
+        <xs:annotation>
+            <xs:documentation>
+                Configures additional TLS host verification (based on com.hazelcast.nio.ssl.TlsHostVerifier interface)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="policy-class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Fully qualified class name implementing com.hazelcast.nio.ssl.TlsHostVerifier 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled-on-server" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    The TLS verifier by default only runs on client side of SSL connection.
+                    Configuring this flag to true causes the verifier will run also on the server side.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -820,7 +820,15 @@ class ConfigCompatibilityChecker {
             return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null
                     && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
                     && nullSafeEqual(c1.getFactoryImplementation(), c2.getFactoryImplementation()))
-                    && nullSafeEqual(c1.getProperties(), c2.getProperties());
+                    && nullSafeEqual(c1.getProperties(), c2.getProperties())
+                    && isCompatible(c1.getHostVerificationConfig(), c2.getHostVerificationConfig());
+        }
+
+        private static boolean isCompatible(HostVerificationConfig c1, HostVerificationConfig c2) {
+            return c1 == c2 || (c1 != null && c2 != null
+                    && nullSafeEqual(c1.getPolicyClassName(), c2.getPolicyClassName())
+                    && nullSafeEqual(c1.getProperties(), c2.getProperties()))
+                    && c1.isEnabledOnServer() == c2.isEnabledOnServer();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -34,6 +34,8 @@ import java.util.Properties;
 import static com.hazelcast.config.ConfigXmlGenerator.MASK_FOR_SENSITIVE_DATA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -359,6 +361,26 @@ public class ConfigXmlGeneratorTest {
         assertTrue(new EventJournalConfigChecker().check(
                 journalConfig,
                 xmlConfig.getCacheEventJournalConfig(cacheName)));
+    }
+
+    @Test
+    public void testTlsHostVerification() {
+        Config cfg = new Config();
+        SSLConfig sslConfig = new SSLConfig();
+        HostVerificationConfig hostVerification = new HostVerificationConfig();
+        hostVerification.setEnabledOnServer(true);
+        hostVerification.setPolicyClassName("example.mycompany.FooVerifier");
+        hostVerification.setProperty("test", "value");
+        sslConfig.setHostVerificationConfig(hostVerification);
+        cfg.getNetworkConfig().setSSLConfig(sslConfig);
+
+        HostVerificationConfig generatedConfig = getNewConfigViaXMLGenerator(cfg).getNetworkConfig().getSSLConfig()
+                .getHostVerificationConfig();
+        assertNotNull(generatedConfig);
+        assertEquals("example.mycompany.FooVerifier", generatedConfig.getPolicyClassName());
+        assertTrue(generatedConfig.isEnabledOnServer());
+        assertEquals("value", generatedConfig.getProperties().get("test"));
+
     }
 
     private DiscoveryConfig getDummyDiscoveryConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -234,6 +234,41 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testSSLConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <network>\n"
+                + "        <ssl enabled=\"true\">\r\n"
+                + "          <factory-class-name>\r\n"
+                + "              com.hazelcast.nio.ssl.BasicSSLContextFactory\r\n"
+                + "          </factory-class-name>\r\n"
+                + "          <properties>\r\n"
+                + "            <property name=\"protocol\">TLS</property>\r\n"
+                + "          </properties>\r\n"
+                + "          <host-verification policy-class-name=\"com.example.Verifier\"\r\n"
+                + "              enabled-on-server=\"true\">\r\n"
+                + "            <properties>\r\n"
+                + "              <property name=\"host\">127.0.0.1</property>\r\n"
+                + "            </properties>\r\n"
+                + "          </host-verification>\r\n"
+                + "        </ssl>\r\n"
+                + "    </network>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        SSLConfig sslConfig = config.getNetworkConfig().getSSLConfig();
+        assertTrue(sslConfig.isEnabled());
+        assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory", sslConfig.getFactoryClassName());
+        assertEquals(1, sslConfig.getProperties().size());
+        assertEquals("TLS", sslConfig.getProperties().get("protocol"));
+
+        HostVerificationConfig hostVerification = sslConfig.getHostVerificationConfig();
+        assertEquals("com.example.Verifier", hostVerification.getPolicyClassName());
+        assertTrue(hostVerification.isEnabledOnServer());
+        assertEquals(1, hostVerification.getProperties().size());
+        assertEquals("127.0.0.1", hostVerification.getProperties().get("host"));
+    }
+
+    @Test
     public void readPortCount() {
         // check when it is explicitly set
         Config config = buildConfig(HAZELCAST_START_TAG


### PR DESCRIPTION
This PR introduces changes for TLS host validation support which will be available in enterprise.

The OS side of the feature introduces mainly `TlsHostVerifier` interface and related changes in configuration.

```java
public interface TlsHostVerifier {

    void init(Properties properties);
 
    /**
     * Verifies the given host address and its list of {@link Certificate}s are valid combination for this
     * {@link TlsHostVerifier} implementation. If the verification fails, the {@link SSLPeerUnverifiedException} is thrown.
     */
    void verifyHost(InetAddress hostAddress, Certificate[] hostCertificates) throws SSLPeerUnverifiedException;
}
```

```xml
<hazelcast>
  <network>
    <ssl enabled="true">
      <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>
      <properties>
        <property name="keyStore">keymaterial/server.keystore</property>
        <property name="keyStorePassword">fybymAd18U5E1Ukb</property>
        <property name="trustStore">keymaterial/server.truststore</property>
        <property name="trustStorePassword">fZ1tqgwhbphlT9BO</property>
        <property name="protocol">TLS</property>
      </properties>
      <host-verification policy-class-name="com.hazelcast.nio.ssl.BasicHostVerifier"
          enabled-on-server="true">
        <properties/>
      </host-verification>
    </ssl>
  </network>
</hazelcast>
```

The counterpart PR hazelcast/hazelcast-enterprise#1815 includes the integration logic and the default host verifier implementation.
