### PR TITLE
Added backup tests for IList, IQueue and ISet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
@@ -97,6 +97,10 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return name;
     }
 
+    public int getPartitionId() {
+        return partitionId;
+    }
+
     public boolean add(E e) {
         checkObjectNotNull(e);
         final Data value = getNodeEngine().toData(e);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -64,7 +64,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
 
     protected abstract Collection<CollectionItem> getCollection();
 
-    protected abstract Map<Long, CollectionItem> getMap();
+    public abstract Map<Long, CollectionItem> getMap();
 
     public long add(Data value) {
         final CollectionItem item = new CollectionItem(nextId(), value);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
@@ -177,7 +177,7 @@ public class ListContainer extends CollectionContainer {
     }
 
     @Override
-    protected Map<Long, CollectionItem> getMap() {
+    public Map<Long, CollectionItem> getMap() {
         if (itemMap == null) {
             if (itemList != null && !itemList.isEmpty()) {
                 itemMap = createHashMap(itemList.size());

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -913,7 +913,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
      *
      * @return backup replica map from item ID to queue item
      */
-    private Map<Long, QueueItem> getBackupMap() {
+    public Map<Long, QueueItem> getBackupMap() {
         if (backupMap == null) {
             if (itemQueue != null) {
                 backupMap = createHashMap(itemQueue.size());

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
@@ -87,6 +87,10 @@ abstract class QueueProxySupport extends AbstractDistributedObject<QueueService>
         }
     }
 
+    public int getPartitionId() {
+        return partitionId;
+    }
+
     boolean offerInternal(Data data, long timeout) throws InterruptedException {
         checkObjectNotNull(data);
 
@@ -156,10 +160,6 @@ abstract class QueueProxySupport extends AbstractDistributedObject<QueueService>
     boolean compareAndRemove(Collection<Data> dataList, boolean retain) {
         CompareAndRemoveOperation operation = new CompareAndRemoveOperation(name, dataList, retain);
         return (Boolean) invokeAndGet(operation);
-    }
-
-    private int getPartitionId() {
-        return partitionId;
     }
 
     protected void checkObjectNotNull(Object o) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
@@ -86,7 +86,7 @@ public class SetContainer extends CollectionContainer {
     }
 
     @Override
-    protected Map<Long, CollectionItem> getMap() {
+    public Map<Long, CollectionItem> getMap() {
         if (itemMap == null) {
             if (itemSet != null && !itemSet.isEmpty()) {
                 itemMap = createHashMap(itemSet.size());

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/AbstractCollectionBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/AbstractCollectionBackupTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+
+import java.util.Collection;
+
+import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupList;
+import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupQueue;
+import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public abstract class AbstractCollectionBackupTest extends HazelcastTestSupport {
+
+    protected enum CollectionType {
+        LIST,
+        QUEUE,
+        SET
+    }
+
+    protected static final int ITEM_COUNT = 1000;
+    protected static final int BACKUP_COUNT = 4;
+
+    protected static final ILogger LOGGER = Logger.getLogger(AbstractCollectionBackupTest.class);
+
+    protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+    protected Config config = new Config();
+
+    protected final void testBackups(CollectionType collectionType, String collectionName, int partitionId) {
+        // scale up
+        LOGGER.info("Scaling up to " + (BACKUP_COUNT + 1) + " members...");
+        for (int backupCount = 1; backupCount <= BACKUP_COUNT; backupCount++) {
+            factory.newHazelcastInstance(config);
+            waitAllForSafeState(factory.getAllHazelcastInstances());
+            assertEquals(backupCount + 1, factory.getAllHazelcastInstances().iterator().next().getCluster().getMembers().size());
+
+            assertBackupCollection(collectionType, collectionName, partitionId, backupCount);
+        }
+
+        // scale down
+        LOGGER.info("Scaling down to 1 member...");
+        for (int backupCount = BACKUP_COUNT - 1; backupCount > 0; backupCount--) {
+            factory.getAllHazelcastInstances().iterator().next().shutdown();
+            waitAllForSafeState(factory.getAllHazelcastInstances());
+            assertEquals(backupCount + 1, factory.getAllHazelcastInstances().iterator().next().getCluster().getMembers().size());
+
+            assertBackupCollection(collectionType, collectionName, partitionId, backupCount);
+        }
+    }
+
+    private void assertBackupCollection(CollectionType collectionType, String collectionName, int partitionId, int backupCount) {
+        HazelcastInstance[] instances = factory.getAllHazelcastInstances().toArray(new HazelcastInstance[0]);
+        LOGGER.info("Testing " + backupCount + " backups on " + instances.length + " members");
+
+        for (int i = 1; i <= backupCount; i++) {
+            HazelcastInstance backupInstance = getBackupInstance(instances, partitionId, i);
+            Collection<Integer> backupCollection = null;
+            switch (collectionType) {
+                case LIST:
+                    backupCollection = getBackupList(backupInstance, collectionName);
+                    break;
+                case QUEUE:
+                    backupCollection = getBackupQueue(backupInstance, collectionName);
+                    break;
+                case SET:
+                    backupCollection = getBackupSet(backupInstance, collectionName);
+                    break;
+                default:
+                    fail("Unknown collectionType " + collectionType);
+            }
+
+            assertEqualsStringFormat("expected %d items in backupCollection, but found %d", ITEM_COUNT, backupCollection.size());
+            for (int item = 0; item < ITEM_COUNT; item++) {
+                assertTrue("backupCollection should contain item " + item, backupCollection.contains(item));
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl;
+
+import com.hazelcast.collection.impl.collection.CollectionContainer;
+import com.hazelcast.collection.impl.collection.CollectionItem;
+import com.hazelcast.collection.impl.collection.CollectionService;
+import com.hazelcast.collection.impl.list.ListService;
+import com.hazelcast.collection.impl.queue.QueueContainer;
+import com.hazelcast.collection.impl.queue.QueueItem;
+import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.collection.impl.set.SetService;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+
+public final class CollectionTestUtil {
+
+    private CollectionTestUtil() {
+    }
+
+    public static <E> List<E> getBackupList(HazelcastInstance backupInstance, String listName) {
+        CollectionService service = getNodeEngineImpl(backupInstance).getService(ListService.SERVICE_NAME);
+        CollectionContainer collectionContainer = service.getContainerMap().get(listName);
+        Map<Long, CollectionItem> map = collectionContainer.getMap();
+
+        List<E> backupList = new ArrayList<E>(map.size());
+        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
+        for (CollectionItem collectionItem : map.values()) {
+            E value = serializationService.toObject(collectionItem.getValue());
+            backupList.add(value);
+        }
+        return backupList;
+    }
+
+    public static <E> Queue<E> getBackupQueue(HazelcastInstance backupInstance, String queueName) {
+        QueueService service = getNodeEngineImpl(backupInstance).getService(QueueService.SERVICE_NAME);
+        QueueContainer container = service.getOrCreateContainer(queueName, true);
+        Map<Long, QueueItem> map = container.getBackupMap();
+
+        Queue<E> backupQueue = new LinkedList<E>();
+        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
+        for (QueueItem queueItem : map.values()) {
+            E value = serializationService.toObject(queueItem.getData());
+            backupQueue.add(value);
+        }
+        return backupQueue;
+    }
+
+    public static <E> Set<E> getBackupSet(HazelcastInstance backupInstance, String setName) {
+        CollectionService service = getNodeEngineImpl(backupInstance).getService(SetService.SERVICE_NAME);
+        CollectionContainer collectionContainer = service.getContainerMap().get(setName);
+        Map<Long, CollectionItem> map = collectionContainer.getMap();
+
+        Set<E> backupSet = new HashSet<E>();
+        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
+        for (CollectionItem collectionItem : map.values()) {
+            E value = serializationService.toObject(collectionItem.getValue());
+            backupSet.add(value);
+        }
+        return backupSet;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBackupTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.list;
+
+import com.hazelcast.collection.impl.AbstractCollectionBackupTest;
+import com.hazelcast.collection.impl.collection.AbstractCollectionProxyImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IList;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ListBackupTest extends AbstractCollectionBackupTest {
+
+    private static final String LIST_NAME = "ListBackupTest";
+
+    @Test
+    public void testBackups() {
+        config.getListConfig(LIST_NAME)
+                .setBackupCount(BACKUP_COUNT)
+                .setAsyncBackupCount(0);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        IList<Integer> list = hz.getList(LIST_NAME);
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            list.add(i);
+        }
+
+        int partitionId = ((AbstractCollectionProxyImpl) list).getPartitionId();
+        LOGGER.info("List " + LIST_NAME + " is stored in partition " + partitionId);
+
+        testBackups(CollectionType.LIST, LIST_NAME, partitionId);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBackupTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.collection.impl.AbstractCollectionBackupTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueueBackupTest extends AbstractCollectionBackupTest {
+
+    private static final String QUEUE_NAME = "QueueBackupTest";
+
+    @Test
+    public void testBackups() {
+        config.getQueueConfig(QUEUE_NAME)
+                .setBackupCount(BACKUP_COUNT)
+                .setAsyncBackupCount(0);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        IQueue<Integer> queue = hz.getQueue(QUEUE_NAME);
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            queue.add(i);
+        }
+
+        int partitionId = ((QueueProxySupport) queue).getPartitionId();
+        LOGGER.info("Queue " + QUEUE_NAME + " is stored in partition " + partitionId);
+
+        testBackups(CollectionType.QUEUE, QUEUE_NAME, partitionId);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBackupTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.set;
+
+import com.hazelcast.collection.impl.AbstractCollectionBackupTest;
+import com.hazelcast.collection.impl.collection.AbstractCollectionProxyImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ISet;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SetBackupTest extends AbstractCollectionBackupTest {
+
+    private static final String SET_NAME = "SetBackupTest";
+
+    @Test
+    public void testBackups() {
+        config.getSetConfig(SET_NAME)
+                .setBackupCount(BACKUP_COUNT)
+                .setAsyncBackupCount(0);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        ISet<Integer> set = hz.getSet(SET_NAME);
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            set.add(i);
+        }
+
+        int partitionId = ((AbstractCollectionProxyImpl) set).getPartitionId();
+        LOGGER.info("Set " + SET_NAME + " is stored in partition " + partitionId);
+
+        testBackups(CollectionType.SET, SET_NAME, partitionId);
+    }
+}


### PR DESCRIPTION
I see messed up backups in my `SetSplitBrainTest` and `ListSplitBrainTest`, so I wanted to see if there is a general problem with backups on collections.

The test scales a cluster up and down and checks all backups on all members on every step.