### PR TITLE
Prevents doing invocation on invalid target when partition table update is late

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -64,7 +64,7 @@ public interface ClientConnectionManager extends ConnectionListenable {
 
     Collection<ClientConnection> getActiveConnections();
 
-    Address getOwnerConnectionAddress() ;
+    Address getOwnerConnectionAddress();
 
     ClientPrincipal getPrincipal();
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 
 import java.io.IOException;
 
-public final class SmartClientInvocationService extends AbstractClientInvocationService {
+public class SmartClientInvocationService extends AbstractClientInvocationService {
 
     private final LoadBalancer loadBalancer;
 
@@ -40,6 +40,9 @@ public final class SmartClientInvocationService extends AbstractClientInvocation
         final Address owner = partitionService.getPartitionOwner(partitionId);
         if (owner == null) {
             throw new IOException("Partition does not have an owner. partitionId: " + partitionId);
+        }
+        if (!isMember(owner)) {
+            throw new TargetNotMemberException("Partition owner '" + owner + "' is not a member.");
         }
         invocation.getClientMessage().setPartitionId(partitionId);
         Connection connection = getOrTriggerConnect(owner);
@@ -87,7 +90,7 @@ public final class SmartClientInvocationService extends AbstractClientInvocation
         return null;
     }
 
-    private boolean isMember(Address target) {
+    boolean isMember(Address target) {
         final Member member = client.getClientClusterService().getMember(target);
         return member != null;
     }


### PR DESCRIPTION
Quorum tests that revealed this bug were failing because client is
doing  invocation on a member that is not available in its memberlist.
That address is known by client because it is in partition table.
This can only occur in small time period between memberlist and
partiton table update. This fix makes sures invocations get
`TargetNotMemberException` in that period and retry.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1339
fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1322