### PR TITLE
Additional Flake ID changes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddLockConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMultiMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddQueueConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableIdGeneratorConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableTopicConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReplicatedMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddRingbufferConfigCodec;
@@ -69,6 +70,7 @@ import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -376,6 +378,14 @@ public class ClientDynamicClusterConfig extends Config {
         ClientMessage request = DynamicConfigAddEventJournalConfigCodec.encodeRequest(eventJournalConfig.getMapName(),
                 eventJournalConfig.getCacheName(), eventJournalConfig.isEnabled(), eventJournalConfig.getCapacity(),
                 eventJournalConfig.getTimeToLiveSeconds());
+        invoke(request);
+        return this;
+    }
+
+    @Override
+    public Config addReliableIdGeneratorConfig(ReliableIdGeneratorConfig reliableIdGeneratorConfig) {
+        ClientMessage request = DynamicConfigAddReliableIdGeneratorConfigCodec.encodeRequest(reliableIdGeneratorConfig.getName(),
+                reliableIdGeneratorConfig.getPrefetchCount(), reliableIdGeneratorConfig.getPrefetchValidityMillis());
         invoke(request);
         return this;
     }
@@ -1043,6 +1053,26 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public Config setUserCodeDeploymentConfig(UserCodeDeploymentConfig userCodeDeploymentConfig) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public ReliableIdGeneratorConfig getReliableIdGeneratorConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setReliableIdGeneratorConfigs(Map<String, ReliableIdGeneratorConfig> map) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
@@ -668,7 +668,7 @@
                     <xs:documentation>
                         For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.
                         Time unit is milliseconds.
-                        If value is &lt;= 0, validity is unlimited. Default value is 10000 (10 seconds).
+                        If value is &lt;= 0, validity is unlimited. Default value is 600,000 (10 minutes).
                         The IDs contain timestamp component, which ensures rough global ordering of IDs. If an ID
                         is assigned to an event that occurred much later, it will be much out of order.
                         If you don't need ordering, set this value to 0.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
@@ -650,7 +650,7 @@
     </xs:complexType>
     <xs:complexType name="reliable-id-generator">
         <xs:all>
-            <xs:element name="prefetch-count" minOccurs="0">
+            <xs:element name="prefetch-count" minOccurs="0" default="100">
                 <xs:annotation>
                     <xs:documentation>
                         How many IDs are pre-fetched on the background when one call to newId() is made.
@@ -663,7 +663,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="prefetch-validity-millis" type="xs:long" minOccurs="0">
+            <xs:element name="prefetch-validity-millis" type="xs:long" minOccurs="0" default="600000">
                 <xs:annotation>
                     <xs:documentation>
                         For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -159,7 +159,7 @@
 
     <reliable-id-generator name="default">
         <prefetch-count>100</prefetch-count>
-        <prefetch-validity-millis>10000</prefetch-validity-millis>
+        <prefetch-validity-millis>600000</prefetch-validity-millis>
     </reliable-id-generator>
 
     <query-caches>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -2924,12 +2924,12 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attribute name="prefetchValidityMillis" type="xs:long" default="10000" use="optional">
+        <xs:attribute name="prefetchValidityMillis" type="xs:long" default="600000" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.
                     Time unit is milliseconds.
-                    If value is &lt;= 0, validity is unlimited. Default value is 10000 (10 seconds).
+                    If value is &lt;= 0, validity is unlimited. Default value is 600,000 (10 minutes).
                     The IDs contain timestamp component, which ensures rough global ordering of IDs. If an ID
                     is assigned to an event that occurred much later, it will be much out of order.
                     If you don't need ordering, set this value to 0.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -34,6 +34,7 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddLockConfigMessag
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMultiMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddQueueConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableIdGeneratorConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableTopicConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReplicatedMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddRingbufferConfigMessageTask;
@@ -44,7 +45,6 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddTopicConfigMessa
 import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableExecutorDisposeResultMessageTask;
 import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableExecutorRetrieveAndDisposeResultMessageTask;
 import com.hazelcast.client.impl.protocol.task.executorservice.durable.DurableExecutorRetrieveResultMessageTask;
