### PR TITLE
[FORWARD PORT] Make GetCacheEntryRequest serializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -66,6 +66,7 @@ import com.hazelcast.cache.impl.record.CacheDataRecord;
 import com.hazelcast.cache.impl.record.CacheObjectRecord;
 import com.hazelcast.client.impl.protocol.task.cache.CacheAssignAndGetUuidsOperation;
 import com.hazelcast.client.impl.protocol.task.cache.CacheAssignAndGetUuidsOperationFactory;
+import com.hazelcast.internal.management.request.GetCacheEntryRequest;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -148,8 +149,10 @@ public final class CacheDataSerializerHook
     public static final short EVENT_JOURNAL_INTERNAL_CACHE_EVENT = 59;
     public static final short EVENT_JOURNAL_READ_RESULT_SET = 60;
     public static final int PRE_JOIN_CACHE_CONFIG = 61;
+    public static final int CACHE_BROWSER_ENTRY_VIEW = 62;
+    public static final int GET_CACHE_ENTRY_VIEW_PROCESSOR = 63;
 
-    private static final int LEN = PRE_JOIN_CACHE_CONFIG + 1;
+    private static final int LEN = GET_CACHE_ENTRY_VIEW_PROCESSOR + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -455,6 +458,20 @@ public final class CacheDataSerializerHook
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new PreJoinCacheConfig();
+                    }
+                };
+        constructors[CACHE_BROWSER_ENTRY_VIEW] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new GetCacheEntryRequest.CacheBrowserEntryView();
+                    }
+                };
+        constructors[GET_CACHE_ENTRY_VIEW_PROCESSOR] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new GetCacheEntryRequest.GetCacheEntryViewEntryProcessor();
                     }
                 };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -19,15 +19,21 @@ package com.hazelcast.internal.management.request;
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheEntryProcessorEntry;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.core.ReadOnly;
 import com.hazelcast.instance.HazelcastInstanceCacheManager;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
+import java.io.IOException;
 
 import static com.hazelcast.util.JsonUtil.getString;
 
@@ -56,18 +62,18 @@ public class GetCacheEntryRequest implements ConsoleRequest {
     }
 
     @Override
