### PR TITLE
[BACKPORT] [cache] Support JCache 1.1

### DIFF
--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -202,13 +202,13 @@
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
             <classifier>tests</classifier>
-            <version>1.0.0</version>
+            <version>${jsr107.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
-            <version>1.0.0</version>
+            <version>${jsr107.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
@@ -73,6 +73,7 @@ final class CacheStatsHandler {
     void onPutIfAbsent(long startNanos, boolean saved) {
         if (saved) {
             statistics.increaseCachePuts();
+            statistics.increaseCacheMisses();
             statistics.addPutTimeNanos(System.nanoTime() - startNanos);
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -80,7 +80,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
     }
 
     private void enableStatisticManagementOnNodes(String cacheName, boolean statOrMan, boolean enabled) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         checkNotNull(cacheName, "cacheName cannot be null");
         ClientCacheHelper.enableStatisticManagementOnNodes(client, getCacheNameWithPrefix(cacheName),
                 statOrMan, enabled);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.util.StringUtil;
 
 import java.io.IOException;
 import java.net.URI;
@@ -145,7 +146,11 @@ public final class HazelcastClientCachingProvider extends AbstractHazelcastCachi
     }
 
     private ClientConfig getDefaultClientConfig() {
-        return new XmlClientConfigBuilder().build();
+        ClientConfig clientConfig = new XmlClientConfigBuilder().build();
+        if (namedDefaultHzInstance && StringUtil.isNullOrEmpty(clientConfig.getInstanceName())) {
+            clientConfig.setInstanceName(SHARED_JCACHE_INSTANCE_NAME);
+        }
+        return clientConfig;
     }
 
     protected ClientConfig getConfigFromLocation(String location, ClassLoader classLoader, String instanceName)

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
@@ -34,9 +34,12 @@ import org.junit.runner.RunWith;
 import javax.cache.spi.CachingProvider;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
+import static com.hazelcast.cache.jsr.JsrTestUtil.clearSystemProperties;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -62,8 +65,6 @@ public class ClientCachingProviderTest extends CachingProviderTest {
             throw new AssertionError("Could not construct named hazelcast client instance: " +
                     e.getMessage());
         }
-        instances.add(instance1);
-        instances.add(instance2);
         instances.add(instance3);
         cachingProvider = createCachingProvider(instance1);
     }
@@ -89,6 +90,17 @@ public class ClientCachingProviderTest extends CachingProviderTest {
         HazelcastInstance otherInstance = HazelcastClient.getHazelcastClientByName(instanceName);
         assertNotNull(otherInstance);
         otherInstance.getLifecycleService().terminate();
+    }
+
+    @Override
+    protected Collection<HazelcastInstance> getStartedInstances() {
+        return HazelcastClient.getAllHazelcastClients();
+    }
+
+    @Override
+    protected void cleanupForDefaultCacheManagerTest() {
+        clearSystemProperties();
+        clearCachingProviderRegistry();
     }
 
     @After

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -295,20 +295,14 @@
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
             <classifier>tests</classifier>
-            <version>1.0.0</version>
+            <version>${jsr107.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
-            <version>1.0.0</version>
+            <version>${jsr107.tck.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>test-domain</artifactId>
-                    <groupId>javax.cache</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -108,7 +108,7 @@ public abstract class AbstractHazelcastCacheManager
 
     private <K, V, C extends Configuration<K, V>> ICacheInternal<K, V> createCacheInternal(String cacheName,
             C configuration) throws IllegalArgumentException {
-        checkIfManagerNotClosed();
+        ensureOpen();
         checkNotNull(cacheName, "cacheName must not be null");
         checkNotNull(configuration, "configuration must not be null");
 
@@ -180,7 +180,7 @@ public abstract class AbstractHazelcastCacheManager
 
     @Override
     public <K, V> ICache<K, V> getCache(String cacheName, Class<K> keyType, Class<V> valueType) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         checkNotNull(keyType, "keyType can not be null");
         checkNotNull(valueType, "valueType can not be null");
         ICacheInternal<?, ?> cache = getCacheUnchecked(cacheName);
@@ -204,7 +204,7 @@ public abstract class AbstractHazelcastCacheManager
     }
 
     public <K, V>  ICache<K, V> getOrCreateCache(String cacheName, CacheConfig<K, V> cacheConfig) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         ICacheInternal<?, ?> cache = caches.get(cacheNameWithPrefix);
         if (cache == null) {
@@ -215,7 +215,7 @@ public abstract class AbstractHazelcastCacheManager
 
     @Override
     public <K, V> ICache<K, V> getCache(String cacheName) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         ICacheInternal<?, ?> cache = getCacheUnchecked(cacheName);
         if (cache != null) {
             Configuration<?, ?> configuration = cache.getConfiguration(CacheConfig.class);
@@ -262,7 +262,7 @@ public abstract class AbstractHazelcastCacheManager
 
     @Override
     public Iterable<String> getCacheNames() {
-        checkIfManagerNotClosed();
+        ensureOpen();
         Set<String> names;
         names = new LinkedHashSet<String>();
         for (Map.Entry<String, ICacheInternal<?, ?>> entry : caches.entrySet()) {
@@ -281,7 +281,7 @@ public abstract class AbstractHazelcastCacheManager
 
     @Override
     public void removeCache(String cacheName, boolean destroy) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         checkNotNull(cacheName, "cacheName cannot be null");
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         ICacheInternal<?, ?> cache = caches.remove(cacheNameWithPrefix);
@@ -366,7 +366,7 @@ public abstract class AbstractHazelcastCacheManager
         return isClosed.get() || !hazelcastInstance.getLifecycleService().isRunning();
     }
 
-    protected void checkIfManagerNotClosed() {
+    protected void ensureOpen() {
         if (isClosed()) {
             throw new IllegalStateException("CacheManager " + cacheNamePrefix + " is already closed.");
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -262,17 +262,14 @@ public abstract class AbstractHazelcastCacheManager
 
     @Override
     public Iterable<String> getCacheNames() {
+        checkIfManagerNotClosed();
         Set<String> names;
-        if (isClosed()) {
-            names = Collections.emptySet();
-        } else {
-            names = new LinkedHashSet<String>();
-            for (Map.Entry<String, ICacheInternal<?, ?>> entry : caches.entrySet()) {
-                String nameWithPrefix = entry.getKey();
-                int index = nameWithPrefix.indexOf(cacheNamePrefix) + cacheNamePrefix.length();
-                final String name = nameWithPrefix.substring(index);
-                names.add(name);
-            }
+        names = new LinkedHashSet<String>();
+        for (Map.Entry<String, ICacheInternal<?, ?>> entry : caches.entrySet()) {
+            String nameWithPrefix = entry.getKey();
+            int index = nameWithPrefix.indexOf(cacheNamePrefix) + cacheNamePrefix.length();
+            final String name = nameWithPrefix.substring(index);
+            names.add(name);
         }
         return Collections.unmodifiableCollection(names);
     }
@@ -371,7 +368,7 @@ public abstract class AbstractHazelcastCacheManager
 
     protected void checkIfManagerNotClosed() {
         if (isClosed()) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("CacheManager " + cacheNamePrefix + " is already closed.");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -218,15 +218,7 @@ public abstract class AbstractHazelcastCacheManager
         ensureOpen();
         ICacheInternal<?, ?> cache = getCacheUnchecked(cacheName);
         if (cache != null) {
-            Configuration<?, ?> configuration = cache.getConfiguration(CacheConfig.class);
-            if (Object.class.equals(configuration.getKeyType()) && Object.class.equals(configuration.getValueType())) {
-                return ensureOpenIfAvailable((ICacheInternal<K, V>) cache);
-            } else {
-                throw new IllegalArgumentException(
-                        "Cache " + cacheName + " was " + "defined with specific types Cache<" + configuration.getKeyType() + ", "
-                                + configuration.getValueType() + "> "
-                                + "in which case CacheManager.getCache(String, Class, Class) must be used");
-            }
+            return ensureOpenIfAvailable((ICacheInternal<K, V>) cache);
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
@@ -36,6 +36,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.WeakHashMap;
 
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getProperty;
+
 /**
  * Abstract {@link CachingProvider} implementation providing shared functionality to server and client caching
  * providers.
@@ -52,6 +55,20 @@ import java.util.WeakHashMap;
  */
 public abstract class AbstractHazelcastCachingProvider
         implements CachingProvider {
+
+    /**
+     * Name of default {@link HazelcastInstance} which may be started when obtaining the default {@link CachingProvider}.
+     */
+    public static final String SHARED_JCACHE_INSTANCE_NAME = "_hzinstance_jcache_shared";
+
+    /**
+     * System property to control whether the default Hazelcast instance, which may be started when obtaining the default
+     * {@link CachingProvider}, will have an instance name set or not. When not set or when system property
+     * {@code hazelcast.named.jcache.instance} is {@code "true"}, then a common instance name is used to get-or-create the
+     * default {@link HazelcastInstance}. When system property {@code hazelcast.named.jcache.instance} is {@code "false"}, then
+     * no instance name is set on the default configuration.
+     */
+    public static final String NAMED_JCACHE_HZ_INSTANCE = "hazelcast.named.jcache.instance";
 
     protected static final ILogger LOGGER = Logger.getLogger(HazelcastCachingProvider.class);
 
@@ -77,6 +94,7 @@ public abstract class AbstractHazelcastCachingProvider
 
     protected final ClassLoader defaultClassLoader;
     protected final URI defaultURI;
+    protected final boolean namedDefaultHzInstance = parseBoolean(getProperty(NAMED_JCACHE_HZ_INSTANCE, "true"));
 
     private final Map<ClassLoader, Map<URI, AbstractHazelcastCacheManager>> cacheManagers;
 
@@ -246,7 +264,7 @@ public abstract class AbstractHazelcastCachingProvider
         if (scheme == null) {
             // interpret as place holder
             try {
-                String resolvedPlaceholder = System.getProperty(location.getRawSchemeSpecificPart());
+                String resolvedPlaceholder = getProperty(location.getRawSchemeSpecificPart());
                 if (resolvedPlaceholder == null) {
                     return false;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -84,7 +84,7 @@ public class HazelcastServerCacheManager
 
     @Override
     public void enableManagement(String cacheName, boolean enabled) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         checkNotNull(cacheName, "cacheName cannot be null");
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         cacheService.setManagementEnabled(null, cacheNameWithPrefix, enabled);
@@ -93,7 +93,7 @@ public class HazelcastServerCacheManager
 
     @Override
     public void enableStatistics(String cacheName, boolean enabled) {
-        checkIfManagerNotClosed();
+        ensureOpen();
         checkNotNull(cacheName, "cacheName cannot be null");
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         cacheService.setStatisticsEnabled(null, cacheNameWithPrefix, enabled);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.StringUtil;
 
 import java.io.IOException;
 import java.net.URI;
@@ -154,7 +155,11 @@ public final class HazelcastServerCachingProvider
     }
 
     private Config getDefaultConfig() {
-        return new XmlConfigBuilder().build();
+        Config config = new XmlConfigBuilder().build();
+        if (namedDefaultHzInstance && StringUtil.isNullOrEmpty(config.getInstanceName())) {
+            config.setInstanceName(SHARED_JCACHE_INSTANCE_NAME);
+        }
+        return config;
     }
 
     private Config getConfigFromLocation(String location, ClassLoader classLoader, String instanceName)

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachingProviderTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache;
 
+import com.hazelcast.cache.impl.AbstractHazelcastCachingProvider;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
@@ -32,15 +33,21 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceName;
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByLocation;
+import static com.hazelcast.cache.jsr.JsrTestUtil.cleanup;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -194,6 +201,45 @@ public class CachingProviderTest extends HazelcastTestSupport {
         assertCacheManagerInstance(cacheManager, instance3);
     }
 
+    @Test
+    public void whenDefaultCacheManager_withUnnamedDefaultInstance_thenNoSharedNameHazelcastInstanceExists() {
+        cleanupForDefaultCacheManagerTest();
+        try {
+            System.setProperty(AbstractHazelcastCachingProvider.NAMED_JCACHE_HZ_INSTANCE, "false");
+            CachingProvider defaultCachingProvider = Caching.getCachingProvider();
+            CacheManager defaultCacheManager = defaultCachingProvider.getCacheManager();
+            Collection<HazelcastInstance> instances = getStartedInstances();
+            for (HazelcastInstance instance : instances) {
+                if (AbstractHazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME.equals(instance.getName())) {
+                    fail("The default named HazelcastInstance shouldn't have been started");
+                }
+            }
+            defaultCachingProvider.close();
+        } finally {
+            cleanup();
+        }
+    }
+
+    @Test
+    public void whenDefaultCacheManager_thenSharedNameHazelcastInstanceExists() {
+        cleanupForDefaultCacheManagerTest();
+        try {
+            CachingProvider defaultCachingProvider = Caching.getCachingProvider();
+            CacheManager defaultCacheManager = defaultCachingProvider.getCacheManager();
+            Collection<HazelcastInstance> instances = getStartedInstances();
+            boolean sharedInstanceStarted = false;
+            for (HazelcastInstance instance : instances) {
+                if (instance.getName().equals(AbstractHazelcastCachingProvider.SHARED_JCACHE_INSTANCE_NAME)) {
+                    sharedInstanceStarted = true;
+                }
+            }
+            assertTrue("The default named HazelcastInstance should have been started", sharedInstanceStarted);
+            defaultCachingProvider.close();
+        } finally {
+            cleanup();
+        }
+    }
+
     protected void assertCacheManagerInstance(HazelcastCacheManager cacheManager, HazelcastInstance instance) {
         assertEquals(instance, cacheManager.getHazelcastInstance());
     }
@@ -202,5 +248,14 @@ public class CachingProviderTest extends HazelcastTestSupport {
         HazelcastInstance otherInstance = Hazelcast.getHazelcastInstanceByName(instanceName);
         assertNotNull(otherInstance);
         otherInstance.getLifecycleService().terminate();
+    }
+
+    protected Collection<HazelcastInstance> getStartedInstances() {
+        return Hazelcast.getAllHazelcastInstances();
+    }
+
+    // tests for the default cache manager require cleanup before running which must be overridden for client-side tests
+    protected void cleanupForDefaultCacheManagerTest() {
+        cleanup();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/jsr/JsrTestUtil.java
@@ -88,7 +88,6 @@ public final class JsrTestUtil {
         setSystemProperty("CacheManagerImpl", "com.hazelcast.cache.HazelcastCacheManager");
         setSystemProperty("javax.cache.Cache", "com.hazelcast.cache.ICache");
         setSystemProperty("javax.cache.Cache.Entry", "com.hazelcast.cache.impl.CacheEntry");
-        setSystemProperty("org.jsr107.tck.management.agentId", "TCKMbeanServer");
         setSystemProperty("javax.cache.annotation.CacheInvocationContext",
                 "javax.cache.annotation.impl.cdi.CdiCacheKeyInvocationContextImpl");
     }

--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -156,6 +156,38 @@ public class CacheStatsTest extends CacheTestSupport {
     }
 
     @Test
+    public void testPutStat_whenPutIfAbsent_andKeysDoNotExist() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.putIfAbsent(i, "Value-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCachePuts());
+    }
+
+    @Test
+    public void testPutStat_whenPutIfAbsent_andKeysExist() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.putIfAbsent(i, "NewValue-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCachePuts());
+    }
+
+    @Test
     public void testAveragePutTimeStat() {
         ICache<Integer, String> cache = createCache();
         CacheStatistics stats = cache.getLocalCacheStatistics();
@@ -418,6 +450,38 @@ public class CacheStatsTest extends CacheTestSupport {
                 return stats.getCacheMisses();
             }
         }, GET_COUNT - ENTRY_COUNT);
+    }
+
+    @Test
+    public void testMissStat_whenPutIfAbsent_andKeysDoNotExist() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.putIfAbsent(i, "Value-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCacheMisses());
+    }
+
+    @Test
+    public void testMissStat_whenPutIfAbsent_andKeysAlreadyExist() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.putIfAbsent(i, "NewValue-" + i);
+        }
+
+        assertEquals(0, stats.getCacheMisses());
     }
 
     public void testMissPercentageStat() {

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
         <sonar.language>java</sonar.language>
         <sonar.verbose>true</sonar.verbose>
 
-        <jsr107.api.version>1.0.0</jsr107.api.version>
+        <jsr107.api.version>1.1.0</jsr107.api.version>
+        <jsr107.tck.version>1.1.0</jsr107.tck.version>
 
         <h2.version>1.3.160</h2.version>
         <atomikos.version>3.9.3</atomikos.version>


### PR DESCRIPTION
Backport of #12014 

JCache 1.1 compatibility fixes:

- Cache config key value type checks are not enforced in CacheManager.getCache()
- CacheManager.getCacheNames throws exception when CacheManager is already closed
- Cache.putIfAbsent statistics effects properly applied
- Minor cleanup & fix to start a named HazelcastInstance when the default CachingProvider is in use