-import com.hazelcast.reliableidgen.impl.client.NewIdBatchMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapAggregateMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapAggregateWithPredicateMessageTask;
 import com.hazelcast.client.impl.protocol.task.map.MapEventJournalReadTask;
@@ -72,6 +72,7 @@ import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecut
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorTaskIsDoneFromPartitionMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.reliableidgen.impl.client.NewIdBatchMessageTask;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -2049,6 +2050,11 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.DynamicConfigAddEventJournalConfigCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new AddEventJournalConfigMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableIdGeneratorConfigCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new AddReliableIdGeneratorConfigMessageTask(clientMessage, node, connection);
             }
         };
 //endregion

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableIdGeneratorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableIdGeneratorConfigMessageTask.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.dynamicconfig;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableIdGeneratorConfigCodec;
+import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public class AddReliableIdGeneratorConfigMessageTask
+        extends AbstractAddConfigMessageTask<DynamicConfigAddReliableIdGeneratorConfigCodec.RequestParameters> {
+
+    public AddReliableIdGeneratorConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected DynamicConfigAddReliableIdGeneratorConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return DynamicConfigAddReliableIdGeneratorConfigCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return DynamicConfigAddReliableIdGeneratorConfigCodec.encodeResponse();
+    }
+
+    @Override
+    protected IdentifiedDataSerializable getConfig() {
+        ReliableIdGeneratorConfig config = new ReliableIdGeneratorConfig(parameters.name);
+        config.setPrefetchCount(parameters.prefetchCount);
+        config.setPrefetchValidityMillis(parameters.prefetchValidity);
+        return config;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "addReliableIdGeneratorConfig";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableIdGeneratorConfig.java
@@ -43,7 +43,7 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
     /**
      * Default value for {@link #getPrefetchValidityMillis()}.
      */
-    public static final long DEFAULT_PREFETCH_VALIDITY_MILLIS = 10000;
+    public static final long DEFAULT_PREFETCH_VALIDITY_MILLIS = 600000;
 
     private String name;
     private int prefetchCount = DEFAULT_PREFETCH_COUNT;
@@ -130,7 +130,7 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
      * <p>
      * Time unit is milliseconds.
      * <p>
-     * If value is &lt;= 0, validity is unlimited. Default value is 10000 (10 seconds).
+     * If value is &lt;= 0, validity is unlimited. Default value is 600,000 (10 minutes).
      * <p>
      * The IDs contain timestamp component, which ensures rough global ordering of IDs. If an ID
      * is assigned to an event that occurred much later, it will be much out of order. If you don't need

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/ReliableIdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/ReliableIdGenerator.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.internal.cluster.ClusterService;
 
 /**
- * Creates cluster-wide unique ID generator. Generated IDs are {@code long} primitive values
+ * A cluster-wide unique ID generator. Generated IDs are {@code long} primitive values
  * and are k-ordered (roughly ordered). IDs are in the range from {@code Long.MIN_VALUE} to
  * {@code Long.MAX_VALUE}. This type of generator is generally known as Flake ID generator.
  * <p>

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxy.java
@@ -63,7 +63,7 @@ public class ReliableIdGeneratorProxy
     private final ILogger logger;
 
     /**
-     * The highest timestamp|seq value returned so far. The value is not shifted to most significant bits.
+     * The next timestamp|seq value to be returned. The value is not shifted to most significant bits.
      */
     private final AtomicLong generatedValue = new AtomicLong(Long.MIN_VALUE);
 
@@ -89,6 +89,8 @@ public class ReliableIdGeneratorProxy
                         return ReliableIdGeneratorProxy.this.newIdBatch(batchSize);
                     }
                 });
+
+        logger.finest("Created ReliableIdGeneratorProxy, name='" + name + "'");
     }
 
     @Override
@@ -186,6 +188,7 @@ public class ReliableIdGeneratorProxy
 
         // we ignore possible double initialization
         this.nodeId = nodeId;
+        logger.fine("Node ID assigned to '" + name + "': " + nodeId);
         return nodeId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxy.java
@@ -90,7 +90,9 @@ public class ReliableIdGeneratorProxy
                     }
                 });
 
-        logger.finest("Created ReliableIdGeneratorProxy, name='" + name + "'");
+        if (logger.isFinestEnabled()) {
+            logger.finest("Created ReliableIdGeneratorProxy, name='" + name + "'");
+        }
     }
 
     @Override
