### PR TITLE
Fix client txn map invocations deserializes data on server

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapProjectSerializationTest extends HazelcastTestSupport {
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Before
+    public void setup() {
+
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    public static class ValuesProjection
+            extends Projection<Map.Entry<Integer, OnlyDeserializedTwiceObject>, OnlyDeserializedTwiceObject>
+            implements Serializable {
+
+        @Override
+        public OnlyDeserializedTwiceObject transform(Map.Entry<Integer, OnlyDeserializedTwiceObject> input) {
+            return input.getValue();
+        }
+    }
+
+    @Test
+    public void testProjectObjectShouldDeserializedOnlyTwice() {
+        // One deserialization on server when object is accessed from transform
+        // Second deserialization on client side when result passed to user
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        IMap<Integer, OnlyDeserializedTwiceObject> map = client.getMap("test");
+        OnlyDeserializedTwiceObject value = new OnlyDeserializedTwiceObject("test");
+        map.put(1, value);
+        Collection<OnlyDeserializedTwiceObject> result = map.project(new ValuesProjection());
+
+        assertEquals(Collections.singletonList(value), result);
+    }
+
+    private static class OnlyDeserializedTwiceObject implements DataSerializable {
+
+        private String value;
+
+        private static AtomicInteger readCalled = new AtomicInteger(0);
+
+        public OnlyDeserializedTwiceObject() {
+        }
+
+        public OnlyDeserializedTwiceObject(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeUTF(value);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            if (readCalled.incrementAndGet() > 2) {
+                throw new AssertionError("Read called more than twice!!!");
+            }
+            value = in.readUTF();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof OnlyDeserializedTwiceObject)) {
+                return false;
+            }
+
+            OnlyDeserializedTwiceObject that = (OnlyDeserializedTwiceObject) o;
+
+            return value.equals(that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/SampleIdentified.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/SampleIdentified.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.txn.serialization;
+
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+class SampleIdentified implements IdentifiedDataSerializable {
+
+    public static final int FACTORY_ID = 1;
+    public static final int CLASS_ID = 1;
+    private int amount;
+
+    public SampleIdentified() {
+    }
+
+    public SampleIdentified(int amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(amount);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        amount = in.readInt();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SampleIdentified)) {
+            return false;
+        }
+
+        SampleIdentified that = (SampleIdentified) o;
+
+        return amount == that.amount;
+    }
+
+    @Override
+    public int hashCode() {
+        return amount;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CLASS_ID;
+    }
+
+    @Override
+    public String toString() {
+        return "SampleIdentified{" +
+                "amount=" + amount +
+                '}';
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.txn.serialization;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TxnMapDeserializationTest extends HazelcastTestSupport {
+
+    private static final Object EXISTING_KEY = new SampleIdentified(1);
+    private static final Object EXISTING_VALUE = new SampleIdentified(2);
+    private static final Object NEW_KEY = new SampleIdentified(3);
+    private static final Object NEW_VALUE = new SampleIdentified(4);
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private TransactionalMap<Object, Object> map;
+    private TransactionContext context;
+
+    @Before
+    public void setup() {
+        //Identified factory is only set to client, to make sure there is no deserialization on server.
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getSerializationConfig().
+                addDataSerializableFactory(SampleIdentified.FACTORY_ID, new DataSerializableFactory() {
+                    @Override
+                    public IdentifiedDataSerializable create(int typeId) {
+                        return new SampleIdentified();
+                    }
+                });
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        client.getMap("test").put(EXISTING_KEY, EXISTING_VALUE);
+        client.getMap("test").get(EXISTING_KEY);
+
+        context = client.newTransactionContext();
+        context.beginTransaction();
+        map = context.getMap("test");
+    }
+
+    @After
+    public void tearDown() {
+        context.commitTransaction();
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testMapUpdate() {
+        assertEquals(EXISTING_VALUE, map.put(EXISTING_KEY, NEW_VALUE));
+    }
+
+    @Test
+    public void testMapPut() {
+        assertNull(map.put(NEW_KEY, NEW_VALUE));
+    }
+
+    @Test
+    public void testMapPutTwiceToSameKey() {
+        assertNull(map.put(NEW_KEY, NEW_VALUE));
+        assertEquals(NEW_VALUE, map.put(NEW_KEY, NEW_VALUE));
+    }
+
+    @Test
+    public void testMapPutGet() {
+        assertEquals(EXISTING_VALUE, map.put(EXISTING_KEY, NEW_VALUE));
+        assertEquals(NEW_VALUE, map.get(EXISTING_KEY));
+    }
+
+    @Test
+    public void testMapGet() {
+        assertEquals(EXISTING_VALUE, map.get(EXISTING_KEY));
+    }
+
+    @Test
+    public void testMapValues() {
+        assertContains(map.values(), EXISTING_VALUE);
+    }
+
+    @Test
+    public void testMapKeySet() {
+        assertContains(map.keySet(), EXISTING_KEY);
+    }
+
+    @Test
+    public void testMapContainsKey() {
+        assertTrue(map.containsKey(EXISTING_KEY));
+    }
+
+    @Test
+    public void testMapRemove() {
+        assertEquals(EXISTING_VALUE, map.remove(EXISTING_KEY));
+    }
+
+    @Test
+    public void testMapRemoveIfEqual() {
+        assertTrue(map.remove(EXISTING_KEY, EXISTING_VALUE));
+    }
+
+    @Test
+    public void testMapReplace() {
+        assertTrue(map.replace(EXISTING_KEY, EXISTING_VALUE, NEW_VALUE));
+    }
+
+    @Test
+    public void testMapReplaceAndGet() {
+        assertEquals(EXISTING_VALUE, map.replace(EXISTING_KEY, NEW_VALUE));
+    }
+
+    @Test
+    public void testGetForUpdate() {
+        assertEquals(EXISTING_VALUE, map.getForUpdate(EXISTING_KEY));
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapProjectMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapProjectMessageTask.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.IterationType;
 
 import java.util.ArrayList;
@@ -78,13 +77,12 @@ public abstract class DefaultMapProjectMessageTask<P>
         }
 
         Set result = QueryResultUtils.transformToSet(nodeEngine.getSerializationService(), combinedResult,
-                getPredicate(), IterationType.VALUE, false);
+                getPredicate(), IterationType.VALUE, false, true);
 
         List<Data> serialized = new ArrayList<Data>(result.size());
 
-        SerializationService serializationService = nodeEngine.getSerializationService();
         for (Object row : result) {
-            serialized.add(serializationService.toData(row));
+            serialized.add((Data) row);
         }
 
         return serialized;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -677,7 +677,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
                     .build();
             result = queryEngine.execute(query, Target.ALL_NODES);
         }
-        return transformToSet(serializationService, result, predicate, iterationType, uniqueResult);
+        return transformToSet(serializationService, result, predicate, iterationType, uniqueResult, false);
     }
 
     @Override
@@ -698,7 +698,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
                 .iterationType(IterationType.KEY)
                 .build();
         QueryResult result = queryEngine.execute(query, Target.LOCAL_NODE);
-        return transformToSet(serializationService, result, predicate, IterationType.KEY, false);
+        return transformToSet(serializationService, result, predicate, IterationType.KEY, false, false);
     }
 
     @Override
@@ -819,7 +819,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
                 .projection(projection)
                 .build();
         QueryResult result = queryEngine.execute(query, Target.ALL_NODES);
-        return transformToSet(serializationService, result, TruePredicate.INSTANCE, IterationType.VALUE, false);
+        return transformToSet(serializationService, result, TruePredicate.INSTANCE, IterationType.VALUE, false, false);
     }
 
     @Override
