### PR TITLE
Items not to be added to Ringbuffer on store error

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/RingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RingbufferStore.java
@@ -26,29 +26,48 @@ public interface RingbufferStore<T> {
     /**
      * Stores one item with it's corresponding sequence.
      *
+     * Exceptions thrown by this method prevent {@link com.hazelcast.ringbuffer.Ringbuffer}
+     * from adding the item. It is the responsibility of the store to
+     * ensure that it keeps consistent with the Ringbuffer and in case
+     * of an exception is thrown, the data is not in the store.
+     *
      * @param sequence the sequence ID of the data
      * @param data     the value of the data to store
+     * @see com.hazelcast.ringbuffer.Ringbuffer#add(Object)
+     * @see com.hazelcast.ringbuffer.Ringbuffer#addAsync(Object, com.hazelcast.ringbuffer.OverflowPolicy)
      */
     void store(long sequence, T data);
 
     /**
-     * Stores multiple entries. Implementation of this method can optimize the store operation.
+     * Stores multiple items. Implementation of this method can optimize the store operation.
+     *
+     * Exceptions thrown by this method prevents {@link com.hazelcast.ringbuffer.Ringbuffer}
+     * from adding any of the items. It is the responsibility of the store
+     * to ensure that it keeps consistent with the Ringbuffer and in case
+     * of an exception is thrown the passed data is not in the store.
      *
      * @param firstItemSequence the sequence of the first item
      * @param items             the items that are being stored
+     * @see com.hazelcast.ringbuffer.Ringbuffer#addAllAsync(java.util.Collection, com.hazelcast.ringbuffer.OverflowPolicy)
      */
     void storeAll(long firstItemSequence, T[] items);
 
     /**
-     * Loads the value of a given sequence. Null value means that the item was not found.
+     * Loads the value of a given sequence. Null value means that the item
+     * was not found. This method is invoked by the ringbuffer if an item
+     * is requested with a sequence which is no longer in the Ringbuffer.
      *
      * @param sequence the sequence of the requested item
      * @return requested item, null if not found
+     * @see com.hazelcast.ringbuffer.Ringbuffer#readOne(long)
+     * @see com.hazelcast.ringbuffer.Ringbuffer#readManyAsync(long, int, int, IFunction)
      */
     T load(long sequence);
 
     /**
-     * Return the largest sequence seen by the data store. Can return -1 if the data store doesn't have or can't access any data.
+     * Return the largest sequence seen by the data store. Can return -1 if
+     * the data store doesn't have or can't access any data. Used to
+     * initialize a Ringbuffer with the previously seen largest sequence number.
      *
      * @return the largest sequence of the data in the data store
      */

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/Ringbuffer.java
@@ -26,7 +26,7 @@ import java.util.Collection;
  * A Ringbuffer is a data-structure where the content is stored in a ring like structure. A ringbuffer has a capacity so it
  * won't grow beyond that capacity and endanger the stability of the system. If that capacity is exceeded, than the oldest
  * item in the ringbuffer is overwritten.
- *
+ * <p>
  * The ringbuffer has 2 always incrementing sequences:
  * <ol>
  * <li>
@@ -39,23 +39,33 @@ import java.util.Collection;
  * </li>
  * </ol>
  * The items in the ringbuffer can be found by a sequence that is in between (inclusive) the head and tail sequence.
- *
+ * <p>
  * If data is read from a ringbuffer with a sequence that is smaller than the headSequence, it means that the data
  * is not available anymore and a {@link StaleSequenceException} is thrown.
- *
- * A Ringbuffer currently is not a distributed data-structure. So all data is stored in a single partition; comparable to the
- * IQueue implementation. But we'll provide an option to partition the data in the near future.
- *
+ * <p>
+ * A Ringbuffer currently is a replicated but not partitioned data-structure. So all data is stored in a single partition;
+ * comparable to the IQueue implementation. But we'll provide an option to partition the data in the near future.
+ * <p>
  * A Ringbuffer can be used in a similar way as a queue, but one of the key differences is that a queue.take is destructive,
  * meaning that only 1 thread is able to take an item. A ringbuffer.read is not destructive, so you can have multiple threads
  * reading the same item multiple times.
- *
+ * <p>
  * The Ringbuffer is the backing data-structure for the reliable {@link com.hazelcast.core.ITopic} implementation. See
  * {@link com.hazelcast.config.ReliableTopicConfig}.
+ * <p>
+ * A Ringbuffer can be configured to be backed by a {@link com.hazelcast.core.RingbufferStore}. All writer methods delegate to
+ * the store to persist the items, while reader methods try to read items from the store if not found in the in-memory Ringbuffer.
+ * <p>
+ * When a Ringbuffer is constructed with a backing store, head and tail sequences are set to the following
+ * <ul>
+ * <li>tailSequence: lastStoreSequence</li>
+ * <li>headSequence: lastStoreSequence + 1</li>
+ * </ul>
+ * where lastStoreSequence is the sequence of the previously last stored item.
  *
  * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
  *
- * @param <E>
+ * @param <E> The type of the elements that the Ringbuffer contains
  */
 public interface Ringbuffer<E> extends DistributedObject {
 
@@ -67,31 +77,34 @@ public interface Ringbuffer<E> extends DistributedObject {
     long capacity();
 
     /**
-     * Returns number of items in the ringbuffer.
-     *
-     * If no ttl is set, the size will always be equal to capacity after the head completed the first loop
-     * around the ring. This is because no items are getting retired.
+     * Returns number of items in the Ringbuffer.
+     * <p>
+     * If no ttl is set, the size will always be equal to capacity after the head completed the first loop around the ring.
+     * This is because no items are getting retired.
      *
      * @return the size.
      */
     long size();
 
     /**
-     * Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
-     *
-     * The initial value of the tail is -1.
+     * Returns the sequence of the tail. The tail is the side of the Ringbuffer where the items are added to.
+     * <p>
+     * The initial value of the tail is -1 if the Ringbuffer is not backed by a store, otherwise tail sequence will be set to
+     * the sequence of the previously last stored item.
      *
      * @return the sequence of the tail.
      */
     long tailSequence();
 
     /**
-     * Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the
-     * ringbuffer are found.
-     *
+     * Returns the sequence of the head. The head is the side of the Ringbuffer where the oldest items in the Ringbuffer are
+     * found.
+     * <p>
      * If the RingBuffer is empty, the head will be one more than the tail.
-     *
-     * The initial value of the head is 0 (1 more than tail).
+     * <p>
+     * The initial value of the head is 0 if the Ringbuffer is not backed by a store, otherwise head sequence
+     * will be set to the sequence of the previously last stored item + 1. In both cases head sequence is 1 more than the tail
+     * sequence.
      *
      * @return the sequence of the head.
      */
@@ -99,9 +112,9 @@ public interface Ringbuffer<E> extends DistributedObject {
 
     /**
      * Returns the remaining capacity of the ringbuffer.
-     *
+     * <p>
      * The returned value could be stale as soon as it is returned.
-     *
+     * <p>
      * If ttl is not set, the remaining capacity will always be the capacity.
      *
      * @return the remaining capacity.
@@ -112,16 +125,20 @@ public interface Ringbuffer<E> extends DistributedObject {
      * Adds an item to the tail of the Ringbuffer. If there is no space in the Ringbuffer, the add will overwrite the oldest
      * item in the ringbuffer no matter what the ttl is. For more control on this behavior, check the
      * {@link #addAsync(Object, OverflowPolicy)} and the {@link OverflowPolicy}.
-     *
+     * <p>
      * The returned value is the sequence of the added item. Using this sequence you can read the added item.
-     *
+     * <p>
      * <h3>Using the sequence as ID</h3>
      * This sequence will always be unique for this Ringbuffer instance so it can be used as a unique ID generator if you are
      * publishing items on this Ringbuffer. However you need to take care of correctly determining an initial ID when any node
-     * uses the ringbuffer for the first time. The most reliable way to do that is to write a dummy item into the ringbuffer and
+     * uses the Ringbuffer for the first time. The most reliable way to do that is to write a dummy item into the Ringbuffer and
      * use the returned sequence as initial ID. On the reading side, this dummy item should be discard. Please keep in mind that
      * this ID is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
      * to find that item.
+     * <p>
+     * If the Ringbuffer is backed by a {@link com.hazelcast.core.RingbufferStore}, the item gets persisted by the underlying
+     * store via {@link com.hazelcast.core.RingbufferStore#store(long, Object)}. Note that in case an exception is thrown by the
+     * store, it prevents the item from being added to the Ringbuffer, keeping the store, primary and the backups consistent.
      *
      * @param item the item to add.
      * @return the sequence of the added item.
@@ -132,29 +149,33 @@ public interface Ringbuffer<E> extends DistributedObject {
 
     /**
      * Asynchronously writes an item with a configurable {@link OverflowPolicy}.
-     *
-     * If there is space in the ringbuffer, the call will return the sequence of the written item.
-     *
+     * <p>
+     * If there is space in the Ringbuffer, the call will return the sequence of the written item.
+     * <p>
      * If there is no space, it depends on the overflow policy what happens:
      * <ol>
-     * <li>{@link OverflowPolicy#OVERWRITE}: we just overwrite the oldest item in the ringbuffer and we violate
+     * <li>{@link OverflowPolicy#OVERWRITE}: we just overwrite the oldest item in the Ringbuffer and we violate
      * the ttl</li>
      * <li>{@link OverflowPolicy#FAIL}: we return -1 </li>
      * </ol>
-     *
-     * The reason that FAIL exist is to give the opportunity to obey the ttl. If blocking behavior is required,
-     * this can be implemented using retrying in combination with a exponential backoff. Example:
-     * <code>
+     * <p>
+     * The reason that FAIL exist is to give the opportunity to obey the ttl. If blocking behavior is required, this can be
+     * implemented using retrying in combination with an exponential backoff. Example:
+     * <pre>{@code
      * long sleepMs = 100;
      * for (; ; ) {
-     * long result = ringbuffer.addAsync(item, FAIL).get();
-     * if (result != -1) {
-     * break;
+     *   long result = ringbuffer.addAsync(item, FAIL).get();
+     *   if (result != -1) {
+     *     break;
+     *   }
+     *   TimeUnit.MILLISECONDS.sleep(sleepMs);
+     *   sleepMs = min(5000, sleepMs * 2);
      * }
-     * TimeUnit.MILLISECONDS.sleep(sleepMs);
-     * sleepMs = min(5000, sleepMs * 2);
-     * }
-     * </code>
+     * }</pre>
+     * <p>
+     * If the Ringbuffer is backed by a {@link com.hazelcast.core.RingbufferStore}, the item gets persisted by the underlying
+     * store via {@link com.hazelcast.core.RingbufferStore#store(long, Object)}. Note that in case an exception is thrown by the
+     * store, it prevents the item from being added to the Ringbuffer, keeping the store, primary and the backups consistent.
      *
      * @param item           the item to add
      * @param overflowPolicy the OverflowPolicy to use.
@@ -165,25 +186,30 @@ public interface Ringbuffer<E> extends DistributedObject {
 
     /**
      * Reads one item from the Ringbuffer.
-     *
+     * <p>
      * If the sequence is one beyond the current tail, this call blocks until an item is added.
-     *
+     * <p>
      * This means that the ringbuffer can be processed using the following idiom:
-     * <code>
-     * Ringbuffer&lt;String&gt; ringbuffer = hz.getRingbuffer("rb");
+     * <pre>{@code
+     * Ringbuffer<String> ringbuffer = hz.getRingbuffer("rb");
      * long seq = ringbuffer.headSequence();
      * while(true){
-     * String item = ringbuffer.readOne(seq);
-     * seq++;
-     * ... process item
+     *   String item = ringbuffer.readOne(seq);
+     *   seq++;
+     *   ... process item
      * }
-     * </code>
+     * }</pre>
      *
      * This method is not destructive unlike e.g. a queue.take. So the same item can be read by multiple readers or it can be
      * read multiple times by the same reader.
-     *
+     * <p>
      * Currently it isn't possible to control how long this call is going to block. In the future we could add e.g.
      * tryReadOne(long sequence, long timeout, TimeUnit unit).
+     * <p>
+     * If the item is not in the Ringbuffer an attempt is made to read it from the underlying
+     * {@link com.hazelcast.core.RingbufferStore} via {@link com.hazelcast.core.RingbufferStore#load(long)} if store is
+     * configured for the Ringbuffer. These cases may increase the execution time significantly depending on the implementation
+     * of the store. Note that exceptions thrown by the store are propagated to the caller.
      *
      * @param sequence the sequence of the item to read.
      * @return the read item
@@ -200,25 +226,30 @@ public interface Ringbuffer<E> extends DistributedObject {
 
     /**
      * Adds all the items of a collection to the tail of the Ringbuffer.
-     *
-     * A addAll is likely to outperform multiple calls to {@link #add(Object)} due to better io utilization and a reduced number
+     * <p>
+     * An addAll is likely to outperform multiple calls to {@link #add(Object)} due to better io utilization and a reduced number
      * of executed operations.
-     *
+     * <p>
      * If the batch is empty, the call is ignored.
-     *
+     * <p>
      * When the collection is not empty, the content is copied into a different data-structure. This means that:
      * <ol>
      * <li>after this call completes, the collection can be re-used.</li>
      * <li>the collection doesn't need to be serializable</li>
      * </ol>
-     *
-     * If the collection is larger than the capacity of the ringbuffer, then the items that were written first will
-     * be overwritten. Therefor this call will not block.
-     *
+     * <p>
+     * If the collection is larger than the capacity of the Ringbuffer, then the items that were written first will
+     * be overwritten. Therefore this call will not block.
+     * <p>
      * The items are inserted in the order of the Iterator of the collection. If an addAll is executed concurrently with
      * an add or addAll, no guarantee is given that items are contiguous.
-     *
+     * <p>
      * The result of the future contains the sequenceId of the last written item
+     * <p>
+     * If the Ringbuffer is backed by a {@link com.hazelcast.core.RingbufferStore}, the items are persisted by the underlying
+     * store via {@link com.hazelcast.core.RingbufferStore#storeAll(long, Object[])}. Note that in case an exception is thrown by
+     * the store, it makes the Ringbuffer not adding any of the items to the primary and the backups. Keeping the store
+     * consistent with the primary and the backups is the responsibility of the store.
      *
      * @param collection the batch of items to add.
      * @return the ICompletableFuture to synchronize on completion.
@@ -232,15 +263,21 @@ public interface Ringbuffer<E> extends DistributedObject {
     /**
      * Reads a batch of items from the Ringbuffer. If the number of available items after the first read item is smaller than
      * the maxCount, these items are returned. So it could be the number of items read is smaller than the maxCount.
-     *
+     * <p>
      * If there are less items available than minCount, then this call blocks.
-     *
+     * <p>
      * Reading a batch of items is likely to perform better because less overhead is involved.
-     *
+     * <p>
      * A filter can be provided to only select items that need to be read. If the filter is null, all items are read.
      * If the filter is not null, only items where the filter function returns true are returned. Using filters is a good
      * way to prevent getting items that are of no value to the receiver. This reduces the amount of IO and the number of
      * operations being executed, and can result in a significant performance improvement.
+     * <p>
+     * For each item not available in the Ringbuffer an attempt is made to read it from the underlying
+     * {@link com.hazelcast.core.RingbufferStore} via multiple invocations of
+     * {@link com.hazelcast.core.RingbufferStore#load(long)}, if store is configured for the Ringbuffer. These cases may
+     * increase the execution time significantly depending on the implementation of the store. Note that exceptions thrown by
+     * the store are propagated to the caller.
      *
      * @param startSequence the startSequence of the first item to read.
      * @param minCount      the minimum number of items to read.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -45,6 +45,11 @@ public class ArrayRingbuffer<T> implements Ringbuffer<T> {
     }
 
     @Override
+    public long peekNextTailSequence() {
+        return tailSequence + 1;
+    }
+
+    @Override
     public void setTailSequence(long sequence) {
         this.tailSequence = sequence;
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
@@ -49,6 +49,15 @@ public interface Ringbuffer<T> {
     long tailSequence();
 
     /**
+     * Returns the next sequence which the tail will be at after the next
+     * item is added. Please note that there is no item in the Ringbuffer
+     * with the returned sequence at the time of the call.
+     *
+     * @return the next sequence of the tail
+     */
+    long peekNextTailSequence();
+
+    /**
      * Sets the tail sequence. The tail sequence cannot be less than {@link #headSequence()} - 1.
      *
      * @param tailSequence the new tail sequence

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/ArrayRingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/ArrayRingbufferTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -48,6 +49,7 @@ public class ArrayRingbufferTest {
         rb.checkBlockableReadSequence(rb.headSequence() - 1);
     }
 
+    @Test
     public void testBlockableReadFutureSequenceOk() {
         final ArrayRingbuffer rb = fullRingbuffer();
         rb.checkBlockableReadSequence(rb.tailSequence() + 1);
@@ -61,10 +63,18 @@ public class ArrayRingbufferTest {
 
     @Test
     public void testIsEmpty() {
-        final ArrayRingbuffer rb = new ArrayRingbuffer(5);
+        final ArrayRingbuffer<String> rb = new ArrayRingbuffer<String>(5);
         assertTrue(rb.isEmpty());
         rb.add("");
         assertFalse(rb.isEmpty());
+    }
+
+    @Test
+    public void testPeekNextSequenceNumberReturnsTheNext() {
+        final ArrayRingbuffer<String> rb = new ArrayRingbuffer<String>(5);
+        long nextTailSequence = rb.peekNextTailSequence();
+        long sequenceAdded = rb.add("");
+        assertEquals(sequenceAdded, nextTailSequence);
     }
 
     private static ArrayRingbuffer fullRingbuffer() {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreFailureConsistencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreFailureConsistencyTest.java
@@ -1,0 +1,168 @@
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.config.RingbufferStoreConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.Partition;
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.ringbuffer.OverflowPolicy;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.config.RingbufferConfig.DEFAULT_CAPACITY;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RingbufferStoreFailureConsistencyTest extends HazelcastTestSupport {
+
+    private static final String RINGBUFFER_NAME = "testRingbuffer";
+    private static final String INIT_VALUE = "INIT";
+    private static final String ONE = "One";
+    private static final String TWO = "Two";
+    private static final String THREE = "Three";
+
+    @Mock
+    private RingbufferStore<String> store;
+    private Ringbuffer<String> ringbufferPrimary;
+    private Ringbuffer<String> ringbufferBackup;
+    private HazelcastInstance primaryInstance;
+
+    private static Config getConfig(String ringbufferName, int capacity, RingbufferStoreConfig ringbufferStoreConfig) {
+        Config config = new Config();
+        RingbufferConfig rbConfig = config
+                .getRingbufferConfig(ringbufferName)
+                .setInMemoryFormat(OBJECT)
+                .setBackupCount(1)
+                .setCapacity(capacity);
+        rbConfig.setRingbufferStoreConfig(ringbufferStoreConfig);
+        return config;
+    }
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setStoreImplementation(store);
+        Config config = getConfig(RINGBUFFER_NAME, DEFAULT_CAPACITY, rbStoreConfig);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        primaryInstance = getPrimaryInstance(instance, instance2);
+        HazelcastInstance backupInstance = getBackupInstance(instance, instance2);
+
+        ringbufferPrimary = primaryInstance.getRingbuffer(RINGBUFFER_NAME);
+        ringbufferBackup = backupInstance.getRingbuffer(RINGBUFFER_NAME);
+    }
+
+    @Test
+    public void testAdd_PrimaryAndBackupIsConsistentAfterStoreFailure() throws Exception {
+        long seqInit = ringbufferPrimary.add(INIT_VALUE);
+        long seqTwo = seqInit;
+        doThrow(new IllegalStateException("Expected test exception")).when(store).store(seqInit + 2, TWO);
+
+        long seqOne = ringbufferPrimary.add(ONE);
+        try {
+            seqTwo = ringbufferPrimary.add(TWO);
+        } catch (HazelcastException expected) {
+            // do nothing
+        }
+        long seqThree = ringbufferPrimary.add(THREE);
+
+        verifySecondItemWasNotAdded(ringbufferPrimary, seqOne, seqTwo, seqThree);
+        terminatePrimary();
+        verifySecondItemWasNotAdded(ringbufferBackup, seqOne, seqTwo, seqThree);
+    }
+
+    @Test
+    public void testAddAsync_PrimaryAndBackupIsConsistentAfterStoreFailure() throws Exception {
+        long seqInit = ringbufferPrimary.add(INIT_VALUE);
+        long seqTwo = seqInit;
+        doThrow(new IllegalStateException("Expected test exception")).when(store).store(seqInit + 2, TWO);
+
+        ICompletableFuture<Long> seqOneFuture = ringbufferPrimary.addAsync(ONE, OverflowPolicy.OVERWRITE);
+        ICompletableFuture<Long> seqTwoFuture = ringbufferPrimary.addAsync(TWO, OverflowPolicy.OVERWRITE);
+        ICompletableFuture<Long> seqThreeFuture = ringbufferPrimary.addAsync(THREE, OverflowPolicy.OVERWRITE);
+
+        long seqOne = seqOneFuture.get();
+        try {
+            seqTwo = seqTwoFuture.get();
+        } catch (ExecutionException expected) {
+            // do nothing
+        }
+        long seqThree = seqThreeFuture.get();
+
+        verifySecondItemWasNotAdded(ringbufferPrimary, seqOne, seqTwo, seqThree);
+        terminatePrimary();
+        verifySecondItemWasNotAdded(ringbufferBackup, seqOne, seqTwo, seqThree);
+    }
+
+    @Test
+    public void testAddAllAsync_PrimaryAndBackupIsConsistentAfterStoreFailure() throws Exception {
+        long primaryTailSequenceBeforeAddingAll = ringbufferPrimary.tailSequence();
+        long seqFirstItem = ringbufferPrimary.tailSequence() + 1;
+        doThrow(new IllegalStateException("Expected test exception")).when(store).storeAll(eq(seqFirstItem), any(String[].class));
+
+        ICompletableFuture<Long> result = ringbufferPrimary.addAllAsync(newArrayList(ONE, TWO, THREE), OverflowPolicy.FAIL);
+        try {
+            result.get();
+        } catch (ExecutionException expected) {
+            // do nothing
+        }
+        long primarySequenceAfterAddingAll = ringbufferPrimary.tailSequence();
+
+        assertEquals(primaryTailSequenceBeforeAddingAll, primarySequenceAfterAddingAll);
+        terminatePrimary();
+        assertEquals(primarySequenceAfterAddingAll, ringbufferBackup.tailSequence());
+    }
+
+    private HazelcastInstance getPrimaryInstance(HazelcastInstance instance, HazelcastInstance instance2) {
+        Partition primaryPartition = instance.getPartitionService().getPartition(RINGBUFFER_NAME);
+        String primaryInstanceUuid = primaryPartition.getOwner().getUuid();
+        String instanceOneUuid = instance.getCluster().getLocalMember().getUuid();
+        return primaryInstanceUuid.equals(instanceOneUuid) ? instance : instance2;
+    }
+
+    private HazelcastInstance getBackupInstance(HazelcastInstance instance, HazelcastInstance instance2) {
+        Partition primaryPartition = instance.getPartitionService().getPartition(RINGBUFFER_NAME);
+        String primaryInstanceUuid = primaryPartition.getOwner().getUuid();
+        String instanceOneUuid = instance.getCluster().getLocalMember().getUuid();
+        return primaryInstanceUuid.equals(instanceOneUuid) ? instance2 : instance;
+    }
+
+    private void verifySecondItemWasNotAdded(Ringbuffer<String> ringbuffer, long seqOne, long seqTwo, long seqThree)
+            throws InterruptedException {
+        assertEquals(ONE, ringbuffer.readOne(seqOne));
+        assertEquals(INIT_VALUE, ringbuffer.readOne(seqTwo));
+        assertEquals(ONE, ringbuffer.readOne(seqThree - 1));
+        assertEquals(THREE, ringbuffer.readOne(seqThree));
+    }
+
+    private void terminatePrimary() {
+        primaryInstance.getLifecycleService().terminate();
+    }
+}


### PR DESCRIPTION
- Fail Ringbuffer add operations (add, addAsync, addAllAsync) in case the underlying store throws an exception
- Define contracts and interactions between Ringbuffer and RingbufferStore
- Format Ringbuffer javadoc
- Bring terms and spelling to a common ground (ringbuffer -> Ringbuffer, entries -> items etc)
- Resolves contradiction between reference manual and javadoc:
	manual: "Hazelcast Ringbuffer is a distributed data structure..."
	javadoc: "Ringbuffer currently is not a distributed data-structure..."

Fixes #11209