### PR TITLE
[FORWARD PORT] Remove default limit for the number of visible instances on MC

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -69,6 +69,7 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -224,7 +225,7 @@ public class TimedMemberStateFactory {
                                 Collection<StatisticsAwareService> services) {
         int count = 0;
         Config config = instance.getConfig();
-        Set<String> longInstanceNames = createHashSet(maxVisibleInstanceCount);
+        LinkedList<String> longInstanceNames = new LinkedList<String>();
         for (StatisticsAwareService service : services) {
             if (count < maxVisibleInstanceCount) {
                 if (service instanceof MapService) {
@@ -272,7 +273,7 @@ public class TimedMemberStateFactory {
 
     private int handleExecutorService(MemberStateImpl memberState, int count, Config config,
                                       Map<String, LocalExecutorStats> executorServices,
-                                      Set<String> longInstanceNames) {
+                                      List<String> longInstanceNames) {
 
         for (Map.Entry<String, LocalExecutorStats> entry : executorServices.entrySet()) {
             String name = entry.getKey();
@@ -289,7 +290,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleMultimap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMultiMapStats> multiMaps,
-                               Set<String> longInstanceNames) {
+                               List<String> longInstanceNames) {
         for (Map.Entry<String, LocalMultiMapStats> entry : multiMaps.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -305,7 +306,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleReplicatedMap(MemberStateImpl memberState, int count, Config
-            config, Map<String, LocalReplicatedMapStats> replicatedMaps, Set<String> longInstanceNames) {
+            config, Map<String, LocalReplicatedMapStats> replicatedMaps, List<String> longInstanceNames) {
         for (Map.Entry<String, LocalReplicatedMapStats> entry : replicatedMaps.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -321,7 +322,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleReliableTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics,
-                            Set<String> longInstanceNames) {
+                            List<String> longInstanceNames) {
         for (Map.Entry<String, LocalTopicStats> entry : topics.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -337,7 +338,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics,
-                            Set<String> longInstanceNames) {
+                            List<String> longInstanceNames) {
         for (Map.Entry<String, LocalTopicStats> entry : topics.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -353,7 +354,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleQueue(MemberStateImpl memberState, int count, Config config, Map<String, LocalQueueStats> queues,
-                            Set<String> longInstanceNames) {
+                            List<String> longInstanceNames) {
         for (Map.Entry<String, LocalQueueStats> entry : queues.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -369,7 +370,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleMap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMapStats> maps,
-                          Set<String> longInstanceNames) {
+                          List<String> longInstanceNames) {
         for (Map.Entry<String, LocalMapStats> entry : maps.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -385,7 +386,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleWan(MemberStateImpl memberState, int count, Map<String, LocalWanStats> wans,
-                          Set<String> longInstanceNames) {
+                          List<String> longInstanceNames) {
         for (Map.Entry<String, LocalWanStats> entry : wans.entrySet()) {
             String schemeName = entry.getKey();
             LocalWanStats stats = entry.getValue();
@@ -397,7 +398,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleCache(MemberStateImpl memberState, int count, CacheConfig config, CacheStatistics cacheStatistics,
-                            Set<String> longInstanceNames) {
+                            List<String> longInstanceNames) {
         memberState.putLocalCacheStats(config.getNameWithPrefix(), new LocalCacheStatsImpl(cacheStatistics));
         longInstanceNames.add("j:" + config.getNameWithPrefix());
         return ++count;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
@@ -24,22 +24,21 @@ import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.monitor.impl.MemberStateImpl;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 
 import static com.hazelcast.util.JsonUtil.getArray;
 import static com.hazelcast.util.JsonUtil.getBoolean;
 import static com.hazelcast.util.JsonUtil.getLong;
 import static com.hazelcast.util.JsonUtil.getObject;
 import static com.hazelcast.util.JsonUtil.getString;
-import static com.hazelcast.util.SetUtil.createHashSet;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 
 public final class TimedMemberState implements Cloneable, JsonSerializable {
 
     long time;
     MemberStateImpl memberState;
-    Set<String> instanceNames;
+    List<String> instanceNames;
     List<String> memberList;
     boolean master;
     String clusterName;
@@ -79,11 +78,11 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         return time;
     }
 
-    public Set<String> getInstanceNames() {
+    public List<String> getInstanceNames() {
         return instanceNames;
     }
 
-    public void setInstanceNames(Set<String> longInstanceNames) {
+    public void setInstanceNames(List<String> longInstanceNames) {
         this.instanceNames = longInstanceNames;
     }
 
@@ -168,8 +167,8 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         time = getLong(json, "time");
         master = getBoolean(json, "master");
         clusterName = getString(json, "clusterName");
+        instanceNames = new LinkedList<String>();
         final JsonArray jsonInstanceNames = getArray(json, "instanceNames");
-        instanceNames = createHashSet(jsonInstanceNames.size());
         for (JsonValue instanceName : jsonInstanceNames.values()) {
             instanceNames.add(instanceName.asString());
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -516,7 +516,7 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.jmx.update.interval.seconds", 5, SECONDS);
 
     public static final HazelcastProperty MC_MAX_VISIBLE_INSTANCE_COUNT
-            = new HazelcastProperty("hazelcast.mc.max.visible.instance.count", 100);
+            = new HazelcastProperty("hazelcast.mc.max.visible.instance.count", Integer.MAX_VALUE);
     public static final HazelcastProperty MC_MAX_VISIBLE_SLOW_OPERATION_COUNT
             = new HazelcastProperty("hazelcast.mc.max.visible.slow.operations.count", 10);
     public static final HazelcastProperty MC_URL_CHANGE_ENABLED

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -28,7 +29,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Set;
+import java.util.List;
 
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
@@ -52,7 +53,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         hz.getExecutorService("trial");
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
-        Set<String> instanceNames = timedMemberState.getInstanceNames();
+        List<String> instanceNames = timedMemberState.getInstanceNames();
 
         assertEquals("dev", timedMemberState.clusterName);
         assertContains(instanceNames, "c:trial");
@@ -62,6 +63,26 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         assertContains(instanceNames, "rt:trial");
         assertContains(instanceNames, "r:trial");
         assertContains(instanceNames, "e:trial");
+    }
+
+    @Test
+    public void testMaxVisibleInstanceCount() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.MC_MAX_VISIBLE_INSTANCE_COUNT.getName(), "3");
+        HazelcastInstance hz = createHazelcastInstance(config);
+        TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
+
+        hz.getMap("trial").put(1, 1);
+        hz.getMultiMap("trial").put(2, 2);
+        hz.getQueue("trial").offer(3);
+        hz.getTopic("trial").publish("Hello");
+        hz.getReliableTopic("trial").publish("Hello");
+
+        TimedMemberState timedMemberState = factory.createTimedMemberState();
+        List<String> instanceNames = timedMemberState.getInstanceNames();
+
+        assertEquals("dev", timedMemberState.clusterName);
+        assertEquals(3, instanceNames.size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.LinkedList;
+import java.util.List;
 
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
@@ -47,7 +47,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        Set<String> instanceNames = new HashSet<String>();
+        List<String> instanceNames = new LinkedList<String>();
         instanceNames.add("topicStats");
 
         hz = createHazelcastInstance();


### PR DESCRIPTION
hazelcast.mc.max.visible.instance.count group property is used for
limiting the number of visible instances on Management Center. Its
default value is updated to Integer.MAX_VALUE, effectively removing
the limit if it's not configured explicitly. The current value of 100
confuses user when it's hit, as the users don't configure them. Should
it be needed to limit the number of visible instances, it can still be
configured to a lower number.

Also fixes #12095 

Forward port of https://github.com/hazelcast/hazelcast/pull/12105

(cherry picked from commit 44e7628)