### PR TITLE
Implemented split-brain healing for MultiMap

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1370,6 +1370,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     multiMapConfigBuilder.addPropertyValue("entryListenerConfigs", listeners);
                 } else if ("quorum-ref".equals(nodeName)) {
                     multiMapConfigBuilder.addPropertyValue("quorumName", getTextContent(childNode));
+                } else if ("merge-policy".equals(nodeName)) {
+                    handleMergePolicyConfig(childNode, multiMapConfigBuilder);
                 }
             }
             multiMapManagedMap.put(name, multiMapConfigBuilder.getBeanDefinition());

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -1265,6 +1265,7 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
                                 </xs:sequence>
                                 <xs:attribute name="name" type="xs:string" use="optional" default="default"/>
                                 <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
@@ -1287,8 +1288,7 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="value-collection-type" type="xs:string" use="optional"
-                                              default="SET">
+                                <xs:attribute name="value-collection-type" type="xs:string" use="optional" default="SET">
                                     <xs:annotation>
                                         <xs:documentation>
                                             Type of value collection. It can be Set or List.
@@ -1305,8 +1305,7 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="binary" use="optional" type="parameterized-boolean"
-                                              default="true">
+                                <xs:attribute name="binary" use="optional" type="parameterized-boolean" default="true">
                                     <xs:annotation>
                                         <xs:documentation>
                                             By default, BINARY in-memory format is used, meaning that the object is stored

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -583,6 +583,9 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
                 assertTrue(listener.isIncludeValue());
             }
         }
+        MergePolicyConfig mergePolicyConfig = testMultiMapConfig.getMergePolicyConfig();
+        assertEquals("PassThroughMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(1234, mergePolicyConfig.getBatchSize());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -481,13 +481,13 @@
             <hz:event-journal map-name="mapName" cache-name="cacheName" enabled="true"
                               capacity="123" time-to-live-seconds="321"/>
 
-            <hz:multimap name="testMultimap"
-                         value-collection-type="LIST" binary="false" statistics-enabled="false">
+            <hz:multimap name="testMultimap" value-collection-type="LIST" binary="false" statistics-enabled="false">
                 <hz:entry-listeners>
                     <hz:entry-listener class-name="com.hazelcast.spring.DummyEntryListener" include-value="true"/>
                     <hz:entry-listener implementation="dummyEntryListener" local="true"/>
                 </hz:entry-listeners>
                 <hz:quorum-ref>my-quorum</hz:quorum-ref>
+                <hz:merge-policy batch-size="1234">PassThroughMergePolicy</hz:merge-policy>
             </hz:multimap>
 
             <hz:list name="testList"

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -433,7 +433,9 @@ public class ConfigXmlGenerator {
                 }
                 gen.close();
             }
-            gen.close();
+            MergePolicyConfig mergePolicyConfig = mm.getMergePolicyConfig();
+            gen.node("merge-policy", mergePolicyConfig.getPolicy(), "batch-size", mergePolicyConfig.getBatchSize())
+                    .close();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -29,10 +29,12 @@ import java.util.List;
 
 import static com.hazelcast.util.Preconditions.checkAsyncBackupCount;
 import static com.hazelcast.util.Preconditions.checkBackupCount;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Configuration for MultiMap.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
 
     /**
@@ -52,13 +54,15 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
 
     private String name;
     private String valueCollectionType = DEFAULT_VALUE_COLLECTION_TYPE.toString();
-    private List<EntryListenerConfig> listenerConfigs;
+    private List<EntryListenerConfig> listenerConfigs = new ArrayList<EntryListenerConfig>();
     private boolean binary = true;
     private int backupCount = DEFAULT_SYNC_BACKUP_COUNT;
     private int asyncBackupCount = DEFAULT_ASYNC_BACKUP_COUNT;
     private boolean statisticsEnabled = true;
     private String quorumName;
-    private MultiMapConfigReadOnly readOnly;
+    private MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
+
+    private transient MultiMapConfigReadOnly readOnly;
 
     public MultiMapConfig() {
     }
@@ -67,28 +71,16 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
         setName(name);
     }
 
-    public MultiMapConfig(MultiMapConfig defConfig) {
-        this.name = defConfig.getName();
-        this.valueCollectionType = defConfig.valueCollectionType;
-        this.binary = defConfig.binary;
-        this.backupCount = defConfig.backupCount;
-        this.asyncBackupCount = defConfig.asyncBackupCount;
-        this.statisticsEnabled = defConfig.statisticsEnabled;
-        this.listenerConfigs = new ArrayList<EntryListenerConfig>(defConfig.getEntryListenerConfigs());
-        this.quorumName = defConfig.quorumName;
-    }
-
-    /**
-     * Gets immutable version of this configuration.
-     *
-     * @return Immutable version of this configuration
-     * @deprecated this method will be removed in 4.0; it is meant for internal usage only
-     */
-    public MultiMapConfigReadOnly getAsReadOnly() {
-        if (readOnly == null) {
-            readOnly = new MultiMapConfigReadOnly(this);
-        }
-        return readOnly;
+    public MultiMapConfig(MultiMapConfig config) {
+        this.name = config.getName();
+        this.valueCollectionType = config.valueCollectionType;
+        this.listenerConfigs.addAll(config.listenerConfigs);
+        this.binary = config.binary;
+        this.backupCount = config.backupCount;
+        this.asyncBackupCount = config.asyncBackupCount;
+        this.statisticsEnabled = config.statisticsEnabled;
+        this.quorumName = config.quorumName;
+        this.mergePolicyConfig = config.mergePolicyConfig;
     }
 
     /**
@@ -172,9 +164,6 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
      * @return the list of entry listeners for this MultiMap
      */
     public List<EntryListenerConfig> getEntryListenerConfigs() {
-        if (listenerConfigs == null) {
-            listenerConfigs = new ArrayList<EntryListenerConfig>();
-        }
         return listenerConfigs;
     }
 
@@ -319,6 +308,25 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
         return this;
     }
 