@@ -840,7 +840,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
                 .projection(projection)
                 .build();
         QueryResult result = queryEngine.execute(query, Target.ALL_NODES);
-        return transformToSet(serializationService, result, predicate, IterationType.VALUE, false);
+        return transformToSet(serializationService, result, predicate, IterationType.VALUE, false, false);
     }
 
     @Override
@@ -913,8 +913,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
      * mutated and the cluster is stable (there are no migrations or membership changes).
      * In other cases, the iterator may not return some entries or may return an entry twice.
      *
-     * @param fetchSize   the size of the batches which will be sent when iterating the data
-     * @param partitionId the partition ID which is being iterated
+     * @param fetchSize      the size of the batches which will be sent when iterating the data
+     * @param partitionId    the partition ID which is being iterated
      * @param prefetchValues whether to send values along with keys (if {@code true}) or
      *                       to fetch them lazily when iterating (if {@code false})
      * @return the iterator for the projected entries

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultUtils.java
@@ -32,12 +32,13 @@ public final class QueryResultUtils {
     }
 
     public static Set transformToSet(
-            SerializationService ss, QueryResult queryResult, Predicate predicate, IterationType iterationType, boolean unique) {
+            SerializationService ss, QueryResult queryResult, Predicate predicate,
+            IterationType iterationType, boolean unique, boolean binary) {
         if (predicate instanceof PagingPredicate) {
-            Set result = new QueryResultCollection(ss, IterationType.ENTRY, false, unique, queryResult);
+            Set result = new QueryResultCollection(ss, IterationType.ENTRY, binary, unique, queryResult);
             return getSortedQueryResultSet(new ArrayList(result), (PagingPredicate) predicate, iterationType);
         } else {
-            return new QueryResultCollection(ss, iterationType, false, unique, queryResult);
+            return new QueryResultCollection(ss, iterationType, binary, unique, queryResult);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -141,7 +141,9 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         operation.setThreadId(ThreadUtil.getThreadId());
         int partitionId = partitionService.getPartitionId(keyData);
         try {
-            Future future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
+            Future future = operationService.createInvocationBuilder(SERVICE_NAME, operation, partitionId)
+                    .setResultDeserialized(false)
+                    .invoke();
             return future.get();
         } catch (Throwable t) {
             throw rethrow(t);


### PR DESCRIPTION
Two issues found was txnMap.values and txnMap.get on an entry
put before transaction started.

Added tests for all transactional map methods.

fixes https://github.com/hazelcast/hazelcast/issues/11885