### PR TITLE
Refactored map merge operation

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientListenersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientListenersTest.java
@@ -131,7 +131,7 @@ public class ClientListenersTest extends HazelcastTestSupport {
         Data key = serializationService.toData(1);
         Data value = serializationService.toData(new ClientRegressionWithMockNetworkTest.SamplePortable(1));
         EntryView entryView = EntryViews.createSimpleEntryView(key, value, Mockito.mock(Record.class));
-        MergeOperation op = new MergeOperation(map.getName(), key, entryView, new PassThroughMergePolicy());
+        MergeOperation op = new MergeOperation(map.getName(), entryView, new PassThroughMergePolicy(), false);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
         operationService.invokeOnPartition(MapService.SERVICE_NAME, op, partitionId);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -69,13 +69,11 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
     }
 
     private void handleUpdate(MapReplicationUpdate replicationUpdate) {
-        EntryView entryView = replicationUpdate.getEntryView();
+        EntryView<Data, Data> entryView = replicationUpdate.getEntryView();
         MapMergePolicy mergePolicy = replicationUpdate.getMergePolicy();
         String mapName = replicationUpdate.getMapName();
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(mapName);
-        Data dataKey = mapServiceContext.toData(entryView.getKey(), mapContainer.getPartitioningStrategy());
-        MapOperation operation = operationProvider.createMergeOperation(mapName, dataKey, entryView, mergePolicy, true);
+        MapOperation operation = operationProvider.createMergeOperation(mapName, entryView, mergePolicy, true);
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(entryView.getKey());
             Future f = nodeEngine.getOperationService()

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -164,7 +164,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                     Data value = mapServiceContext.toData(record.getValue());
                     EntryView<Data, Data> entryView = createSimpleEntryView(key, value, record);
 
-                    Operation operation = operationProvider.createMergeOperation(mapName, key, entryView, mergePolicy, false);
+                    Operation operation = operationProvider.createMergeOperation(mapName, entryView, mergePolicy, false);
                     try {
                         int partitionId = partitionService.getPartitionId(key);
                         operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId)

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -36,7 +36,7 @@ public interface MapEventPublisher {
      * @param mapName   the map name
      * @param entryView the updated entry
      */
-    void publishWanReplicationUpdate(String mapName, EntryView entryView);
+    void publishWanReplicationUpdate(String mapName, EntryView<Data, Data> entryView);
 
     /**
      * Notifies the WAN subsystem of a map entry removal on a replica owner.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -84,7 +84,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
     }
 
     @Override
-    public void publishWanReplicationUpdate(String mapName, EntryView entryView) {
+    public void publishWanReplicationUpdate(String mapName, EntryView<Data, Data> entryView) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         MapReplicationUpdate replicationEvent
                 = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(), entryView);
@@ -173,13 +173,13 @@ public class MapEventPublisherImpl implements MapEventPublisher {
      * @param eventType     the event type
      * @param dataKey       the key of the event map entry
      * @param oldValue      the old value of the map entry
-     * @param newValue         the new value of the map entry
+     * @param newValue      the new value of the map entry
      * @param mergingValue  the value used when performing a merge operation in case of a {@link EntryEventType#MERGED} event.
      *                      This value together with the old value produced the new value.
      */
     private void publishEvent(Collection<EventRegistration> registrations, Address caller, String mapName,
-                                     EntryEventType eventType, Data dataKey, Object oldValue, Object newValue,
-                                     Object mergingValue) {
+                              EntryEventType eventType, Data dataKey, Object oldValue, Object newValue,
+                              Object mergingValue) {
 
         EntryEventDataCache eventDataCache = filteringStrategy.getEntryEventDataCache();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -184,9 +184,9 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createMergeOperation(String name, Data dataKey, EntryView<Data, Data> entryView,
+    public MapOperation createMergeOperation(String name, EntryView<Data, Data> mergingEntry,
                                              MapMergePolicy policy, boolean disableWanReplicationEvent) {
-        return new MergeOperation(name, dataKey, entryView, policy, disableWanReplicationEvent);
+        return new MergeOperation(name, mergingEntry, policy, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -105,8 +105,8 @@ public interface MapOperationProvider {
 
     MapOperation createTxnSetOperation(String name, Data dataKey, Data value, long version, long ttl);
 
-    MapOperation createMergeOperation(String name, Data dataKey, EntryView<Data, Data> entryView,
-                                      MapMergePolicy policy, boolean disableWanReplicationEvent);
+    MapOperation createMergeOperation(String name, EntryView<Data, Data> entryView, MapMergePolicy policy,
+                                      boolean disableWanReplicationEvent);
 
     MapOperation createMapFlushOperation(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -165,9 +165,9 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createMergeOperation(String name, Data dataKey, EntryView<Data, Data> entryView,
+    public MapOperation createMergeOperation(String name, EntryView<Data, Data> mergingEntry,
                                              MapMergePolicy policy, boolean disableWanReplicationEvent) {
-        return getDelegate().createMergeOperation(name, dataKey, entryView, policy, disableWanReplicationEvent);
+        return getDelegate().createMergeOperation(name, mergingEntry, policy, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -39,20 +39,15 @@ public class MergeOperation extends BasePutOperation {
     private transient boolean merged;
     private transient Data mergingValue;
 
-    public MergeOperation(String name, Data dataKey, EntryView<Data, Data> entryView,
-                          MapMergePolicy policy) {
-        this(name, dataKey, entryView, policy, false);
+    public MergeOperation() {
     }
 
-    public MergeOperation(String name, Data dataKey, EntryView<Data, Data> entryView,
+    public MergeOperation(String name, EntryView<Data, Data> mergingEntry,
                           MapMergePolicy policy, boolean disableWanReplicationEvent) {
-        super(name, dataKey, null);
-        this.mergingEntry = entryView;
+        super(name, mergingEntry.getKey(), null);
+        this.mergingEntry = mergingEntry;
         this.mergePolicy = policy;
         this.disableWanReplicationEvent = disableWanReplicationEvent;
-    }
-
-    public MergeOperation() {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.wan.ReplicationEventObject;
 import com.hazelcast.wan.impl.WanDataSerializerHook;
@@ -30,12 +31,12 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
 
     String mapName;
     MapMergePolicy mergePolicy;
-    EntryView entryView;
+    EntryView<Data, Data> entryView;
 
     public MapReplicationUpdate() {
     }
 
-    public MapReplicationUpdate(String mapName, MapMergePolicy mergePolicy, EntryView entryView) {
+    public MapReplicationUpdate(String mapName, MapMergePolicy mergePolicy, EntryView<Data, Data> entryView) {
         this.mergePolicy = mergePolicy;
         this.mapName = mapName;
         this.entryView = entryView;
@@ -57,7 +58,7 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
         this.mergePolicy = mergePolicy;
     }
 
-    public EntryView getEntryView() {
+    public EntryView<Data, Data> getEntryView() {
         return entryView;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheIMapEventHandlingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheIMapEventHandlingTest.java
@@ -106,7 +106,7 @@ public class QueryCacheIMapEventHandlingTest extends HazelcastTestSupport {
         Data valueData = serializationService.toData(mergedValue);
         EntryView<Data, Data> entryView = createSimpleEntryView(keyData, valueData, Mockito.mock(Record.class));
 
-        MergeOperation mergeOperation = new MergeOperation(mapName, keyData, entryView, new PassThroughMergePolicy());
+        MergeOperation mergeOperation = new MergeOperation(mapName, entryView, new PassThroughMergePolicy(), false);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
         Future<Object> future = operationService.invokeOnPartition(SERVICE_NAME, mergeOperation, partitionId);
         future.get();


### PR DESCRIPTION
  Removed passing `key` to MergeOperation since key is already there inside entry-view