### PR TITLE
[BACKPORT]Converted query results to object memory format while creating query-…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
@@ -16,15 +16,20 @@
 
 package com.hazelcast.map.impl.tx;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Wrapper for value objects with type information.
  */
-public class TxnValueWrapper {
+class TxnValueWrapper {
 
     Object value;
     Type type;
 
-    public TxnValueWrapper(Object value, Type type) {
+    TxnValueWrapper(@Nullable Object value, @Nonnull Type type) {
+        assert type != null;
+
         this.value = value;
         this.type = type;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionRegressionTest.java
@@ -30,7 +30,8 @@ import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
@@ -49,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(NightlyTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MapTransactionRegressionTest extends HazelcastTestSupport {
 
     private final TransactionOptions options = new TransactionOptions()


### PR DESCRIPTION
…result-set if txn is not originated from client

- fixed is cherry-picked  from https://github.com/hazelcast/hazelcast/pull/12050
- additionally set category of `MapTransactionRegressionTest` to quick