### PR TITLE
Added cluster version check for dynamic atomic configurations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -211,7 +211,6 @@ public class Node {
             metricsRegistry.collectMetrics(nodeExtension);
             healthMonitor = new HealthMonitor(this);
 
-
             clientEngine = new ClientEngineImpl(this);
             connectionManager = nodeContext.createConnectionManager(this, serverSocketChannel);
             discoveryService = createDiscoveryService(
@@ -221,6 +220,8 @@ public class Node {
             textCommandService = new TextCommandServiceImpl(this);
             multicastService = createMulticastService(addressPicker.getBindAddress(), this, config, logger);
             joiner = nodeContext.createJoiner(this);
+
+            config.setClusterService(clusterService);
         } catch (Throwable e) {
             try {
                 serverSocketChannel.close();

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigRollingUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigRollingUpgradeTest.java
@@ -1,5 +1,8 @@
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.cluster.Versions;
@@ -24,5 +27,23 @@ public class DynamicConfigRollingUpgradeTest extends HazelcastTestSupport {
         HazelcastInstance hazelcastInstance = createHazelcastInstance();
 
         hazelcastInstance.getConfig().addMapConfig(new MapConfig(randomName()));
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testThrowsExceptionWhenAddingAtomicLongConfigInClusterVersion39() {
+        // system properties are cleared automatically by the Hazelcast Runner
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_9.toString());
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+
+        hazelcastInstance.getConfig().addAtomicLongConfig(new AtomicLongConfig(randomMapName()));
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testThrowsExceptionWhenAddingAtomicReferenceConfigInClusterVersion39() {
+        // system properties are cleared automatically by the Hazelcast Runner
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_9.toString());
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+
+        hazelcastInstance.getConfig().addAtomicReferenceConfig(new AtomicReferenceConfig(randomMapName()));
     }
 }


### PR DESCRIPTION
* throws ConfigurationException if adding an AtomicLongConfig
  when cluster version is below 3.10
* throws ConfigurationException if adding an AtomicReferenceConfig
  when cluster version is below 3.10

Fixes https://github.com/hazelcast/hazelcast/issues/12000