+    /**
+     * Gets the {@link MergePolicyConfig} for this MultiMap.
+     *
+     * @return the {@link MergePolicyConfig} for this MultiMap
+     */
+    public MergePolicyConfig getMergePolicyConfig() {
+        return mergePolicyConfig;
+    }
+
+    /**
+     * Sets the {@link MergePolicyConfig} for this MultiMap.
+     *
+     * @return the updated MultiMapConfig
+     */
+    public MultiMapConfig setMergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
+        this.mergePolicyConfig = checkNotNull(mergePolicyConfig, "mergePolicyConfig cannot be null");
+        return this;
+    }
+
     public String toString() {
         return "MultiMapConfig{"
                 + "name='" + name + '\''
@@ -328,6 +336,7 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
                 + ", backupCount=" + backupCount
                 + ", asyncBackupCount=" + asyncBackupCount
                 + ", quorumName=" + quorumName
+                + ", mergePolicyConfig=" + mergePolicyConfig
                 + '}';
     }
 
@@ -345,7 +354,7 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeUTF(valueCollectionType);
-        if (listenerConfigs == null) {
+        if (listenerConfigs == null || listenerConfigs.isEmpty()) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
@@ -360,6 +369,7 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
         out.writeBoolean(statisticsEnabled);
         if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             out.writeUTF(quorumName);
+            out.writeObject(mergePolicyConfig);
         }
     }
 
@@ -382,21 +392,21 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
         statisticsEnabled = in.readBoolean();
         if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             quorumName = in.readUTF();
+            mergePolicyConfig = in.readObject();
         }
     }
 
     @Override
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MultiMapConfig)) {
             return false;
         }
 
         MultiMapConfig that = (MultiMapConfig) o;
-
         if (binary != that.binary) {
             return false;
         }
@@ -409,22 +419,27 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
         if (statisticsEnabled != that.statisticsEnabled) {
             return false;
         }
-        if (!name.equals(that.name)) {
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (valueCollectionType != null
+                ? !valueCollectionType.equals(that.valueCollectionType)
+                : that.valueCollectionType != null) {
+            return false;
+        }
+        if (listenerConfigs != null ? !listenerConfigs.equals(that.listenerConfigs) : that.listenerConfigs != null) {
             return false;
         }
         if (quorumName != null ? !quorumName.equals(that.quorumName) : that.quorumName != null) {
             return false;
         }
-        if (valueCollectionType != null
-                ? !valueCollectionType.equals(that.valueCollectionType) : that.valueCollectionType != null) {
-            return false;
-        }
-        return listenerConfigs != null ? listenerConfigs.equals(that.listenerConfigs) : that.listenerConfigs == null;
+        return mergePolicyConfig != null ? mergePolicyConfig.equals(that.mergePolicyConfig) : that.mergePolicyConfig == null;
     }
 
     @Override
-    public int hashCode() {
-        int result = name.hashCode();
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public final int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (valueCollectionType != null ? valueCollectionType.hashCode() : 0);
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (binary ? 1 : 0);
@@ -432,6 +447,20 @@ public class MultiMapConfig implements IdentifiedDataSerializable, Versioned {
         result = 31 * result + asyncBackupCount;
         result = 31 * result + (statisticsEnabled ? 1 : 0);
         result = 31 * result + (quorumName != null ? quorumName.hashCode() : 0);
+        result = 31 * result + (mergePolicyConfig != null ? mergePolicyConfig.hashCode() : 0);
         return result;
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration
+     * @deprecated this method will be removed in 4.0; it is meant for internal usage only
+     */
+    public MultiMapConfigReadOnly getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new MultiMapConfigReadOnly(this);
+        }
+        return readOnly;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfigReadOnly.java
@@ -95,4 +95,9 @@ public class MultiMapConfigReadOnly extends MultiMapConfig {
     public MultiMapConfig setQuorumName(String quorumName) {
         throw new UnsupportedOperationException("This config is read-only multimap: " + getName());
     }
+
+    @Override
+    public MultiMapConfig setMergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
+        throw new UnsupportedOperationException("This config is read-only multimap: " + getName());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1184,6 +1184,9 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 multiMapConfig.setBinary(getBooleanValue(value));
             } else if ("quorum-ref".equals(nodeName)) {
                 multiMapConfig.setQuorumName(value);
+            } else if ("merge-policy".equals(nodeName)) {
+                MergePolicyConfig mergePolicyConfig = createMergePolicyConfig(n);
+                multiMapConfig.setMergePolicyConfig(mergePolicyConfig);
             }
         }
         config.addMultiMapConfig(multiMapConfig);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
@@ -27,6 +27,8 @@ import com.hazelcast.multimap.impl.operations.EntrySetOperation;
 import com.hazelcast.multimap.impl.operations.EntrySetResponse;
 import com.hazelcast.multimap.impl.operations.GetAllOperation;
 import com.hazelcast.multimap.impl.operations.KeySetOperation;
+import com.hazelcast.multimap.impl.operations.MergeBackupOperation;
+import com.hazelcast.multimap.impl.operations.MergeOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapReplicationOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
 import com.hazelcast.multimap.impl.operations.MultiMapResponse;
@@ -114,6 +116,9 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
     public static final int MULTIMAP_RESPONSE = 46;
     public static final int ENTRY_SET_RESPONSE = 47;
 
