### PR TITLE
Fixes for tx map near cache test failure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
@@ -58,7 +58,7 @@ public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
         MetaDataGenerator metaData = getPartitionMetaDataGenerator(cacheService);
 
         int partitionId = segment.getPartitionId();
-        partitionUuid = metaData.getUuidOrNull(partitionId);
+        partitionUuid = metaData.getOrCreateUuid(partitionId);
 
         cacheNameSequencePairs = new ArrayList(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.nearcache;
 
-import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.nearcache.NearCache;
@@ -30,7 +29,6 @@ import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EventListenerFilter;
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.invalidation.MemberMapMetaDataFetcher;
@@ -135,17 +133,6 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     public boolean destroyNearCache(String mapName) {
         invalidator.destroy(mapName, nodeEngine.getLocalMember().getUuid());
         return super.destroyNearCache(mapName);
-    }
-
-    public Object getFromNearCache(String mapName, Object key) {
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        if (!mapContainer.hasInvalidationListener()) {
-            return null;
-        }
-
-        NearCacheConfig nearCacheConfig = mapContainer.getMapConfig().getNearCacheConfig();
-        NearCache<Object, Object> nearCache = getOrCreateNearCache(mapName, nearCacheConfig);
-        return nearCache.get(key);
     }
 
     public Invalidator getInvalidator() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
@@ -66,7 +66,7 @@ public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
         MetaDataGenerator metaData = getPartitionMetaDataGenerator(mapService);
 
         int partitionId = container.getPartitionId();
-        partitionUuid = metaData.getUuidOrNull(partitionId);
+        partitionUuid = metaData.getOrCreateUuid(partitionId);
 
         for (ServiceNamespace namespace : namespaces) {
             if (mapNameSequencePairs == emptyList()) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -170,6 +170,8 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
         NearCacheTestContext<Integer, String, Data, String> context = createContext();
 
         waitForExpectedClusterSize();
+        waitAllForSafeState(hazelcastFactory.getAllHazelcastInstances());
+
         assertBackingIMapSize(context);
 
         // populate the data structure


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/11456

Commit explanations:

- Cause of test failure seems related to stale-read-detectors data removal due to the null partition uuid. This can happen as a result of race between owner assignment and repairing-handler initialization: https://github.com/hazelcast/hazelcast/commit/2998067681c059905391b3a2c6b9864b9f610961
- Also this pr includes a fix for another race between migration and repairing-handler initialization while creating uuids: https://github.com/hazelcast/hazelcast/commit/7b94e214b6993cff99d08a01e80b1b1cfb092fb0
- And removed this [line](https://github.com/hazelcast/hazelcast/compare/maintenance-3.x...ahmetmircik:fix/3.9.3/txMapNearCache?expand=1#diff-983bc3dfb117738e8d88db7dcff365abL88) it is no need, txn proxy init handles that:https://github.com/hazelcast/hazelcast/commit/095603ccf8e8b6ca20175053dfa26cf8dd30e619
  