-    public void writeResponse(ManagementCenterService mcs, JsonObject root) throws Exception {
+    public void writeResponse(ManagementCenterService mcs, JsonObject root) {
         InternalSerializationService serializationService = mcs.getHazelcastInstance().getSerializationService();
         HazelcastInstanceCacheManager cacheManager = mcs.getHazelcastInstance().getCacheManager();
         ICache<Object, Object> cache = cacheManager.getCache(cacheName);
         CacheEntryView cacheEntry = null;
 
         if ("string".equals(type)) {
-            cacheEntry = cache.invoke(key, ENTRY_PROCESSOR, cacheEntry);
+            cacheEntry = cache.invoke(key, ENTRY_PROCESSOR);
         } else if ("long".equals(type)) {
-            cacheEntry = cache.invoke(Long.valueOf(key), ENTRY_PROCESSOR, cacheEntry);
+            cacheEntry = cache.invoke(Long.valueOf(key), ENTRY_PROCESSOR);
         } else if ("integer".equals(type)) {
-            cacheEntry = cache.invoke(Integer.valueOf(key), ENTRY_PROCESSOR, cacheEntry);
+            cacheEntry = cache.invoke(Integer.valueOf(key), ENTRY_PROCESSOR);
         }
         JsonObject result = new JsonObject();
         if (cacheEntry != null) {
@@ -89,42 +95,113 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         key = getString(json, "key");
     }
 
-    private static class GetCacheEntryViewEntryProcessor implements EntryProcessor<Object, Object, CacheEntryView> {
+    public static class GetCacheEntryViewEntryProcessor implements EntryProcessor<Object, Object, CacheEntryView>,
+            IdentifiedDataSerializable, ReadOnly {
         @Override
         public CacheEntryView process(MutableEntry mutableEntry, Object... objects) throws EntryProcessorException {
-            final CacheEntryProcessorEntry entry = (CacheEntryProcessorEntry) mutableEntry;
-            final CacheRecord record = entry.getRecord();
-            CacheEntryView<Object, Object> cacheEntryView = new CacheEntryView<Object, Object>() {
-                //Key is defined by Management Center user
-                @Override
-                public String getKey() {
-                    return null;
-                }
-                @Override
-                public Object getValue() {
-                    return record.getValue();
-                }
-                @Override
-                public long getExpirationTime() {
-                    return record.getExpirationTime();
-                }
+            CacheEntryProcessorEntry entry = (CacheEntryProcessorEntry) mutableEntry;
+            if (entry.getRecord() == null) {
+                return null;
+            }
 
-                @Override
-                public long getCreationTime() {
-                    return record.getCreationTime();
-                }
+            return new CacheBrowserEntryView(entry);
+        }
 
-                @Override
-                public long getLastAccessTime() {
-                    return record.getLastAccessTime();
-                }
+        @Override
+        public int getFactoryId() {
+            return CacheDataSerializerHook.F_ID;
+        }
 
-                @Override
-                public long getAccessHit() {
-                    return record.getAccessHit();
-                }
-            };
-            return cacheEntryView;
+        @Override
+        public int getId() {
+            return CacheDataSerializerHook.GET_CACHE_ENTRY_VIEW_PROCESSOR;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+        }
+    }
+
+    public static class CacheBrowserEntryView implements CacheEntryView<Object, Object>, IdentifiedDataSerializable {
+        private Object value;
+        private long expirationTime;
+        private long creationTime;
+        private long lastAccessTime;
+        private long accessHit;
+
+        public CacheBrowserEntryView() {
+        }
+
+        CacheBrowserEntryView(CacheEntryProcessorEntry entry) {
+            this.value = entry.getValue();
+
+            CacheRecord record = entry.getRecord();
+            this.expirationTime = record.getExpirationTime();
+            this.creationTime = record.getCreationTime();
+            this.lastAccessTime = record.getLastAccessTime();
+            this.accessHit = record.getAccessHit();
+        }
+
+        @Override
+        public Object getKey() {
+            return null;
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+
+        @Override
+        public long getExpirationTime() {
+            return expirationTime;
+        }
+
+        @Override
+        public long getCreationTime() {
+            return creationTime;
+        }
+
+        @Override
+        public long getLastAccessTime() {
+            return lastAccessTime;
+        }
+
+        @Override
+        public long getAccessHit() {
+            return accessHit;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return CacheDataSerializerHook.F_ID;
+        }
+
+        @Override
+        public int getId() {
+            return CacheDataSerializerHook.CACHE_BROWSER_ENTRY_VIEW;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeObject(value);
+            out.writeLong(expirationTime);
+            out.writeLong(creationTime);
+            out.writeLong(lastAccessTime);
+            out.writeLong(accessHit);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            value = in.readObject();
+            expirationTime = in.readLong();
+            creationTime = in.readLong();
+            lastAccessTime = in.readLong();
+            accessHit = in.readLong();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetCacheEntryRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetCacheEntryRequestTest.java
@@ -18,57 +18,134 @@ package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.cache.CacheTestSupport;
-import com.hazelcast.cache.ICache;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICacheManager;
 import com.hazelcast.internal.management.request.GetCacheEntryRequest;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import javax.cache.Cache;
+import java.util.Collection;
+import java.util.Random;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class GetCacheEntryRequestTest extends CacheTestSupport {
+    private static final Random random = new Random();
 
-    private HazelcastInstance hz;
-    private ManagementCenterService managementCenterService;
+    private TestHazelcastInstanceFactory instanceFactory;
+    private HazelcastInstance[] instances;
+    private String cacheName = randomName();
+    private String value = randomString();
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameters(name = "inMemoryFormat:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {BINARY}, {OBJECT},
+        });
+    }
 
     @Override
     protected HazelcastInstance getHazelcastInstance() {
-        return hz;
+        return instances[0];
+    }
+
+    protected CacheSimpleConfig getCacheConfig() {
+        return new CacheSimpleConfig().setName(cacheName).setInMemoryFormat(inMemoryFormat);
     }
 
     @Override
     protected void onSetup() {
-        Config config = new Config();
-        config.addCacheConfig(new CacheSimpleConfig().setName("test"));
-        config.getCacheConfig("test").setStatisticsEnabled(true);
-        hz = createHazelcastInstance(config);
-        managementCenterService = getNode(hz).getManagementCenterService();
+        Config config = getConfig();
+        config.addCacheConfig(getCacheConfig());
+
+        instanceFactory = createHazelcastInstanceFactory(2);
+        instances = new HazelcastInstance[2];
+        for (int i = 0; i < instances.length; i++) {
+            instances[i] = instanceFactory.newHazelcastInstance(config);
+        }
     }
 
     @Override
     protected void onTearDown() {
-        hz.shutdown();
+        instanceFactory.shutdownAll();
     }
 
     @Test
-    public void testGetCacheEntry() throws Exception {
-        GetCacheEntryRequest request = new GetCacheEntryRequest("string", "test", "1");
-        ICacheManager hazelcastCacheManager = hz.getCacheManager();
-        ICache<String, String> cache = hazelcastCacheManager.getCache("test");
-        cache.put("1", "one");
+    public void testGetCacheEntry_string() {
+        String key = randomString();
 
-        JsonObject jsonObject = new JsonObject();
-        request.writeResponse(managementCenterService, jsonObject);
-        JsonObject result = (JsonObject) jsonObject.get("result");
-        assertEquals("one", result.get("cacheBrowse_value").asString());
+        cacheManager.getCache(cacheName).put(key, value);
+
+        JsonObject result = sendRequestToInstance(instances[0], new GetCacheEntryRequest("string", cacheName, key));
+        assertEquals(value, result.get("cacheBrowse_value").asString());
+    }
+
+    @Test
+    public void testGetCacheEntry_long() {
+        long key = random.nextLong();
+
+        cacheManager.getCache(cacheName).put(key, value);
+
+        JsonObject result = sendRequestToInstance(instances[0],
+                new GetCacheEntryRequest("long", cacheName, String.valueOf(key)));
+        assertEquals(value, result.get("cacheBrowse_value").asString());
+    }
+
+    @Test
+    public void testGetCacheEntry_integer() {
+        int key = random.nextInt();
+
+        cacheManager.getCache(cacheName).put(key, value);
+
+        JsonObject result = sendRequestToInstance(instances[0],
+                new GetCacheEntryRequest("integer", cacheName, String.valueOf(key)));
+        assertEquals(value, result.get("cacheBrowse_value").asString());
+    }
+
+    @Test
+    public void testGetCacheEntry_remoteMember() {
+        Cache<String, String> cache = cacheManager.getCache(cacheName);
+
+        String key = generateKeyOwnedBy(instances[0]);
+        String value = randomString();
+
+        cache.put(key, value);
+
+        JsonObject result = sendRequestToInstance(instances[1], new GetCacheEntryRequest("string", cacheName, key));
+        assertEquals(value, result.get("cacheBrowse_value").asString());
+    }
+
+    @Test
+    public void testGetCacheEntry_missingKey() {
+        String key = generateKeyOwnedBy(instances[1]);
+
+        JsonObject result = sendRequestToInstance(instances[0], new GetCacheEntryRequest("string", cacheName, key));
+        assertNull(result.get("cacheBrowse_value"));
+    }
+
+    private JsonObject sendRequestToInstance(HazelcastInstance instance, GetCacheEntryRequest request) {
+        ManagementCenterService managementCenterService = getNode(instance).getManagementCenterService();
+        JsonObject responseJson = new JsonObject();
+        request.writeResponse(managementCenterService, responseJson);
+        return (JsonObject) responseJson.get("result");
     }
 }


### PR DESCRIPTION
GetCacheEntryRequest is used by MC to browse cache entries. Currently,
the EntryProcessor it uses is not serializable and doesn't work for
keys on remote members, causing deserialization failure on the member
when it tries to get the entry from another member. This commit makes
both the EntryProcessor used and its return type serializable.

Fixes hazelcast/management-center#603

Forward port of https://github.com/hazelcast/hazelcast/pull/11985

(cherry picked from commit c84483b and 27162c6)