### PR TITLE
Make IMap & ICache MergeOperation not implement MutatingOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -25,13 +25,12 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class CacheMergeOperation
         extends AbstractCacheOperation
-        implements BackupAwareOperation, MutatingOperation {
+        implements BackupAwareOperation {
 
     private CacheMergePolicy mergePolicy;
     private CacheEntryView<Data, Data> mergingEntry;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -20,9 +20,10 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
-public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation {
+public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
 
     protected transient Data dataOldValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -32,7 +32,7 @@ import static com.hazelcast.map.impl.operation.EntryOperator.operator;
 /**
  * @see EntryOperation for Offloadable support.
  */
-public class EntryBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
+public class EntryBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     private EntryBackupProcessor entryProcessor;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -38,7 +38,8 @@ import static com.hazelcast.map.impl.operation.EntryOperator.operator;
  *
  * See the javadoc on {@link EntryOperation}
  */
-public class EntryOffloadableSetUnlockOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, Notifier {
+public class EntryOffloadableSetUnlockOperation extends KeyBasedMapOperation
+        implements BackupAwareOperation, Notifier {
 
     protected Data newValue;
     protected Data oldValue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -38,6 +38,7 @@ import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -134,7 +135,8 @@ import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
  * GOTCHA: This operation LOADS missing keys from map-store, in contrast with PartitionWideEntryOperation.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class EntryOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, BlockingOperation {
+public class EntryOperation extends KeyBasedMapOperation implements BackupAwareOperation, BlockingOperation,
+        MutatingOperation {
 
     private static final int SET_UNLOCK_FAST_RETRY_LIMIT = 10;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
@@ -25,7 +25,7 @@ import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 
-public class EvictBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
+public class EvictBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     protected boolean unlockKey;
     protected boolean disableWanReplicationEvent;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -20,41 +20,40 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.PartitionAwareOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
-public abstract class MutatingKeyBasedMapOperation extends MapOperation
-        implements PartitionAwareOperation, MutatingOperation {
+public abstract class KeyBasedMapOperation extends MapOperation
+        implements PartitionAwareOperation {
 
     protected Data dataKey;
     protected long threadId;
     protected Data dataValue;
     protected long ttl = DEFAULT_TTL;
 
-    public MutatingKeyBasedMapOperation() {
+    public KeyBasedMapOperation() {
     }
 
-    public MutatingKeyBasedMapOperation(String name, Data dataKey) {
+    public KeyBasedMapOperation(String name, Data dataKey) {
         super(name);
         this.dataKey = dataKey;
     }
 
-    protected MutatingKeyBasedMapOperation(String name, Data dataKey, Data dataValue) {
+    protected KeyBasedMapOperation(String name, Data dataKey, Data dataValue) {
         super(name);
         this.dataKey = dataKey;
         this.dataValue = dataValue;
     }
 
-    protected MutatingKeyBasedMapOperation(String name, Data dataKey, long ttl) {
+    protected KeyBasedMapOperation(String name, Data dataKey, long ttl) {
         super(name);
         this.dataKey = dataKey;
         this.ttl = ttl;
     }
 
-    protected MutatingKeyBasedMapOperation(String name, Data dataKey, Data dataValue, long ttl) {
+    protected KeyBasedMapOperation(String name, Data dataKey, Data dataValue, long ttl) {
         super(name);
         this.dataKey = dataKey;
         this.dataValue = dataValue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public abstract class LockAwareOperation extends MutatingKeyBasedMapOperation implements BlockingOperation {
+public abstract class LockAwareOperation extends KeyBasedMapOperation implements BlockingOperation {
 
     protected LockAwareOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
-public final class PutBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
+public final class PutBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     // todo unlockKey is a logic just used in transactional put operations.
     // todo It complicates here there should be another Operation for that logic. e.g. TxnSetBackup

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class PutIfAbsentOperation extends BasePutOperation {
+public class PutIfAbsentOperation extends BasePutOperation implements MutatingOperation {
 
     private boolean successful;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class PutOperation extends BasePutOperation {
+public class PutOperation extends BasePutOperation implements MutatingOperation {
 
     public PutOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class PutTransientOperation extends BasePutOperation {
+public class PutTransientOperation extends BasePutOperation implements MutatingOperation {
 
     public PutTransientOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -25,7 +25,7 @@ import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 
-public class RemoveBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
+public class RemoveBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     protected boolean unlockKey;
     protected boolean disableWanReplicationEvent;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -20,10 +20,11 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class ReplaceIfSameOperation extends BasePutOperation {
+public class ReplaceIfSameOperation extends BasePutOperation implements MutatingOperation {
 
     private Data expect;
     private boolean successful;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class ReplaceOperation extends BasePutOperation {
+public class ReplaceOperation extends BasePutOperation implements MutatingOperation {
 
     private boolean successful;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
@@ -18,11 +18,12 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
 
-public class SetOperation extends BasePutOperation {
+public class SetOperation extends BasePutOperation implements MutatingOperation {
 
     private boolean newRecord;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class TryPutOperation extends BasePutOperation {
+public class TryPutOperation extends BasePutOperation implements MutatingOperation {
 
     public TryPutOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -30,7 +30,7 @@ import java.io.IOException;
 /**
  * An operation to prepare transaction by locking the key on key backup owner.
  */
-public class TxnPrepareBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation, MutatingOperation {
+public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
     private String lockOwner;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -32,7 +32,7 @@ import java.io.IOException;
 /**
  * An operation to prepare transaction by locking the key on the key owner.
  */
-public class TxnPrepareOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
+public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * An operation to rollback transaction by unlocking the key on key backup owner.
  */
-public class TxnRollbackBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
+public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     private String lockOwner;
     private long lockThreadId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.tx;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -34,7 +34,7 @@ import java.io.IOException;
 /**
  * An operation to rollback transaction by unlocking the key on key owner.
  */
-public class TxnRollbackOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, Notifier {
+public class TxnRollbackOperation extends KeyBasedMapOperation implements BackupAwareOperation, Notifier {
 
     private String ownerUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ import java.io.IOException;
 /**
  * An operation to unlock and set (key,value) on the partition .
  */
-public class TxnSetOperation extends BasePutOperation implements MapTxnOperation {
+public class TxnSetOperation extends BasePutOperation implements MapTxnOperation, MutatingOperation {
 
     private long version;
     private transient boolean shouldBackup;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * An operation to unlock key on the backup owner.
  */
-public class TxnUnlockBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
+public class TxnUnlockBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     private String ownerUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.io.IOException;
 /**
  * An operation to unlock key on the partition owner.
  */
-public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOperation, BackupAwareOperation {
+public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOperation, BackupAwareOperation, MutatingOperation {
 
     private long version;
     private String ownerUuid;

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.impl.operation.BaseRemoveOperation;
-import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
@@ -156,7 +156,7 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
         }
     }
 
-    private static class ExceptionThrowingRemoveBackupOperation extends MutatingKeyBasedMapOperation {
+    private static class ExceptionThrowingRemoveBackupOperation extends KeyBasedMapOperation {
 
         private ExceptionThrowingRemoveBackupOperation() {
         }


### PR DESCRIPTION
Merges cannot be stopped by quorum.
MergeOperations should not implement MutatingInterface since they will be blocked by no quorum, which may mean that the cluster never merges correctly.

EE side: https://github.com/hazelcast/hazelcast-enterprise/pull/1850
  
  