### PR TITLE
Endianness fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization;
 
+import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
@@ -37,6 +38,9 @@ public interface InternalSerializationService extends SerializationService, Disp
     /**
      * Writes the obj to a byte array. This call is exactly the same as calling {@link #toData(Object)} and
      * then calling {@link Data#toByteArray()}. But it doesn't force a HeapData object being created.
+     * <p>
+     * <b>IMPORTANT:</b> The byte order used to serialize {@code obj}'s serializer type ID is always
+     * {@link ByteOrder#BIG_ENDIAN}.
      */
     byte[] toBytes(Object obj);
 
@@ -47,12 +51,19 @@ public interface InternalSerializationService extends SerializationService, Disp
      *
      * The padded bytes are not zero'd out since they will be written by the caller. Zero'ing them out would be waste of
      * time.
-     *
+     * <p>
      * If you want to convert an object to a Data (or its byte representation) then you want to have the partition hash, because
      * that is part of the Data-definition.
      *
      * But if you want to serialize an object to a byte-array and don't care for the Data partition-hash, the hash can be
      * disabled.
+     * <p>
+     * <b>IMPORTANT:</b> The byte order used to serialize {@code obj}'s serializer type ID is the byte order
+     * configured in {@link SerializationConfig#getByteOrder()}.
+     *
+     * @param obj                       object to write to byte array
+     * @param leftPadding               offset from beginning of byte array to start writing the object's bytes
+     * @param insertPartitionHash       {@code true} to include the partition hash in the byte array, otherwise {@code false}
      */
     byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash);
 
@@ -84,6 +95,19 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     ClassLoader getClassLoader();
 
+    /**
+     * Returns the byte order used when serializing/deserializing objects. A notable exception is the top-level object's
+     * {@code serializerTypeId}: when using {@link #toBytes(Object)}, the object's {@code serializerTypeId} is serialized
+     * always in {@link ByteOrder#BIG_ENDIAN}, while when using {@link #toBytes(Object, int, boolean)}, the configured
+     * byte order is used. Inner objects (for example those serialized within an
+     * {@code IdentifiedDataSerializable}'s {@code writeData(ObjectDataOutput)} with
+     * {@link ObjectDataOutput#writeObject(Object)}) always use the configured byte order.
+     *
+     * @return the {@link ByteOrder} which is configured for this {@link InternalSerializationService}.
+     * @see com.hazelcast.config.SerializationConfig#setByteOrder(ByteOrder)
+     * @see com.hazelcast.config.SerializationConfig#setUseNativeByteOrder(boolean)
+     * @see com.hazelcast.config.SerializationConfig#setAllowUnsafe(boolean)
+     */
     ByteOrder getByteOrder();
 
     byte getVersion();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -130,11 +130,17 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     @Override
     public byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash) {
-        return toBytes(obj, leftPadding, insertPartitionHash, globalPartitioningStrategy);
+        return toBytes(obj, leftPadding, insertPartitionHash, globalPartitioningStrategy, getByteOrder());
     }
 
     private byte[] toBytes(Object obj, int leftPadding, boolean writeHash, PartitioningStrategy strategy) {
+        return toBytes(obj, leftPadding, writeHash, strategy, BIG_ENDIAN);
+    }
+
+    private byte[] toBytes(Object obj, int leftPadding, boolean writeHash, PartitioningStrategy strategy,
+                           ByteOrder serializerTypeIdByteOrder) {
         checkNotNull(obj);
+        checkNotNull(serializerTypeIdByteOrder);
 
         BufferPool pool = bufferPoolThreadLocal.get();
         BufferObjectDataOutput out = pool.takeOutputBuffer();
@@ -147,7 +153,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
                 out.writeInt(partitionHash, BIG_ENDIAN);
             }
 
-            out.writeInt(serializer.getTypeId(), BIG_ENDIAN);
+            out.writeInt(serializer.getTypeId(), serializerTypeIdByteOrder);
 
             serializer.write(out, obj);
             return out.toByteArray();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -36,6 +36,7 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.SerializerHook;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.util.StringUtil;
 import com.hazelcast.util.function.Supplier;
 
 import java.nio.ByteOrder;
