### PR TITLE
Enhance IMap javadoc on value vs reference semantics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -84,8 +84,8 @@ import java.util.concurrent.TimeUnit;
  * </pre>
  * </li>
  * <li>Be careful while using default interface method implementations from {@link ConcurrentMap} and {@link Map}. Under
- * the hood they are typically implemented as a sequence of more primitive map operations, therefore atomicity of the
- * operation as a whole can't be guaranteed.</li>
+ * the hood they are typically implemented as a sequence of more primitive map operations, therefore the operations won't
+ * be executed atomically.</li>
  * </ul>
  * <p>
  * This class does <em>not</em> allow {@code null} to be used as a key or value.

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -84,7 +84,7 @@ import java.util.concurrent.TimeUnit;
  * </pre>
  * </li>
  * <li>Be careful while using default interface method implementations from {@link ConcurrentMap} and {@link Map}. Under
- * the hood they typically implemented as a sequence of more primitive map operations, therefore atomicity of the
+ * the hood they are typically implemented as a sequence of more primitive map operations, therefore atomicity of the
  * operation as a whole can't be guaranteed.</li>
  * </ul>
  * <p>

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -64,9 +64,10 @@ import java.util.concurrent.TimeUnit;
  * <li>Methods, including but not limited to {@code keySet}, {@code values}, {@code entrySet}, return a collection
  * clone of the values. The collection is <b>NOT</b> backed by the map, so changes to the map are <b>NOT</b> reflected
  * in the collection, and vice-versa.</li>
- * <li>Methods, including but not limited to {@code computeIfPresent}, may behave incorrectly if the value passed to
- * the update function is modified in-place and returned as a result of the invocation. You should create a new
- * value instance and return it as a result.
+ * <li>Since Hazelcast is compiled with Java 1.6, we can't override default methods introduced in later Java versions,
+ * nor can we add documentation to them. Methods, including but not limited to {@code computeIfPresent}, may behave
+ * incorrectly if the value passed to the update function is modified in-place and returned as a result of the invocation.
+ * You should create a new value instance and return it as a result.
  * <p>
  * For example, following code fragment will behave incorrectly and will enter an infinite loop:
  * <pre>

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -49,6 +49,9 @@ import java.util.concurrent.TimeUnit;
  * use of the {@code equals} method when comparing objects. Instead of the {@code equals} method, this
  * implementation compares the serialized byte version of the objects.</b>
  * <p>
+ * <b>Moreover, stored values are handled as having a value type semantics, while standard Java implementations treat them
+ * as having a reference type semantics.</b>
+ * <p>
  * <b>Gotchas:</b>
  * <ul>
  * <li>Methods, including but not limited to {@code get}, {@code containsKey}, {@code containsValue}, {@code evict},
@@ -61,6 +64,9 @@ import java.util.concurrent.TimeUnit;
  * <li>Methods, including but not limited to {@code keySet}, {@code values}, {@code entrySet}, return a collection
  * clone of the values. The collection is <b>NOT</b> backed by the map, so changes to the map are <b>NOT</b> reflected
  * in the collection, and vice-versa.</li>
+ * <li>Methods, including but not limited to {@code computeIfPresent}, may behave incorrectly if the value passed to
+ * {@code remappingFunction} is modified in-place and returned as a result of the invocation. You should create a new
+ * value instance and return it as a result.</li>
  * </ul>
  * <p>
  * This class does <em>not</em> allow {@code null} to be used as a key or value.


### PR DESCRIPTION
Additionally, the test case for ConcurrentMap.computeIfPresent-like
behavior is provided to ensure we are supporting it properly in its
current restricted form.

Closes: https://github.com/hazelcast/hazelcast/issues/11816