### PR TITLE
Use existing near-cache for TransactionalMap, do not create a new one

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.nearcache;
 
-import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.nearcache.NearCache;
@@ -30,7 +29,6 @@ import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EventListenerFilter;
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.invalidation.MemberMapMetaDataFetcher;
@@ -135,17 +133,6 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     public boolean destroyNearCache(String mapName) {
         invalidator.destroy(mapName, nodeEngine.getLocalMember().getUuid());
         return super.destroyNearCache(mapName);
-    }
-
-    public Object getFromNearCache(String mapName, Object key) {
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        if (!mapContainer.hasInvalidationListener()) {
-            return null;
-        }
-
-        NearCacheConfig nearCacheConfig = mapContainer.getMapConfig().getNearCacheConfig();
-        NearCache<Object, Object> nearCache = getOrCreateNearCache(mapName, nearCacheConfig);
-        return nearCache.get(key);
     }
 
     public Invalidator getInvalidator() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -68,7 +68,6 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
 
     private final boolean serializeKeys;
     private final RecordComparator recordComparator;
-    private final NearCache<Object, Object> nearCache;
 
     TransactionalMapProxySupport(String name, MapService mapService, NodeEngine nodeEngine, Transaction transaction) {
         super(nodeEngine, mapService, transaction);
@@ -85,7 +84,6 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         this.recordComparator = mapServiceContext.getRecordComparator(mapConfig.getInMemoryFormat());
         this.nearCacheEnabled = mapConfig.isNearCacheEnabled();
         NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
-        this.nearCache = nearCacheEnabled ? mapNearCacheManager.getOrCreateNearCache(name, nearCacheConfig) : null;
         this.serializeKeys = nearCacheEnabled && nearCacheConfig.isSerializeKeys();
     }
 
@@ -167,11 +165,21 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
             return;
         }
 
+        NearCache<Object, Object> nearCache = mapNearCacheManager.getNearCache(name);
+        if (nearCache == null) {
+            return;
+        }
+
         nearCache.remove(nearCacheKey);
     }
 
     private Object getCachedValue(Object nearCacheKey, boolean deserializeValue) {
-        Object value = mapNearCacheManager.getFromNearCache(name, nearCacheKey);
+        NearCache<Object, Object> nearCache = mapNearCacheManager.getNearCache(name);
+        if (nearCache == null) {
+            return null;
+        }
+
+        Object value = nearCache.get(nearCacheKey);
         if (value == null) {
             return NOT_CACHED;
         }


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/11456

Otherwise creating a near cache can result with unexpected behavior as in failed test in the issue. This is because, stale read detector slowly detects pre-populated data by txn map as stale and removes it from the near cache upon creation of underlying regular imap proxy. Near cache can only be populated by regular imap not txn one.
  