### PR TITLE
Cleanup of Hazelcast XML files

### DIFF
--- a/hazelcast-client/src/test/resources/hazelcast-cache-entrylistener-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-cache-entrylistener-test.xml
@@ -20,9 +20,10 @@
     Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.10.xsd
     or the documentation at https://hazelcast.org/documentation/
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <cache name="entrylistenertestcache">
         <expiry-policy-factory>

--- a/hazelcast-client/src/test/resources/hazelcast-client-c1.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c1.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
     <group>
         <name>cluster1</name>

--- a/hazelcast-client/src/test/resources/hazelcast-client-c2.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c2.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
     <group>
         <name>cluster2</name>

--- a/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncReconnect.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncReconnect.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
 <connection-strategy reconnect-mode="ASYNC" />
 

--- a/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
 <connection-strategy async-start="true" />
 

--- a/hazelcast-client/src/test/resources/hazelcast-client-discovery-spi-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-discovery-spi-test.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
   <properties>
     <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast-client/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
@@ -20,9 +20,10 @@
     Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.10.xsd
     or the documentation at https://hazelcast.org/documentation/
 -->
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
     <query-caches>
         <query-cache mapName="testQueryCacheXmlConfigWithWildCardMap*" name="queryCacheName*">

--- a/hazelcast-client/src/test/resources/hazelcast-client-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-test.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
     <instance-name>MyInstanceName</instance-name>
 

--- a/hazelcast-client/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast-client/src/test/resources/test-hazelcast-jcache.xml
@@ -31,9 +31,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
 
     <instance-name>test-hazelcast-jcache</instance-name>
 

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -21,9 +21,11 @@
     or the documentation at https://hazelcast.org/documentation/
 -->
 <!--suppress XmlDefaultAttributeValue -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
+
     <group>
         <name>dev</name>
         <password>dev-pass</password>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -23,9 +23,11 @@ https://hazelcast.com/schema/config/hazelcast-config-3.10.xsd or the Reference M
 https://hazelcast.org/documentation/.
 -->
 <!--suppress XmlDefaultAttributeValue -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
+
     <!--
         You can use the <import> element to load different Hazelcast declarative configuration files you prepared.
         You can import as many XML files as you want and hence compose your Hazelcast configuration

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
@@ -15,11 +15,12 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd
-           http://www.hazelcast.com/schema/sample hazelcast-sample-service.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:s="http://www.hazelcast.com/schema/sample"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+           http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
+
     <group>
         <name>dev</name>
         <password>dev-pass</password>

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.xml
@@ -15,11 +15,15 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd
-           http://www.hazelcast.com/schema/sample hazelcast-sample-service.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:s="http://www.hazelcast.com/schema/sample"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+           http://www.hazelcast.com/schema/sample
+           hazelcast-sample-service.xsd
+           http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
+
     <group>
         <name>dev</name>
         <password>dev-pass</password>

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -15,10 +15,11 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.10.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config">
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
+
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>
     </properties>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -33,9 +33,11 @@
     4. If a configuration cannot be found, Hazelcast will use the default hazelcast configuration
        ’hazelcast-default.xml’, which is included in the the Hazelcast jar
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
+
     <group>
         <name>dev</name>
         <password>dev-pass</password>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <map name="testQueryCacheXmlConfigWithWildCardMap*">
         <backup-count>1</backup-count>

--- a/hazelcast/src/test/resources/test-hazelcast-client.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.xml
@@ -15,7 +15,11 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config">
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.10.xsd">
+
     <group>
         <name>foobar</name>
         <password>dev-pass</password>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
   <properties>
     <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
   <properties>
     <property name="hazelcast.discovery.enabled">true</property>

--- a/hazelcast/src/test/resources/test-hazelcast-invalid-cache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-invalid-cache.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <group>
         <name>F4D03AC8-B5F7-4542-9BAD-0A94BA48E95D</name>

--- a/hazelcast/src/test/resources/test-hazelcast-jcache-partition-lost-listener.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache-partition-lost-listener.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <group>
         <name>test-group1</name>

--- a/hazelcast/src/test/resources/test-hazelcast-jcache-with-quorum.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache-with-quorum.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <group>
         <name>test-group1</name>

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <instance-name>test-hazelcast-jcache</instance-name>
 

--- a/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <group>
         <name>test-group2</name>

--- a/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
 
     <group>
         <name>test-group1</name>

--- a/hazelcast/src/test/resources/test-hazelcast.xml
+++ b/hazelcast/src/test/resources/test-hazelcast.xml
@@ -15,9 +15,11 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.10.xsd">
+
     <group>
         <name>foobar</name>
         <password>dev-pass</password>


### PR DESCRIPTION
* unified XML file header
* removed unused `hazelcast-sample-service.xsd` in `hazelcast-mapstore-config.xml`

It's the same order of fields used in the Spring XML files now.