### PR TITLE
Fix for client icmp oome problem

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientICMPManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientICMPManager.java
@@ -180,6 +180,13 @@ public class ClientICMPManager implements ConnectionListener {
                 }
             } catch (Throwable ignored) {
                 EmptyStatement.ignore(ignored);
+            } finally {
+                //because ping and connection removal runs concurrently,
+                //it could be the case that we created an entry for a dead connection.
+                //if connection closed while we are pinging, remove the related entry
+                if (!connection.isAlive()) {
+                    icmpFailureDetector.remove(connection);
+                }
             }
         }
     }


### PR DESCRIPTION
Due to race between closing connection and periodic pings,
there was entries created by periodic pings for dead connections.
Since cleanup of those connections are done already, entries
were not be deleted anymore.

Added a second check after pings to check if connection is dead.
If a connection is dead, we do the cleanup, so that no entries
will be left for dead connections.

fixes https://github.com/hazelcast/hazelcast/issues/12129