### PR TITLE
RecordStore method reordering

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -279,14 +279,6 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
 
     long getOwnedEntryCost();
 
-    /**
-     * Returns {@code true} if all key and value loading tasks have completed
-     * on this record store.
-     */
-    boolean isLoaded();
-
-    void checkIfLoaded() throws RetryableHazelcastException;
-
     int clear();
 
     boolean isEmpty();
@@ -323,33 +315,15 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
      */
     void doPostEvictionOperations(Record record, boolean backup);
 
-    /**
-     * Triggers loading values for the given {@code keys} from the
-     * defined {@link com.hazelcast.core.MapLoader}.
-     * The values will be loaded asynchronously and this method will
-     * return as soon as the value loading task has been offloaded
-     * to a different thread.
-     *
-     * @param keys                  the keys for which values will be loaded
-     * @param replaceExistingValues if the existing entries for the keys should
-     *                              be replaced with the loaded values
-     */
-    void loadAllFromStore(List<Data> keys, boolean replaceExistingValues);
-
-    /**
-     * Advances the state of the map key loader for this partition and sets the key
-     * loading future result if the {@code lastBatch} is {@code true}.
-     * <p>
-     * If there was an exception during key loading, you may pass it as the
-     * {@code exception} paramter and it will be set as the result of the future.
-     *
-     * @param lastBatch if the last key batch was sent
-     * @param exception an exception that occurred during key loading
-     */
-    void updateLoadStatus(boolean lastBatch, Throwable exception);
-
     MapDataStore<Data, Object> getMapDataStore();
 
+    InvalidationQueue<ExpiredKey> getExpiredKeys();
+
+    /**
+     * Returns the partition id this RecordStore belongs to.
+     *
+     * @return the partition id.
+     */
     int getPartitionId();
 
     /**
@@ -375,21 +349,6 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
      */
     boolean shouldEvict();
 
-    /**
-     * Triggers key and value loading if there is no ongoing or completed
-     * key loading task, otherwise does nothing.
-     * The actual loading is done on a separate thread.
-     *
-     * @param replaceExistingValues if the existing entries for the loaded keys should be replaced
-     */
-    void loadAll(boolean replaceExistingValues);
-
-    /**
-     * Resets the map loader state if necessary and triggers initial key and
-     * value loading if it has not been done before.
-     */
-    void maybeDoInitialLoad();
-
     Storage createStorage(RecordFactory<R> recordFactory, InMemoryFormat memoryFormat);
 
     Record createRecord(Object value, long ttlMillis, long now);
@@ -402,6 +361,11 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
     void disposeDeferredBlocks();
 
     void destroy();
+
+    /**
+     * Initialize the recordStore after creation
+     */
+    void init();
 
     Storage getStorage();
 
@@ -430,15 +394,56 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
     void setPreMigrationLoadedStatus(boolean loaded);
 
     /**
-     * Initialize the recordStore after creation
-     */
-    void init();
-
-    /**
      * @return {@code true} if the key loading and dispatching has finished on
      * this record store
      */
     boolean isKeyLoadFinished();
 
-    InvalidationQueue<ExpiredKey> getExpiredKeys();
+    /**
+     * Returns {@code true} if all key and value loading tasks have completed
+     * on this record store.
+     */
+    boolean isLoaded();
+
+    void checkIfLoaded() throws RetryableHazelcastException;
+
+    /**
+     * Triggers key and value loading if there is no ongoing or completed
+     * key loading task, otherwise does nothing.
+     * The actual loading is done on a separate thread.
+     *
+     * @param replaceExistingValues if the existing entries for the loaded keys should be replaced
+     */
+    void loadAll(boolean replaceExistingValues);
+
+    /**
+     * Resets the map loader state if necessary and triggers initial key and
+     * value loading if it has not been done before.
+     */
+    void maybeDoInitialLoad();
+
+    /**
+     * Triggers loading values for the given {@code keys} from the
+     * defined {@link com.hazelcast.core.MapLoader}.
+     * The values will be loaded asynchronously and this method will
+     * return as soon as the value loading task has been offloaded
+     * to a different thread.
+     *
+     * @param keys                  the keys for which values will be loaded
+     * @param replaceExistingValues if the existing entries for the keys should
+     *                              be replaced with the loaded values
+     */
+    void loadAllFromStore(List<Data> keys, boolean replaceExistingValues);
+
+    /**
+     * Advances the state of the map key loader for this partition and sets the key
+     * loading future result if the {@code lastBatch} is {@code true}.
+     * <p>
+     * If there was an exception during key loading, you may pass it as the
+     * {@code exception} paramter and it will be set as the result of the future.
+     *
+     * @param lastBatch if the last key batch was sent
+     * @param exception an exception that occurred during key loading
+     */
+    void updateLoadStatus(boolean lastBatch, Throwable exception);
 }


### PR DESCRIPTION
All maploader methods are grouped together instead of illogically
scattered throoughput the interface. This makes it easier to get
an overview of the relevant load methods.