### PR TITLE
Defer partition member group initialization until node joins

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -355,9 +355,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         logger.fine("Adding " + member);
         lock.lock();
         try {
-            partitionStateManager.updateMemberGroupsSize();
             lastMaster = node.getClusterService().getMasterAddress();
-
+            if (!member.localMember()) {
+                partitionStateManager.updateMemberGroupsSize();
+            }
             if (node.isMaster()) {
                 if (partitionStateManager.isInitialized()) {
                     final ClusterState clusterState = nodeEngine.getClusterService().getClusterState();


### PR DESCRIPTION
Initialize partition member group after node joins the cluster.
Otherwise MemberGroupFactory is called with partially initialized local member
during node start.

(cherry picked from commit c0ae064067cd0a525ced715729cb01071c17cdf0)

Backport of https://github.com/hazelcast/hazelcast/pull/11933

Fixes https://github.com/hazelcast/hazelcast-aws/issues/50