+    public static final int MERGE_CONTAINER = 48;
+    public static final int MERGE_OPERATION = 49;
+    public static final int MERGE_BACKUP_OPERATION = 50;
 
     public int getFactoryId() {
         return F_ID;
@@ -121,7 +126,7 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
 
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors
-                = new ConstructorFunction[ENTRY_SET_RESPONSE + 1];
+                = new ConstructorFunction[MERGE_BACKUP_OPERATION + 1];
         constructors[CLEAR_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ClearBackupOperation();
@@ -302,6 +307,21 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
         constructors[ENTRY_SET_RESPONSE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new EntrySetResponse();
+            }
+        };
+        constructors[MERGE_CONTAINER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MultiMapMergeContainer();
+            }
+        };
+        constructors[MERGE_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MergeOperation();
+            }
+        };
+        constructors[MERGE_BACKUP_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MergeBackupOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapMergeContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapMergeContainer.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Container for the merge operation of a {@link com.hazelcast.core.MultiMap}.
+ */
+public class MultiMapMergeContainer implements IdentifiedDataSerializable {
+
+    private Data key;
+    private Collection<MultiMapRecord> records;
+    private long creationTime;
+    private long lastAccessTime;
+    private long lastUpdateTime;
+    private int hits;
+
+    public MultiMapMergeContainer() {
+    }
+
+    public MultiMapMergeContainer(Data key, Collection<MultiMapRecord> records, long creationTime, long lastAccessTime,
+                                  long lastUpdateTime, int hits) {
+        this.key = key;
+        this.records = records;
+        this.creationTime = creationTime;
+        this.lastAccessTime = lastAccessTime;
+        this.lastUpdateTime = lastUpdateTime;
+        this.hits = hits;
+    }
+
+    public Data getKey() {
+        return key;
+    }
+
+    public Collection<MultiMapRecord> getRecords() {
+        return records;
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public int getHits() {
+        return hits;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MultiMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MultiMapDataSerializerHook.MERGE_CONTAINER;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeData(key);
+        out.writeInt(records.size());
+        for (MultiMapRecord record : records) {
+            out.writeObject(record);
+        }
+        out.writeLong(creationTime);
+        out.writeLong(lastAccessTime);
+        out.writeLong(lastUpdateTime);
+        out.writeInt(hits);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        key = in.readData();
+        int size = in.readInt();
+        records = new ArrayList<MultiMapRecord>(size);
+        for (int i = 0; i < size; i++) {
+            MultiMapRecord record = in.readObject();
+            records.add(record);
+        }
+        creationTime = in.readLong();
+        lastAccessTime = in.readLong();
+        lastUpdateTime = in.readLong();
+        hits = in.readInt();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -16,17 +16,21 @@
 
 package com.hazelcast.multimap.impl;
 
+import com.hazelcast.collection.impl.collection.CollectionService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStoreInfo;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.monitor.LocalMultiMapStats;
 import com.hazelcast.monitor.impl.LocalMultiMapStatsImpl;
+import com.hazelcast.multimap.impl.operations.MergeOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapReplicationOperation;
 import com.hazelcast.multimap.impl.txn.TransactionalMultiMapProxy;
 import com.hazelcast.nio.Address;
@@ -46,9 +50,14 @@ import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionalObject;
@@ -57,19 +66,24 @@ import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.Math.max;
@@ -77,7 +91,7 @@ import static java.lang.Math.min;
 
 public class MultiMapService implements ManagedService, RemoteService, FragmentedMigrationAwareService,
         EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsAwareService<LocalMultiMapStats>,
-        QuorumAwareService {
+        QuorumAwareService, SplitBrainHandlerService {
 
     public static final String SERVICE_NAME = "hz:impl:multiMapService";
 
@@ -88,6 +102,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
     private static final int REPLICA_ADDRESS_SLEEP_WAIT_MILLIS = 1000;
 
     private final NodeEngine nodeEngine;
+    private final SplitBrainMergePolicyProvider mergePolicyProvider;
     private final MultiMapPartitionContainer[] partitionContainers;
     private final ConcurrentMap<String, LocalMultiMapStatsImpl> statsMap = createConcurrentHashMap(STATS_MAP_INITIAL_CAPACITY);
     private final ConstructorFunction<String, LocalMultiMapStatsImpl> localMultiMapStatsConstructorFunction
@@ -113,6 +128,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
     public MultiMapService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
+        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         this.partitionContainers = new MultiMapPartitionContainer[partitionCount];
         this.dispatcher = new MultiMapEventsDispatcher(this, nodeEngine.getClusterService());
@@ -476,5 +492,137 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
     public void ensureQuorumPresent(String distributedObjectName, QuorumType requiredQuorumPermissionType) {
         quorumService.ensureQuorumPresent(getQuorumName(distributedObjectName), requiredQuorumPermissionType);
+    }
+
+    @Override
+    public Runnable prepareMergeRunnable() {
+        Map<MultiMapPartitionContainer, Map<String, MultiMapContainer>> itemMap = createHashMap(partitionContainers.length);
+        IPartitionService partitionService = nodeEngine.getPartitionService();
+
+        for (int partitionId = 0; partitionId < partitionContainers.length; partitionId++) {
+            // add your owned entries to the map so they will be merged
+            if (!partitionService.isPartitionOwner(partitionId)) {
+                continue;
+            }
+
+            MultiMapPartitionContainer partitionContainer = partitionContainers[partitionId];
+            ConcurrentMap<String, MultiMapContainer> partitionContainerContainerMap = partitionContainer.containerMap;
+            for (Map.Entry<String, MultiMapContainer> entry : partitionContainerContainerMap.entrySet()) {
+                MultiMapContainer container = entry.getValue();
+                if (!(getMergePolicy(container) instanceof DiscardMergePolicy)) {
+                    String name = entry.getKey();
+                    Map<String, MultiMapContainer> map = itemMap.get(partitionContainer);
+                    if (map == null) {
+                        map = createHashMap(partitionContainerContainerMap.size());
+                        itemMap.put(partitionContainer, map);
+                    }
+                    map.put(name, container);
+                }
+            }
+
+            // clear all items either owned or backup
+            partitionContainer.containerMap.clear();
+        }
+
+        return new Merger(itemMap);
+    }
+
+    private SplitBrainMergePolicy getMergePolicy(MultiMapContainer container) {
+        String mergePolicyName = container.getConfig().getMergePolicyConfig().getPolicy();
+        return mergePolicyProvider.getMergePolicy(mergePolicyName);
+    }
+
+    private class Merger implements Runnable {
+
+        private static final int TIMEOUT_FACTOR = 500;
+
+        private final Map<MultiMapPartitionContainer, Map<String, MultiMapContainer>> itemMap;
+
+        Merger(Map<MultiMapPartitionContainer, Map<String, MultiMapContainer>> itemMap) {
+            this.itemMap = itemMap;
+        }
+
+        @Override
+        public void run() {
+            final ILogger logger = nodeEngine.getLogger(CollectionService.class);
+            final Semaphore semaphore = new Semaphore(0);
+
+            ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
+                @Override
+                public void onResponse(Object response) {
+                    semaphore.release(1);
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    logger.warning("Error while running merge operation: " + t.getMessage());
+                    semaphore.release(1);
+                }
+            };
+
+            // we cannot merge into a 3.9 cluster, since not all members may understand the QueueMergeOperation
+            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
+                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge MultiMap instances");
+                return;
+            }
+
+            int itemCount = 0;
+            int operationCount = 0;
+            for (Map.Entry<MultiMapPartitionContainer, Map<String, MultiMapContainer>> itemMapEntry : itemMap.entrySet()) {
+                MultiMapPartitionContainer partitionContainer = itemMapEntry.getKey();
+                Map<String, MultiMapContainer> containerMap = itemMapEntry.getValue();
+                int partitionId = partitionContainer.partitionId;
+
+                for (Map.Entry<String, MultiMapContainer> entry : containerMap.entrySet()) {
+                    String name = entry.getKey();
+                    MultiMapContainer container = entry.getValue();
+                    SplitBrainMergePolicy mergePolicy = getMergePolicy(container);
+                    int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
+
+                    List<MultiMapMergeContainer> mergeEntries = new ArrayList<MultiMapMergeContainer>(batchSize);
+                    for (Map.Entry<Data, MultiMapValue> multiMapValueEntry : container.getMultiMapValues().entrySet()) {
+                        Data key = multiMapValueEntry.getKey();
+                        MultiMapValue multiMapValue = multiMapValueEntry.getValue();
+                        Collection<MultiMapRecord> records = multiMapValue.getCollection(false);
+                        itemCount += records.size();
+
+                        MultiMapMergeContainer mergeContainer = new MultiMapMergeContainer(key, records,
+                                container.getCreationTime(), container.getLastAccessTime(), container.getLastUpdateTime(),
+                                multiMapValue.getHits());
+                        mergeEntries.add(mergeContainer);
+
+                        if (mergeEntries.size() == batchSize) {
+                            sendBatch(partitionId, name, mergePolicy, mergeEntries, mergeCallback);
+                            mergeEntries = new ArrayList<MultiMapMergeContainer>(batchSize);
+                            operationCount++;
+                        }
+                    }
+                    if (mergeEntries.size() > 0) {
+                        sendBatch(partitionId, name, mergePolicy, mergeEntries, mergeCallback);
+                        operationCount++;
+                    }
+                    containerMap.clear();
+                }
+            }
+            itemMap.clear();
+
+            try {
+                semaphore.tryAcquire(operationCount, itemCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                logger.finest("Interrupted while waiting for merge operation...");
+            }
+        }
+
+        private void sendBatch(int partitionId, String name, SplitBrainMergePolicy mergePolicy,
+                               List<MultiMapMergeContainer> mergeEntries, ExecutionCallback<Object> mergeCallback) {
+            MergeOperation operation = new MergeOperation(name, mergeEntries, mergePolicy);
+            try {
+                nodeEngine.getOperationService()
+                        .invokeOnPartition(SERVICE_NAME, operation, partitionId)
+                        .andThen(mergeCallback);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap.impl.operations;
+
+import com.hazelcast.multimap.impl.MultiMapContainer;
+import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
+import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.multimap.impl.MultiMapValue;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.BackupOperation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import static com.hazelcast.util.MapUtil.createHashMap;
+
+public class MergeBackupOperation extends MultiMapOperation implements BackupOperation {
+
+    private Map<Data, Collection<MultiMapRecord>> backupEntries;
+
+    public MergeBackupOperation() {
+    }
+
+    MergeBackupOperation(String name, Map<Data, Collection<MultiMapRecord>> backupEntries) {
+        super(name);
+        this.backupEntries = backupEntries;
+    }
+
+    @Override
+    public void run() throws Exception {
+        response = true;
+        MultiMapContainer container = getOrCreateContainer();
+        for (Map.Entry<Data, Collection<MultiMapRecord>> entry : backupEntries.entrySet()) {
+            Data key = entry.getKey();
+            Collection<MultiMapRecord> value = entry.getValue();
+            MultiMapValue containerValue = container.getOrCreateMultiMapValue(key);
+            Collection<MultiMapRecord> collection = containerValue.getCollection(false);
+            collection.clear();
+            if (!collection.addAll(value)) {
+                response = false;
+            }
+        }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(backupEntries.size());
+        for (Map.Entry<Data, Collection<MultiMapRecord>> entry : backupEntries.entrySet()) {
+            out.writeData(entry.getKey());
+            Collection<MultiMapRecord> collection = entry.getValue();
+            out.writeInt(collection.size());
+            for (MultiMapRecord record : collection) {
+                out.writeObject(record);
+            }
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        backupEntries = createHashMap(size);
+        for (int i = 0; i < size; i++) {
+            Data key = in.readData();
+            int collectionSize = in.readInt();
+            Collection<MultiMapRecord> collection = new ArrayList<MultiMapRecord>(collectionSize);
+            for (int j = 0; j < collectionSize; j++) {
+                MultiMapRecord record = in.readObject();
+                collection.add(record);
+            }
+            backupEntries.put(key, collection);
+        }
+    }
+
+    @Override
+    public int getId() {
+        return MultiMapDataSerializerHook.MERGE_BACKUP_OPERATION;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeOperation.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap.impl.operations;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.multimap.impl.MultiMapContainer;
+import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
+import com.hazelcast.multimap.impl.MultiMapMergeContainer;
+import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.multimap.impl.MultiMapValue;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
+import static com.hazelcast.util.MapUtil.createHashMap;
+
+public class MergeOperation extends MultiMapOperation implements BackupAwareOperation {
+
+    private List<MultiMapMergeContainer> mergeEntries;
+    private SplitBrainMergePolicy mergePolicy;
+
+    private transient Map<Data, Collection<MultiMapRecord>> resultMap;
+
+    public MergeOperation() {
+    }
+
+    public MergeOperation(String name, List<MultiMapMergeContainer> mergeEntries,
+                          SplitBrainMergePolicy mergePolicy) {
+        super(name);
+        this.mergeEntries = mergeEntries;
+        this.mergePolicy = mergePolicy;
+    }
+
+    @Override
+    public void run() throws Exception {
+        MultiMapContainer container = getOrCreateContainer();
+        resultMap = createHashMap(mergeEntries.size());
+        for (MultiMapMergeContainer mergeEntry : mergeEntries) {
+            Data key = mergeEntry.getKey();
+            if (!container.canAcquireLock(key, getCallerUuid(), -1)) {
+                Object valueKey = getNodeEngine().getSerializationService().toObject(key);
+                getLogger().info("Skipped merging of locked key '" + valueKey + "' on MultiMap '" + name + "'");
+                continue;
+            }
+
+            SplitBrainMergeEntryView<Data, MultiMapMergeContainer> mergingEntry
+                    = createSplitBrainMergeEntryView(key, mergeEntry);
+            MultiMapValue result = container.merge(mergingEntry, mergePolicy);
+            if (result != null) {
+                resultMap.put(key, result.getCollection(false));
+                publishEvent(EntryEventType.MERGED, key, result, null);
+            }
+        }
+        response = !resultMap.isEmpty();
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new MergeBackupOperation(name, resultMap);
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        return !resultMap.isEmpty();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(mergeEntries.size());
+        for (MultiMapMergeContainer mergingEntry : mergeEntries) {
+            out.writeObject(mergingEntry);
+        }
+        out.writeObject(mergePolicy);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        mergeEntries = new ArrayList<MultiMapMergeContainer>(size);
+        for (int i = 0; i < size; i++) {
+            MultiMapMergeContainer mergingEntry = in.readObject();
+            mergeEntries.add(mergingEntry);
+        }
+        mergePolicy = in.readObject();
+    }
+
+    @Override
+    public int getId() {
+        return MultiMapDataSerializerHook.MERGE_OPERATION;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
@@ -19,6 +19,9 @@ package com.hazelcast.spi.merge;
 import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.collection.impl.collection.CollectionItem;
 import com.hazelcast.collection.impl.queue.QueueItem;
+import com.hazelcast.multimap.impl.MultiMapContainer;
+import com.hazelcast.multimap.impl.MultiMapMergeContainer;
+import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -38,9 +41,9 @@ public final class SplitBrainEntryViews {
     private SplitBrainEntryViews() {
     }
 
-    public static <V> SplitBrainMergeEntryView<Boolean, V> createSplitBrainMergeEntryView(boolean isExistingContainer, V value) {
-        return new SimpleSplitBrainEntryView<Boolean, V>()
-                .setKey(isExistingContainer)
+    public static <K, V> SplitBrainMergeEntryView<K, V> createSplitBrainMergeEntryView(K key, V value) {
+        return new SimpleSplitBrainEntryView<K, V>()
+                .setKey(key)
                 .setValue(value);
     }
 
@@ -56,6 +59,28 @@ public final class SplitBrainEntryViews {
                 .setKey(item.getItemId())
                 .setValue(item.getData())
                 .setCreationTime(item.getCreationTime());
+    }
+
+    public static SplitBrainMergeEntryView<Data, Object> createSplitBrainMergeEntryView(MultiMapMergeContainer container,
+                                                                                        MultiMapRecord record) {
+        return new SimpleSplitBrainEntryView<Data, Object>()
+                .setKey(container.getKey())
+                .setValue(record.getObject())
+                .setCreationTime(container.getCreationTime())
+                .setLastAccessTime(container.getLastAccessTime())
+                .setLastUpdateTime(container.getLastUpdateTime())
+                .setHits(container.getHits());
+    }
+
+    public static SplitBrainMergeEntryView<Data, Object> createSplitBrainMergeEntryView(MultiMapContainer container, Data key,
+                                                                                        MultiMapRecord record, int hits) {
+        return new SimpleSplitBrainEntryView<Data, Object>()
+                .setKey(key)
+                .setValue(record.getObject())
+                .setCreationTime(container.getCreationTime())
+                .setLastAccessTime(container.getLastAccessTime())
+                .setLastUpdateTime(container.getLastUpdateTime())
+                .setHits(hits);
     }
 
     public static SplitBrainMergeEntryView<String, HyperLogLog>

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -952,7 +952,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <!--<xs:element name="partition-strategy" type="xs:string" minOccurs="0" maxOccurs="1" />-->
             <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
@@ -965,6 +964,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -234,6 +234,7 @@
     <multimap name="default">
         <backup-count>1</backup-count>
         <value-collection-type>SET</value-collection-type>
+        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
     </multimap>
 
     <list name="default">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1079,7 +1079,9 @@ https://hazelcast.org/documentation/.
             <entry-listener include-value="true" local="true">com.hazelcast.examples.EntryListener</entry-listener>
         </entry-listeners>
         <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
+        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
     </multimap>
+
     <!--
         ===== HAZELCAST REPLICATED MAP CONFIGURATION =====
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -490,8 +490,9 @@ class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.isBinary(), c2.isBinary())
                     && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
                     && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
                     && nullSafeEqual(c1.getQuorumName(), c2.getQuorumName())
-                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled());
+                    && ConfigCompatibilityChecker.isCompatible(c1.getMergePolicyConfig(), c2.getMergePolicyConfig());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -523,6 +523,25 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
+    public void testMultiMapConfig() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(DiscardMergePolicy.class.getSimpleName())
+                .setBatchSize(2342);
+
+        MultiMapConfig multiMapConfig = new MultiMapConfig()
+                .setName("myMultiMap")
+                .setBackupCount(2)
+                .setAsyncBackupCount(3)
+                .setBinary(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        Config config = new Config().addMultiMapConfig(multiMapConfig);
+        Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        assertEquals(multiMapConfig, xmlConfig.getMultiMapConfig("myMultiMap"));
+    }
+
+    @Test
     public void testWanConfig() {
         HashMap<String, Comparable> props = new HashMap<String, Comparable>();
         props.put("prop1", "val1");

--- a/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigReadOnlyTest.java
@@ -93,4 +93,9 @@ public class MultiMapConfigReadOnlyTest {
     public void setStatisticsEnabledOfReadOnlyMultiMapConfigShouldFail() {
         getReadOnlyConfig().setStatisticsEnabled(true);
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setMergePolicy() {
+        getReadOnlyConfig().setMergePolicyConfig(new MergePolicyConfig());
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigTest.java
@@ -16,18 +16,22 @@
 
 package com.hazelcast.config;
 
-import static org.junit.Assert.assertSame;
-
-import java.util.Locale;
-
+import com.hazelcast.config.MultiMapConfig.ValueCollectionType;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import com.hazelcast.config.MultiMapConfig.ValueCollectionType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
+import java.util.Locale;
+
+import static org.junit.Assert.assertSame;
 
 /**
  * Tests for {@link MultiMapConfig} class.
@@ -36,10 +40,11 @@ import com.hazelcast.test.annotation.QuickTest;
 @Category({QuickTest.class, ParallelTest.class})
 public class MultiMapConfigTest {
 
+    private MultiMapConfig multiMapConfig = new MultiMapConfig();
+
     @Test
     public void testValueCollectionTypeSelection() {
         Locale locale = Locale.getDefault();
-        MultiMapConfig multiMapConfig = new MultiMapConfig();
         multiMapConfig.setValueCollectionType("list");
         try {
             assertSame(ValueCollectionType.LIST, multiMapConfig.getValueCollectionType());
@@ -48,5 +53,30 @@ public class MultiMapConfigTest {
         } finally {
             Locale.setDefault(locale);
         }
+    }
+
+    @Test
+    public void testMergePolicy() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(HigherHitsMergePolicy.class.getName())
+                .setBatchSize(2342);
+
+        multiMapConfig.setMergePolicyConfig(mergePolicyConfig);
+
+        assertSame(mergePolicyConfig, multiMapConfig.getMergePolicyConfig());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MultiMapConfig.class)
+                .allFieldsShouldBeUsedExcept("readOnly")
+                .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                .withPrefabValues(MultiMapConfigReadOnly.class,
+                        new MultiMapConfigReadOnly(new MultiMapConfig("red")),
+                        new MultiMapConfigReadOnly(new MultiMapConfig("black")))
+                .withPrefabValues(MergePolicyConfig.class,
+                        new MergePolicyConfig(PutIfAbsentMergePolicy.class.getName(), 100),
+                        new MergePolicyConfig(DiscardMergePolicy.class.getName(), 200))
+                .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1596,17 +1596,26 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     @Test
     public void testMultiMapConfig() {
         String xml = HAZELCAST_START_TAG
-                + "    <multimap name=\"foobar\">\n"
+                + "  <multimap name=\"myMultiMap\">"
+                + "        <backup-count>2</backup-count>"
+                + "        <async-backup-count>3</async-backup-count>"
                 + "        <quorum-ref>customQuorumRule</quorum-ref>"
-                + "    </multimap>\n"
+                + "        <merge-policy batch-size=\"23\">CustomMergePolicy</merge-policy>"
+                + "  </multimap>"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        MultiMapConfig multiMapConfig = config.getMultiMapConfig("foobar");
+        assertFalse(config.getMultiMapConfigs().isEmpty());
 
         // TODO -> not full config checked
-        assertFalse(config.getMultiMapConfigs().isEmpty());
+        MultiMapConfig multiMapConfig = config.getMultiMapConfig("myMultiMap");
+        assertEquals(2, multiMapConfig.getBackupCount());
+        assertEquals(3, multiMapConfig.getAsyncBackupCount());
+
+        MergePolicyConfig mergePolicyConfig = multiMapConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
         assertEquals("customQuorumRule", multiMapConfig.getQuorumName());
+        assertEquals(23, mergePolicyConfig.getBatchSize());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
+import com.hazelcast.spi.merge.LatestAccessMergePolicy;
+import com.hazelcast.spi.merge.LatestUpdateMergePolicy;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.SplitBrainTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static com.hazelcast.multimap.MultiMapTestUtil.getBackupMultiMap;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests different split-brain scenarios for {@link MultiMap}.
+ * <p>
+ * Most merge policies are tested with {@link MultiMapConfig#isBinary()} as {@code true} only, since they don't check the value.
+ * <p>
+ * The {@link MergeIntegerValuesMergePolicy} is tested with both in-memory formats, since it's using the value to merge.
+ * <p>
+ * The {@link DiscardMergePolicy}, {@link PassThroughMergePolicy} and {@link PutIfAbsentMergePolicy} are also
+ * tested with a data structure, which is only created in the smaller cluster.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
+
+    @Parameters(name = "isBinary:{0}, mergePolicy:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {true, DiscardMergePolicy.class},
+                {true, HigherHitsMergePolicy.class},
+                {true, LatestAccessMergePolicy.class},
+                {true, LatestUpdateMergePolicy.class},
+                {true, PassThroughMergePolicy.class},
+                {true, PutIfAbsentMergePolicy.class},
+
+                {true, MergeIntegerValuesMergePolicy.class},
+                {false, MergeIntegerValuesMergePolicy.class},
+        });
+    }
+
+    @Parameter
+    public boolean isBinary;
+
+    @Parameter(value = 1)
+    public Class<? extends SplitBrainMergePolicy> mergePolicyClass;
+
+    private String multiMapNameA = randomMapName("multiMapA-");
+    private String multiMapNameB = randomMapName("multiMapB-");
+    private MultiMap<Object, Object> multiMapA1;
+    private MultiMap<Object, Object> multiMapA2;
+    private MultiMap<Object, Object> multiMapB1;
+    private MultiMap<Object, Object> multiMapB2;
+    private Map<Object, Collection<Object>> backupMultiMapA;
+    private Map<Object, Collection<Object>> backupMultiMapB;
+    private MergeLifecycleListener mergeLifecycleListener;
+
+    @Override
+    protected Config config() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(mergePolicyClass.getName())
+                .setBatchSize(10);
+
+        Config config = super.config();
+        config.getMultiMapConfig(multiMapNameA)
+                .setBinary(isBinary)
+                .setMergePolicyConfig(mergePolicyConfig)
+                .setStatisticsEnabled(true)
+                .setBackupCount(1)
+                .setAsyncBackupCount(0);
+        config.getMultiMapConfig(multiMapNameB)
+                .setBinary(isBinary)
+                .setMergePolicyConfig(mergePolicyConfig)
+                .setStatisticsEnabled(true)
+                .setBackupCount(1)
+                .setAsyncBackupCount(0);
+        return config;
+    }
+
+    @Override
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
+        waitAllForSafeState(instances);
+
+        Map<Object, Collection<Object>> backupMap = getBackupMultiMap(instances, multiMapNameA);
+        assertEquals("backupMultiMap should contain 0 entries", 0, backupMap.size());
+    }
+
+    @Override
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        mergeLifecycleListener = new MergeLifecycleListener(secondBrain.length);
+        for (HazelcastInstance instance : secondBrain) {
+            instance.getLifecycleService().addLifecycleListener(mergeLifecycleListener);
+        }
+
+        multiMapA1 = firstBrain[0].getMultiMap(multiMapNameA);
+        multiMapA2 = secondBrain[0].getMultiMap(multiMapNameA);
+        multiMapB2 = secondBrain[0].getMultiMap(multiMapNameB);
+
+        if (mergePolicyClass == DiscardMergePolicy.class) {
+            afterSplitDiscardMergePolicy();
+        }
+        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+            afterSplitHigherHitsMergePolicy();
+        }
+        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+            afterSplitLatestAccessMergePolicy();
+        }
+        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+            afterSplitLatestUpdateMergePolicy();
+        }
+        if (mergePolicyClass == PassThroughMergePolicy.class) {
+            afterSplitPassThroughMergePolicy();
+        }
+        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+            afterSplitPutIfAbsentMergePolicy();
+        }
+        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+            afterSplitCustomMergePolicy();
+        }
+    }
+
+    @Override
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
+        // wait until merge completes
+        mergeLifecycleListener.await();
+
+        multiMapB1 = instances[0].getMultiMap(multiMapNameB);
+
+        backupMultiMapA = getBackupMultiMap(instances, multiMapNameA);
+        backupMultiMapB = getBackupMultiMap(instances, multiMapNameB);
+
+        if (mergePolicyClass == DiscardMergePolicy.class) {
+            afterMergeDiscardMergePolicy();
+        }
+        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+            afterMergeHigherHitsMergePolicy();
+        }
+        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+            afterMergeLatestAccessMergePolicy();
+        }
+        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+            afterMergeLatestUpdateMergePolicy();
+        }
+        if (mergePolicyClass == PassThroughMergePolicy.class) {
+            afterMergePassThroughMergePolicy();
+        }
+        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+            afterMergePutIfAbsentMergePolicy();
+        }
+        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+            afterMergeCustomMergePolicy();
+        }
+    }
+
+    private void afterSplitDiscardMergePolicy() {
+        multiMapA1.put("key1", "value1");
+        multiMapA1.put("key1", "value2");
+
+        multiMapA2.put("key1", "DiscardedValue1a");
+        multiMapA2.put("key1", "DiscardedValue1b");
+        multiMapA2.put("key2", "DiscardedValue2a");
+        multiMapA2.put("key2", "DiscardedValue2b");
+
+        multiMapB2.put("key", "DiscardedValue1");
+        multiMapB2.put("key", "DiscardedValue2");
+    }
+
+    private void afterMergeDiscardMergePolicy() {
+        assertMultiMapsA("key1", "value1", "value2");
+        assertMultiMapsA("key2");
+
+        assertMultiMapsB("key");
+    }
+
+    private void afterSplitHigherHitsMergePolicy() {
+        multiMapA1.put("key1", "higherHitsValue1");
+        multiMapA1.put("key2", "value2");
+
+        // increase hits number
+        multiMapA1.get("key1");
+        multiMapA1.get("key1");
+
+        multiMapA2.put("key1", "value1");
+        multiMapA2.put("key2", "higherHitsValue2");
+
+        // increase hits number
+        multiMapA2.get("key2");
+        multiMapA2.get("key2");
+    }
+
+    private void afterMergeHigherHitsMergePolicy() {
+        assertMultiMapsA("key1", "value1", "higherHitsValue1");
+        assertMultiMapsA("key2", "value2", "higherHitsValue2");
+
+        assertEquals(4, multiMapA1.size());
+        assertEquals(4, multiMapA2.size());
+        assertEquals(2, backupMultiMapA.size());
+    }
+
+    private void afterSplitLatestAccessMergePolicy() {
+        multiMapA1.put("key1", "value1");
+        // access to record
+        multiMapA1.get("key1");
+
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        multiMapA2.put("key1", "LatestAccessedValue1");
+        // access to record
+        multiMapA2.get("key1");
+
+        multiMapA2.put("key2", "value2");
+        // access to record
+        multiMapA2.get("key2");
+
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        multiMapA1.put("key2", "LatestAccessedValue2");
+        // access to record
+        multiMapA1.get("key2");
+    }
+
+    private void afterMergeLatestAccessMergePolicy() {
+        assertMultiMapsA("key1", "value1", "LatestAccessedValue1");
+        assertMultiMapsA("key2", "value2", "LatestAccessedValue2");
+
+        assertEquals(4, multiMapA1.size());
+        assertEquals(4, multiMapA2.size());
+        assertEquals(2, backupMultiMapA.size());
+    }
+
+    private void afterSplitLatestUpdateMergePolicy() {
+        multiMapA1.put("key1", "value1");
+
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        multiMapA2.put("key1", "LatestUpdatedValue1");
+        multiMapA2.put("key2", "value2");
+
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        multiMapA1.put("key2", "LatestUpdatedValue2");
+    }
+
+    private void afterMergeLatestUpdateMergePolicy() {
+        assertMultiMapsA("key1", "value1", "LatestUpdatedValue1");
+        assertMultiMapsA("key2", "value2", "LatestUpdatedValue2");
+
+        assertEquals(4, multiMapA1.size());
+        assertEquals(4, multiMapA2.size());
+        assertEquals(2, backupMultiMapA.size());
+    }
+
+    private void afterSplitPassThroughMergePolicy() {
+        multiMapA1.lock("lockedKey");
+        multiMapA1.put("lockedKey", "lockedValue");
+        multiMapA1.put("key1", "value1");
+        multiMapA1.put("key1", "value2");
+
+        multiMapA2.put("lockedKey", "PassThroughValue");
+        multiMapA2.put("key1", "PassThroughValue1a");
+        multiMapA2.put("key1", "PassThroughValue1b");
+        multiMapA2.put("key2", "PassThroughValue2a");
+        multiMapA2.put("key2", "PassThroughValue2b");
+
+        multiMapB2.put("key", "PassThroughValue");
+    }
+
+    private void afterMergePassThroughMergePolicy() {
+        assertTrue("Expected lockedKey to be locked", multiMapA1.isLocked("lockedKey"));
+        multiMapA1.unlock("lockedKey");
+        assertFalse("Expected lockedKey to be unlocked", multiMapA1.isLocked("lockedKey"));
+
+        assertMultiMapsA("lockedKey", "lockedValue");
+        assertMultiMapsA("key1", "value1", "value2", "PassThroughValue1a", "PassThroughValue1b");
+        assertMultiMapsA("key2", "PassThroughValue2a", "PassThroughValue2b");
+
+        assertEquals(7, multiMapA1.size());
+        assertEquals(7, multiMapA2.size());
+        assertEquals(3, backupMultiMapA.size());
+
+        assertMultiMapsB("key", "PassThroughValue");
+
+        assertEquals(1, multiMapB1.size());
+        assertEquals(1, multiMapB2.size());
+        assertEquals(1, backupMultiMapB.size());
+    }
+
+    private void afterSplitPutIfAbsentMergePolicy() {
+        multiMapA1.put("key1", "PutIfAbsentValue1a");
+        multiMapA1.put("key1", "PutIfAbsentValue1b");
+
+        multiMapA2.put("key1", "value");
+        multiMapA2.put("key2", "PutIfAbsentValue2a");
+        multiMapA2.put("key2", "PutIfAbsentValue2b");
+
+        multiMapB2.put("key", "PutIfAbsentValue");
+    }
+
+    private void afterMergePutIfAbsentMergePolicy() {
+        assertMultiMapsA("key1", "value", "PutIfAbsentValue1a", "PutIfAbsentValue1b");
+        assertMultiMapsA("key2", "PutIfAbsentValue2a", "PutIfAbsentValue2b");
+
+        assertEquals(5, multiMapA1.size());
+        assertEquals(5, multiMapA2.size());
+        assertEquals(2, backupMultiMapA.size());
+
+        assertMultiMapsB("key", "PutIfAbsentValue");
+
+        assertEquals(1, multiMapB1.size());
+        assertEquals(1, multiMapB2.size());
+        assertEquals(1, backupMultiMapB.size());
+    }
+
+    private void afterSplitCustomMergePolicy() {
+        multiMapA1.put("key", 1);
+        multiMapA2.put("key", "value");
+    }
+
+    private void afterMergeCustomMergePolicy() {
+        assertMultiMapsA("key", 1);
+
+        assertEquals(1, multiMapA1.size());
+        assertEquals(1, multiMapA2.size());
+        assertEquals(1, backupMultiMapA.size());
+    }
+
+    private void assertMultiMapsA(String key, Object... objects) {
+        assertMultiMaps(multiMapA1, multiMapA2, backupMultiMapA, key, objects);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void assertMultiMapsB(String key, Object... objects) {
+        assertMultiMaps(multiMapB1, multiMapB2, backupMultiMapB, key, objects);
+    }
+
+    private static void assertMultiMaps(MultiMap<Object, Object> multiMap1, MultiMap<Object, Object> multiMap2,
+                                        Map<Object, Collection<Object>> backupMultiMap, String key, Object... objects) {
+        Collection<Object> collection1 = multiMap1.get(key);
+        Collection<Object> collection2 = multiMap2.get(key);
+        Collection<Object> backupCollection = backupMultiMap.get(key);
+        if (objects.length > 0) {
+            Collection<Object> expected = asList(objects);
+            assertContainsAll(collection1, expected);
+            assertContainsAll(collection2, expected);
+            assertContainsAll(backupCollection, expected);
+
+            assertEquals(objects.length, multiMap1.valueCount(key));
+            assertEquals(objects.length, multiMap2.valueCount(key));
+            assertEquals(objects.length, backupCollection.size());
+        } else {
+            assertTrue("multiMap1 should be empty for " + key + ", but was " + collection1, collection1.isEmpty());
+            assertTrue("multiMap2 should be empty for " + key + ", but was " + collection2, collection2.isEmpty());
+            assertNull("backupMultiMap should be null for " + key + ", but was " + backupCollection, backupCollection);
+
+            assertEquals(0, multiMap1.valueCount(key));
+            assertEquals(0, multiMap2.valueCount(key));
+        }
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -467,6 +467,7 @@
             <entry-listener include-value="true" local="true">com.hazelcast.examples.EntryListener</entry-listener>
         </entry-listeners>
         <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
+        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
     </multimap>
 
     <replicatedmap name="dummy">


### PR DESCRIPTION
The split-brain healing has been implemented for `MultiMap`. Locked keys are ignored during the merge. The `MultiMapConfig.equals()` method has been fixed and the test is now working.

- [x] `MultiMap` merge operation isn't a `BlockingOperation` and doesn't acquire key locks (see `MultiMapBackupAwareOperation`)
- [x] `MultiMapConfig.equals()` test fails and is ignored

Depends on https://github.com/hazelcast/hazelcast/pull/11788