### PR TITLE
Generate wan replication event inside afterRun method of merge operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -27,15 +27,17 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
 public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation {
 
     protected transient Data dataOldValue;
+    protected transient Data dataMergingValue;
     protected transient EntryEventType eventType;
     protected transient boolean putTransient;
 
     public BasePutOperation(String name, Data dataKey, Data value) {
-        super(name, dataKey, value, -1);
+        super(name, dataKey, value, DEFAULT_TTL);
     }
 
     public BasePutOperation(String name, Data dataKey, Data value, long ttl) {
@@ -49,15 +51,15 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
     public void afterRun() {
         mapServiceContext.interceptAfterPut(name, dataValue);
         Object value = isPostProcessing(recordStore) ? recordStore.getRecord(dataKey).getValue() : dataValue;
-
-        mapEventPublisher.publishEvent(getCallerAddress(), name, getEventType(), dataKey, dataOldValue, value);
+        mapEventPublisher.publishEvent(getCallerAddress(), name, getEventType(),
+                dataKey, dataOldValue, value, dataMergingValue);
         invalidateNearCache(dataKey);
         publishWANReplicationEvent(mapEventPublisher, value);
         evict(dataKey);
     }
 
     private void publishWANReplicationEvent(MapEventPublisher mapEventPublisher, Object value) {
-        if (!mapContainer.isWanReplicationEnabled()) {
+        if (!mapContainer.isWanReplicationEnabled() || !canThisOpGenerateWANEvent()) {
             return;
         }
 
@@ -68,6 +70,14 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         final Data valueConvertedData = mapServiceContext.toData(value);
         final EntryView entryView = EntryViews.createSimpleEntryView(dataKey, valueConvertedData, record);
         mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+    }
+
+    /**
+     * @return {@code true} if this operation can generate WAN event, otherwise return {@code false}
+     * to indicate WAN event generation is not allowed for this operation
+     */
+    protected boolean canThisOpGenerateWANEvent() {
+        return true;
     }
 
     private EntryEventType getEventType() {

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
@@ -22,17 +22,22 @@ import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.SimpleEntryView;
+import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -199,6 +204,48 @@ public class WanReplicationTest extends HazelcastTestSupport {
         instance1 = factory.newHazelcastInstance(config);
 
         assertEquals(dummyWanReplication, getWanReplicationImpl(instance1));
+    }
+
+    @Test
+    public void merge_operation_generates_wan_replication_event() {
+        boolean enableWANReplicationEvent = true;
+        runMergeOpForWAN(enableWANReplicationEvent);
+
+        assertTotalQueueSize(1);
+    }
+
+    @Test
+    public void merge_operation_does_not_generate_wan_replication_event_when_disabled() {
+        boolean enableWANReplicationEvent = false;
+        runMergeOpForWAN(enableWANReplicationEvent);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertTotalQueueSize(0);
+            }
+        }, 3);
+    }
+
+    private void runMergeOpForWAN(boolean enableWANReplicationEvent) {
+        // init hazelcast instances
+        String mapName = "merge_operation_generates_wan_replication_event";
+        initInstancesAndMap(mapName);
+
+        // get internal services to use in this test
+        HazelcastInstance node = instance1;
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(node);
+        InternalPartitionService partitionService = nodeEngineImpl.getPartitionService();
+        InternalOperationService operationService = nodeEngineImpl.getOperationService();
+        SerializationService ss = nodeEngineImpl.getSerializationService();
+        MapService mapService = nodeEngineImpl.getService(MapService.SERVICE_NAME);
+        MapOperationProvider operationProvider = mapService.getMapServiceContext().getMapOperationProvider(mapName);
+
+        // prepare and send one merge operation
+        Data data = ss.toData(1);
+        SimpleEntryView<Data, Data> entryView = new SimpleEntryView<Data, Data>().withKey(data).withValue(data);
+        MapOperation op = operationProvider.createMergeOperation(mapName, entryView, new PassThroughMergePolicy(), !enableWANReplicationEvent);
+        operationService.createInvocationBuilder(MapService.SERVICE_NAME, op, partitionService.getPartitionId(data)).invoke();
     }
 
     private void initInstancesAndMap(String name) {


### PR DESCRIPTION
Before this PR, `MergeOperation` was not able to generate any WAN events.

- [ ] Needs ee counterpart