### PR TITLE
RecordStore no longer extends LocalRecordStoreStats.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.LocalRecordStoreStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
@@ -181,16 +182,18 @@ public class LocalMapStatsProvider {
             return;
         }
 
+        LocalRecordStoreStats stats = recordStore.getLocalRecordStoreStats();
+
         onDemandStats.incrementLockedEntryCount(recordStore.getLockedEntryCount());
-        onDemandStats.incrementHits(recordStore.getHits());
+        onDemandStats.incrementHits(stats.getHits());
         onDemandStats.incrementDirtyEntryCount(recordStore.getMapDataStore().notFinishedOperationsCount());
         onDemandStats.incrementOwnedEntryMemoryCost(recordStore.getOwnedEntryCost());
         if (NATIVE  != recordStore.getMapContainer().getMapConfig().getInMemoryFormat()) {
             onDemandStats.incrementHeapCost(recordStore.getOwnedEntryCost());
         }
         onDemandStats.incrementOwnedEntryCount(recordStore.size());
-        onDemandStats.setLastAccessTime(recordStore.getLastAccessTime());
-        onDemandStats.setLastUpdateTime(recordStore.getLastUpdateTime());
+        onDemandStats.setLastAccessTime(stats.getLastAccessTime());
+        onDemandStats.setLastUpdateTime(stats.getLastUpdateTime());
         onDemandStats.setBackupCount(recordStore.getMapContainer().getMapConfig().getTotalBackupCount());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -31,6 +31,8 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordComparator;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.impl.record.Records;
+import com.hazelcast.monitor.LocalRecordStoreStats;
+import com.hazelcast.monitor.impl.LocalRecordStoreStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -65,10 +67,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     protected final MapEventJournal eventJournal;
 
     protected Storage<Data, Record> storage;
-
-    private long hits;
-    private long lastAccess;
-    private long lastUpdate;
+    protected final LocalRecordStoreStatsImpl stats = new LocalRecordStoreStatsImpl();
 
     protected AbstractRecordStore(MapContainer mapContainer, int partitionId) {
         this.name = mapContainer.getName();
@@ -83,6 +82,11 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         this.mapDataStore = mapStoreContext.getMapStoreManager().getMapDataStore(name, partitionId);
         this.lockStore = createLockStore();
         this.eventJournal = mapServiceContext.getEventJournal();
+    }
+
+    @Override
+    public LocalRecordStoreStats getLocalRecordStoreStats() {
+        return stats;
     }
 
     @Override
@@ -209,49 +213,8 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         return storage;
     }
 
-    @Override
-    public long getHits() {
-        return hits;
-    }
-
-    @Override
-    public long getLastAccessTime() {
-        return lastAccess;
-    }
-
-    @Override
-    public long getLastUpdateTime() {
-        return lastUpdate;
-    }
-
-    @Override
-    public void increaseHits() {
-        this.hits++;
-    }
-
-    @Override
-    public void increaseHits(long hits) {
-        this.hits += hits;
-    }
-
-    @Override
-    public void decreaseHits(long hits) {
-        this.hits -= hits;
-    }
-
-    @Override
-    public void setLastAccessTime(long time) {
-        this.lastAccess = Math.max(this.lastAccess, time);
-    }
-
-    @Override
-    public void setLastUpdateTime(long time) {
-        this.lastUpdate = Math.max(this.lastUpdate, time);
-    }
-
-
     protected void updateStatsOnPut(boolean newRecord, long now) {
-        setLastUpdateTime(now);
+        stats.setLastUpdateTime(now);
 
         if (!newRecord) {
             updateStatsOnGet(now);
@@ -259,17 +222,11 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     }
 
     protected void updateStatsOnPut(long hits) {
-        increaseHits(hits);
+        stats.increaseHits(hits);
     }
 
     protected void updateStatsOnGet(long now) {
-        setLastAccessTime(now);
-        increaseHits();
-    }
-
-    protected void resetStats() {
-        this.hits = 0;
-        this.lastAccess = 0;
-        this.lastUpdate = 0;
+        stats.setLastAccessTime(now);
+        stats.increaseHits();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -532,7 +532,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         mapDataStore.reset();
         storage.clear(false);
         eventJournal.destroy(mapContainer.getObjectNamespace(), partitionId);
-        resetStats();
+        stats.reset();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -38,12 +38,14 @@ import java.util.Set;
 /**
  * Defines a record-store.
  */
-public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
+public interface RecordStore<R extends Record> {
 
     /**
      * Default TTL value of a record.
      */
     long DEFAULT_TTL = -1L;
+
+    LocalRecordStoreStats getLocalRecordStoreStats();
 
     String getName();
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalRecordStoreStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalRecordStoreStatsImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.monitor.impl;
+
+import com.hazelcast.monitor.LocalRecordStoreStats;
+
+public class LocalRecordStoreStatsImpl implements LocalRecordStoreStats {
+    private long hits;
+    private long lastAccess;
+    private long lastUpdate;
+
+    @Override
+    public long getHits() {
+        return hits;
+    }
+
+    @Override
+    public long getLastAccessTime() {
+        return lastAccess;
+    }
+
+    @Override
+    public long getLastUpdateTime() {
+        return lastUpdate;
+    }
+
+    @Override
+    public void increaseHits() {
+        this.hits++;
+    }
+
+    @Override
+    public void increaseHits(long hits) {
+        this.hits += hits;
+    }
+
+    @Override
+    public void decreaseHits(long hits) {
+        this.hits -= hits;
+    }
+
+    @Override
+    public void setLastAccessTime(long time) {
+        this.lastAccess = Math.max(this.lastAccess, time);
+    }
+
+    @Override
+    public void setLastUpdateTime(long time) {
+        this.lastUpdate = Math.max(this.lastUpdate, time);
+    }
+
+    public void reset() {
+        this.hits = 0;
+        this.lastAccess = 0;
+        this.lastUpdate = 0;
+    }
+}


### PR DESCRIPTION
It should have been modelled as a 'has a' instead of an 'is a' relation.

Apart from that, it makes the RecordStore even more complicated than it should be.