### PR TITLE
[BACKPORT] Start script warning for already started cluster to include PID

### DIFF
--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -25,10 +25,10 @@ if NOT "%MAX_HEAP_SIZE%" == "" (
 
 set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar"
 
-FOR /F "tokens=* USEBACKQ" %%F IN (`tasklist /FI "WINDOWTITLE eq hazelcast %CLASSPATH%" 2^>NUL ^| find /I /C "java"`) DO (
-SET COUNT=%%F
+FOR /F "tokens=2 delims=," %%F in ('tasklist /NH /FI "WINDOWTITLE eq hazelcast %CLASSPATH%" /fo csv') DO (
+SET PID=%%F
 )
-IF NOT "%COUNT%"=="0" (
+IF NOT "%PID%"=="" (
     goto alreadyrunning
 )
 
@@ -46,7 +46,7 @@ ECHO JAVA_HOME environment variable must be set!
 pause
 
 :alreadyrunning
-ECHO Another Hazelcast instance is already started in this folder. To start a new instance, please unzip the zip file in a new folder.
+ECHO Another Hazelcast instance (PID=%PID%) is already started in this folder. To start a new instance, please unzip the zip file in a new folder.
 pause
 
 :endofscript

--- a/hazelcast/src/main/resources/start.sh
+++ b/hazelcast/src/main/resources/start.sh
@@ -50,10 +50,10 @@ echo "########################################"
 
 PID=$(cat "${PID_FILE}");
 if [ -z "${PID}" ]; then
-    echo "Process id for hazelcast instance is written to location: {$PID_FILE}"
+    echo "Process ID for Hazelcast instance is written to location: {$PID_FILE}"
     $RUN_JAVA -server $JAVA_OPTS com.hazelcast.core.server.StartServer &
     echo $! > ${PID_FILE}
 else
-    echo "Another hazelcast instance is already started in this folder. To start a new instance, please unzip hazelcast-${project.version}.zip/tar.gz in a new folder."
+    echo "Another Hazelcast instance (PID=${PID}) is already started in this folder. To start a new instance, please unzip hazelcast-${project.version}.zip/tar.gz in a new folder."
     exit 0
 fi


### PR DESCRIPTION
We let only one Hazelcast instance to be started from within one
directory. If another one is tried to be started, we don't let it and
print a warning. This fix adds the PID of the already running cluster
to the warning message.

Fixes #11834

(cherry picked from commit c918f2b)