@@ -188,7 +190,9 @@ public class ReliableIdGeneratorProxy
 
         // we ignore possible double initialization
         this.nodeId = nodeId;
-        logger.fine("Node ID assigned to '" + name + "': " + nodeId);
+        if (logger.isFineEnabled()) {
+            logger.fine("Node ID assigned to '" + name + "': " + nodeId);
+        }
         return nodeId;
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -3381,7 +3381,7 @@
 
     <xs:complexType name="reliable-id-generator">
         <xs:all>
-            <xs:element name="prefetch-count" minOccurs="0">
+            <xs:element name="prefetch-count" minOccurs="0" default="100">
                 <xs:annotation>
                     <xs:documentation>
                         How many IDs are pre-fetched on the background when one call to newId() is made.
@@ -3394,7 +3394,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="prefetch-validity-millis" type="xs:long" minOccurs="0">
+            <xs:element name="prefetch-validity-millis" type="xs:long" minOccurs="0" default="600000">
                 <xs:annotation>
                     <xs:documentation>
                         For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -3399,7 +3399,7 @@
                     <xs:documentation>
                         For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.
                         Time unit is milliseconds.
-                        If value is &lt;= 0, validity is unlimited. Default value is 10000 (10 seconds).
+                        If value is &lt;= 0, validity is unlimited. Default value is 600,000 (10 minutes).
                         The IDs contain timestamp component, which ensures rough global ordering of IDs. If an ID
                         is assigned to an event that occurred much later, it will be much out of order.
                         If you don't need ordering, set this value to 0.

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -271,7 +271,7 @@
 
     <reliable-id-generator name="default">
         <prefetch-count>100</prefetch-count>
-        <prefetch-validity-millis>10000</prefetch-validity-millis>
+        <prefetch-validity-millis>600000</prefetch-validity-millis>
     </reliable-id-generator>
 
     <atomic-long name="default">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1555,14 +1555,14 @@ https://hazelcast.org/documentation/.
         * <prefetch-validity-millis>:
         For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.
         Time unit is milliseconds.
-        If value is <= 0, validity is unlimited. Default value is 10000 (10 seconds).
+        If value is <= 0, validity is unlimited. Default value is 600,000 (10 minutes).
         The IDs contain timestamp component, which ensures rough global ordering of IDs. If an ID
         is assigned to an event that occurred much later, it will be much out of order. If you don't need
         ordering, set this value to 0.
     -->
     <reliable-id-generator name="default">
         <prefetch-count>100</prefetch-count>
-        <prefetch-validity-millis>10000</prefetch-validity-millis>
+        <prefetch-validity-millis>600000</prefetch-validity-millis>
     </reliable-id-generator>
 
     <!--

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -47,6 +47,7 @@ import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
+import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -530,6 +531,15 @@ public class DynamicConfigTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testReliableIdGeneratorConfig() {
+        ReliableIdGeneratorConfig config = new ReliableIdGeneratorConfig(randomName())
+                .setPrefetchCount(123)
+                .setPrefetchValidityMillis(456);
+        driver.getConfig().addReliableIdGeneratorConfig(config);
+        assertConfigurationsEqualsOnAllMembers(config);
+    }
+
+    @Test
     public void testSemaphoreConfig() {
         SemaphoreConfig semaphoreConfig = new SemaphoreConfig()
                 .setName(name)
@@ -744,6 +754,13 @@ public class DynamicConfigTest extends HazelcastTestSupport {
             assertEquals(cacheEventJournalConfig, registeredConfig);
             registeredConfig = instance.getConfig().getMapEventJournalConfig(mapName);
             assertEquals(mapEventJournalConfig, registeredConfig);
+        }
+    }
+
+    private void assertConfigurationsEqualsOnAllMembers(ReliableIdGeneratorConfig config) {
+        for (HazelcastInstance instance : members) {
+            ReliableIdGeneratorConfig registeredConfig = instance.getConfig().getReliableIdGeneratorConfig(config.getName());
+            assertEquals(config, registeredConfig);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.6.0-3</client.protocol.version>
+        <client.protocol.version>1.6.0-4</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
- Add support in `ClientDynamicClusterConfig`
- Change default prefetch-validity to 10 minutes