### PR TITLE
Converted query results to object memory format while creating query-…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
@@ -16,15 +16,20 @@
 
 package com.hazelcast.map.impl.tx;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Wrapper for value objects with type information.
  */
-public class TxnValueWrapper {
+class TxnValueWrapper {
 
     Object value;
     Type type;
 
-    public TxnValueWrapper(Object value, Type type) {
+    TxnValueWrapper(@Nullable Object value, @Nonnull Type type) {
+        assert type != null;
+
         this.value = value;
         this.type = type;
     }


### PR DESCRIPTION
…result-set if txn is not originated from client

- Added tx.isOriginatedFromClient()

closes https://github.com/hazelcast/hazelcast/issues/12016

- [ ] Backport to maintenance