### PR TITLE
Make the slow scheduled executor tests run in serial

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceSlowTest.java
@@ -22,13 +22,14 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.ScheduledExecutorServiceSlowTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({SlowTest.class, ParallelTest.class})
 public class ClientScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceSlowTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICountDownLatch;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({SlowTest.class, ParallelTest.class})
 public class ScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceTestSupport {
 


### PR DESCRIPTION
Since these are consuming a lot of memory, it could be the case that memory starting to be problem. 

related to https://github.com/hazelcast/hazelcast/issues/11683