### PR TITLE
start expiration task lazily

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
@@ -110,7 +110,8 @@ public final class ExpirationTimeSetter {
      */
     public static void setTTLAndUpdateExpiryTime(long operationTTLMillis, Record record,
                                                  MapConfig mapConfig, boolean entryCreated) {
-        record.setTtl(pickTTLMillis(operationTTLMillis, record.getTtl(), mapConfig, entryCreated));
+        long ttlMillis = pickTTLMillis(operationTTLMillis, record.getTtl(), mapConfig, entryCreated);
+        record.setTtl(ttlMillis);
 
         long maxIdleMillis = calculateMaxIdleMillis(mapConfig);
         setExpirationTime(record, maxIdleMillis);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -49,6 +49,12 @@ public class ClearExpiredOperation extends AbstractLocalOperation implements Par
 
     @Override
     public void run() throws Exception {
+        if (getNodeEngine().getLocalMember().isLiteMember()) {
+            // this operation shouldn't run on lite members. This situation can potentially be seen
+            // when converting a data-member to lite-member during merge operations.
+            return;
+        }
+
         MapService mapService = getService();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -177,6 +177,10 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         if (ttl > 0L && ttl < Long.MAX_VALUE) {
             hasEntryWithCustomTTL = true;
         }
+
+        if (isRecordStoreExpirable()) {
+            mapServiceContext.getExpirationManager().scheduleExpirationTask();
+        }
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -154,6 +154,11 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         scheduleWithRepetition(completableFutureTask, INITIAL_DELAY, PERIOD, TimeUnit.MILLISECONDS);
     }
 
+    // only used in tests
+    public LoggingScheduledExecutor getScheduledExecutorService() {
+        return scheduledExecutorService;
+    }
+
     @Override
     public ManagedExecutorService register(String name, int defaultPoolSize, int defaultQueueCapacity, ExecutorType type) {
         ExecutorConfig config = nodeEngine.getConfig().getExecutorConfigs().get(name);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerStressTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.eviction;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ExpirationManagerStressTest extends HazelcastTestSupport {
+
+    @Test
+    public void ensure_expiration_task_started_after_many_concurrent_start_stops() {
+        final ExpirationManager expirationManager = getExpirationManager(createHazelcastInstance());
+
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        LinkedList<Thread> threads = new LinkedList<Thread>();
+
+        for (int j = 0; j < 2; j++) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        ClusterState[] states = ClusterState.values();
+                        for (final ClusterState state : states) {
+                            expirationManager.onClusterStateChange(state);
+                        }
+                        expirationManager.onClusterStateChange(ClusterState.ACTIVE);
+                    }
+                }
+            };
+
+            threads.add(thread);
+        }
+
+        for (int i = 0; i < 2; i++) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        LifecycleEvent.LifecycleState[] lifecycleStates = LifecycleEvent.LifecycleState.values();
+                        for (final LifecycleEvent.LifecycleState lifecycleState : lifecycleStates) {
+                            expirationManager.stateChanged(new LifecycleEvent(lifecycleState));
+                        }
+                        expirationManager.stateChanged(new LifecycleEvent(LifecycleEvent.LifecycleState.MERGED));
+                    }
+                }
+            };
+
+            threads.add(thread);
+        }
+
+        for (int i = 0; i < 2; i++) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        expirationManager.scheduleExpirationTask();
+                        expirationManager.unscheduleExpirationTask();
+                        expirationManager.scheduleExpirationTask();
+                    }
+                }
+            };
+
+            threads.add(thread);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        sleepSeconds(5);
+        stop.set(true);
+
+        assertJoinable(threads.toArray(new Thread[threads.size()]));
+
+        assertTrue(expirationManager.isScheduled());
+    }
+
+    static ExpirationManager getExpirationManager(HazelcastInstance node) {
+        MapService mapService = getNodeEngineImpl(node).getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        return mapServiceContext.getExpirationManager();
+    }
+}


### PR DESCRIPTION
Previously expiration task is scheduled whenever map-service is started. But with this PR, it will be started when it is needed. For example, when member type is lite, it will not be started and for example, task-start will wait until first put with expiry.