### PR TITLE
Changed copyright to 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ Hazelcast is available under the Apache 2 License. Please see the [Licensing sec
 
 #### Copyright
 
-Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 
 Visit [www.hazelcast.com](http://www.hazelcast.com/) for more info.

--- a/checkstyle/ClassHeader.txt
+++ b/checkstyle/ClassHeader.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-all/src/main/assemble/src.xml
+++ b/hazelcast-all/src/main/assemble/src.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-all/src/main/java/com/hazelcast/PlaceHolder.java
+++ b/hazelcast-all/src/main/java/com/hazelcast/PlaceHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-all/src/main/java/com/hazelcast/package-info.java
+++ b/hazelcast-all/src/main/java/com/hazelcast/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/ElementParser.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/ElementParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2012 JBoss by Red Hat
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/package-info.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/ExportPackageViewer.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/ExportPackageViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/InstructionDefinitionTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/InstructionDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/PackageDefinitionTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/PackageDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientOutOfMemoryHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientOutOfMemoryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientNotActiveException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientNotActiveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientOfflineException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientOfflineException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/LoadBalancer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/LoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CallbackAwareClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CallbackAwareClientDelegatingFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheStatisticsImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheStatisticsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/OneShotExecutionCallback.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/OneShotExecutionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientAwsConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientAwsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathXmlConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathXmlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConnectionStrategyConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConnectionStrategyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientIcmpPingConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientIcmpPingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientSecurityConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientSecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientUserCodeDeploymentConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientUserCodeDeploymentConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientXmlElements.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientXmlElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ProxyFactoryConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ProxyFactoryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/QueryCacheConfigBuilderHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/QueryCacheConfigBuilderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/SocketOptions.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/SocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AuthenticationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AuthenticationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientICMPManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientICMPManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientConnectionManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientLockReferenceIdGenerator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientLockReferenceIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientLoggingService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientLoggingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientMessageDecoder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientMessageDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientManagedContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientManagedContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientInvokerWrapper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientInvokerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheScheduler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContextSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ListenerInfo.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ListenerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/QueryCacheToListenerMapper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/QueryCacheToListenerMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapQueryPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapQueryPartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCardinalityEstimatorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCardinalityEstimatorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableIdGeneratorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableIdGeneratorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/AbstractClientTxnCollectionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/AbstractClientTxnCollectionProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTransactionUtil.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTransactionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnListProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMultiMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnSetProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionContextProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionContextProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionContextProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionContextProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientListenerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientPartitionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientPartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxyDescriptor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxyDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxyDescriptorProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxyDescriptorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxyFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientTransactionContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientTransactionManagerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientTransactionManagerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/EventHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientProxyFactoryWithContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientProxyFactoryWithContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientServiceNotFoundException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientServiceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientTransactionManagerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientTransactionManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientUserCodeDeploymentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ConnectionHeartbeatListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ConnectionHeartbeatListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ListenerMessageCodec.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ListenerMessageCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/NonSmartClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/NonSmartClientInvocationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/AbstractClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/AbstractClientListenerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientRegistrationKey.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientRegistrationKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/LazyDistributedObjectEvent.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/LazyDistributedObjectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/AbstractLoadBalancer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/AbstractLoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/AddressHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/AddressHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/RandomLB.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/RandomLB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/RoundRobinLB.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/RoundRobinLB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/StaticLB.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/StaticLB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/package-info.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.0.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.1.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.1.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.2.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.3.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.3.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.4.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.4.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.5.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.5.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.6.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.6.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.7.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.7.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-default.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/classloading/JavaXCacheDependencyClientTest.java
+++ b/hazelcast-client/src/test/java/classloading/JavaXCacheDependencyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
+++ b/hazelcast-client/src/test/java/classloading/ThreadLeakClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientBackpressureBouncingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientExtensionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientListenersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientListenersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientOutOfMemoryHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientOwnershipTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientOwnershipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientProtocolTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientProtocolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ConnectedClientOperationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ConnectedClientOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/MembershipListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/MembershipListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/NonSmartClientRoutingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/NonSmartClientRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/aggregation/ClientAggregatorsSpecTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/aggregation/ClientAggregatorsSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/aggregation/ClientMapAggregateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/aggregation/ClientMapAggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/atomiclong/ClientAtomicLongTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/atomiclong/ClientAtomicLongTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/atomicreference/AtomicReferenceBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/atomicreference/AtomicReferenceBasicClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/atomicreference/ClientAtomicReferenceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/atomicreference/ClientAtomicReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/AbstractClientCachePartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/AbstractClientCachePartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheEntryListenerTestFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheEntryListenerTestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientBasicCacheJournalTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientBasicCacheJournalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheEntryExpiredLatchCountdownListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheEntryExpiredLatchCountdownListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePutAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePutAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientManagerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/DummyClientCachePartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/DummyClientCachePartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/eviction/ClientCacheEvictionPolicyComparatorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/eviction/ClientCacheEvictionPolicyComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/CallbackAwareClientDelegatingFutureTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/CallbackAwareClientDelegatingFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheCreateUseDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheProxyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheStaleReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheRecordStateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheRecordStateStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/CacheMetaDataGeneratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/CacheMetaDataGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheNearCacheSmokeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheNearCacheSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheReconciliationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheReconciliationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/instance/ClientCacheHazelcastInstanceAwareTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/instance/ClientCacheHazelcastInstanceAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/instance/ClientCacheThroughHazelcastInstanceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/instance/ClientCacheThroughHazelcastInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheEntryListenerExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheExpiryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheExpiryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheInvokeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithExpiryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithExpiryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithoutReadThroughTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWithoutReadThroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWriterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheLoaderWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMBStatisticsBeanTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMBStatisticsBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMXBeanTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheMXBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerManagementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CacheWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderClassLoaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CachingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ClientServerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CompletionListenerFutureTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/CompletionListenerFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/DurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/DurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/EntryProcessorExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/EntryProcessorExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ExpiryPolicyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ExpiryPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/FactoryBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/FactoryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/GetTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/GetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/JsrClientTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/MutableConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/PutTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/PutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/RemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/RemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ReplaceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/ReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByReferenceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByValueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/StoreByValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/TypesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/jsr/TypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/stats/ClientCacheStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/stats/ClientCacheStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cardinality/ClientCardinalityEstimatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterServiceMemberListTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterServiceMemberListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientListTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientSetTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/ClientSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/impl/set/SetBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/impl/set/SetBasicClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/InvalidConfigurationClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/InvalidConfigurationClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/LegacyMatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/LegacyMatchingPointConfigPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/MatchingPointConfigPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTestXmlConfig.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connectionstrategy/ConfiguredBehaviourTestXmlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/countdownlatch/ClientCountDownLatchTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/countdownlatch/ClientCountDownLatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/discovery/AwsCloudDiscoveryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/discovery/AwsCloudDiscoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceCancelTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceCancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExecuteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExecuteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceInvokeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceSubmitTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceSubmitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ExecutionDelayTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ExecutionDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ExecutorServiceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ExecutorServiceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutionDelayTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutionDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceExecuteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceExecuteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceSubmitTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceSubmitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableRetrieveResultTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableRetrieveResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/AppendCallable.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/AppendCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/CancellationAwareTask.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/CancellationAwareTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/FailingCallable.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/FailingCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/GetMemberUuidTask.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/GetMemberUuidTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/MapPutPartitionAwareCallable.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/MapPutPartitionAwareCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/MapPutPartitionAwareRunnable.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/MapPutPartitionAwareRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/MapPutRunnable.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/MapPutRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/NullCallable.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/NullCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/SelectAllMembers.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/SelectAllMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/SelectNoMembers.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/tasks/SelectNoMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/helpers/PortableHelpersFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/helpers/PortableHelpersFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/helpers/SimpleClientInterceptor.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/helpers/SimpleClientInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/idgenerator/ClientIdGeneratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/idgenerator/ClientIdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicClusterConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicClusterConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientICacheManagerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientICacheManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggerConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggingServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggingServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/internal/diagnostics/SystemLogPluginConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/internal/diagnostics/SystemLogPluginConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/internal/diagnostics/config/ClientConfigValidatorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/internal/diagnostics/config/ClientConfigValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientExecutionPoolSizeLowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientExecutionPoolSizeLowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestNonSmartRouting.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestNonSmartRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestSmartRouting.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestSmartRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/leak/ListenerLeakTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/loadBalancer/ClientRandomLBTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/loadBalancer/ClientRandomLBTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/loadBalancer/ClientRoundRobinLBTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/loadBalancer/ClientRoundRobinLBTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/loadBalancer/ClientStaticLBTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/loadBalancer/ClientStaticLBTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConcurrentLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConcurrentLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockWithTerminationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockWithTerminationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/LegacyClientConditionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/LegacyClientConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapQueryPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientBasicMapJournalTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientBasicMapJournalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapEvictAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapEvictAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapInMemoryFormatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapInMemoryFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoaderExceptionHandlingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoaderExceptionHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapRemoveAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapRemoveAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTryLockConcurrentTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTryLockConcurrentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_BasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_TxnTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_TxnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWANExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWithIndexCreationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWithIndexCreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPartitionPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPartitionPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryBounceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryBounceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientWriteBehindFlushTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientWriteBehindFlushTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapQueryPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/SimpleClientMapInterceptorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/SimpleClientMapInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/helpers/AMapStore.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/helpers/AMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/helpers/GenericEvent.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/helpers/GenericEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/LocalMapStatsUnderOnGoingClientUpdateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/LocalMapStatsUnderOnGoingClientUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStalenessTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStalenessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapRecordStateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapRecordStateStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheBatchInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheBatchInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/GetAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/GetAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/MapNearCacheInvalidationFromClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/MapNearCacheInvalidationFromClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheStatsStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheStatsStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapReconciliationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapReconciliationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientEvictionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheClientContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheClientContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheDestroyResourcesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheDestroyResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheEventHandlingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheEventHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheEventLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheEventLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheIndexTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheMemoryLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheMethodsWithPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheMethodsWithPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheRecoveryUponEventLossTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheRecoveryUponEventLossTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheSimpleStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheSimpleStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheXmlConfigWithWildcardTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/ClientQueryCacheXmlConfigWithWildcardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/subscriber/TestClientSubscriberContext.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/querycache/subscriber/TestClientSubscriberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/AbstractClientMapReduceJobTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/AbstractClientMapReduceJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientListSetMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientListSetMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMultiMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMultiMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMultiMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMultiMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ListSetMapReduceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ListSetMapReduceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AbstractAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AbstractAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AvgAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AvgAggregationMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AvgAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AvgAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/BaseAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/BaseAggregationMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/BaseAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/BaseAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MapAggregationLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MapAggregationLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MaxAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MaxAggregationMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MaxAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MaxAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MinAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MinAggregationMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MinAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MinAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MultiMapAggregationLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MultiMapAggregationLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/SumAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/SumAggregationMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/SumAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/SumAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenerStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapReturnedCollectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapReturnedCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/oome/OomeOnClientAuthenticationMain.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/oome/OomeOnClientAuthenticationMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/oome/OomeOnClientShutdownMain.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/oome/OomeOnClientShutdownMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/PartitionServiceProxyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/PartitionServiceProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/projection/ClientMapProjectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/projection/ClientMapProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ClientClusterProxyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ClientClusterProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ProxyEqualityTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ProxyEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ProxyManagerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/ProxyManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/txn/ClientTransactionUtilTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/txn/ClientTransactionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientDisruptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientDisruptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueuePerformanceBenchmark.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueuePerformanceBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/QuorumTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/QuorumTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/reliableidgen/impl/ReliableIdGenerator_ClientIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/reliableidgen/impl/ReliableIdGenerator_ClientIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/reliableidgen/impl/ReliableIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/reliableidgen/impl/ReliableIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapPutSerializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapPutSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/DummyClientReplicatedMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/DummyClientReplicatedMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferBasicClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceSlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreThreadedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreThreadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/ClientProxyDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/ClientProxyDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/AwsAddressProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/AwsAddressProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/AwsAddressTranslatorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/AwsAddressTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientProxyFactoryWithContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientProxyFactoryWithContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientToMemberDiscoveryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientToMemberDiscoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/properties/ClientPropertyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/properties/ClientPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/ClientEntryListenerDisconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/ClientEntryListenerDisconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/ClientMapStandaloneTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/ClientMapStandaloneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyElement.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyKey.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyPortableElement.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyPortableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarter.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/AtomicLongStableReadStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/AtomicLongStableReadStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/AtomicLongUpdateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/AtomicLongUpdateStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/StressTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/StressTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TwoWayBlockableExecutor.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TwoWayBlockableExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/AbstractClientDriverFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/AbstractClientDriverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/MultiSocketClientDriverFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/MultiSocketClientDriverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/UnisocketClientDriverFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/bounce/UnisocketClientDriverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicOverloadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicOverloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientTopicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue9766Test.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue9766Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 package com.hazelcast.client.topic;/*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTransactionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnDisconnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnDisconnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnListTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnQueueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnReconnectModeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnReconnectModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnSetTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnUniSocketTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnUniSocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientUniSocketTxnTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientUniSocketTxnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXACompatibilityTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXACompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXATest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/SampleIdentified.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/SampleIdentified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/usercodedeployment/ClientUserCodeDeploymentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/util/ClientStateListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-cache-entrylistener-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-cache-entrylistener-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-c1.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-c2.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncReconnect.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncReconnect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-connection-strategy-asyncStart-true.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-discovery-spi-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-discovery-spi-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-dummy-multicast-discovery-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/hazelcast-client-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/log4j.properties
+++ b/hazelcast-client/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/log4j2-info.xml
+++ b/hazelcast-client/src/test/resources/log4j2-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/resources/log4j2.xml
+++ b/hazelcast-client/src/test/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/CacheManagerBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/CacheManagerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastTypeBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastTypeBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/SpringHazelcastCachingProvider.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/SpringHazelcastCachingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringAware.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringManagedContext.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringManagedContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/context/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/context/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/hibernate/RegionFactoryBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/hibernate/RegionFactoryBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/hibernate/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/hibernate/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/ManagedTransactionalTaskContext.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/ManagedTransactionalTaskContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.1.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.1.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.2.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.3.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.3.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.4.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.4.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.7.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.7.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyCachePartitionLostListenerImpl.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyCachePartitionLostListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryServiceProvider.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategyFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyEntryListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyEntryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyItemListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMapEvictionPolicy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMapEvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMapPartitionLostListenerImpl.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMapPartitionLostListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMemberAddressProvider.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMemberAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMembershipListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMembershipListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMessageListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyNodeFilter.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyNodeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyProxyFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQueueStore.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQueueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQueueStoreFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQueueStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumFunction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyRingbufferStore.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyRingbufferStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyRingbufferStoreFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyRingbufferStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummySSLContextFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummySSLContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummySocketInterceptor.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummySocketInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyStore.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyStoreFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyWanConsumer.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyWanConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyWanReplication.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyWanReplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/MyService.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/MyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/MyServiceConfig.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/MyServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/MyServiceConfigParser.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/MyServiceConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestBeansApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestBeansApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientConfigAndSpringDefaults.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientConfigAndSpringDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestEmptyApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestEmptyApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/AbstractHazelcastCacheReadTimeoutTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/AbstractHazelcastCacheReadTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/CacheMapLoader.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/CacheMapLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheNoReadTimeoutTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheNoReadTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithJavaConfig.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithJavaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithPropFile.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheReadTimeoutTestWithPropFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/IDummyBean.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/IDummyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/IDummyTimeoutBean.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/IDummyTimeoutBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/IJCacheDummyBean.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/IJCacheDummyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListenerFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheEntryListenerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoader.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoaderFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheLoaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerClientTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerDITest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriter.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriterFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheCacheWriterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicyFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCacheExpiryPolicyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCachePartitionLostListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/JCachePartitionLostListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/DummyTransactionManager.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/DummyTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/LiteMemberTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/LiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/MyEvictionPolicyComparator.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/MyEvictionPolicyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeBean.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeBeanHazelcastInjected.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeBeanHazelcastInjected.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeCallableTask.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeCallableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeEntryProcessor.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeRunnableTask.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeRunnableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTask.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTransactionalRunnableTask.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTransactionalRunnableTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTransactionalTask.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTransactionalTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeValue.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestAutoWire.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestAutoWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestIssue2676.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestIssue2676.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestManagedContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestManagedContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/hibernate/TestHibernateApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/hibernate/TestHibernateApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/replicatedmap/TestReplicatedMapApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/replicatedmap/TestReplicatedMapApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyCredentialsFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyCredentialsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyLoginModule.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyPermissionPolicy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyPermissionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummySecurityInterceptor.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummySecurityInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/SecureApplicationContextTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/SecureApplicationContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummyDataSerializableFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummyDataSerializableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummyPortableFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummyPortableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializableObject1.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializableObject1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializableObject2.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializableObject2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializer.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/serialization/DummySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/cacheManager-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-DI.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheCacheManager-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/jCacheClientCacheManager-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/no-readtimeout-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config-prop-file.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/readtimeout-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-application-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-issue-2676-application-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-lite-member-application-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/hibernate/hibernate-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/replicatedmap/replicatedMap-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/withoutconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/withoutconfig-applicationContext-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/hazelcast-default.properties
+++ b/hazelcast-spring/src/test/resources/hazelcast-default.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/hazelcast-sample-service.xsd
+++ b/hazelcast-spring/src/test/resources/hazelcast-sample-service.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/log4j.properties
+++ b/hazelcast-spring/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/log4j2-info.xml
+++ b/hazelcast-spring/src/test/resources/log4j2-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/log4j2.xml
+++ b/hazelcast-spring/src/test/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast-spring/src/test/resources/test-issue-2676.properties
+++ b/hazelcast-spring/src/test/resources/test-issue-2676.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregators.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AggregatorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AggregatorDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxByAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxByAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinByAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinByAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/BackupAwareEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/BackupAwareEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/BuiltInCacheMergePolicies.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/BuiltInCacheMergePolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheNotExistsException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheNotExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/StorageTypeAwareCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/StorageTypeAwareCacheMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractClusterWideIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheClearResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheClearResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryCountResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryCountResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryIterationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryIterationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryListenerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryListenerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryProcessorEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryProcessorEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryProcessorResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryProcessorResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIterationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIterationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMXBeanImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMXBeanImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsMXBeanImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsMXBeanImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSyncListenerCompleter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSyncListenerCompleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ClusterWideIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheInternal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/MXBeanUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/MXBeanUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/SplitBrainAwareCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/SplitBrainAwareCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/TCKMBeanServerBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/TCKMBeanServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/AbstractICacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/AbstractICacheEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CacheWanEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CacheWanEventPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/ICacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/ICacheEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/InternalCachePartitionLostListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/InternalCachePartitionLostListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalSubscribeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/DeserializingEventJournalCacheEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/InternalEventJournalCacheEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/impl/EntryCountCacheEvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/impl/EntryCountCacheEvictionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/policy/CacheMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/policy/CacheMergePolicyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/policy/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/policy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractBackupCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractBackupCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractMutatingCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractMutatingCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheBackupEntryProcessorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheBackupEntryProcessorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheContainsKeyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryIteratorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryIteratorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryProcessorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryProcessorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetInvalidationMetaDataOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheKeyIteratorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheKeyIteratorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheManagementConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheManagementConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/MutableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/MutableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PartitionWideCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PartitionWideCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheObjectRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/SampleableCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/SampleableCacheRecordMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/journal/EventJournalCacheEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/journal/EventJournalCacheEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/journal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/journal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/HyperLogLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/HyperLogLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoding.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AbstractCardinalityEstimatorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AbstractCardinalityEstimatorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/EstimateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/EstimateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/AuthenticationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/AddInterceptorOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/AddInterceptorOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientPartitionListenerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientPartitionListenerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/CollectRemoteTransactionsOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/CollectRemoteTransactionsOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/CompositeMessageTaskFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/CompositeMessageTaskFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ReAuthenticationOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ReAuthenticationOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/RemoveInterceptorOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/RemoveInterceptorOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientPrincipal.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/DistributedObjectInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/DistributedObjectInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/SecureRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/SecureRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/AbstractClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/AbstractClientOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/GetConnectedClientsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/GetConnectedClientsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/OperationFactoryWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/OperationFactoryWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/AuthenticationStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/AuthenticationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/MessageTaskFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/MessageTaskFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/MessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/MessageTaskFactoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractCallableMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractCallableMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractRemoveListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractTransactionalMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractTransactionalMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddPartitionListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddPartitionListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddPartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddPartitionLostListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ClientStatisticsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ClientStatisticsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DeployClassesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DeployClassesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DestroyProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/DestroyProxyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetDistributedObjectsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetDistributedObjectsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/MessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/MessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/NoSuchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/NoSuchMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/PingMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/PingMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemoveAllListenersMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemoveAllListenersMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemoveDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemoveDistributedObjectListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemovePartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemovePartitionLostListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAddAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAddAndGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAlterAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAlterAndGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAlterMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongApplyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongApplyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongCompareAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongCompareAndSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongDecrementAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongDecrementAndGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndAlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndAlterMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndIncrementMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndIncrementMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetAndSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongIncrementAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongIncrementAndGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceAlterAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceAlterAndGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceAlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceAlterMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceApplyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceApplyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceCompareAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceCompareAndSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceContainsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceGetAndAlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceGetAndAlterMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceGetAndSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceGetAndSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceIsNullMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceIsNullMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceSetAndGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceSetAndGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/AtomicReferenceSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomicreference/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheAllPartitionsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheAllPartitionsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheClientNearCacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheClientNearCacheInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddNearCacheInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddNearCacheInvalidationListenerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddPartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddPartitionLostListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAssignAndGetUuidsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAssignAndGetUuidsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAssignAndGetUuidsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAssignAndGetUuidsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAssignAndGetUuidsOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAssignAndGetUuidsOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheContainsKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheCreateConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheCreateConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheDestroyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheDestroyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEntryProcessorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEntryProcessorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalReadTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheEventJournalSubscribeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAndRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAndRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAndReplaceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAndReplaceMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateEntriesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheLoadAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheLoadAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CachePutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CachePutAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CachePutIfAbsentMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CachePutIfAbsentMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CachePutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CachePutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveInvalidationListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveInvalidationListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemovePartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemovePartitionLostListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheReplaceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheReplaceMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/Pre38CacheAddInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/Pre38CacheAddInvalidationListenerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cardinality/CardinalityEstimatorAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cardinality/CardinalityEstimatorAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cardinality/CardinalityEstimatorEstimateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cardinality/CardinalityEstimatorEstimateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionAwaitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionAwaitMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionBeforeAwaitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionBeforeAwaitMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionSignalAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionSignalAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionSignalMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/ConditionSignalMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/condition/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchAwaitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchAwaitMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchCountDownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchCountDownMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchGetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchGetCountMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchTrySetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/CountDownLatchTrySetCountMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/countdownlatch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AbstractAddConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AbstractAddConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCacheConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCardinalityEstimatorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddCardinalityEstimatorConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddDurableExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddDurableExecutorConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddEventJournalConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddEventJournalConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddExecutorConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddListConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddListConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddLockConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddLockConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMultiMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMultiMapConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddQueueConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddQueueConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableIdGeneratorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableIdGeneratorConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableTopicConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReliableTopicConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddRingbufferConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddRingbufferConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddScheduledExecutorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddScheduledExecutorConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSemaphoreConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSemaphoreConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSetConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddSetConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddTopicConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddTopicConfigMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/EvictionConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/EvictionConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/ListenerConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/ListenerConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/MapStoreConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/MapStoreConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/NearCacheConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/NearCacheConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/PredicateConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/PredicateConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/QueryCacheConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/QueryCacheConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/QueueStoreConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/QueueStoreConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/RingbufferStoreConfigHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/RingbufferStoreConfigHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/AbstractExecutorServiceCancelMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/AbstractExecutorServiceCancelMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceIsShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceIsShutdownMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceShutdownMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorDisposeResultMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorDisposeResultMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorIsShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorIsShutdownMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorRetrieveAndDisposeResultMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorRetrieveAndDisposeResultMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorRetrieveResultMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorRetrieveResultMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorShutdownMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorSubmitToPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllWithIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddAllWithIndexMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddWithIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddWithIndexMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRemoveAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRetainAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIndexOfMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIndexOfMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIsEmptyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListIteratorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListLastIndexOfMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListLastIndexOfMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListListIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListListIteratorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveWithIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveWithIndexMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSubMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListSubMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockForceUnlockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetLockCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetLockCountMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetRemainingLeaseTimeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetRemainingLeaseTimeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedByCurrentThreadMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedByCurrentThreadMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockTryLockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockUnlockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAllPartitionsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapClientNearCacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapClientNearCacheInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapAggregateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapAggregateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapProjectMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapProjectMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapQueryMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddIndexMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddIndexMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddInterceptorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddInterceptorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddNearCacheInvalidationListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddNearCacheInvalidationListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddPartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddPartitionLostListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAggregateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAggregateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAggregateWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAggregateWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAssignAndGetUuidsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAssignAndGetUuidsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAssignAndGetUuidsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAssignAndGetUuidsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAssignAndGetUuidsOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAssignAndGetUuidsOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearNearCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearNearCacheMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsValueMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDeleteMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDeleteMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapDestroyCacheMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntriesWithPagingPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntriesWithPagingPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntriesWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntriesWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntrySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalReadTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEventJournalSubscribeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEvictAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEvictAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEvictMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEvictMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnAllKeysMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchKeysMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchWithQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchWithQueryMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFlushMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFlushMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapForceUnlockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetEntryViewMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetEntryViewMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsEmptyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsLockedMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetWithPagingPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetWithPagingPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadGivenKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadGivenKeysMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapMadePublishableMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapMadePublishableMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapProjectionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapProjectionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapProjectionWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapProjectionWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutIfAbsentMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutIfAbsentMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutTransientMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutTransientMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveIfSameMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveIfSameMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveInterceptorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveInterceptorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemovePartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemovePartitionLostListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapReplaceIfSameMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapReplaceIfSameMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapReplaceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapReplaceMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetReadCursorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetReadCursorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSubmitToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSubmitToKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryLockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapUnlockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesWithPagingPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesWithPagingPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/Pre38MapAddNearCacheEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/Pre38MapAddNearCacheEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceCancelMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceCancelMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForCustomMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForCustomMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForListMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForListMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMapMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMultiMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMultiMapMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceJobProcessInformationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceJobProcessInformationMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/AbstractMultiMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/AbstractMultiMapAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapAddEntryListenerToKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsEntryMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsValueMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapEntrySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapForceUnlockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapIsLockedMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapKeySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapUnlockMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValueCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValueCountMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValuesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRemoveAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueCompareAndRetainAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueContainsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMaxSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMaxSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIsEmptyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIteratorMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueOfferMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueOfferMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePeekMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePeekMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePollMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePollMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueuePutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemainingCapacityMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemainingCapacityMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueTakeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueTakeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerToKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerToKeyWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerToKeyWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddEntryListenerWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddNearCacheListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapAddNearCacheListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapContainsKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapContainsValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapContainsValueMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapEntrySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapIsEmptyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapKeySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapPutAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapRemoveEntryListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapValuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapValuesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferCapacityMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferCapacityMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferHeadSequenceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferHeadSequenceMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadOneMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadOneMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferRemainingCapacityMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferRemainingCapacityMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferTailSequenceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferTailSequenceMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorGetAllScheduledMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorGetAllScheduledMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromAddressMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromPartitionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreAcquireMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreAcquireMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreAvailablePermitsMessageTasks.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreAvailablePermitsMessageTasks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreDrainPermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreDrainPermitsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreInitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreInitMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreReducePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreReducePermitsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreReleaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreReleaseMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreTryAcquireMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreTryAcquireMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetClearMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRemoveAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRetainAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetGetAllMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetIsEmptyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetRemoveListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicAddMessageListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicAddMessageListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicPublishMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicPublishMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicRemoveMessageListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicRemoveMessageListenerMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionCommitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionCommitMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionCreateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionRollbackMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/TransactionRollbackMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAClearRemoteTransactionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAClearRemoteTransactionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAFinalizeTransactionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAFinalizeTransactionMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionCommitMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionCommitMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionCreateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionPrepareMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionPrepareMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionRollbackMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionRollbackMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/TransactionalListAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/TransactionalListAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/TransactionalListRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/TransactionalListRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/TransactionalListSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/TransactionalListSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionallist/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapContainsKeyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapDeleteMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapDeleteMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapGetForUpdateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapGetForUpdateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapIsEmptyMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapPutIfAbsentMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapPutIfAbsentMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapRemoveIfSameMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapRemoveIfSameMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapReplaceIfSameMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapReplaceIfSameMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapReplaceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapReplaceMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapSetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapValuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapValuesMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapValuesWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapValuesWithPredicateMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapGetMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapPutMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapRemoveEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapRemoveEntryMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapValueCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/TransactionalMultiMapValueCountMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmultimap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueueOfferMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueueOfferMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueuePeekMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueuePeekMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueuePollMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueuePollMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueueSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueueSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueueTakeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/TransactionalQueueTakeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalqueue/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/TransactionalSetAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/TransactionalSetAddMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/TransactionalSetRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/TransactionalSetRemoveMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/TransactionalSetSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/TransactionalSetSizeMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalset/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageChannelInboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitter.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientProtocolBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientProtocolBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ParameterUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ParameterUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/SafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/SafeBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/client/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/MemberAttributeOperationType.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/MemberAttributeOperationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/AndMemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/AndMemberSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/MemberSelectors.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/MemberSelectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/OrMemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/OrMemberSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/CollectionTxnUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/CollectionTxnUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionItem.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/TxCollectionItem.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/TxCollectionItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionCompareAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionCompareAndRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionContainsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionGetAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionIsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionIsEmptyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionSizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/common/DataAwareItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/common/DataAwareItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListAddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListAddAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListAddOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListIndexOfOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListIndexOfOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSubOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSubOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvictionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueItem.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CheckAndEvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CheckAndEvictOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ContainsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/IsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/IsEmptyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/IteratorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/IteratorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PeekOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PeekOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemainingCapacityOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemainingCapacityOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/SizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/SizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTxnOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTxnOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/TransactionLogRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/TransactionLogRecordKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionCommitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionCommitBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionCommitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveAddOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionReserveRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTransactionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTransactionRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnRemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnlist/TransactionalListProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnlist/TransactionalListProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionLogRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionLogRecordKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TxQueueItem.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TxQueueItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/BaseTxnQueueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/BaseTxnQueueOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/QueueTransactionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/QueueTransactionRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnCommitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnCommitBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnCommitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPeekOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPeekOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPollBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPollOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAlterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAtomicLongOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAtomicLongOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddAndGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterAndGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/CompareAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/CompareAndSetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAddOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAlterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndSetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAlterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAtomicReferenceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAtomicReferenceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/CompareAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/CompareAndSetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndSetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetAndGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/LatchKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/LatchKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AbstractCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AbstractCountDownLatchOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/GetCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/GetCountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/SetCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/SetCountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ObjectNamespaceSerializationHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ObjectNamespaceSerializationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/WaitersInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/WaitersInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetLockCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetLockCountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetRemainingLeaseTimeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetRemainingLeaseTimeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/IsLockedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/IsLockedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AvailableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AvailableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDetachMemberBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDetachMemberBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDetachMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDetachMemberOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AtomicLongConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AtomicLongConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AtomicReferenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AtomicReferenceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfiguration.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheDeserializedValues.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheDeserializedValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CountDownLatchConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CountDownLatchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/CredentialsFactoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CredentialsFactoryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EventJournalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/GlobalSerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GlobalSerializerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/GroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GroupConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/HostVerificationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HostVerificationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartClusterDataRecoveryPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartClusterDataRecoveryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/InterfacesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InterfacesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListenerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MCMutualAuthConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MCMutualAuthConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAddressProviderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAddressProviderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberGroupConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionPolicyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionPolicyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QuorumConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QuorumConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/QuorumListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QuorumListenerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableIdGeneratorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableIdGeneratorConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableIdGeneratorConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SSLConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityInterceptorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityInterceptorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/ServicesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServicesConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SocketInterceptorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SocketInterceptorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfigReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WANQueueFullBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WANQueueFullBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanAcknowledgeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanAcknowledgeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyMatchingPointConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyMatchingPointConfigPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyWildcardConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyWildcardConfigPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/MatchingPointConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/MatchingPointConfigPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/WildcardConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/WildcardConfigPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyTypeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/SimplePropertyDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/SimplePropertyDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/ValueValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/ValueValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/console/DefaultLineReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/DefaultLineReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/console/Echo.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/Echo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/console/LineReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/LineReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/console/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/AbstractIMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AbstractIMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/BaseMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/BaseMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/BaseMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/BaseMultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/BaseQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/BaseQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ClientListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ClientListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ClientService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/DuplicateInstanceNameException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DuplicateInstanceNameException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Endpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Endpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ExecutionCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ExecutionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IBiFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ICacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ICollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ICompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ICondition.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ICountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICountDownLatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IList.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ILock.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ILock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ISemaphore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ISemaphore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ISet.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ISet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ITopic.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ITopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/IndeterminateOperationStateException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IndeterminateOperationStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/LocalMemberResetException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LocalMemberResetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ManagedContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ManagedContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoaderLifecycleSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoaderLifecycleSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStoreAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStoreAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Message.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MessageListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MigrationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MigrationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MultiExecutionCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MultiExecutionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Offloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Offloadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/OperationTimeoutException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/OperationTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/OutOfMemoryHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/OutOfMemoryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/Partition.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Partition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionAwareKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionAwareKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitioningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/PostProcessingMapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PostProcessingMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/PrefixedDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PrefixedDistributedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/QueueStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/QueueStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/QueueStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/QueueStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/ReplicatedMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ReplicatedMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/RingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RingbufferStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/RingbufferStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RingbufferStoreFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/RuntimeInterruptedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RuntimeInterruptedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalList.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/TypeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/server/StartServer.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/server/StartServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/server/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorServiceFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/DurableExecutorServiceFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/TaskRingBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/TaskRingBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/AbstractDurableExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/AbstractDurableExecutorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DisposeResultBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DisposeResultBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DisposeResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DisposeResultOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DurableExecutorWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DurableExecutorWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/ReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveAndDisposeResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveAndDisposeResultOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveResultOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/ShutdownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/ShutdownOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/CancellableDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/CancellableDelegatingFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/RunnableAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/RunnableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CallableTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CancellationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CancellationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/ShutdownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/ShutdownOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/BackupTaskState.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/BackupTaskState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/BackupTaskStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/BackupTaskStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/HotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/HotRestartService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/InternalHotRestartService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/NoOpHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/NoOpHotRestartService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/NoopInternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/NoopInternalHotRestartService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/AddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AddressPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,7 @@ public class DefaultNodeExtension implements NodeExtension {
         }
         systemLogger.info("Hazelcast " + buildInfo.getVersion()
                 + " (" + build + ") starting at " + node.getThisAddress());
-        systemLogger.info("Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.");
+        systemLogger.info("Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.");
         systemLogger.info("Configured Hazelcast Serialization version: " + buildInfo.getSerializationVersion());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultOutOfMemoryHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultOutOfMemoryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastManagedContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastManagedContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/JetBuildInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/JetBuildInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtensionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryErrorDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryErrorDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/TerminatedLifecycleService.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/TerminatedLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/instance/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapterMethod.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapterMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/MethodNotAvailable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/MethodNotAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/MethodNotAvailableException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/MethodNotAvailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextProtocolsDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextProtocolsDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TypeAwareCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TypeAwareCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/EntryConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/EntryConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MapNameAndKeyPair.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MapNameAndKeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/Stats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/Stats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterClock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterStateListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterStateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterVersionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterVersionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/DeadlineClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/DeadlineClusterFailureDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/FailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/FailureDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualClusterFailureDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PingFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PingFailureDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterTopologyChangedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterTopologyChangedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersViewMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersViewMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainMulticastListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AbstractClusterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AbstractClusterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AbstractJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AbstractJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AuthenticationFailureOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AuthenticationFailureOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AuthorizationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AuthorizationOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/BeforeJoinCheckFailureOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/BeforeJoinCheckFailureOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/CommitClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/CommitClusterStateOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ConfigMismatchOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ExplicitSuspicionOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ExplicitSuspicionOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FetchMembersViewOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FetchMembersViewOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/GroupMismatchOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/GroupMismatchOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatComplaintOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatComplaintOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinMastershipClaimOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinMastershipClaimOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterResponseOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterResponseOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PromoteLiteMemberOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PromoteLiteMemberOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/TriggerExplicitSuspicionOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/TriggerExplicitSuspicionOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/TriggerMemberListPublishOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/TriggerMemberListPublishOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/WanReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/WanReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/WhoisMasterOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/WhoisMasterOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitorLevel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitorLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationDescriptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/StoreLatencyPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/StoreLatencyPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemPropertiesPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemPropertiesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AbstractDynamicConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AddDynamicConfigOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AggregatingMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/AggregatingMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigCheckMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigCheckMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigPreJoinOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyDynamicConfigListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyDynamicConfigListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/CompositeEvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/CompositeEvictionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/Evictable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/Evictable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictableEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictableEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictableStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictableStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionCandidate.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionCandidate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionConfiguration.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyEvaluatorProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyEvaluatorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionStrategyType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionStrategyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/Expirable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/Expirable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ExpirationChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ExpirationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/EvictionPolicyEvaluator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/EvictionPolicyEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/sampling/SampleableEvictableStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/sampling/SampleableEvictableStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/sampling/SamplingEvictionStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/sampling/SamplingEvictionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/sampling/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/strategy/sampling/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/AtomicLongMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/AtomicLongMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/AtomicReferenceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/AtomicReferenceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ClientEngineMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ClientEngineMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ConnectionManagerMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ConnectionManagerMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/CountDownLatchMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/CountDownLatchMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/EventServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/EventServiceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ExecutorServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ExecutorServiceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/HazelcastMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/HazelcastMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ListMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ListMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/LocalStatsDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/LocalStatsDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/LockMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/LockMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MBeans.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MBeans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedAnnotation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedDescription.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedExecutorServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagedExecutorServiceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MapMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MultiMapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MultiMapMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/NodeMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/NodeMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ProxyServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ProxyServiceMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/QueueMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/QueueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReliableTopicMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReliableTopicMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReplicatedMapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ReplicatedMapMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/SemaphoreMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/SemaphoreMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/SetMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/SetMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/TopicMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/TopicMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/LocalMapStatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/LocalMapStatsSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/LocalMultiMapStatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/LocalMultiMapStatsSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/LocalQueueStatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/LocalQueueStatsSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/StatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/StatsSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/suppliers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/JsonSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/JsonSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterConnectionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterIdentifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/MonitoredThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/MonitoredThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ScriptEngineManagerContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ScriptEngineManagerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ThreadDumpGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ThreadDumpGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientEndPointDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ConnectionManagerDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ConnectionManagerDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/EventServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/EventServiceDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MXBeansDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MXBeansDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ManagedExecutorDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ManagedExecutorDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/OperationServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/OperationServiceDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PartitionServiceBeanDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PartitionServiceBeanDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PermissionConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PermissionConfigDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ProxyServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ProxyServiceDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationInvocationDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationInvocationDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanReplicationConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanReplicationConfigDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AbstractManagementOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AbstractManagementOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ClearWanQueuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ClearWanQueuesOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ThreadDumpOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ThreadDumpOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateManagementCenterUrlOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateManagementCenterUrlOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdatePermissionConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdatePermissionConfigOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/AsyncConsoleRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/AsyncConsoleRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeClusterStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeClusterStateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClearWanQueuesRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClearWanQueuesRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClusterPropsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClusterPropsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleCommandRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleCommandRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequestConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequestConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ForceStartNodeRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ForceStartNodeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetClusterStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetClusterStateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetMapEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetMapEntryRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetMemberSystemPropertiesRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetMemberSystemPropertiesRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/MapConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/MapConfigRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/MemberConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/MemberConfigRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/PromoteMemberRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/PromoteMemberRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/RunGcRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/RunGcRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ShutdownClusterRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ShutdownClusterRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ThreadDumpRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ThreadDumpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/TriggerPartialStartRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/TriggerPartialStartRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/UpdatePermissionConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/UpdatePermissionConfigRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/ByteAccessStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/ByteAccessStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/ConcurrentHeapMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/ConcurrentHeapMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/ConcurrentMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/ConcurrentMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/GlobalMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/GlobalMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/GlobalMemoryAccessorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/GlobalMemoryAccessorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/GlobalMemoryAccessorType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/GlobalMemoryAccessorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/HeapMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/HeapMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAllocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/AlignmentUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/AlignmentUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/ByteArrayAccessStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/ByteArrayAccessStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/CustomByteAccessStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/CustomByteAccessStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/EndiannessUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/EndiannessUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/MemoryManagerBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/MemoryManagerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/DiscardableMetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/DiscardableMetricsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/DoubleGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/DoubleGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/DoubleProbeFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/DoubleProbeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Gauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Gauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/LongGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/LongGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/LongProbeFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/LongProbeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Metric.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeLevel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/AbstractGauge.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/AbstractGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LockStripe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LockStripe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/ProbeRenderer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/ProbeRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/NearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/NearCacheRecordMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/SampleableNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/SampleableNearCacheRecordMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/AbstractBaseNearCacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/AbstractBaseNearCacheInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchNearCacheInvalidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataFetcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MinimalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MinimalPartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/NonStopInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/NonStopInvalidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/SingleNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/SingleNearCacheInvalidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetectorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetectorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/maxsize/EntryCountNearCacheEvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/maxsize/EntryCountNearCacheEvictionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/maxsize/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/maxsize/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/AbstractNearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/AbstractNearCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/NearCacheDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/NearCacheDataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/NearCacheObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/NearCacheObjectRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/record/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheObjectRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheObjectRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelCloseListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelCloseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelOutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelOutboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/EventLoopGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/EventLoopGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/InitResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/InitResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundFrame.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/ChannelInboundHandlerWithCounters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/ChannelInboundHandlerWithCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratableHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioEventLoopGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioEventLoopGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MigrationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/AbstractHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningEventLoopGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningEventLoopGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningInputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningInputThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningOutputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningOutputThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationCycleOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationCycleOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/NonFragmentedServiceNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/NonFragmentedServiceNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplicaVersionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplicaVersionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionTableView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionTableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaErrorLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaErrorLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckPartitionReplicaVersionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckPartitionReplicaVersionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalMigrationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalMigrationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NopPartitionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/NopPartitionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionEventManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionEventManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionLostListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionLostListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionPortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionPrimaryReplicaAntiEntropyTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaChangeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaFragmentVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaFragmentVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionServiceState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionServiceState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/ReplicaFragmentSyncInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/ReplicaFragmentSyncInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationDestinationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationDestinationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationSourceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationSourceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FetchPartitionStateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/HasOngoingMigration.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/HasOngoingMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/SafeStateCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/SafeStateCheckOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownResponseOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/DataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/DataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InputOutputFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/PortableContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/PortableContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/PortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/PortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/SerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/SerializationServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayDataSerializableFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayDataSerializableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayListStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ArrayListStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ClassDefinitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ClassDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ClassDefinitionWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ClassDefinitionWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ConstantSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldDefinitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/LinkedListStreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/LinkedListStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/MorphingPortableReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableHookLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableHookLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableNavigatorContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableNavigatorContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePathCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePathCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePosition.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePositionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePositionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePositionNavigator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePositionNavigator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializerHookLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializerHookLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeInputOutputFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/UserCodeDeploymentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassloadingMutexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassloadingMutexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/GlobalMutex.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/GlobalMutex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ThreadLocalClassCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ThreadLocalClassCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/UserCodeDeploymentSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/UserCodeDeploymentSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassBlacklistFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassBlacklistFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassWhitelistFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassWhitelistFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberAttributeFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberAttributeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberProviderFilterParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberProviderFilterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/ClassDataFinderOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/ClassDataFinderOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/DeployClassesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/operation/DeployClassesOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/BufferingInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/BufferingInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/LockGuard.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/LockGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/RuntimeAvailableProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/RuntimeAvailableProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandomProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandomProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ToHeapDataConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ToHeapDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/HsaHeapMemoryManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/HsaHeapMemoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMapHsa.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMapHsa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongLongCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongLongCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSetHsa.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSetHsa.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueue.java
@@ -1,6 +1,6 @@
 /*
  * Original work Copyright 2015 Real Logic Ltd.
- * Modified work Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Modified work Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorSingleQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorSingleQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/MPSCQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/MPSCQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueue.java
@@ -1,6 +1,6 @@
 /*
  * Original work Copyright 2015 Real Logic Ltd.
- * Modified work Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Modified work Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueue.java
@@ -1,6 +1,6 @@
 /*
  * Original work Copyright 2015 Real Logic Ltd.
- * Modified work Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Modified work Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/Pipe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/Pipe.java
@@ -1,6 +1,6 @@
 /*
  * Original work Copyright 2015 Real Logic Ltd.
- * Modified work Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Modified work Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/QueuedPipe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/QueuedPipe.java
@@ -1,6 +1,6 @@
 /*
  * Original work Copyright 2015 Real Logic Ltd.
- * Modified work Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Modified work Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ThreadFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ThreadFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  * Portions Copyright 2016 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/Counter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/MwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/MwCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AlwaysApplyFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AlwaysApplyFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AndFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AndFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/Filter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/ChainingFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/futures/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/futures/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray12byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray12byteKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray16byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray16byteKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray8byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray8byteKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor12byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor12byteKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor16byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor16byteKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor8byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor8byteKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/CapacityUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/CapacityUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyNoValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyNoValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArrayBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/iterator/RestartingMemberIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/iterator/RestartingMemberIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/iterator/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/iterator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/IntMemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/IntMemArrayQuickSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/LongMemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/LongMemArrayQuickSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/MemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/MemArrayQuickSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/QuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/QuickSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalInitialSubscriberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalInitialSubscriberState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/journal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/AbstractLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/AbstractLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4jFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4jFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/LogEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LogEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/LogListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LogListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggerFactorySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggerFactorySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggingServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/NoLogFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/NoLogFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/Slf4jFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Slf4jFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/StandardLoggerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/StandardLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/logging/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryBackupProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryBackupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/EventLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EventLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/LockAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/LockAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/MapPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapPartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/ReachedMaxSizeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/ReachedMaxSizeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/eviction/LFUEvictionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/eviction/LFUEvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/eviction/LRUEvictionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/eviction/LRUEvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/eviction/MapEvictionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/eviction/MapEvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/eviction/RandomEvictionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/eviction/RandomEvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/eviction/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/eviction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BinaryMapEntryCostEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BinaryMapEntryCostEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DataAwareEntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DataAwareEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryCostEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryCostEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryListenerAdaptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryListenerAdaptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EventListenerFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EventListenerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ExpirationTimeSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InterceptorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InterceptorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InternalEntryListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InternalEntryListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapPartitionLostListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapPartitionLostListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LegacyAsyncMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LegacyAsyncMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ListenerAdapters.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ListenerAdapters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LockAwareLazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LockAwareLazyMapEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapClientAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapClientAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapIndexSynchronizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapIndexSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerFlagOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerFlagOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionLostEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionLostEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPostJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPostJoinAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapQuorumAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapQuorumAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRecordKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextEventListenerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextEventListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextInterceptorSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextInterceptorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStatisticsAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStatisticsAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapTransactionalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapTransactionalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapValueCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapValueCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NullEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NullEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/OwnedEntryCostEstimatorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/OwnedEntryCostEstimatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitioningStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitioningStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapPortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractFilteringStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/DefaultEntryEventFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/DefaultEntryEventFilteringStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventDataCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventDataCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/FilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/FilteringStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublishingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheEventPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheNaturalFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheNaturalFilteringStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/Evictor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/Evictor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractMapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractMapPartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractMapQueryPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractMapQueryPartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapPartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapQueryPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapQueryPartitionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/DeserializingEventJournalMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/InternalEventJournalMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/AbstractMapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/AbstractMapDataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/EmptyMapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/EmptyMapDataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreManagers.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreManagers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/StoreConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/StoreConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/AbstractWriteBehindProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/BoundedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/BoundedWriteBehindQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CyclicWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CyclicWriteBehindQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/IPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/IPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/SynchronizedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/SynchronizedWriteBehindQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueues.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/AddedDelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/AddedDelayedEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DelayedEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DelayedEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DelayedEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DeletedDelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DeletedDelayedEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/NullValueDelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/NullValueDelayedEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MemberMinimalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MemberMinimalPartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/UuidFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/UuidFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AccumulatorConsumerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AccumulatorConsumerOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AwaitMapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AwaitMapFlushOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearNearCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableLockMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableLockMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsEmptyOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsEmptyOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsKeyLoadFinishedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsKeyLoadFinishedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyLoadStatusOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyLoadStatusOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyLoadStatusOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyLoadStatusOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchKeysOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchKeysOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchWithQueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchWithQueryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapGetInvalidationMetaDataOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviders.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NotifyMapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NotifyMapFlushOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReadonlyKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReadonlyKeyBasedMapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveFromLoadAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SizeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SizeOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SynchronizeIndexesForPartitionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SynchronizeIndexesForPartitionTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TriggerLoadIfNeededOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TriggerLoadIfNeededOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanEventHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanEventHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/AccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/AccumulationExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResultProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResultProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsAccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsAccumulationExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/DefaultIndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/DefaultIndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/IndexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/IndexProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSizeLimiter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSizeLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultProcessorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultProcessorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/InvokerWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/InvokerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/ListenerRegistrationHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/ListenerRegistrationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeInvokerWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeInvokerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/Registry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/Registry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AbstractAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AbstractAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/Accumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/Accumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfoSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorScannerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorScannerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/BasicAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/BasicAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/CyclicBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/CyclicBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultCyclicBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultCyclicBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchIMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchIMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventDataBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventDataBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/SingleIMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/SingleIMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultPartitionSequencer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultPartitionSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultSubscriberSequencerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultSubscriberSequencerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/PartitionSequencer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/PartitionSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/Sequenced.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/Sequenced.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/SubscriberSequencerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/SubscriberSequencerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/AccumulatorSweeper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/AccumulatorSweeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/BatchPublisherAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/BatchPublisherAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/CoalescingPublisherAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/CoalescingPublisherAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/DefaultPublisherContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/DefaultPublisherContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/EventPublisherAccumulatorProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/EventPublisherAccumulatorProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/MapListenerRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/MapListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/MapPublisherRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/MapPublisherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/NonStopPublisherAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/NonStopPublisherAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PartitionAccumulatorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PartitionAccumulatorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/QueryCacheListenerRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/QueryCacheListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractSubscriberContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractSubscriberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/EventPublisherHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/EventPublisherHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/EvictionOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/EvictionOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCacheListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCacheListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/MapSubscriberRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/MapSubscriberRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEndToEndConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEndToEndProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEventListenerAdapters.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEventListenerAdapters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequests.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/DestroyQueryCacheOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/MadePublishableOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/PublisherCreateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/PublisherCreateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/ReadAndResetAccumulatorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/ReadAndResetAccumulatorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/SetReadCursorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/SetReadCursorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/AbstractQueryCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/AbstractQueryCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/DataQueryCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/DataQueryCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/DataQueryCacheRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/DataQueryCacheRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/ObjectQueryCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/ObjectQueryCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/ObjectQueryCacheRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/ObjectQueryCacheRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/QueryCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/QueryCacheRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/QueryCacheRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/QueryCacheRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/utils/QueryCacheUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/utils/QueryCacheUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/utils/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/utils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecordWithStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/CachedDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/CachedDataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/CachedDataRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/CachedDataRecordWithStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordWithStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordWithStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordReplicationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordReplicationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/ExpiredKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/ExpiredKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTxnOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTxnOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/VersionedValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/VersionedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/journal/EventJournalMapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/journal/EventJournalMapEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/journal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/journal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryAddedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryAddedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryEvictedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryEvictedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryExpiredListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryExpiredListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryMergedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryMergedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryRemovedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryRemovedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryUpdatedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryUpdatedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EventLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EventLostListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapClearedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapClearedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapEvictedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapEvictedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapPartitionLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapPartitionLostListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/HigherHitsMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/IgnoreMergingEntryMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/IgnoreMergingEntryMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/MapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/MapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/MergePolicyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PassThroughMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/map/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Collator.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Collator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Combiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Combiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Context.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Job.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobCompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobProcessInformation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobProcessInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/MappingJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/MappingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/PartitionIdAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/PartitionIdAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Reducer.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Reducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducingJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducingSubmittableJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducingSubmittableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/RemoteMapReduceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/RemoteMapReduceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/TrackableJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/TrackableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Aggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Aggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Aggregations.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Aggregations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/PropertyExtractor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/PropertyExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Supplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Supplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AcceptAllSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AcceptAllSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AggType.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AggType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AggregationsDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AggregationsDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AvgTuple.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AvgTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/KeyPredicateSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/KeyPredicateSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/PredicateSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/PredicateSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SetAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SetAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/AbstractJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/AbstractJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/AbstractJobTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/AbstractJobTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/CombinerResultList.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/CombinerResultList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/HashMapAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/HashMapAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReducePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReducePortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceSimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceSimpleEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/NodeJobTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/NodeJobTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/IntermediateChunkNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/IntermediateChunkNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/LastChunkNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/LastChunkNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/MapReduceNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/MapReduceNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/MemberAwareMapReduceNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/MemberAwareMapReduceNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/ReducingFinishedNotification.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/ReducingFinishedNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/notification/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/CancelJobSupervisorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/CancelJobSupervisorOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/FireNotificationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/FireNotificationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/GetResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/GetResultOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/GetResultOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/GetResultOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeysAssignmentResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/NotifyRemoteExceptionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/NotifyRemoteExceptionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/PostPonePartitionProcessing.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/PostPonePartitionProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessStatsUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessStatsUpdateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessingOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestMemberIdAssignment.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestMemberIdAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionMapping.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionProcessed.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionProcessed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionReducing.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionReducing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/RequestPartitionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/StartProcessingJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/StartProcessingJobOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobProcessInformationImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobProcessInformationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobTaskConfiguration.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobTaskConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceMappingPhase.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceMappingPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MapCombineTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MapCombineTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MappingPhase.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MappingPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MemberAssigningJobProcessInformationImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MemberAssigningJobProcessInformationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/ReducerChunk.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/ReducerChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/ReducerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/ReducerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/ReducerTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/ReducerTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TransferableJobProcessInformation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TransferableJobProcessInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/DefaultGarbageCollectorStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/DefaultGarbageCollectorStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/DefaultMemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/DefaultMemoryStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/GCStatsSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/GCStatsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/GarbageCollectorStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/GarbageCollectorStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemorySize.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemorySize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryStatsSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryStatsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/NativeOutOfMemoryError.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/NativeOutOfMemoryError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/memory/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/HotRestartState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/HotRestartState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalCacheStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalExecutorStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalExecutorStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalGCStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalGCStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalInstanceStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalInstanceStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMemoryStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMultiMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMultiMapStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalOperationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalOperationStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalQueueStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalQueueStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalRecordStoreStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalRecordStoreStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalReplicatedMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalReplicatedMapStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalTopicStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalTopicStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/MemberPartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/MemberPartitionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/MemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/MemberState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/NearCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/NearCacheStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/NodeState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/WanSyncState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/WanSyncState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/HotRestartStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/HotRestartStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalCacheStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalExecutorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalExecutorStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalGCStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalGCStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMemoryStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMemoryStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalOperationStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalOperationStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalQueueStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalQueueStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalRecordStoreStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalRecordStoreStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberPartitionStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberPartitionStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NodeStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NodeStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/WanSyncStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/WanSyncStateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/ValueCollectionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/ValueCollectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/EntrySetResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/KeySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/KeySetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapKeyBasedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapKeyBasedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/SizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/SizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ValuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ValuesOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionRecordKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnGenerateRecordIdOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnGenerateRecordIdOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/BufferObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/BufferObjectDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/BufferObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/BufferObjectDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionListenable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionListenable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/Disposable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Disposable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/PacketIOHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/PacketIOHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/VersionAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/VersionAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelOutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelOutboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/BinaryInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/BinaryInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArraySerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArraySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ClassDefinitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializableFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/FieldType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/HazelcastSerializationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/HazelcastSerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/IdentifiedDataSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/IdentifiedDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Portable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Portable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Serializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/StreamSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/StreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/TypedByteArrayDeserializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/TypedByteArrayDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/TypedDataSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/TypedDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/TypedStreamDeserializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/TypedStreamDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/VersionedPortable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/VersionedPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/Versioned.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/Versioned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/VersionedDataSerializableFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/VersionedDataSerializableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/BasicSSLContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/BasicSSLContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactorySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLEngineFactorySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/TlsHostVerifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/TlsHostVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientChannelOutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientChannelOutboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelOutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelOutboundHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpAcceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionChannelErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionChannelErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiService.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/Activator.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/Activator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastInternalOSGiService.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastInternalOSGiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/ScriptEngineActivator.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/ScriptEngineActivator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/osgi/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/BackupSafeMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/BackupSafeMemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ConfigMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ConfigMemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/DefaultMemberGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/DefaultMemberGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/HostAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/HostAwareMemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactoryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SPIAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SPIAwareMemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/projection/Projection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/Projection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/projection/Projections.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/Projections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/ProjectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/ProjectionDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/projection/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/EntryObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/EntryObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicateAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicateAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/Parser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/QueryConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/QueryConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/QueryException.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/QueryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/VisitablePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/VisitablePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ArgumentParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueExtractor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReadingException.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReadingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/BaseIndexStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/ComparisonType.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/ComparisonType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultArgumentParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultValueCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DefaultValueCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DuplicateDetectingMultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DuplicateDetectingMultiResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Extractable.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Extractable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FastMultiResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FastMultiResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexCopyBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexCopyBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/MapIndexInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/MapIndexInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/MultiResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/MultiResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntriesSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntriesSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SingleResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SingleResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/EvictableGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/EvictableGetterCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ExtractorHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Getter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Getter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ImmutableMultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ImmutableMultiResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MultiResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullMultiValueGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/PortableGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/PortableGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/SuffixModifierUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/SuffixModifierUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ThisGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ThisGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompoundPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompoundPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EmptyOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EmptyOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FlatteningVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FlatteningVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NegatablePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NegatablePredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitorUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/Quorum.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/Quorum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumService.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumType.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/ReliableIdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/ReliableIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/AutoBatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/AutoBatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/IdBatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/IdBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/NewIdBatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/NewIdBatchOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/NodeIdOutOfRangeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/NodeIdOutOfRangeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/client/NewIdBatchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/impl/client/NewIdBatchMessageTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/reliableidgen/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/reliableidgen/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/PartitionContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEvictionProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapKeys.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableEntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapValueCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapValueCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractNamedSerializableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractNamedSerializableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractSerializableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractSerializableOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsValueOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EntrySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EntrySetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EvictionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EvictionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/IsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/IsEmptyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/KeySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/KeySetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SizeOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ValuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ValuesOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/VersionResponsePair.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/VersionResponsePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/DataReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/DataReplicatedRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/InternalReplicatedMapStorage.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/InternalReplicatedMapStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ObjectReplicatedRecordStorage.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ObjectReplicatedRecordStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/RecordMigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/RecordMigrationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedEntryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedEntryEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedQueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedQueryEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/ReplicatedMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/ReplicatedMapMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/OverflowPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/OverflowPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/ReadResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/ReadResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/Ringbuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferExpirationPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferExpirationPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferStoreWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/PortableReadResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/PortableReadResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/RingbufferPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/RingbufferPortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/GenericOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/GenericOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/DuplicateTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/DuplicateTaskException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/IScheduledFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/NamedTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/NamedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/ScheduledTaskHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/ScheduledTaskHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/ScheduledTaskStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/ScheduledTaskStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StatefulTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StatefulTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/TaskUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/TaskUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripper.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/InvokeOnMembers.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/InvokeOnMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/NamedTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/NamedTaskDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberBin.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberBin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberOwnedContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberOwnedContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledRunnableAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledRunnableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskStatisticsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskLifecycleListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskLifecycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractBackupAwareSchedulerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractBackupAwareSchedulerOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractGetAllScheduledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractGetAllScheduledOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractSchedulerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractSchedulerOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnMemberOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnPartitionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnPartitionOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnPartitionOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetDelayOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetDelayOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetResultOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetStatisticsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetStatisticsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsCanceledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsCanceledOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsDoneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/IsDoneOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ResultReadyNotifyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ResultReadyNotifyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ScheduleTaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ScheduleTaskBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ScheduleTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ScheduleTaskOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ShutdownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ShutdownOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncBackupStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncBackupStateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/ICredentialsFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/ICredentialsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/IPermissionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/IPermissionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/Parameters.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/SecureCallable.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecureCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityService.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AllPermissions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AllPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicLongPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicLongPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicReferencePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicReferencePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CardinalityEstimatorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CardinalityEstimatorPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermissionCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermissionCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ConfigPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ConfigPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CountDownLatchPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CountDownLatchPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/DenyAllPermissionCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/DenyAllPermissionCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/DurableExecutorServicePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/DurableExecutorServicePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ExecutorServicePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ExecutorServicePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ListPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ListPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/LockPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/LockPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapReducePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapReducePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MultiMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MultiMapPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/QueuePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/QueuePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReliableIdGeneratorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReliableIdGeneratorPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ScheduledExecutorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ScheduledExecutorPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SemaphorePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SemaphorePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SetPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SetPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TopicPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TopicPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/UserCodeDeploymentPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/UserCodeDeploymentPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractLocalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractLocalOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractWaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractWaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/BackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/BackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/BackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/BackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/BlockingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/BlockingOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/CallStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CallStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/CallsPerMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CallsPerMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/CanCancelOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CanCancelOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ClientAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ClientAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ConfigurableService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ConfigurableService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/CoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CoreService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/DistributedObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DistributedObjectNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventPublishingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExceptionAction.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExceptionAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/FragmentedMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/FragmentedMigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/InitializingObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InitializingObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/LiveOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/LiveOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/LiveOperationsTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/LiveOperationsTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ManagedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAddressProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/MigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/NamedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NamedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/Notifier.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Notifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ObjectNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PreJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PreJoinAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ProxyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ProxyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/QuorumAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/QuorumAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ReadonlyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ReadonlyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/RemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/RemoteService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ReplicationSupportingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ServiceConfigurationParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ServiceConfigurationParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespaceAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ServiceNamespaceAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/SharedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SharedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainAwareDataContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainAwareDataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergeEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergeEntryView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SplitBrainMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/UrgentSystemOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/UrgentSystemOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/annotation/Beta.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/annotation/Beta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/annotation/PrivateApi.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/annotation/PrivateApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/annotation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/annotation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/NodeFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/NodeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveryNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveryNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryServiceProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceSettings.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoveryReceiver.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoveryReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/DistributedObjectDestroyedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/DistributedObjectDestroyedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/PartitionMigratingException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/PartitionMigratingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseAlreadySentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseAlreadySentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableIOException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ServiceNotFoundException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ServiceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/SilentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/SilentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BinaryOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BinaryOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/CountingMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/CountingMigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionSpecificRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionSpecificRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableCachePartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableCachePartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableDistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableDistributedObjectEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableEntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableEntryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableItemEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableMapPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortableMapPartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PortablePartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PortablePartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SerializableList.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SerializableList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SerializationServiceSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SerializationServiceSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SimpleExecutionCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SimpleExecutionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiPortableHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/InternalEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/InternalEventService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/FutureUtilExceptionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/FutureUtilExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/RemoteEventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/RemoteEventProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/TrueEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/TrueEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/AbstractRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/AbstractRegistrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/DeregistrationOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/OnJoinRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/OnJoinRegistrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperationSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/SendEventOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/SendEventOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/InternalExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/InternalExecutionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingCallableTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingCallableTaskDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationHostileThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationHostileThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunnerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/OperationParker.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/OperationParker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSetEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSetEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationConstant.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundOperationHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundOperationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareFactoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareFactoryAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareOperationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupAckResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupAckResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationutil/Operations.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationutil/Operations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationutil/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationutil/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/InternalProxyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/InternalProxyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyEventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyEventProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/DistributedObjectDestroyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/InitializeDistributedObjectOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/InitializeDistributedObjectOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/RemoteServiceDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/RemoteServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/RemoteServiceDescriptorProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/RemoteServiceDescriptorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/AbstractMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/AbstractMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/MigrationEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/MigrationEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/serialization/SerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/serialization/SerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/spi/serialization/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/serialization/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/ReliableMessageListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/ReliableMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/topic/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/HazelcastXAResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/HazelcastXAResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionManagerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionManagerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionNotActiveException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionNotActiveException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionTimedOutException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionTimedOutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalTaskContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalTaskContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TargetAwareTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TargetAwareTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionalObjectKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionalObjectKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/AbstractTxOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/AbstractTxOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/BroadcastTxRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/BroadcastTxRollbackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupLogOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/TransactionAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/TransactionAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/AbstractXAOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/AbstractXAOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/CollectRemoteTransactionsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/CollectRemoteTransactionsOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/XaReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/XaReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/Base64.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Base64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ByteArrayProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ByteArrayProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/Clock.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ClockProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ClockProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ConstructorFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConstructorFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/EmptyStatement.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/EmptyStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ICMPHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ICMPHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/IConcurrentMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/IConcurrentMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/IterableUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/IterableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/IterationType.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/IterationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/JVMUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/JVMUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/MD5Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MD5Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/MemoryInfoAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MemoryInfoAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/MutableInteger.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MutableInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/MutableLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MutableLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/RandomPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/RandomPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/RuntimeMemoryInfoAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/RuntimeMemoryInfoAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/SetUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SetUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/SortingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SortingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/StateMachine.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/ThreadUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ThreadUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableListIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableListIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/UuidUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UuidUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/VersionAwareConstructorFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/VersionAwareConstructorFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ComposedKeyMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ComposedKeyMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InternalListMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InternalListMultiMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InternalSetMultimap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InternalSetMultimap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/BackoffIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/BackoffIdleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/BusySpinIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/BusySpinIdleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/IdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/IdleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/NoOpIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/NoOpIdleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/AbstractExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/AbstractExecutorThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletableFutureTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletableFutureTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/ExecutorType.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/ExecutorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/HazelcastManagedThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/HazelcastManagedThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/LoggingScheduledExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/LoggingScheduledExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/NamedThreadPoolExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/NamedThreadPoolExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/SingleExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/SingleExecutorThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/StripedRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/StripedRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/TimeoutRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/TimeoutRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/BiConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/BiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/Consumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/IntFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/IntFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/LongFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/LongFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/LongLongConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/LongLongConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/Supplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/Supplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/function/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/CoalescingDelayedTrigger.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/CoalescingDelayedTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/CompositeKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/CompositeKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskSchedulerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskSchedulerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduleType.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduledEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduledEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduledEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduledEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/version/Version.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/version/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/ReplicationEventObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/ReplicationEventObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WANReplicationQueueFullException.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WANReplicationQueueFullException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanSyncStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanSyncStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanDataSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationPublisherDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationPublisherDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/wan/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.PortableHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.PortableHook
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 
 #
 # /*
-#  * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+#  * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #  *
 #  * Licensed under the Apache License, Version 2.0 (the "License");
 #  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-common-config-3.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-common-config-3.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-common-config-3.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-common-config-3.1.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.1.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.1.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.3.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.3.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.4.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.4.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.7.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/template/com/hazelcast/instance/GeneratedBuildProperties.java
+++ b/hazelcast/src/main/template/com/hazelcast/instance/GeneratedBuildProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/AbstractJavaXCacheDependencyTest.java
+++ b/hazelcast/src/test/java/classloading/AbstractJavaXCacheDependencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/AbstractThreadLeakTest.java
+++ b/hazelcast/src/test/java/classloading/AbstractThreadLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/JavaXCacheDependencyTest.java
+++ b/hazelcast/src/test/java/classloading/JavaXCacheDependencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/LeakingApplication.java
+++ b/hazelcast/src/test/java/classloading/LeakingApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/ThreadLeakTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/ThreadLocalLeakTest.java
+++ b/hazelcast/src/test/java/classloading/ThreadLocalLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/domain/Person.java
+++ b/hazelcast/src/test/java/classloading/domain/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/classloading/domain/PersonEntryProcessor.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AbstractAggregatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AbstractAggregatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregationMemberBounceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AvgAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AvgAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/CountAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/CountAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregatePerformanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregatePerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapWordCountAggregationBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapWordCountAggregationBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MaxAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MaxAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MinAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MinAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/Person.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/RandomNumberSupplier.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/RandomNumberSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/SumAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/SumAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/Sums.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/Sums.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/TestSamples.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/TestSamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/TimeoutInMillis.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/TimeoutInMillis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/ValueContainer.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/ValueContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicSingleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicSingleMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheClusterWideIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheClusterWideIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheCreationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheEntryViewsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheEntryViewsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheFromDifferentNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheFromDifferentNodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheLoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheLoadAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheManagementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePutAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePutAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheQuorumConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheQuorumConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheReadWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheReadWriteThroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheResourceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/CacheEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/CacheEntryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheEvictionPolicyComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheEvictionPolicyComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheCreateUseDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheCreateUseDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/InvalidationEventQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/InvalidationEventQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/JCacheDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/JCacheDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/BasicCacheJournalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/CacheReplicationOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/CacheReplicationOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheHazelcastInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheHazelcastInstanceAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheEntryListenerExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheExpiryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheExpiryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheInvokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithExpiryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithExpiryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithoutReadThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWithoutReadThroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheLoaderWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMBStatisticsBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMBStatisticsBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMXBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheMXBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerManagementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CacheWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CachingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ClientServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/CompletionListenerFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/CompletionListenerFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/DurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/DurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/EntryProcessorExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/EntryProcessorExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ExpiryPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ExpiryPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/FactoryBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/FactoryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/GetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/GetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableCacheEntryListenerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/MutableConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/PutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/PutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/RemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/RemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/ReplaceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/ReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByReferenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/StoreByValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/TypesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/TypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/AbstractCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/AbstractCacheMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheMergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheMergePolicyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogConstantsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoderAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoderAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/operations/AggregateOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/operations/AggregateOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientTypesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/operations/OperationFactoryWrapperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/operations/OperationFactoryWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/AuthenticationStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/AuthenticationStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientExceptionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/codec/StackTraceElementCodecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/codec/StackTraceElementCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageSplitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ParameterUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ParameterUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientExceptionFactoryTestSimple.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientExceptionFactoryTestSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageAccumulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/FlyweightTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/FlyweightTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/FuzzyClientProtocolBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/FuzzyClientProtocolBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/MapMessageEncodeDecodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/MapMessageEncodeDecodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/RawProtocolAuthenticationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/RawProtocolAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/test/CustomComparator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/CustomComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/test/DistortInvalidationMetadataEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/DistortInvalidationMetadataEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/BadConfigurationMemberStartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/BadConfigurationMemberStartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterMembershipListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterMembershipListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterServiceMemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterServiceMemberListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterShutdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/NodeShutdownEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/NodeShutdownEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/cluster/memberselector/MemberSelectorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/memberselector/MemberSelectorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/AbstractCollectionBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/AbstractCollectionBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ClusterListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ClusterListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueTestsFrom2X.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueTestsFrom2X.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/StoreLatencyPlugin_QueueIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/StoreLatencyPlugin_QueueIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetEqualsHashTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetEqualsHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnlist/TransactionListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnlist/TransactionListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnqueue/TransactionQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnqueue/TransactionQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnset/TransactionalSetAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnset/TransactionalSetAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnset/TransactionalSetBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnset/TransactionalSetBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnset/TransactionalSetBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnset/TransactionalSetBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongClientRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongClientRequestTest.java
@@ -1,5 +1,5 @@
 ///*
-// * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+// * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 // *
 // * Licensed under the Apache License, Version 2.0 (the "License");
 // * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceInstanceSharingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceInstanceSharingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockLeaseMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockLeaseMemberBounceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ProducerConsumerConditionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ProducerConsumerConditionStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/AbstractSemaphoreQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/AbstractSemaphoreQuorumTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.concurrent.semaphore;
 
 import com.hazelcast.config.Config;

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractBasicConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheDeserializedValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheDeserializedValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheEvictionConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheEvictionConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheEvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheEvictionConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleEntryListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleEntryListenerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigDefaultsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/CountDownLatchConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CountDownLatchConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/DiscoveryStrategyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DiscoveryStrategyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/DiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DiscoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/EventJournalConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EventJournalConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ExecutorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/GroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/GroupConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/InterfacesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InterfacesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/IterableNodeListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IterableNodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/JoinConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/JoinConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/LegacyCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LegacyCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/LegacyConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LegacyConfigPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ListConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ListConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/LockConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LockConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/LockConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LockConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapAttributeConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapAttributeConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapAttributeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapAttributeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapIndexConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapIndexConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MatchingPointConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MatchingPointConfigPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MemberAttributeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MemberAttributeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyReadOnlyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyReadOnlyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MyService.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfig.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfigParser.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/NetworkConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NetworkConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/QueueConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueueConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/QueueStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueueStoreConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RegexConfigPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/SemaphoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SemaphoreConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/SetConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SetConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/SymmetricEncryptionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SymmetricEncryptionConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/WanConsumerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanConsumerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/WanPublisherConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanPublisherConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/WanReplicationConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanReplicationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefReadOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanReplicationRefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/WildcardConfigPatternMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WildcardConfigPatternMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigWithSystemPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigWithSystemPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/CacheConfigHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/CacheConfigHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DummyMapStore.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DummyMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/properties/PropertyTypeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/properties/PropertyTypeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/properties/ValueValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/properties/ValueValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/EntryAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/EntryAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/MapListenerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/MapListenerAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/OutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/OutOfMemoryHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/server/StartServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/server/StartServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/standalone/AllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/standalone/AllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/core/standalone/LongRunningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/standalone/LongRunningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSingleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSingleNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSmallClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSpecificSetupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableSpecificSetupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/impl/operations/DurableExecutorWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/impl/operations/DurableExecutorWaitNotifyKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/CompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/CompletableFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCreateDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCreateDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/LongRunningTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/LongRunningTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ScriptCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ScriptCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/ScriptRunnable.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ScriptRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/SpecificSetupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SpecificSetupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/impl/DistributedExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/impl/DistributedExecutorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterRaceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterRaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/hotrestart/BackupTaskStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/hotrestart/BackupTaskStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/hotrestart/BackupTaskStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/hotrestart/BackupTaskStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/hotrestart/NoopHotRestartServicesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/hotrestart/NoopHotRestartServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultAddressPickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultOutOfMemoryHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/LifeCycleListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/LifeCycleListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/ManagedContextInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/ManagedContextInstanceAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/NodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/NodeExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/NodeStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/NodeStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryErrorDispatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryErrorDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryHandlerHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryHandlerHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/DataStructureLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/DataStructureLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheCacheLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheCacheLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheCompletionListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheCompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheReplaceEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheReplaceEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapMapStore.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcher.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/MethodAvailableMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/memcache/MemcacheUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/memcache/MemcacheUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/rest/RestValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/rest/RestValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/VersionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/VersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/ClusterFailureDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PingFailureDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/fd/PingFailureDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ChangeClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ChangeClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterRollingRestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterRollingRestartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionInitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionInitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustCheckerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembersViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/BuildInfoPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/BuildInfoPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriterImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/InvocationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/InvocationPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/PendingInvocationsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/PendingInvocationsPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginResetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginResetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemPropertiesPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemPropertiesPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSlowPreJoinBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSlowPreJoinBouncingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainLiteMemberOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSplitBrain_whenConfigExistsInSmallerBrainLiteMemberOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/CompositeEvictionCheckerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/CompositeEvictionCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionPolicyEvaluatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionPolicyEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LockMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LockMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDataHolder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MapMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MultiMapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MultiMapMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReliableTopicMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReliableTopicMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReplicatedMapMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/ReplicatedMapMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ClearWanQueuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ClearWanQueuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ConsoleRequestConstantsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ConsoleRequestConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ForceStartNodeRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ForceStartNodeRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetCacheEntryRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetCacheEntryRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetClusterStateRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetMapEntryRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetMapEntryRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MapConfigRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MapConfigRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/PartitionServiceBeanDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/PartitionServiceBeanDTOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ShutdownClusterRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ShutdownClusterRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ThreadDumpRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ThreadDumpRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TriggerPartialStartRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TriggerPartialStartRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/UpdateManagementCenterUrlRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/UpdateManagementCenterUrlRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ZuluExcludeRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ZuluExcludeRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/ClusterHotRestartStatusDTOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanReplicationConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanReplicationConfigDTOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/GlobalMemoryAccessorRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/GlobalMemoryAccessorRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AbstractUnsafeDependentMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AbstractUnsafeDependentMemoryAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AlignmentUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AlignmentUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/HeapMemoryManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/HeapMemoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/RequiresUnalignedMemoryAccessSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/RequiresUnalignedMemoryAccessSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnsafeAvailability.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnsafeAvailability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/UnsafeUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/UnsafeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeLevelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeLevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LongGaugeImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LongGaugeImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeLevelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeLevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterMetricTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterMetricTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheInvalidationListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheSerializationCountConfigBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheSerializationCountConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/StaleReadDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/AbstractChannelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/AbstractChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioEventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioEventLoopGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnectionManager_ConnectMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnection_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_TcpIpConnection_TransferStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioEventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioEventLoopGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnectionManager_ConnectMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_TcpIpConnection_TransferStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioEventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioEventLoopGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnectionManager_ConnectMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnection_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_TcpIpConnection_TransferStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectionKeysSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectionKeysSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectorModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectorModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectorOptimizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectorOptimizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_EventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_EventLoopGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnectionManager_ConnectMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_TransferStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractMigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractMigrationCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/InternalPartitionServiceStackOverflowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/InternalPartitionServiceStackOverflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/InternalPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/InternalPartitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionAssignmentsCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionReplicaVersionsCorrectnessStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionReplicaVersionsCorrectnessStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionReplicaVersionsView.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionReplicaVersionsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRuntimeStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionRuntimeStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionTableViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowGracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowGracefulShutdownCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowMigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowMigrationCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowPartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowPartitionAssignmentsCorrectnessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/TestPartitionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/TestPartitionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/DummyInternalPartition.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/DummyInternalPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalMigrationListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationPlannerCycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationPlannerCycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationPlannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationPlannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateCheckerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/ReplicaSyncInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/ReplicaSyncInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestAbstractMigrationAwareService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestAbstractMigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestBackupPutOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestBackupPutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestGetOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestIncrementOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestIncrementOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestMigrationAwareService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestMigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestPutOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestPutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestReplicationOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/TestReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestAbstractFragmentOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestAbstractFragmentOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentBackupPutOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentBackupPutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentGetOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentGetOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentIncrementOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentIncrementOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentPutOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentPutOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentReplicationOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentReplicationOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentedMigrationAwareService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentedMigrationAwareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestServiceNamespace.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestServiceNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ArrayDataSerializableFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ArrayDataSerializableFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/BoundsCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/BoundsCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ClassAndFieldDefinitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ClassAndFieldDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/CompressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/CompressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/FactoryIdHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/FactoryIdHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/HeapDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/HeapDataTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/MorphingPortableReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/MorphingPortableReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamNonFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamNonFinalMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortablePathCursorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortablePathCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortablePositionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortablePositionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortableUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortableUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInputAndOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/VersionedObjectDataInputAndOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberProviderFilterParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberProviderFilterParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/BufferingInputStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/BufferingInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/InvocationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/InvocationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/LockGuardTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/LockGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/RuntimeAvailableProcessorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/RuntimeAvailableProcessorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ThreadLocalRandomProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ThreadLocalRandomProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ToHeapDataConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ToHeapDataConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/HsaHeapMemoryManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/HsaHeapMemoryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/Long2LongMapHsaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/Long2LongMapHsaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/LongSetHsaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/LongSetHsaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorSingleQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorSingleQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/MwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/MwCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SafeSwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SafeSwCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SwCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/filter/AlwaysApplyFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/filter/AlwaysApplyFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/CapacityUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/CapacityUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyNoValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyNoValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/sort/QuickSorterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/sort/QuickSorterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/AbstractLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4j2LoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4j2LoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/LogEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/LogEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/LoggerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/LoggerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/LoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/LoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/NoLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/NoLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/logging/Slf4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Slf4jLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractEntryEventTypesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractEntryEventTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationBouncingMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EmbeddedMapInterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EmbeddedMapInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryListenerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryListenerEventTypesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryListenerEventTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryListenerQueryCacheEventTypesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryListenerQueryCacheEventTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EventPublishOrderWithEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EventPublishOrderWithEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/InMemoryFormatTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/InMemoryFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest_WhenMigration.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest_WhenMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapContainerCreationUponDestroyStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapContainerCreationUponDestroyStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapEvictAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapEvictAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapInstanceSharingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapInstanceSharingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapMaxSizeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapMaxSizeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapMergePolicyQuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapMergePolicyQuickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPreconditionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPreconditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBatchingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithCustomInitialSizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithCustomInitialSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWrongTargetForPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWrongTargetForPartitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapQueryPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapQueryPartitionIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_IntKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_IntKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_PreCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_PreCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_QuickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_StringKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_StringKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_TxnTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_TxnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicySerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicySerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/MigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/PartitionPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PartitionPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestCustomMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestCustomMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestData.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestDeleteEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestDeleteEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestDeleteMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestDeleteMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestEntryListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestEntryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestEventCollectingMapPartitionLostListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestEventCollectingMapPartitionLostListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestLoggingEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestLoggingEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestMapListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestMapListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/EntryCostEstimatorFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/EntryCostEstimatorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/EntryListenerAdaptorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/EntryListenerAdaptorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/InterceptorRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/InterceptorRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapKeyLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapKeyLoaderUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapServiceContextImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapServiceContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapStatisticsAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapStatisticsAwareServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/PartitioningStrategyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/PartitioningStrategyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/RecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/SimpleEntryViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/SimpleEntryViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/StoreLatencyPlugin_MapIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/StoreLatencyPlugin_MapIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/client/MapPortableHookTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/client/MapPortableHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/event/EntryEventDataCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/event/EntryEventDataCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/MapEvictionPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/MapEvictionPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/PluggableMemoryInfoAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/PluggableMemoryInfoAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ZeroMemoryInfoAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ZeroMemoryInfoAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/BasicMapJournalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/AbstractMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/AbstractMapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/CountingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/CountingMapLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EventBasedMapStore.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/EventBasedMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/LoadAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapClassLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapCreationDelayWithMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapCreationDelayWithMapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderLifecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderMultiNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderMultiNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreEvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWithPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWithPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteBehindTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteBehindTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/PausingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/PausingMapLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/PostProcessingMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/PostProcessingMapStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/SimpleMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/SimpleMapLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/WriteBehindExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/WriteBehindExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/MapStoreWithCounter.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/MapStoreWithCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TemporaryBlockerMapStore.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TemporaryBlockerMapStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindFailAndRetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindFailAndRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindFlushTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindFlushTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindItemCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindItemCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindMapStoreWithEvictionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindMapStoreWithEvictionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindMapStoreWithLoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindMapStoreWithLoadAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindOnBackupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindOnBackupsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStaleReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStaleReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStoreAllUpdatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStoreAllUpdatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindUponMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindUponMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWriteBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWriteBatchingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWriteDelaySecondsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWriteDelaySecondsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/GetAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/GetAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapInvalidationListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapInvalidationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapRecordStateStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapRecordStateStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheBatchInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheBatchInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLocalImmediateInvalidateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLocalImmediateInvalidateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLocalInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLocalInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStaleReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStaleReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStalenessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStalenessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapInvalidationMetaDataMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapInvalidationMetaDataMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapMetaDataGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapMetaDataGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapReconciliationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapReconciliationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/NonStopInvalidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/NonStopInvalidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/UuidFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/UuidFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/ContainsValueOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/ContainsValueOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/proxy/MapProxyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/proxy/MapProxyImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CustomAttribute.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CustomAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CustomObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CustomObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapEntrySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapEntrySetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryDispatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEventFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeExceededExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeExceededExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeLimiterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultSizeLimiterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/TargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/TargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/AbstractQueryCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/AbstractQueryCacheTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/CyclicBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/CyclicBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/EvictionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/ListenerRegistrationHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/ListenerRegistrationHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCoalescingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCoalescingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheEventLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheEventLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheGuaranteesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheGuaranteesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheIMapEventHandlingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheIMapEventHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheInMemoryFormatTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheInMemoryFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMethodsWithPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMethodsWithPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCachePredicateConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCachePredicateConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheRecoveryUponEventLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheRecoveryUponEventLossTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheSimpleStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheSimpleStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheXmlConfigWildcardTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheXmlConfigWildcardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/TestPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/accumulator/ReadOnlyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/accumulator/ReadOnlyIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/BatchEventDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/BatchEventDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/BatchIMapEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/BatchIMapEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/SingleIMapEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/SingleIMapEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultPartitionSequencerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultPartitionSequencerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/publisher/AccumulatorSweeperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/publisher/AccumulatorSweeperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEventListenerAdaptersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheEventListenerAdaptersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequestsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequestsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/TestSubscriberContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/TestSubscriberContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/utils/QueryCacheUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/utils/QueryCacheUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordWithStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordWithStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordWithStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordWithStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/Person.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionLockingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionLockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TransactionalMapProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TransactionalMapProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheInvalidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/AbstractMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/AbstractMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/HigherHitsMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/HigherHitsMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/IgnoreMergingEntriesMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/IgnoreMergingEntriesMapSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MergePolicyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/PassThroughMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleFunctionalMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleFunctionalMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/CustomDataSourceMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/CustomDataSourceMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/DistributedMapperMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/DistributedMapperMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceManagedContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceManagedContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceParallelRunnerOptions.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceParallelRunnerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MultiMapMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MultiMapMapReduceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/AbstractAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/AbstractAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/DistinctAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/DistinctAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAggregationLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAggregationLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAvgAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAvgAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapBaseAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapBaseAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapCountAggregationPortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapCountAggregationPortableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMaxAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMaxAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMinAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMinAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapSumAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapSumAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapAvgAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapAvgAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapBaseAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapBaseAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMaxAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMaxAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMinAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMinAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapSumAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapSumAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/operation/GetResultOperationFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/operation/GetResultOperationFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/ReducerTaskSchedulerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/ReducerTaskSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/ThreadsafeCombinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/ThreadsafeCombinerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/memory/MemoryStatsSupportTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/MemoryStatsSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mock/IAtomicLongMocks.java
+++ b/hazelcast/src/test/java/com/hazelcast/mock/IAtomicLongMocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/mock/MockUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/mock/MockUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/HotRestartStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/HotRestartStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalCacheStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalCacheStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalExecutorStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalExecutorStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalGCStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalGCStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMemoryStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMemoryStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalOperationStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalOperationStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalQueueStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalQueueStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalTopicStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalTopicStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberPartitionStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberPartitionStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/NodeStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/NodeStateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/ComplexValue.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/ComplexValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapReturnedCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapReturnedCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestsFrom2X.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTestsFrom2X.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTransactionStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/TxnMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/TxnMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/impl/MultiMapEventFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/impl/MultiMapEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/multimap/standalone/SimpleMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/standalone/SimpleMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/AddressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/AddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/BitsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/BitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/ConnectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/NodeIOServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/NodeIOServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/PacketIOHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/PacketIOHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/ProtocolsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ProtocolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/UnsafeHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/UnsafeHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/ByteArrayDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/ByteArrayDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/ComplexDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/ComplexDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/DataDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/DataDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/DataInputOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/DataInputOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/EnumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/EnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/FieldTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/FieldTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/InnerPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/InnerPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/InvalidRawDataPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/InvalidRawDataPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/InvalidRawDataPortable2.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/InvalidRawDataPortable2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/MainPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/MainPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/MorphingBasePortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/MorphingBasePortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/MorphingPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/MorphingPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/NamedPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/NamedPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/NamedPortableV2.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/NamedPortableV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/ObjectCarryingPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/ObjectCarryingPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableClassVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableClassVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/RawDataPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/RawDataPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SampleIdentifiedDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SampleIdentifiedDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationConcurrencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationV1Dataserializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationV1Dataserializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationV1Portable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationV1Portable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializersHazelcastInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializersHazelcastInstanceAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/TestSerializationConstants.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/TestSerializationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/VersionedDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/VersionedDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ADataSerializableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ADataSerializableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AJavaExternalizable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AJavaExternalizable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AJavaSerialiazable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AJavaSerialiazable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/APortableFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnIdentifiedDataSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnIdentifiedDataSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnInnerPortable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/AnInnerPortable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityFileGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomByteArraySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializable.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializer.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/CustomStreamSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/ReferenceObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderQuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderQuickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderTestStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderTestStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/ssl/TestKeyStoreUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ssl/TestKeyStoreUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientChannelOutboundHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientChannelOutboundHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageHandlerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageHandlerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DummyPayload.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DummyPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/EventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/EventLoopGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberChannelInboundHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberChannelInboundHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberChannelOutboundHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberChannelOutboundHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/NioChannelFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/NioChannelFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_AbstractConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_AbstractConnectMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectionListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectionListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_TransmitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_TransmitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTransferStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TestDataFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/TestBundle.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/TestBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/TestBundleContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/TestBundleContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/TestServiceReference.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/TestServiceReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/TestServiceRegistration.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/TestServiceRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptEngineFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptEngineFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptEngineManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptEngineManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptEngineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/AbstractPartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/AbstractPartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerRegistrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/SafeClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/SafeClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/SystemOperationPrecedenseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/SystemOperationPrecedenseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/MapProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/projection/ProjectionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/ProjectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/projection/impl/MultiAttributeProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/impl/MultiAttributeProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/projection/impl/SingleAttributeProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/impl/SingleAttributeProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/ParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/ParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/PredicateBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PredicateBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DateHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DateHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DefaultArgumentParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DefaultArgumentParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DefaultValueCollectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DefaultValueCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DuplicateDetectingMultiResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DuplicateDetectingMultiResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FalsePredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FastMultiResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FastMultiResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/OrResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/OrResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryPerformanceBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryPerformanceBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionSpecification.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesReflectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesReflectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesReflectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesReflectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueDataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInArraySpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInArraySpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInCollectionSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInCollectionSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInListSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInListSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInPortableSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInPortableSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInSingleValueSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionInSingleValueSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionWithExtractorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ExtractionWithExtractorsSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/PortableDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/PortableDataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/EvictableGetterCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/EvictableGetterCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/FieldGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/FieldGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ImmutableMultiResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ImmutableMultiResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MethodGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MethodGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MultiResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MultiResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullMultiValueGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullMultiValueGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/PortableGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/PortableGetterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/SuffixModifierUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/SuffixModifierUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AbstractVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AbstractVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AndPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AndPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/CompoundPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/CompoundPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/DateHandlingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/DateHandlingPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EmptyOptimizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EmptyOptimizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EqualPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/GreaterLessPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/GreaterLessPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/InPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/InPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumReadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/AutoBatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/AutoBatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdConcurrencyTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdConcurrencyTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGeneratorProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGenerator_IdBatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGenerator_IdBatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGenerator_MemberIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGenerator_MemberIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/reliableidgen/impl/ReliableIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/CustomMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/CustomMergePolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/EntryViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/EntryViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazySetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/AbstractReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/AbstractReplicatedMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/MergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/MergePolicyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/OverflowPolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/OverflowPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/ArrayRingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/ArrayRingbufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAsyncAddWithBackoffStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAsyncAddWithBackoffStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferWaitNotifyKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/StoreLatencyPlugin_RingbufferIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/StoreLatencyPlugin_RingbufferIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddOperationsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/AddOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/GenericOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/DelegatingScheduledFutureStripperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/DelegatingScheduledFutureStripperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledHazelcastInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledHazelcastInstanceAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/TaskUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/TaskUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorWaitNotifyKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/OssSecurityUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/OssSecurityUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/AbstractGenericPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/AbstractGenericPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/AbstractMapPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/AbstractMapPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/ActionConstantsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/ActionConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/CachePermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/CachePermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/CardinalityEstimatorPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/CardinalityEstimatorPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/MapPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/MapPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/PermissionTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/PermissionTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/ScheduledExecutorPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/ScheduledExecutorPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/UserCodeDeploymentPermissionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/UserCodeDeploymentPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/serviceprovider/ServiceProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/serviceprovider/ServiceProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestDistributedObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestDistributedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteService.java
+++ b/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteServiceDescriptor.java
+++ b/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteServiceDescriptorProvider.java
+++ b/hazelcast/src/test/java/com/hazelcast/serviceprovider/TestRemoteServiceDescriptorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/AbstractDistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/AbstractDistributedObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/AbstractLocalOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/AbstractLocalOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/CallsPerMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/CallsPerMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/NodeEngineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/NodeEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationCallIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationCallIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MulticastPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/exception/WrongTargetExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/exception/WrongTargetExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AndThenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_ClosedExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_ClosedExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CompleteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetWithTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetWithTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_IsDoneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_JoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_JoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_MiscTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_MiscTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/CountingMigrationAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/CountingMigrationAwareServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecoratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecuteOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecuteOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecutePartitionSpecificRunnableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecutePartitionSpecificRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_GetOperationRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_GetOperationRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsInvocationAllowedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsInvocationAllowedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsOperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsOperationThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsRunAllowedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsRunAllowedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunOrExecuteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunOrExecuteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionSpecificCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionSpecificCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_EntryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl_populateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl_populateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/WaitNotifySplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/WaitNotifySplitBrainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyPriorityOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyPriorityOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_CancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_CancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_GetNewInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_GetNewInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor_GetLastMemberHeartbeatMillisTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor_GetLastMemberHeartbeatMillisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_CallTimeoutTestMillis.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_CallTimeoutTestMillis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_DetectHeartbeatTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_DetectHeartbeatTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_InitInvocationTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_InitInvocationTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedRemoteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedRemoteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NotifyCallTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NotifyCallTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnMemberLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnMemberLeftTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TaskDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TaskDoneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationOutOfOrderBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationOutOfOrderBackupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnTargetLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnTargetLiteMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/RepartitioningStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/RepartitioningStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/SlowOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/SlowOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/VoidOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/VoidOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareFactoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareFactoryAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/memberAddressProvider/MemberAddressProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/memberAddressProvider/MemberAddressProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/partition/MigrationEndpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/partition/MigrationEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/GroupPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/GroupPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/properties/HazelcastPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractTestOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractTestOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/AssertEnabledFilterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AssertEnabledFilterRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/AssertTask.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AssertTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/AutoRegisteredTestRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AutoRegisteredTestRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/ExceptionThrowingCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ExceptionThrowingCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/ExpectedRuntimeException.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ExpectedRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/FailOnTimeoutStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelParametersRunnerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelParametersRunnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParametersRunnerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParametersRunnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialParametersRunnerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialParametersRunnerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/JenkinsDetector.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/JenkinsDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/JenkinsDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/JenkinsDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/ObjectTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ObjectTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/ParallelRunnerOptions.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ParallelRunnerOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/RequireAssertEnabled.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/RequireAssertEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/SaveLoggingPropertiesRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SaveLoggingPropertiesRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainAddMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainAddMemberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupportTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withParallelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withParallelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withSerialTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCategoriesTest_withSerialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestClusterUpgradeUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestClusterUpgradeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestStringUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestStringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestThread.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/TimeConstants.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TimeConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/CompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/CompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/ConfigureParallelRunnerWith.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/ConfigureParallelRunnerWith.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/NightlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/NightlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/ParallelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/ParallelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/QuickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/Repeat.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/Repeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/SlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/TestForCompatibilitySince.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/TestForCompatibilitySince.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceTestConfiguration.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/DriverFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/DriverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/MemberDriverFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/MemberDriverFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingRunListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingRunListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingSerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterMonitor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRecorder.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterThread.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/JitterThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/Mode.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/Mode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/Slot.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/Slot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoinerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/StaticAddressPicker.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/StaticAddressPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/package-info.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/AbstractStarterObjectConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/AbstractStarterObjectConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/AddressConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/AddressConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ConfigConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/DataAwareEntryEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/DataAwareEntryEventConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/EnumConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/EnumConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/GuardianException.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/GuardianException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastVersionLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/IgnoreCompatibilityTestsWithSinceRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/IgnoreCompatibilityTestsWithSinceRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/LifecycleEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/LifecycleEventConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/MapEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/MapEventConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/Utils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/VersionConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/VersionConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/package-info.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastProxyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastProxyFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/package-info.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/DurableSubscriptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/DurableSubscriptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ErrorHandlingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerMock.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicBasicDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicBasicLocalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicCreateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadAbstractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadDistributedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_OnePhaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_OnePhaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionManagerServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionManagerServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/AbstractClockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/AbstractClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/AddressUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/AddressUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/BitSetUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/BitSetUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ClockIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ClockIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ClockPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ClockPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ClockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionTxnUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionTxnUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ExceptionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ExceptionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/FilteringClassLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FilteringClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/HashUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/HashUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ItemCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ItemCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/IterableUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/IterableUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/JVMUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/JVMUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/JumpingSystemClock.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/JumpingSystemClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/MD5UtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/MD5UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/MapUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/MapUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/MutableLongTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/MutableLongTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/PreconditionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PreconditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/QuickMathTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/QuickMathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/RootCauseMatcher.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/RootCauseMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/SampleableConcurrentHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/SampleableConcurrentHashMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/SetUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/SetUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/StateMachineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StateMachineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/StringPartitioningStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StringPartitioningStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/ThreadUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ThreadUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/UnmodifiableLazyListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/UnmodifiableLazyListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/UuidUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/UuidUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/ArrayUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/ArrayUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/ComposedKeyMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/ComposedKeyMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InflatableSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InflatableSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InternalListMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InternalListMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InternalSetMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InternalSetMultiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/concurrent/BackoffIdleStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/concurrent/BackoffIdleStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/concurrent/IdleStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/concurrent/IdleStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CachedExecutorServiceDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CachedExecutorServiceDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CallerRunsExecutor.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CallerRunsExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CancellableDelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CancellableDelegatingFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CompletedFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CompletedFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/StripedExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/StripedExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/TestExecutionCallback.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/TestExecutionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/version/VersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/version/VersionUnknownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/VersionUnknownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanAcknowledgeTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanAcknowledgeTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanSyncStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanSyncStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/DummyWanReplication.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/DummyWanReplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/FullQueueWanReplication.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/FullQueueWanReplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanDataSerializerHookTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanDataSerializerHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXACompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXACompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXAStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXAStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXATest.java
+++ b/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/usercodedeployment/EntryProcessorWithAnonymousAndInner.java
+++ b/hazelcast/src/test/java/usercodedeployment/EntryProcessorWithAnonymousAndInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/usercodedeployment/IncrementingEntryProcessor.java
+++ b/hazelcast/src/test/java/usercodedeployment/IncrementingEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/usercodedeployment/blacklisted/BlacklistedEP.java
+++ b/hazelcast/src/test/java/usercodedeployment/blacklisted/BlacklistedEP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/usercodedeployment/whitelisted/WhitelistedEP.java
+++ b/hazelcast/src/test/java/usercodedeployment/whitelisted/WhitelistedEP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin-invalid-port.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast/src/test/resources/hazelcast-querycache-xml-config-wildcard-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-sample-service.xsd
+++ b/hazelcast/src/test/resources/hazelcast-sample-service.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/log4j2-info.xml
+++ b/hazelcast/src/test/resources/log4j2-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/log4j2.xml
+++ b/hazelcast/src/test/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/logging.properties
+++ b/hazelcast/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-client.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-invalid-cache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-invalid-cache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-jcache-partition-lost-listener.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache-partition-lost-listener.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-jcache-with-quorum.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache-with-quorum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast.xml
+++ b/hazelcast/src/test/resources/test-hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -16,4 +16,4 @@ The name "Hazelcast" must not be used to endorse or promote products
 derived from this software without prior written permission. For
 written permission, please contact talip@hazelcast.com or fuad@hazelcast.com
 
-Copyright (c) 2008-2017 Hazelcast Inc.  All rights reserved.
+Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.

--- a/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
Here it is, our famous once-a-year PR to update the copyright.

I've checked the code with the regex `2008-(?!2018)` to ensure there are no left-overs with other years than 2018