@@ -45,10 +46,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.ByteOrder.nativeOrder;
 
 public class DefaultSerializationServiceBuilder implements SerializationServiceBuilder {
 
+    // System property to override configured byte order for tests
+    private static final String BYTE_ORDER_OVERRIDE_PROPERTY = "hazelcast.serialization.byteOrder";
     private static final int DEFAULT_OUT_BUFFER_SIZE = 4 * 1024;
 
     protected final Map<Integer, DataSerializableFactory> dataSerializableFactories =
@@ -305,12 +309,26 @@ public class DefaultSerializationServiceBuilder implements SerializationServiceB
     }
 
     protected InputOutputFactory createInputOutputFactory() {
+        overrideByteOrder();
+
         if (byteOrder == null) {
             byteOrder = useNativeByteOrder ? nativeOrder() : BIG_ENDIAN;
         }
         return byteOrder == nativeOrder() && allowUnsafe && GlobalMemoryAccessorRegistry.MEM_AVAILABLE
                 ? new UnsafeInputOutputFactory()
                 : new ByteArrayInputOutputFactory(byteOrder);
+    }
+
+    protected void overrideByteOrder() {
+        String byteOrderOverride = System.getProperty(BYTE_ORDER_OVERRIDE_PROPERTY);
+        if (StringUtil.isNullOrEmpty(byteOrderOverride)) {
+            return;
+        }
+        if (BIG_ENDIAN.toString().equals(byteOrderOverride)) {
+            byteOrder = BIG_ENDIAN;
+        } else if (LITTLE_ENDIAN.toString().equals(byteOrderOverride)) {
+            byteOrder = LITTLE_ENDIAN;
+        }
     }
 
     private void addConfigDataSerializableFactories(Map<Integer, DataSerializableFactory> dataSerializableFactories,

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.SerializationServiceBuilder;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.ByteOrder;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DefaultSerializationServiceBuilderTest {
+
+    @Test
+    public void test_byteOrderIsOverridden_whenLittleEndian() {
+        System.setProperty("hazelcast.serialization.byteOrder", "LITTLE_ENDIAN");
+        try {
+            InternalSerializationService serializationService = getSerializationServiceBuilder().build();
+            assertEquals(ByteOrder.LITTLE_ENDIAN, serializationService.getByteOrder());
+        } finally {
+            System.clearProperty("hazelcast.serialization.byteOrder");
+        }
+    }
+
+    @Test
+    public void test_byteOrderIsOverridden_whenBigEndian() {
+        System.setProperty("hazelcast.serialization.byteOrder", "BIG_ENDIAN");
+        try {
+            InternalSerializationService serializationService = getSerializationServiceBuilder().build();
+            assertEquals(ByteOrder.BIG_ENDIAN, serializationService.getByteOrder());
+        } finally {
+            System.clearProperty("hazelcast.serialization.byteOrder");
+        }
+    }
+
+    @Test
+    public void test_versionResetToDefault_whenVersionNegative() {
+        InternalSerializationService serializationService = getSerializationServiceBuilder()
+                .setVersion(Byte.MIN_VALUE).build();
+        assertEquals(BuildInfoProvider.getBuildInfo().getSerializationVersion(), serializationService.getVersion());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_exceptionThrown_whenNegativeVersionOverriddenViaProperty() {
+        System.setProperty(GroupProperty.SERIALIZATION_VERSION.getName(), "127");
+        try {
+            getSerializationServiceBuilder().setVersion(Byte.MIN_VALUE).build();
+        } finally {
+            System.clearProperty(GroupProperty.SERIALIZATION_VERSION.getName());
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_exceptionThrown_whenVersionGreaterThanMax() {
+        getSerializationServiceBuilder().setVersion(Byte.MAX_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_exceptionThrown_whenPortableVersionNegative() {
+        getSerializationServiceBuilder().setPortableVersion(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_exceptionThrown_whenInitialOutputBufferSizeNegative() {
+        getSerializationServiceBuilder().setInitialOutputBufferSize(-1);
+    }
+
+    protected SerializationServiceBuilder getSerializationServiceBuilder() {
+        return new DefaultSerializationServiceBuilder();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -17,27 +17,38 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class OutboundResponseHandlerTest {
+
+    @Parameter
+    public ByteOrder byteOrder;
 
     private OutboundResponseHandler handler;
     private Address thisAddress;
@@ -47,11 +58,18 @@ public class OutboundResponseHandlerTest {
     private Address thatAddress;
     private ConnectionManager connectionManager;
 
+    @Parameters(name = "{0}")
+    public static Object[][] parameters() {
+        return new Object[][] {
+                {BIG_ENDIAN}, {LITTLE_ENDIAN}
+        };
+    }
+
     @Before
     public void setup() throws Exception {
         thisAddress = new Address("127.0.0.1", 5701);
         thatAddress = new Address("127.0.0.1", 5702);
-        serializationService = new DefaultSerializationServiceBuilder().build();
+        serializationService = new DefaultSerializationServiceBuilder().setByteOrder(byteOrder).build();
         node = mock(Node.class);
         connectionManager = mock(ConnectionManager.class);
         when(node.getConnectionManager()).thenReturn(connectionManager);


### PR DESCRIPTION
- Forward port of #12090 (cherry-picked from 2448b83)
- Introduces system property to override configured serialization service byte order for testing (see https://github.com/hazelcast/hazelcast-enterprise/issues/1848)
- Adds some tests to improve coverage of `DefaultSerializationServiceBuilder`