### PR TITLE
Backup operations should not implement MutatingOperation [Quorum]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
@@ -25,14 +25,13 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 /**
  * Backup operation of {@link com.hazelcast.cache.impl.operation.CacheClearOperation}.
  * <p>It simply clears the records.</p>
  */
 public class CacheClearBackupOperation extends AbstractNamedOperation
-        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable, MutatingOperation {
+        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable {
 
     private transient ICacheRecordStore cache;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -32,7 +32,6 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Map;
@@ -42,11 +41,12 @@ import static com.hazelcast.util.MapUtil.createHashMap;
 /**
  * Cache PutAllBackup Operation is the backup operation used by load all operation. Provides backup of
  * multiple entries.
+ *
  * @see com.hazelcast.cache.impl.operation.CacheLoadAllOperation
  */
 public class CachePutAllBackupOperation
         extends AbstractNamedOperation
-        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable, MutatingOperation {
+        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable {
 
     private Map<Data, CacheRecord> cacheRecords;
     private transient ICacheRecordStore cache;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -26,12 +26,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 /**
  * Backup operation for the operation of adding cache entries into record stores.
+ *
  * @see CacheEntryProcessorOperation
  * @see CachePutOperation
  * @see CachePutIfAbsentOperation
@@ -40,7 +40,7 @@ import java.io.IOException;
  */
 public class CachePutBackupOperation
         extends AbstractBackupCacheOperation
-        implements BackupOperation, MutatingOperation {
+        implements BackupOperation {
 
     private CacheRecord cacheRecord;
     private boolean wanOriginated;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -28,7 +28,6 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Set;
@@ -41,7 +40,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
  */
 public class CacheRemoveAllBackupOperation
         extends AbstractNamedOperation
-        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable, MutatingOperation {
+        implements BackupOperation, ServiceNamespaceAware, IdentifiedDataSerializable {
 
     private Set<Data> keys;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveBackupOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -30,7 +29,7 @@ import java.io.IOException;
  */
 public class CacheRemoveBackupOperation
         extends AbstractBackupCacheOperation
-        implements BackupOperation, MutatingOperation {
+        implements BackupOperation {
 
     private boolean wanOriginated;
 

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateBackupOperation.java
@@ -21,13 +21,12 @@ import com.hazelcast.cardinality.impl.CardinalityEstimatorDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class AggregateBackupOperation
         extends AbstractCardinalityEstimatorOperation
-        implements BackupOperation, MutatingOperation {
+        implements BackupOperation {
 
     private long hash;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddAllBackupOperation.java
@@ -22,14 +22,13 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Map;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
 
-public class CollectionAddAllBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class CollectionAddAllBackupOperation extends CollectionOperation implements BackupOperation {
 
     protected Map<Long, Data> valueMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionAddBackupOperation.java
@@ -22,11 +22,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class CollectionAddBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class CollectionAddBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearBackupOperation.java
@@ -21,14 +21,13 @@ import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Set;
 
 import static com.hazelcast.util.SetUtil.createHashSet;
 
-public class CollectionClearBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class CollectionClearBackupOperation extends CollectionOperation implements BackupOperation {
 
     private Set<Long> itemIdSet;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionRemoveBackupOperation.java
@@ -21,11 +21,10 @@ import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class CollectionRemoveBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class CollectionRemoveBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListSetBackupOperation.java
@@ -23,11 +23,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class ListSetBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class ListSetBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long oldItemId;
     private long itemId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/AddAllBackupOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,7 +31,7 @@ import static com.hazelcast.util.MapUtil.createHashMap;
 /**
  * Provides backup functionality for {@link AddAllOperation}
  */
-public class AddAllBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class AddAllBackupOperation extends QueueOperation implements BackupOperation {
 
     private Map<Long, Data> dataMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/ClearBackupOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Set;
@@ -31,7 +30,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
 /**
  * Store items' ID as set when ClearOperation run.
  */
-public class ClearBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class ClearBackupOperation extends QueueOperation implements BackupOperation {
 
     private Set<Long> itemIdSet;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/CompareAndRemoveBackupOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Set;
@@ -31,7 +30,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
 /**
  * This class triggers backup method for items' ID.
  */
-public class CompareAndRemoveBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class CompareAndRemoveBackupOperation extends QueueOperation implements BackupOperation {
 
     private Set<Long> keySet;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/DrainBackupOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Set;
@@ -31,7 +30,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
 /**
  * This class stores items' ID when DrainOperation run.
  */
-public class DrainBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class DrainBackupOperation extends QueueOperation implements BackupOperation {
 
     //can be null
     private Set<Long> itemIdSet;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferBackupOperation.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -31,7 +30,7 @@ import java.io.IOException;
  * Backup items during offer operation.
  */
 public final class OfferBackupOperation extends QueueOperation
-        implements BackupOperation, IdentifiedDataSerializable, MutatingOperation {
+        implements BackupOperation, IdentifiedDataSerializable {
 
     private Data data;
     private long itemId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollBackupOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -30,7 +29,7 @@ import java.io.IOException;
  * Backup items during pool operation.
  */
 public final class PollBackupOperation extends QueueOperation
-        implements BackupOperation, IdentifiedDataSerializable, MutatingOperation {
+        implements BackupOperation, IdentifiedDataSerializable {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/RemoveBackupOperation.java
@@ -21,14 +21,13 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 /**
  * Remove backup of the Queue item.
  */
-public class RemoveBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class RemoveBackupOperation extends QueueOperation implements BackupOperation {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnAddBackupOperation.java
@@ -23,11 +23,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class CollectionTxnAddBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class CollectionTxnAddBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long itemId;
     private Data value;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTxnRemoveBackupOperation.java
@@ -22,11 +22,10 @@ import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class CollectionTxnRemoveBackupOperation extends CollectionOperation implements BackupOperation, MutatingOperation {
+public class CollectionTxnRemoveBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnOfferBackupOperation.java
@@ -23,14 +23,13 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 /**
  * Provides backup operation during transactional offer operation.
  */
-public class TxnOfferBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class TxnOfferBackupOperation extends QueueOperation implements BackupOperation {
 
     private long itemId;
     private Data data;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPollBackupOperation.java
@@ -21,14 +21,14 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.operations.QueueOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
 /**
  * Provides backup operation during transactional poll operation.
  */
-public class TxnPollBackupOperation extends QueueOperation implements MutatingOperation {
+public class TxnPollBackupOperation extends QueueOperation implements BackupOperation {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferBackupOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.collection.impl.queue.operations.QueueOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -36,7 +35,7 @@ import java.io.IOException;
  * @see TxnReserveOfferOperation
  * @see com.hazelcast.core.TransactionalQueue#offer(Object)
  */
-public class TxnReserveOfferBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class TxnReserveOfferBackupOperation extends QueueOperation implements BackupOperation {
 
     private long itemId;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollBackupOperation.java
@@ -23,7 +23,6 @@ import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -33,7 +32,7 @@ import java.io.IOException;
  * @see TransactionalQueue#poll
  * @see TxnPollOperation
  */
-public class TxnReservePollBackupOperation extends QueueOperation implements BackupOperation, MutatingOperation {
+public class TxnReservePollBackupOperation extends QueueOperation implements BackupOperation {
 
     private long itemId;
     private String transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
@@ -20,13 +20,12 @@ import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.ADD_BACKUP;
 
-public class AddBackupOperation extends AbstractAtomicLongOperation implements BackupOperation, MutatingOperation {
+public class AddBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
 
     private long delta;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
@@ -20,13 +20,12 @@ import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.SET_BACKUP;
 
-public class SetBackupOperation extends AbstractAtomicLongOperation implements BackupOperation, MutatingOperation {
+public class SetBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
 
     private long newValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
@@ -21,13 +21,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.SET_BACKUP;
 
-public class SetBackupOperation extends AbstractAtomicReferenceOperation implements BackupOperation, MutatingOperation {
+public class SetBackupOperation extends AbstractAtomicReferenceOperation implements BackupOperation {
 
     private Data newValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
@@ -20,7 +20,6 @@ import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -28,7 +27,7 @@ import static com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializ
 import static java.lang.Boolean.TRUE;
 
 public class CountDownLatchBackupOperation extends AbstractCountDownLatchOperation
-        implements BackupOperation, MutatingOperation {
+        implements BackupOperation {
 
     private int count;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -24,12 +24,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class AwaitBackupOperation extends AbstractLockOperation
-        implements BackupOperation, MutatingOperation {
+        implements BackupOperation {
 
     private String originalCaller;
     private String conditionId;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -23,11 +23,10 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class BeforeAwaitBackupOperation extends AbstractLockOperation implements BackupOperation, MutatingOperation {
+public class BeforeAwaitBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private String conditionId;
     private String originalCaller;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -23,11 +23,10 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class LockBackupOperation extends AbstractLockOperation implements BackupOperation, MutatingOperation {
+public class LockBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private String originalCallerUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalBackupOperation.java
@@ -20,9 +20,8 @@ import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class SignalBackupOperation extends BaseSignalOperation implements BackupOperation, MutatingOperation {
+public class SignalBackupOperation extends BaseSignalOperation implements BackupOperation {
 
     public SignalBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -23,11 +23,10 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class UnlockBackupOperation extends AbstractLockOperation implements BackupOperation, MutatingOperation {
+public class UnlockBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private boolean force;
     private String originalCallerUuid;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class AcquireBackupOperation extends SemaphoreBackupOperation implements MutatingOperation {
+public class AcquireBackupOperation extends SemaphoreBackupOperation {
 
     public AcquireBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class DrainBackupOperation extends SemaphoreBackupOperation implements MutatingOperation {
+public class DrainBackupOperation extends SemaphoreBackupOperation {
 
     public DrainBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class InitBackupOperation extends SemaphoreBackupOperation implements MutatingOperation {
+public class InitBackupOperation extends SemaphoreBackupOperation {
 
     public InitBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class ReduceBackupOperation extends SemaphoreBackupOperation implements MutatingOperation {
+public class ReduceBackupOperation extends SemaphoreBackupOperation {
 
     public ReduceBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class ReleaseBackupOperation extends SemaphoreBackupOperation implements MutatingOperation {
+public class ReleaseBackupOperation extends SemaphoreBackupOperation {
 
     public ReleaseBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DisposeResultBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/DisposeResultBackupOperation.java
@@ -21,12 +21,10 @@ import com.hazelcast.durableexecutor.impl.DurableExecutorDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class DisposeResultBackupOperation extends AbstractDurableExecutorOperation implements BackupOperation,
-        MutatingOperation {
+public class DisposeResultBackupOperation extends AbstractDurableExecutorOperation implements BackupOperation {
 
     private int sequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultBackupOperation.java
@@ -20,13 +20,12 @@ import com.hazelcast.durableexecutor.impl.DurableExecutorDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class PutResultBackupOperation
         extends AbstractDurableExecutorOperation
-        implements BackupOperation, MutatingOperation {
+        implements BackupOperation {
 
     private int sequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/TaskBackupOperation.java
@@ -22,12 +22,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-public class TaskBackupOperation extends AbstractDurableExecutorOperation implements BackupOperation, MutatingOperation {
+public class TaskBackupOperation extends AbstractDurableExecutorOperation implements BackupOperation {
 
     private int sequence;
     private Data callableData;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class ClearBackupOperation extends MapOperation implements BackupOperation, MutatingOperation {
+public class ClearBackupOperation extends MapOperation implements BackupOperation {
 
     public ClearBackupOperation() {
         this(null);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
@@ -18,12 +18,11 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 /**
  * Operation which evicts all keys except locked ones.
  */
-public class EvictAllBackupOperation extends MapOperation implements BackupOperation, MutatingOperation {
+public class EvictAllBackupOperation extends MapOperation implements BackupOperation {
 
     public EvictAllBackupOperation() {
         this(null);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushBackupOperation.java
@@ -21,14 +21,13 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 /**
  * Empties backup write-behind-queues upon {@link IMap#flush()}
  */
-public class MapFlushBackupOperation extends MapOperation implements BackupOperation, MutatingOperation {
+public class MapFlushBackupOperation extends MapOperation implements BackupOperation {
 
     public MapFlushBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -26,7 +26,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +34,7 @@ import java.util.List;
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
 
-public class PutAllBackupOperation extends MapOperation implements PartitionAwareOperation, BackupOperation, MutatingOperation {
+public class PutAllBackupOperation extends MapOperation implements PartitionAwareOperation, BackupOperation {
 
     private MapEntries entries;
     private List<RecordInfo> recordInfos;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -24,7 +24,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +35,7 @@ import java.util.List;
  *
  * @see PutFromLoadAllOperation
  */
-public class PutFromLoadAllBackupOperation extends MapOperation implements BackupOperation, MutatingOperation {
+public class PutFromLoadAllBackupOperation extends MapOperation implements BackupOperation {
 
     private List<Data> keyValueSequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
@@ -30,7 +29,7 @@ import java.io.IOException;
 /**
  * An operation to prepare transaction by locking the key on key backup owner.
  */
-public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation {
+public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
     private String lockOwner;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearBackupOperation.java
@@ -19,9 +19,8 @@ package com.hazelcast.multimap.impl.operations;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class ClearBackupOperation extends MultiMapOperation implements BackupOperation, MutatingOperation {
+public class ClearBackupOperation extends MultiMapOperation implements BackupOperation {
 
     public ClearBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
@@ -22,13 +22,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-public class PutBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation, MutatingOperation {
+public class PutBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     private long recordId;
     private Data value;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllBackupOperation.java
@@ -19,9 +19,8 @@ package com.hazelcast.multimap.impl.operations;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
-public class RemoveAllBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation, MutatingOperation {
+public class RemoveAllBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     public RemoveAllBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
@@ -23,13 +23,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
-public class RemoveBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation, MutatingOperation {
+public class RemoveBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     long recordId;
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
@@ -24,12 +24,12 @@ import com.hazelcast.multimap.impl.operations.MultiMapKeyBasedOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 import java.util.Collection;
 
-public class TxnPutBackupOperation extends MultiMapKeyBasedOperation implements MutatingOperation {
+public class TxnPutBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     long recordId;
     Data value;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
@@ -24,14 +24,14 @@ import com.hazelcast.multimap.impl.operations.MultiMapKeyBasedOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-public class TxnRemoveAllBackupOperation extends MultiMapKeyBasedOperation implements MutatingOperation {
+public class TxnRemoveAllBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     Collection<Long> recordIds;
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -24,13 +24,13 @@ import com.hazelcast.multimap.impl.operations.MultiMapKeyBasedOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
-public class TxnRemoveBackupOperation extends MultiMapKeyBasedOperation implements MutatingOperation {
+public class TxnRemoveBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     long recordId;
     Data value;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -31,7 +30,7 @@ import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_ALL
 /**
  * Backup operation for ring buffer {@link AddAllOperation}. Puts the items under the sequence IDs that the master generated.
  */
-public class AddAllBackupOperation extends AbstractRingBufferOperation implements BackupOperation, MutatingOperation {
+public class AddAllBackupOperation extends AbstractRingBufferOperation implements BackupOperation {
     private long lastSequenceId;
     private Data[] items;
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
@@ -20,7 +20,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
@@ -29,7 +28,7 @@ import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_BAC
 /**
  * Backup operation for ring buffer {@link AddOperation}. Puts the item under the sequence ID that the master generated.
  */
-public class AddBackupOperation extends AbstractRingBufferOperation implements BackupOperation, MutatingOperation {
+public class AddBackupOperation extends AbstractRingBufferOperation implements BackupOperation {
     private long sequenceId;
     private Data item;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
@@ -20,12 +20,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class CancelTaskBackupOperation
-        extends AbstractSchedulerOperation implements BackupOperation, MutatingOperation {
+        extends AbstractSchedulerOperation implements BackupOperation {
 
     private String taskName;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
@@ -19,12 +19,12 @@ package com.hazelcast.scheduledexecutor.impl.operations;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook;
-import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
 public class DisposeBackupTaskOperation
-        extends AbstractSchedulerOperation implements MutatingOperation {
+        extends AbstractSchedulerOperation implements BackupOperation {
 
     private String taskName;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ScheduleTaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/ScheduleTaskBackupOperation.java
@@ -21,12 +21,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook;
 import com.hazelcast.scheduledexecutor.impl.TaskDefinition;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class ScheduleTaskBackupOperation
-        extends AbstractSchedulerOperation implements BackupOperation, MutatingOperation {
+        extends AbstractSchedulerOperation implements BackupOperation {
 
     private TaskDefinition definition;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
@@ -21,6 +21,8 @@ import com.hazelcast.spi.annotation.Beta;
 /**
  * Marker interface for operations that changes map state/data.
  * Used for quorum to reject operations if quorum size not satisfied
+ *
+ * Operations implementing {@link com.hazelcast.spi.BackupOperation} should not be marked with this interface.
  */
 @Beta
 public interface MutatingOperation {


### PR DESCRIPTION
Backup operations should not implement MutatingOperation.
Also fixed a couple of BackupOperations which didn't implement BackupOperation interface.

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1863