### PR TITLE
Ensures CacheConfig exists on all members before test execution

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetCacheEntryRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetCacheEntryRequestTest.java
@@ -136,6 +136,8 @@ public class GetCacheEntryRequestTest extends CacheTestSupport {
 
     @Test
     public void testGetCacheEntry_missingKey() {
+        // ensure CacheConfig already exists on all members
+        cacheManager.getCache(cacheName);
         String key = generateKeyOwnedBy(instances[1]);
 
         JsonObject result = sendRequestToInstance(instances[0], new GetCacheEntryRequest("string", cacheName, key));


### PR DESCRIPTION
GetCacheEntryRequestTest.testGetCacheEntry_missingKey executes the
GetCacheEntryRequest without having first obtained the Cache instance.
This results in a race between the event thread that was adding the
config to the remote member and the entry processor execution,
resulting in the spurious failures in https://github.com/hazelcast/hazelcast-enterprise/issues/1838