### PR TITLE
Fixed lost CollectionItems on backup promotion in ISet and IList

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddOperation.java
@@ -27,10 +27,12 @@ import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.INVALID_ITEM_ID;
+
 public class CollectionAddOperation extends CollectionBackupAwareOperation implements MutatingOperation {
 
     protected Data value;
-    protected long itemId = -1;
+    protected long itemId = INVALID_ITEM_ID;
 
     public CollectionAddOperation() {
     }
@@ -42,7 +44,7 @@ public class CollectionAddOperation extends CollectionBackupAwareOperation imple
 
     @Override
     public boolean shouldBackup() {
-        return itemId != -1;
+        return itemId != INVALID_ITEM_ID;
     }
 
     @Override
@@ -56,12 +58,12 @@ public class CollectionAddOperation extends CollectionBackupAwareOperation imple
             CollectionContainer collectionContainer = getOrCreateContainer();
             itemId = collectionContainer.add(value);
         }
-        response = itemId != -1;
+        response = itemId != INVALID_ITEM_ID;
     }
 
     @Override
     public void afterRun() throws Exception {
-        if (itemId != -1) {
+        if (itemId != INVALID_ITEM_ID) {
             publishEvent(ItemEventType.ADDED, value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveOperation.java
@@ -28,10 +28,12 @@ import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.INVALID_ITEM_ID;
+
 public class CollectionRemoveOperation extends CollectionBackupAwareOperation implements MutatingOperation {
 
     private Data value;
-    private long itemId = -1;
+    private long itemId = INVALID_ITEM_ID;
 
     public CollectionRemoveOperation() {
     }
@@ -54,14 +56,14 @@ public class CollectionRemoveOperation extends CollectionBackupAwareOperation im
 
     @Override
     public void afterRun() throws Exception {
-        if (itemId != -1) {
+        if (itemId != INVALID_ITEM_ID) {
             publishEvent(ItemEventType.REMOVED, value);
         }
     }
 
     @Override
     public boolean shouldBackup() {
-        return itemId != -1;
+        return itemId != INVALID_ITEM_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
@@ -25,13 +25,13 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static java.util.Collections.sort;
 
 public class ListContainer extends CollectionContainer {
 
@@ -156,7 +156,7 @@ public class ListContainer extends CollectionContainer {
         }
         final ArrayList<Data> sub = new ArrayList<Data>(list.size());
         for (CollectionItem item : list) {
-            sub.add((Data) item.getValue());
+            sub.add(item.getValue());
         }
         return sub;
     }
@@ -166,7 +166,9 @@ public class ListContainer extends CollectionContainer {
         if (itemList == null) {
             if (itemMap != null && !itemMap.isEmpty()) {
                 itemList = new ArrayList<CollectionItem>(itemMap.values());
-                Collections.sort(itemList);
+                sort(itemList);
+                CollectionItem lastItem = itemList.get(itemList.size() - 1);
+                setId(lastItem.getItemId() + ID_PROMOTION_OFFSET);
                 itemMap.clear();
             } else {
                 itemList = new ArrayList<CollectionItem>(INITIAL_CAPACITY);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetOperation.java
@@ -29,12 +29,14 @@ import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.INVALID_ITEM_ID;
+
 public class ListSetOperation extends CollectionBackupAwareOperation implements MutatingOperation {
 
     private int index;
     private Data value;
-    private long itemId = -1;
-    private long oldItemId = -1;
+    private long itemId = INVALID_ITEM_ID;
+    private long oldItemId = INVALID_ITEM_ID;
 
     public ListSetOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.ID_PROMOTION_OFFSET;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.MapUtil.createLinkedHashMap;
 import static com.hazelcast.util.SetUtil.createHashSet;
@@ -60,7 +61,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
  */
 @SuppressWarnings("checkstyle:methodcount")
 public class QueueContainer implements IdentifiedDataSerializable {
-    private static final int ID_PROMOTION_OFFSET = 100000;
+
     /**
      * Contains item ID to queue item mappings for current transactions
      */

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
@@ -31,10 +31,12 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.SetUtil.createHashSet;
 
 public class SetContainer extends CollectionContainer {
 
     private static final int INITIAL_CAPACITY = 1000;
+
     private Set<CollectionItem> itemSet;
     private SetConfig config;
 
@@ -75,7 +77,15 @@ public class SetContainer extends CollectionContainer {
     public Set<CollectionItem> getCollection() {
         if (itemSet == null) {
             if (itemMap != null && !itemMap.isEmpty()) {
-                itemSet = new HashSet<CollectionItem>(itemMap.values());
+                itemSet = createHashSet(itemMap.size());
+                long maxItemId = Long.MIN_VALUE;
+                for (CollectionItem collectionItem : itemMap.values()) {
+                    if (collectionItem.getItemId() > maxItemId) {
+                        maxItemId = collectionItem.getItemId();
+                    }
+                    itemSet.add(collectionItem);
+                }
+                setId(maxItemId + ID_PROMOTION_OFFSET);
                 itemMap.clear();
             } else {
                 itemSet = new HashSet<CollectionItem>(INITIAL_CAPACITY);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.INVALID_ITEM_ID;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -109,7 +110,7 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
 
         Data value = getNodeEngine().toData(e);
         Iterator<CollectionItem> iterator = getCollection().iterator();
-        long reservedItemId = -1;
+        long reservedItemId = INVALID_ITEM_ID;
         while (iterator.hasNext()) {
             CollectionItem item = iterator.next();
             if (value.equals(item.getValue())) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveRemoveOperation.java
@@ -26,11 +26,13 @@ import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.INVALID_ITEM_ID;
+
 public class CollectionReserveRemoveOperation extends CollectionOperation implements MutatingOperation {
 
     private String transactionId;
     private Data value;
-    private long reservedItemId = -1;
+    private long reservedItemId = INVALID_ITEM_ID;
 
     public CollectionReserveRemoveOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
@@ -32,6 +32,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.collection.impl.collection.CollectionContainer.INVALID_ITEM_ID;
+
 public class TransactionalSetProxy<E>
         extends AbstractTransactionalCollectionProxy<SetService, E>
         implements TransactionalSet<E> {
@@ -48,7 +50,7 @@ public class TransactionalSetProxy<E>
         checkObjectNotNull(e);
 
         Data value = getNodeEngine().toData(e);
-        if (!getCollection().add(new CollectionItem(-1, value))) {
+        if (!getCollection().add(new CollectionItem(INVALID_ITEM_ID, value))) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/AbstractCollectionBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/AbstractCollectionBackupTest.java
@@ -25,30 +25,95 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import java.util.Collection;
 
-import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupList;
-import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupQueue;
-import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public abstract class AbstractCollectionBackupTest extends HazelcastTestSupport {
 
-    protected enum CollectionType {
-        LIST,
-        QUEUE,
-        SET
-    }
-
-    protected static final int ITEM_COUNT = 1000;
     protected static final int BACKUP_COUNT = 4;
 
-    protected static final ILogger LOGGER = Logger.getLogger(AbstractCollectionBackupTest.class);
+    private static final int ITEM_COUNT = 1000;
+
+    private static final ILogger LOGGER = Logger.getLogger(AbstractCollectionBackupTest.class);
 
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
     protected Config config = new Config();
 
-    protected final void testBackups(CollectionType collectionType, String collectionName, int partitionId) {
+    /**
+     * Returns an instance of a Hazelcast collection, e.g. {@link com.hazelcast.core.ISet}.
+     *
+     * @param instance the {@link HazelcastInstance} to retrieve the collection from
+     * @param name     the name of the collection
+     * @return an instance of a Hazelcast collection
+     */
+    protected abstract Collection<Integer> getHazelcastCollection(HazelcastInstance instance, String name);
+
+    /**
+     * Returns the backup values of a Hazelcast collection.
+     *
+     * @param instance the {@link HazelcastInstance} to retrieve the backup values from
+     * @param name     the name of the collection
+     * @return the backup values of a Hazelcast collection
+     */
+    protected abstract Collection<Integer> getBackupCollection(HazelcastInstance instance, String name);
+
+    /**
+     * Returns the partition ID of the given Hazelcast collection.
+     *
+     * @param collection the Hazelcast collection to retrieve the partition ID from
+     * @return the partition ID of the Hazelcast collection
+     */
+    protected abstract int getPartitionId(Collection collection);
+
+    protected final void testBackupPromotionInternal() {
+        HazelcastInstance[] instances = factory.newInstances(config, 3);
+        HazelcastInstance ownerInstance = instances[0];
+
+        // we add items to the collection, so backups are created on promotedInstance
+        String collectionName = generateKeyOwnedBy(ownerInstance);
+        Collection<Integer> collection = getHazelcastCollection(ownerInstance, collectionName);
+        for (int item = 0; item < ITEM_COUNT / 2; item++) {
+            collection.add(item);
+        }
+
+        int partitionId = getPartitionId(collection);
+        LOGGER.info("Collection " + collectionName + " is stored in partition " + partitionId);
+        HazelcastInstance promotedInstance = getBackupInstance(instances, partitionId, 1);
+        HazelcastInstance backupInstance = getBackupInstance(instances, partitionId, 2);
+
+        // we terminate the ownerInstance, so the backups on promotedInstance have to be promoted
+        factory.terminate(ownerInstance);
+        waitAllForSafeState(factory.getAllHazelcastInstances());
+
+        // we add additional items to the collection, so new backups have to be created on backupInstance
+        collection = getHazelcastCollection(promotedInstance, collectionName);
+        for (int item = ITEM_COUNT / 2; item < ITEM_COUNT; item++) {
+            collection.add(item);
+        }
+        assertEqualsStringFormat("collection should contain %d items, but found %d", ITEM_COUNT, collection.size());
+
+        // we check the backups on the backupInstance, which should contain the old and new items
+        Collection<Integer> backupCollection = getBackupCollection(backupInstance, collectionName);
+        assertEqualsStringFormat("backupCollection should contain %d items, but found %d",
+                ITEM_COUNT, backupCollection.size());
+        for (int item = 0; item < ITEM_COUNT; item++) {
+            assertTrue("backupCollection should contain item " + item, backupCollection.contains(item));
+        }
+    }
+
+    protected final void testBackupMigrationInternal() {
+        HazelcastInstance ownerInstance = factory.newHazelcastInstance(config);
+
+        // create items in the collection
+        String collectionName = generateKeyOwnedBy(ownerInstance);
+        Collection<Integer> collection = getHazelcastCollection(ownerInstance, collectionName);
+        for (int item = 0; item < ITEM_COUNT; item++) {
+            collection.add(item);
+        }
+
+        int partitionId = getPartitionId(collection);
+        LOGGER.info("Collection " + collectionName + " is stored in partition " + partitionId);
+
         // scale up
         LOGGER.info("Scaling up to " + (BACKUP_COUNT + 1) + " members...");
         for (int backupCount = 1; backupCount <= BACKUP_COUNT; backupCount++) {
@@ -56,7 +121,7 @@ public abstract class AbstractCollectionBackupTest extends HazelcastTestSupport 
             waitAllForSafeState(factory.getAllHazelcastInstances());
             assertEquals(backupCount + 1, factory.getAllHazelcastInstances().iterator().next().getCluster().getMembers().size());
 
-            assertBackupCollection(collectionType, collectionName, partitionId, backupCount);
+            assertBackupCollection(collectionName, partitionId, backupCount);
         }
 
         // scale down
@@ -66,31 +131,17 @@ public abstract class AbstractCollectionBackupTest extends HazelcastTestSupport 
             waitAllForSafeState(factory.getAllHazelcastInstances());
             assertEquals(backupCount + 1, factory.getAllHazelcastInstances().iterator().next().getCluster().getMembers().size());
 
-            assertBackupCollection(collectionType, collectionName, partitionId, backupCount);
+            assertBackupCollection(collectionName, partitionId, backupCount);
         }
     }
 
-    private void assertBackupCollection(CollectionType collectionType, String collectionName, int partitionId, int backupCount) {
+    private void assertBackupCollection(String collectionName, int partitionId, int backupCount) {
         HazelcastInstance[] instances = factory.getAllHazelcastInstances().toArray(new HazelcastInstance[0]);
         LOGGER.info("Testing " + backupCount + " backups on " + instances.length + " members");
 
         for (int i = 1; i <= backupCount; i++) {
             HazelcastInstance backupInstance = getBackupInstance(instances, partitionId, i);
-            Collection<Integer> backupCollection = null;
-            switch (collectionType) {
-                case LIST:
-                    backupCollection = getBackupList(backupInstance, collectionName);
-                    break;
-                case QUEUE:
-                    backupCollection = getBackupQueue(backupInstance, collectionName);
-                    break;
-                case SET:
-                    backupCollection = getBackupSet(backupInstance, collectionName);
-                    break;
-                default:
-                    fail("Unknown collectionType " + collectionType);
-            }
-
+            Collection<Integer> backupCollection = getBackupCollection(backupInstance, collectionName);
             assertEqualsStringFormat("expected %d items in backupCollection, but found %d", ITEM_COUNT, backupCollection.size());
             for (int item = 0; item < ITEM_COUNT; item++) {
                 assertTrue("backupCollection should contain item " + item, backupCollection.contains(item));


### PR DESCRIPTION
* fixed lost `CollectionItem`s in `ISet` and `IList` by setting correct `itemId` on backup promotion
* added constant `INVALID_ITEM_ID` to replace magic number `-1`
* added tests to check backup count and content when adding new backups after backup promotion

The issue just occurs on backup promotions, so not on a graceful shutdown (which will trigger a replication/migration). This is why we see it in the split-brain scenario and when using `terminate()`.

This issue was already fixed for `IQueue` via https://github.com/hazelcast/hazelcast/pull/2844 and https://github.com/hazelcast/hazelcast/pull/4275 and applies the same fix for `ISet` and `IQueue`. After the review I also plan to backport this (which needs to include my first PR with the collection backup tests).

Fixes https://github.com/hazelcast/hazelcast/issues/11930
Backport https://github.com/hazelcast/hazelcast/pull/12064
  