### PR TITLE
Log around lock operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -167,7 +167,6 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
         container.clearLockStore(namespace);
     }
 
-
     public LockStoreContainer getLockContainer(int partitionId) {
         return containers[partitionId];
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -157,7 +157,7 @@ public interface LockStore {
      * waiters/signals/expired operations.
      *
      * @param dataKey the lock key
-     * @return if the key was unlocked or is already unlocked
+     * @return {@code false} if there is no lock for the given {@code key} and {@code true} otherwise
      */
     boolean forceUnlock(Data dataKey);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.BlockingOperation;
@@ -44,7 +45,19 @@ public class LockOperation extends AbstractLockOperation implements BlockingOper
 
     @Override
     public void run() throws Exception {
-        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
+        final boolean lockResult = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
+        response = lockResult;
+
+        ILogger logger = getLogger();
+        if (logger.isFinestEnabled()) {
+            if (lockResult) {
+                logger.finest("Acquired lock " + namespace.getObjectName()
+                        + " for " + getCallerAddress() + " - " + getCallerUuid() + ", thread ID: " + threadId);
+            } else {
+                logger.finest("Could not acquire lock " + namespace.getObjectName()
+                        + " as owned by " + getLockStore().getOwnerInfo(key));
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.concurrent.lock.operations;
 
 import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -72,12 +73,27 @@ public class UnlockOperation extends AbstractLockOperation implements Notifier, 
             // we can not check for retry here, hence just throw the exception
             String ownerInfo = lockStore.getOwnerInfo(key);
             throw new IllegalMonitorStateException("Current thread is not owner of the lock! -> " + ownerInfo);
+        } else {
+            ILogger logger = getLogger();
+            if (logger.isFinestEnabled()) {
+                logger.finest("Released lock " + namespace.getObjectName());
+            }
         }
     }
 
     protected final void forceUnlock() {
         LockStoreImpl lockStore = getLockStore();
-        response = lockStore.forceUnlock(key);
+        boolean unlocked = lockStore.forceUnlock(key);
+        this.response = unlocked;
+
+        ILogger logger = getLogger();
+        if (logger.isFinestEnabled()) {
+            if (unlocked) {
+                logger.finest("Released lock " + namespace.getObjectName());
+            } else {
+                logger.finest("Could not release lock " + namespace.getObjectName() + " as it is not locked");
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Log at the finest level when locks are created, acquired, released or destroyed. Log messages added both before and after the operation with contextual information (success, requester, owner) where applicable.

Fixes #11622 
  