### PR TITLE
Revision on logic of choosing new address for owner connection

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -928,7 +928,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         addresses.addAll(providerAddresses);
 
         if (previousOwnerConnectionAddress != null) {
-            putPreviousOwnerAddressToLast(addresses);
+            /*
+             * Previous owner address is moved to last item in set so that client will not try to connect to same one immediately.
+             * It could be the case that address is removed because it is healthy(it not responding to heartbeat/pings)
+             * In that case, trying other addresses first to upgrade make more sense.
+             */
+            addresses.remove(previousOwnerConnectionAddress);
+            addresses.add(previousOwnerConnectionAddress);
         }
         return addresses;
     }
@@ -939,11 +945,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         Set<T> shuffledSet = new LinkedHashSet<T>();
         shuffledSet.addAll(shuffleMe);
         return shuffledSet;
-    }
-
-    private void putPreviousOwnerAddressToLast(Set<Address> addresses) {
-        addresses.remove(previousOwnerConnectionAddress);
-        addresses.add(previousOwnerConnectionAddress);
     }
 
     private ExecutorService createSingleThreadExecutorService(HazelcastClientInstanceImpl client) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -75,6 +75,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -130,6 +131,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     private final NioEventLoopGroup eventLoopGroup;
 
     private volatile Address ownerConnectionAddress;
+    private volatile Address previousOwnerConnectionAddress;
 
     private HeartbeatManager heartbeat;
     private volatile ClientPrincipal principal;
@@ -377,6 +379,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     }
 
     private void setOwnerConnectionAddress(Address ownerConnectionAddress) {
+        this.previousOwnerConnectionAddress = this.ownerConnectionAddress;
         this.ownerConnectionAddress = ownerConnectionAddress;
     }
 
@@ -901,8 +904,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
     }
 
-    private Collection<Address> getPossibleMemberAddresses() {
-        final List<Address> addresses = new LinkedList<Address>();
+    Collection<Address> getPossibleMemberAddresses() {
+        LinkedHashSet<Address> addresses = new LinkedHashSet<Address>();
 
         Collection<Member> memberList = client.getClientClusterService().getMemberList();
         for (Member member : memberList) {
@@ -910,21 +913,37 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         }
 
         if (shuffleMemberList) {
-            Collections.shuffle(addresses);
+            shuffle(addresses);
         }
 
-        List<Address> providerAddresses = new ArrayList<Address>();
+        LinkedHashSet<Address> providerAddresses = new LinkedHashSet<Address>();
         for (AddressProvider addressProvider : addressProviders) {
             providerAddresses.addAll(addressProvider.loadAddresses());
         }
 
         if (shuffleMemberList) {
-            Collections.shuffle(providerAddresses);
+            shuffle(providerAddresses);
         }
 
         addresses.addAll(providerAddresses);
 
+        if (previousOwnerConnectionAddress != null) {
+            putPreviousOwnerAddressToLast(addresses);
+        }
         return addresses;
+    }
+
+    private static <T> Set<T> shuffle(Set<T> set) {
+        List<T> shuffleMe = new ArrayList<T>(set);
+        Collections.shuffle(shuffleMe);
+        Set<T> shuffledSet = new LinkedHashSet<T>();
+        shuffledSet.addAll(shuffleMe);
+        return shuffledSet;
+    }
+
+    private void putPreviousOwnerAddressToLast(Set<Address> addresses) {
+        addresses.remove(previousOwnerConnectionAddress);
+        addresses.add(previousOwnerConnectionAddress);
     }
 
     private ExecutorService createSingleThreadExecutorService(HazelcastClientInstanceImpl client) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -28,7 +28,7 @@ public final class ClientProperty {
 
     /**
      * Client shuffles the given member list to prevent all clients to connect to the same node when
-     * this property is set to false. When it is set to true, the client tries to connect to the nodes
+     * this property is set to true. When it is set to false, the client tries to connect to the nodes
      * in the given order.
      */
     public static final HazelcastProperty SHUFFLE_MEMBER_LIST

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.connection.nio;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConnectMemberListOrderTest extends ClientTestSupport {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Parameterized.Parameters(name = "shuffleMemberList == {0}")
+    public static Collection<Object[]> params() {
+        return asList(new Object[][]{{"false"}, {"true"}});
+    }
+
+    @Parameterized.Parameter
+    public String shuffleMemberList;
+
+    @After
+    public void cleanup() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testPossibleMemberAddressesAfterDisconnection() throws Exception {
+        HazelcastInstance instance = factory.newHazelcastInstance();
+        ClientConfig config = new ClientConfig();
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), shuffleMemberList);
+        HazelcastInstance client = factory.newHazelcastClient(config);
+
+        final CountDownLatch connectedBack = new CountDownLatch(1);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
+                    connectedBack.countDown();
+                }
+            }
+        });
+
+        factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+
+        makeSureConnectedToServers(client, 3);
+        Address lastConnectedMemberAddress = new Address((InetSocketAddress) instance.getLocalEndpoint().getSocketAddress());
+        instance.shutdown();
+
+        assertOpenEventually(connectedBack);
+
+        Collection<Address> possibleMemberAddresses = getPossibleMemberAddresses(client);
+
+        //make sure last known member list is used. otherwise it returns 2
+        assertEquals(3, possibleMemberAddresses.size());
+
+        //make sure previous owner is not first one to tried in next owner connection selection
+        assertNotEquals(lastConnectedMemberAddress, possibleMemberAddresses.iterator().next());
+    }
+
+    private Collection<Address> getPossibleMemberAddresses(HazelcastInstance client) {
+        HazelcastClientInstanceImpl instanceImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManagerImpl connectionManager = (ClientConnectionManagerImpl) instanceImpl.getConnectionManager();
+        return connectionManager.getPossibleMemberAddresses();
+    }
+
+}
+


### PR DESCRIPTION
1. Duplicates in member list is removed.
2. The previously failed member will be last to be retried.

fixes #12082