### PR TITLE
Send NormalResponse's value serializerTypeId with proper endianness

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization;
 
+import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
@@ -37,6 +38,9 @@ public interface InternalSerializationService extends SerializationService, Disp
     /**
      * Writes the obj to a byte array. This call is exactly the same as calling {@link #toData(Object)} and
      * then calling {@link Data#toByteArray()}. But it doesn't force a HeapData object being created.
+     * <p>
+     * <b>IMPORTANT:</b> The byte order used to serialize {@code obj}'s serializer type ID is always
+     * {@link ByteOrder#BIG_ENDIAN}.
      */
     byte[] toBytes(Object obj);
 
@@ -47,12 +51,19 @@ public interface InternalSerializationService extends SerializationService, Disp
      *
      * The padded bytes are not zero'd out since they will be written by the caller. Zero'ing them out would be waste of
      * time.
-     *
+     * <p>
      * If you want to convert an object to a Data (or its byte representation) then you want to have the partition hash, because
      * that is part of the Data-definition.
      *
      * But if you want to serialize an object to a byte-array and don't care for the Data partition-hash, the hash can be
      * disabled.
+     * <p>
+     * <b>IMPORTANT:</b> The byte order used to serialize {@code obj}'s serializer type ID is the byte order
+     * configured in {@link SerializationConfig#getByteOrder()}.
+     *
+     * @param obj                       object to write to byte array
+     * @param leftPadding               offset from beginning of byte array to start writing the object's bytes
+     * @param insertPartitionHash       {@code true} to include the partition hash in the byte array, otherwise {@code false}
      */
     byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash);
 
@@ -84,6 +95,19 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     ClassLoader getClassLoader();
 
+    /**
+     * Returns the byte order used when serializing/deserializing objects. A notable exception is the top-level object's
+     * {@code serializerTypeId}: when using {@link #toBytes(Object)}, the object's {@code serializerTypeId} is serialized
+     * always in {@link ByteOrder#BIG_ENDIAN}, while when using {@link #toBytes(Object, int, boolean)}, the configured
+     * byte order is used. Inner objects (for example those serialized within an
+     * {@code IdentifiedDataSerializable}'s {@code writeData(ObjectDataOutput)} with
+     * {@link ObjectDataOutput#writeObject(Object)}) always use the configured byte order.
+     *
+     * @return the {@link ByteOrder} which is configured for this {@link InternalSerializationService}.
+     * @see com.hazelcast.config.SerializationConfig#setByteOrder(ByteOrder)
+     * @see com.hazelcast.config.SerializationConfig#setUseNativeByteOrder(boolean)
+     * @see com.hazelcast.config.SerializationConfig#setAllowUnsafe(boolean)
+     */
     ByteOrder getByteOrder();
 
     byte getVersion();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -130,11 +130,17 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     @Override
     public byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash) {
-        return toBytes(obj, leftPadding, insertPartitionHash, globalPartitioningStrategy);
+        return toBytes(obj, leftPadding, insertPartitionHash, globalPartitioningStrategy, getByteOrder());
     }
 
     private byte[] toBytes(Object obj, int leftPadding, boolean writeHash, PartitioningStrategy strategy) {
+        return toBytes(obj, leftPadding, writeHash, strategy, BIG_ENDIAN);
+    }
+
+    private byte[] toBytes(Object obj, int leftPadding, boolean writeHash, PartitioningStrategy strategy,
+                           ByteOrder serializerTypeIdByteOrder) {
         checkNotNull(obj);
+        checkNotNull(serializerTypeIdByteOrder);
 
         BufferPool pool = bufferPoolThreadLocal.get();
         BufferObjectDataOutput out = pool.takeOutputBuffer();
@@ -147,7 +153,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
                 out.writeInt(partitionHash, BIG_ENDIAN);
             }
 
-            out.writeInt(serializer.getTypeId(), BIG_ENDIAN);
+            out.writeInt(serializer.getTypeId(), serializerTypeIdByteOrder);
 
             serializer.write(out, obj);
             return out.toByteArray();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -17,27 +17,38 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class OutboundResponseHandlerTest {
+
+    @Parameter
+    public ByteOrder byteOrder;
 
     private OutboundResponseHandler handler;
     private Address thisAddress;
@@ -47,11 +58,18 @@ public class OutboundResponseHandlerTest {
     private Address thatAddress;
     private ConnectionManager connectionManager;
 
+    @Parameters(name = "{0}")
+    public static Object[][] parameters() {
+        return new Object[][] {
+                {BIG_ENDIAN}, {LITTLE_ENDIAN}
+        };
+    }
+
     @Before
     public void setup() throws Exception {
         thisAddress = new Address("127.0.0.1", 5701);
         thatAddress = new Address("127.0.0.1", 5702);
-        serializationService = new DefaultSerializationServiceBuilder().build();
+        serializationService = new DefaultSerializationServiceBuilder().setByteOrder(byteOrder).build();
         node = mock(Node.class);
         connectionManager = mock(ConnectionManager.class);
         when(node.getConnectionManager()).thenReturn(connectionManager);


### PR DESCRIPTION
The `NormalResponse`'s `serializerTypeId` has to be sent as BIG_ENDIAN
however the inner value object must have its `serializerTypeId` sent out
with the configured endianness.

Fixes #12077 on `maintenance-3.x`