### PR TITLE
Rename ReliableIdGenerator -> FlakeIdGenerator

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.config;
 import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.config.ConfigPatternMatcher;
 import com.hazelcast.config.ConfigurationException;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -29,7 +29,7 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.security.Credentials;
@@ -120,8 +120,8 @@ public class ClientConfig {
 
     private ClientUserCodeDeploymentConfig userCodeDeploymentConfig = new ClientUserCodeDeploymentConfig();
 
-    private final Map<String, ReliableIdGeneratorConfig> reliableIdGeneratorConfigMap =
-            new ConcurrentHashMap<String, ReliableIdGeneratorConfig>();
+    private final Map<String, FlakeIdGeneratorConfig> flakeIdGeneratorConfigMap =
+            new ConcurrentHashMap<String, FlakeIdGeneratorConfig>();
 
     /**
      * Sets the pattern matcher which is used to match item names to
@@ -358,42 +358,42 @@ public class ClientConfig {
     }
 
     /**
-     * Returns the map of {@link ReliableIdGenerator} configurations,
+     * Returns the map of {@link FlakeIdGenerator} configurations,
      * mapped by config name. The config name may be a pattern with which the
      * configuration was initially obtained.
      *
      * @return the map configurations mapped by config name
      */
-    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigMap() {
-        return reliableIdGeneratorConfigMap;
+    public Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigMap() {
+        return flakeIdGeneratorConfigMap;
     }
 
     /**
-     * Returns a {@link ReliableIdGeneratorConfig} configuration for the given reliable ID generator name.
+     * Returns a {@link FlakeIdGeneratorConfig} configuration for the given flake ID generator name.
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
      * If there is no config found by the name, it will return the configuration
      * with the name {@code "default"}.
      *
-     * @param name name of the reliable ID generator config
-     * @return the reliable ID generator configuration
+     * @param name name of the flake ID generator config
+     * @return the flake ID generator configuration
      * @throws ConfigurationException if ambiguous configurations are found
      * @see com.hazelcast.partition.strategy.StringPartitioningStrategy#getBaseName(java.lang.String)
      * @see #setConfigPatternMatcher(ConfigPatternMatcher)
      * @see #getConfigPatternMatcher()
      */
-    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String name) {
         String baseName = getBaseName(name);
-        ReliableIdGeneratorConfig config = lookupByPattern(configPatternMatcher, reliableIdGeneratorConfigMap, baseName);
+        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
         if (config != null) {
             return config;
         }
-        return getReliableIdGeneratorConfig("default");
+        return getFlakeIdGeneratorConfig("default");
     }
 
     /**
-     * Returns the {@link ReliableIdGeneratorConfig} for the given name, creating
+     * Returns the {@link FlakeIdGeneratorConfig} for the given name, creating
      * one if necessary and adding it to the collection of known configurations.
      * <p>
      * The configuration is found by matching the the configuration name
@@ -405,62 +405,62 @@ public class ClientConfig {
      * <p>
      * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
-     * explicitly adding it by invoking {@link #addReliableIdGeneratorConfig(ReliableIdGeneratorConfig)}.
+     * explicitly adding it by invoking {@link #addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig)}.
      * <p>
      * Because it adds new configurations if they are not already present,
      * this method is intended to be used before this config is used to
      * create a hazelcast instance. Afterwards, newly added configurations
      * may be ignored.
      *
-     * @param name name of the reliable ID generator config
+     * @param name name of the flake ID generator config
      * @return the cache configuration
      * @throws ConfigurationException if ambiguous configurations are found
      * @see com.hazelcast.partition.strategy.StringPartitioningStrategy#getBaseName(java.lang.String)
      * @see #setConfigPatternMatcher(ConfigPatternMatcher)
      * @see #getConfigPatternMatcher()
      */
-    public ReliableIdGeneratorConfig getReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig getFlakeIdGeneratorConfig(String name) {
         String baseName = getBaseName(name);
-        ReliableIdGeneratorConfig config = lookupByPattern(configPatternMatcher, reliableIdGeneratorConfigMap, baseName);
+        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
         if (config != null) {
             return config;
         }
-        ReliableIdGeneratorConfig defConfig = reliableIdGeneratorConfigMap.get("default");
+        FlakeIdGeneratorConfig defConfig = flakeIdGeneratorConfigMap.get("default");
         if (defConfig == null) {
-            defConfig = new ReliableIdGeneratorConfig("default");
-            reliableIdGeneratorConfigMap.put(defConfig.getName(), defConfig);
+            defConfig = new FlakeIdGeneratorConfig("default");
+            flakeIdGeneratorConfigMap.put(defConfig.getName(), defConfig);
         }
-        config = new ReliableIdGeneratorConfig(defConfig);
+        config = new FlakeIdGeneratorConfig(defConfig);
         config.setName(name);
-        reliableIdGeneratorConfigMap.put(config.getName(), config);
+        flakeIdGeneratorConfigMap.put(config.getName(), config);
         return config;
     }
 
     /**
-     * Adds a reliable ID generator configuration. The configuration is saved under the config
+     * Adds a flake ID generator configuration. The configuration is saved under the config
      * name, which may be a pattern with which the configuration will be
      * obtained in the future.
      *
-     * @param config the reliable ID configuration
+     * @param config the flake ID configuration
      * @return this config instance
      */
-    public ClientConfig addReliableIdGeneratorConfig(ReliableIdGeneratorConfig config) {
-        reliableIdGeneratorConfigMap.put(config.getName(), config);
+    public ClientConfig addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig config) {
+        flakeIdGeneratorConfigMap.put(config.getName(), config);
         return this;
     }
 
     /**
-     * Sets the map of {@link ReliableIdGenerator} configurations,
+     * Sets the map of {@link FlakeIdGenerator} configurations,
      * mapped by config name. The config name may be a pattern with which the
      * configuration will be obtained in the future.
      *
-     * @param map the ReliableIdGenerator configuration map to set
+     * @param map the FlakeIdGenerator configuration map to set
      * @return this config instance
      */
-    public ClientConfig setReliableIdGeneratorConfigMap(Map<String, ReliableIdGeneratorConfig> map) {
-        reliableIdGeneratorConfigMap.clear();
-        reliableIdGeneratorConfigMap.putAll(map);
-        for (Entry<String, ReliableIdGeneratorConfig> entry : map.entrySet()) {
+    public ClientConfig setFlakeIdGeneratorConfigMap(Map<String, FlakeIdGeneratorConfig> map) {
+        flakeIdGeneratorConfigMap.clear();
+        flakeIdGeneratorConfigMap.putAll(map);
+        for (Entry<String, FlakeIdGeneratorConfig> entry : map.entrySet()) {
             entry.getValue().setName(entry.getKey());
         }
         return this;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientXmlElements.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientXmlElements.java
@@ -35,7 +35,7 @@ enum ClientXmlElements {
     INSTANCE_NAME("instance-name", false),
     CONNECTION_STRATEGY("connection-strategy", false),
     USER_CODE_DEPLOYMENT("user-code-deployment", false),
-    RELIABLE_ID_GENERATOR("reliable-id-generator", true);
+    FLAKE_ID_GENERATOR("flake-id-generator", true);
 
     final String name;
     final boolean multipleOccurrence;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -26,8 +26,8 @@ import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionConfig.MaxSizePolicy;
 import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.HostVerificationConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
@@ -60,7 +60,7 @@ import java.util.Set;
 
 import static com.hazelcast.client.config.ClientXmlElements.CONNECTION_STRATEGY;
 import static com.hazelcast.client.config.ClientXmlElements.EXECUTOR_POOL_SIZE;
-import static com.hazelcast.client.config.ClientXmlElements.RELIABLE_ID_GENERATOR;
+import static com.hazelcast.client.config.ClientXmlElements.FLAKE_ID_GENERATOR;
 import static com.hazelcast.client.config.ClientXmlElements.GROUP;
 import static com.hazelcast.client.config.ClientXmlElements.INSTANCE_NAME;
 import static com.hazelcast.client.config.ClientXmlElements.LICENSE_KEY;
@@ -259,8 +259,8 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             handleConnectionStrategy(node);
         } else if (USER_CODE_DEPLOYMENT.isEqual(nodeName)) {
             handleUserCodeDeployment(node);
-        } else if (RELIABLE_ID_GENERATOR.isEqual(nodeName)) {
-            handleReliableIdGenerator(node);
+        } else if (FLAKE_ID_GENERATOR.isEqual(nodeName)) {
+            handleFlakeIdGenerator(node);
         }
     }
 
@@ -346,9 +346,9 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
         clientConfig.addNearCacheConfig(nearCacheConfig);
     }
 
-    private void handleReliableIdGenerator(Node node) {
+    private void handleFlakeIdGenerator(Node node) {
         String name = getAttribute(node, "name");
-        ReliableIdGeneratorConfig config = new ReliableIdGeneratorConfig(name);
+        FlakeIdGeneratorConfig config = new FlakeIdGeneratorConfig(name);
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             String value = getTextContent(child).trim();
@@ -358,7 +358,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
                 config.setPrefetchValidityMillis(Long.parseLong(value));
             }
         }
-        clientConfig.addReliableIdGeneratorConfig(config);
+        clientConfig.addFlakeIdGeneratorConfig(config);
     }
 
     private EvictionConfig getEvictionConfig(Node node) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -30,7 +30,7 @@ import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddLockConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddMultiMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddQueueConfigCodec;
-import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableIdGeneratorConfigCodec;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddFlakeIdGeneratorConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableTopicConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReplicatedMapConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddRingbufferConfigCodec;
@@ -57,6 +57,7 @@ import com.hazelcast.config.CountDownLatchConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.JobTrackerConfig;
@@ -73,7 +74,6 @@ import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -385,9 +385,9 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public Config addReliableIdGeneratorConfig(ReliableIdGeneratorConfig reliableIdGeneratorConfig) {
-        ClientMessage request = DynamicConfigAddReliableIdGeneratorConfigCodec.encodeRequest(reliableIdGeneratorConfig.getName(),
-                reliableIdGeneratorConfig.getPrefetchCount(), reliableIdGeneratorConfig.getPrefetchValidityMillis());
+    public Config addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig flakeIdGeneratorConfig) {
+        ClientMessage request = DynamicConfigAddFlakeIdGeneratorConfigCodec.encodeRequest(flakeIdGeneratorConfig.getName(),
+                flakeIdGeneratorConfig.getPrefetchCount(), flakeIdGeneratorConfig.getPrefetchValidityMillis());
         invoke(request);
         return this;
     }
@@ -1059,22 +1059,22 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
-    public ReliableIdGeneratorConfig getReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig getFlakeIdGeneratorConfig(String name) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
     @Override
-    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String name) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
     @Override
-    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs() {
+    public Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigs() {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 
     @Override
-    public Config setReliableIdGeneratorConfigs(Map<String, ReliableIdGeneratorConfig> map) {
+    public Config setFlakeIdGeneratorConfigs(Map<String, FlakeIdGeneratorConfig> map) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -67,7 +67,7 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -79,7 +79,7 @@ import com.hazelcast.core.ClientService;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
@@ -593,8 +593,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public ReliableIdGenerator getReliableIdGenerator(String name) {
-        return getDistributedObject(ReliableIdGeneratorService.SERVICE_NAME, name);
+    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+        return getDistributedObject(FlakeIdGeneratorService.SERVICE_NAME, name);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.ClientService;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
@@ -192,8 +192,8 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public ReliableIdGenerator getReliableIdGenerator(String name) {
-        return getClient().getReliableIdGenerator(name);
+    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+        return getClient().getFlakeIdGenerator(name);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -36,7 +36,7 @@ import com.hazelcast.client.proxy.ClientCardinalityEstimatorProxy;
 import com.hazelcast.client.proxy.ClientCountDownLatchProxy;
 import com.hazelcast.client.proxy.ClientDurableExecutorServiceProxy;
 import com.hazelcast.client.proxy.ClientExecutorServiceProxy;
-import com.hazelcast.client.proxy.ClientReliableIdGeneratorProxy;
+import com.hazelcast.client.proxy.ClientFlakeIdGeneratorProxy;
 import com.hazelcast.client.proxy.ClientIdGeneratorProxy;
 import com.hazelcast.client.proxy.ClientListProxy;
 import com.hazelcast.client.proxy.ClientLockProxy;
@@ -63,7 +63,7 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -200,7 +200,7 @@ public final class ProxyManager {
                 return new ClientIdGeneratorProxy(IdGeneratorService.SERVICE_NAME, id, context, atomicLong);
             }
         });
-        register(ReliableIdGeneratorService.SERVICE_NAME, ClientReliableIdGeneratorProxy.class);
+        register(FlakeIdGeneratorService.SERVICE_NAME, ClientFlakeIdGeneratorProxy.class);
         register(CardinalityEstimatorService.SERVICE_NAME, ClientCardinalityEstimatorProxy.class);
         register(DistributedScheduledExecutorService.SERVICE_NAME, ClientScheduledExecutorProxy.class);
 

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
@@ -42,7 +42,7 @@
                 <xs:element name="connection-strategy" type="connection-strategy" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="user-code-deployment" type="user-code-deployment" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="reliable-id-generator" type="reliable-id-generator" minOccurs="0"
+                <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0"
                             maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
@@ -648,7 +648,7 @@
             <xs:element name="ports" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
-    <xs:complexType name="reliable-id-generator">
+    <xs:complexType name="flake-id-generator">
         <xs:all>
             <xs:element name="prefetch-count" minOccurs="0" default="100">
                 <xs:annotation>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -157,10 +157,10 @@
         <local-update-policy>INVALIDATE</local-update-policy>
     </near-cache>
 
-    <reliable-id-generator name="default">
+    <flake-id-generator name="default">
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
-    </reliable-id-generator>
+    </flake-id-generator>
 
     <query-caches>
         <query-cache name="query-cache-name" mapName="map-name">

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.config;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.HostVerificationConfig;
@@ -338,15 +338,15 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testReliableIdGeneratorConfig() {
+    public void testFlakeIdGeneratorConfig() {
         String xml = HAZELCAST_CLIENT_START_TAG
-                + "<reliable-id-generator name='gen'>"
+                + "<flake-id-generator name='gen'>"
                 + "  <prefetch-count>3</prefetch-count>"
                 + "  <prefetch-validity-millis>10</prefetch-validity-millis>"
-                + "</reliable-id-generator>"
+                + "</flake-id-generator>"
                 + HAZELCAST_CLIENT_END_TAG;
         ClientConfig config = buildConfig(xml);
-        ReliableIdGeneratorConfig fConfig = config.findReliableIdGeneratorConfig("gen");
+        FlakeIdGeneratorConfig fConfig = config.findFlakeIdGeneratorConfig("gen");
         assertEquals("gen", fConfig.getName());
         assertEquals(3, fConfig.getPrefetchCount());
         assertEquals(10L, fConfig.getPrefetchValidityMillis());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_ClientIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_ClientIntegrationTest.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.reliableidgen.impl;
+package com.hazelcast.client.flakeidgen.impl;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.reliableidgen.impl.ReliableIdConcurrencyTestUtil;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorProxy;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorProxy;
+import com.hazelcast.flakeidgen.impl.FlakeIdConcurrencyTestUtil;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReliableIdGenerator_ClientIntegrationTest {
+public class FlakeIdGenerator_ClientIntegrationTest {
 
     private TestHazelcastFactory factory;
     private HazelcastInstance instance;
@@ -56,8 +56,8 @@ public class ReliableIdGenerator_ClientIntegrationTest {
     @Test
     public void smokeTest() throws Exception {
         before(null);
-        final ReliableIdGenerator generator = instance.getReliableIdGenerator("gen");
-        ReliableIdConcurrencyTestUtil.concurrentlyGenerateIds(new Supplier<Long>() {
+        final FlakeIdGenerator generator = instance.getFlakeIdGenerator("gen");
+        FlakeIdConcurrencyTestUtil.concurrentlyGenerateIds(new Supplier<Long>() {
             @Override
             public Long get() {
                 return generator.newId();
@@ -68,22 +68,22 @@ public class ReliableIdGenerator_ClientIntegrationTest {
     @Test
     public void configTest() throws Exception {
         int myBatchSize = 3;
-        before(new ClientConfig().addReliableIdGeneratorConfig(new ReliableIdGeneratorConfig("gen")
+        before(new ClientConfig().addFlakeIdGeneratorConfig(new FlakeIdGeneratorConfig("gen")
                 .setPrefetchCount(myBatchSize)
                 .setPrefetchValidityMillis(3000)));
-        final ReliableIdGenerator generator = instance.getReliableIdGenerator("gen");
+        final FlakeIdGenerator generator = instance.getFlakeIdGenerator("gen");
 
         assertTrue("This test assumes default validity be larger than 3000 by a good margin",
-                ReliableIdGeneratorConfig.DEFAULT_PREFETCH_VALIDITY_MILLIS >= 5000);
+                FlakeIdGeneratorConfig.DEFAULT_PREFETCH_VALIDITY_MILLIS >= 5000);
         // this should take a batch of 3 IDs from the member and store it in the auto-batcher
         long id1 = generator.newId();
         // this should take second ID from auto-created batch. It should be exactly next to id1
         long id2 = generator.newId();
-        assertEquals(id1 + ReliableIdGeneratorProxy.INCREMENT, id2);
+        assertEquals(id1 + FlakeIdGeneratorProxy.INCREMENT, id2);
 
         Thread.sleep(3000);
         // this ID should be from a new batch, because the validity elapsed
         long id3 = generator.newId();
-        assertTrue(id1 + ReliableIdGeneratorProxy.INCREMENT * myBatchSize < id3);
+        assertTrue(id1 + FlakeIdGeneratorProxy.INCREMENT * myBatchSize < id3);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.reliableidgen.impl;
+package com.hazelcast.client.flakeidgen.impl;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.MemberImpl;
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReliableIdGenerator_NodeIdOverflowIntegrationTest {
+public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -65,7 +65,7 @@ public class ReliableIdGenerator_NodeIdOverflowIntegrationTest {
         for (int i = 0; i < 10; i++) {
             System.out.println("Creating client " + i);
             HazelcastInstance client = factory.newHazelcastClient(clientConfig);
-            ReliableIdGenerator gen = client.getReliableIdGenerator("gen");
+            FlakeIdGenerator gen = client.getFlakeIdGenerator("gen");
             for (int j = 0; j < 100; j++) {
                 // call should not fail
                 gen.newId();
@@ -81,7 +81,7 @@ public class ReliableIdGenerator_NodeIdOverflowIntegrationTest {
         assignOverflowedNodeId(instance2);
 
         HazelcastInstance client = factory.newHazelcastClient();
-        ReliableIdGenerator gen = client.getReliableIdGenerator("gen");
+        FlakeIdGenerator gen = client.getFlakeIdGenerator("gen");
 
         exception.expect(HazelcastException.class);
         exception.expectMessage("All members have node ID out of range");

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -35,7 +35,7 @@ import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.SSLConfig;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -86,7 +86,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         private final ParserContext parserContext;
         private final BeanDefinitionBuilder builder;
         private final ManagedMap<String, BeanDefinition> nearCacheConfigMap;
-        private ManagedMap<String, BeanDefinition> reliableIdGeneratorConfigMap;
+        private ManagedMap<String, BeanDefinition> flakeIdGeneratorConfigMap;
 
         SpringXmlBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
@@ -94,11 +94,11 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.builder.setFactoryMethod("newHazelcastClient");
             this.builder.setDestroyMethodName("shutdown");
             this.nearCacheConfigMap = new ManagedMap<String, BeanDefinition>();
-            this.reliableIdGeneratorConfigMap = new ManagedMap<String, BeanDefinition>();
+            this.flakeIdGeneratorConfigMap = new ManagedMap<String, BeanDefinition>();
 
             this.configBuilder = BeanDefinitionBuilder.rootBeanDefinition(ClientConfig.class);
             configBuilder.addPropertyValue("nearCacheConfigMap", nearCacheConfigMap);
-            configBuilder.addPropertyValue("reliableIdGeneratorConfigMap", reliableIdGeneratorConfigMap);
+            configBuilder.addPropertyValue("flakeIdGeneratorConfigMap", flakeIdGeneratorConfigMap);
         }
 
         AbstractBeanDefinition getBeanDefinition() {
@@ -139,8 +139,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                             configBuilder);
                 } else if ("user-code-deployment".equals(nodeName)) {
                     handleUserCodeDeployment(node);
-                } else if ("reliable-id-generator".equals(nodeName)) {
-                    handleReliableIdGenerator(node);
+                } else if ("flake-id-generator".equals(nodeName)) {
+                    handleFlakeIdGenerator(node);
                 }
             }
             builder.addConstructorArgValue(configBuilder.getBeanDefinition());
@@ -269,11 +269,11 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             nearCacheConfigMap.put(name, nearCacheConfigBuilder.getBeanDefinition());
         }
 
-        private void handleReliableIdGenerator(Node node) {
-            BeanDefinitionBuilder configBuilder = createBeanBuilder(ReliableIdGeneratorConfig.class);
+        private void handleFlakeIdGenerator(Node node) {
+            BeanDefinitionBuilder configBuilder = createBeanBuilder(FlakeIdGeneratorConfig.class);
             fillAttributeValues(node, configBuilder);
             String name = getAttribute(node, "name");
-            reliableIdGeneratorConfigMap.put(name, configBuilder.getBeanDefinition());
+            flakeIdGeneratorConfigMap.put(name, configBuilder.getBeanDefinition());
         }
 
         private void handleEvictionConfig(Node node, BeanDefinitionBuilder configBuilder) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -77,7 +77,7 @@ import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.QuorumListenerConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -188,7 +188,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> jobTrackerManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> replicatedMapManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> quorumManagedMap;
-        private ManagedMap<String, AbstractBeanDefinition> reliableIdGeneratorConfigMap;
+        private ManagedMap<String, AbstractBeanDefinition> flakeIdGeneratorConfigMap;
 
         public SpringXmlConfigBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
@@ -217,7 +217,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
             this.replicatedMapManagedMap = createManagedMap("replicatedMapConfigs");
             this.quorumManagedMap = createManagedMap("quorumConfigs");
-            this.reliableIdGeneratorConfigMap = createManagedMap("reliableIdGeneratorConfigs");
+            this.flakeIdGeneratorConfigMap = createManagedMap("flakeIdGeneratorConfigs");
         }
 
         private ManagedMap<String, AbstractBeanDefinition> createManagedMap(String configName) {
@@ -315,8 +315,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleQuorum(node);
                     } else if ("hot-restart-persistence".equals(nodeName)) {
                         handleHotRestartPersistence(node);
-                    } else if ("reliable-id-generator".equals(nodeName)) {
-                        handleReliableIdGenerator(node);
+                    } else if ("flake-id-generator".equals(nodeName)) {
+                        handleFlakeIdGenerator(node);
                     }
                 }
             }
@@ -338,11 +338,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("hotRestartPersistenceConfig", hotRestartConfigBuilder.getBeanDefinition());
         }
 
-        private void handleReliableIdGenerator(Node node) {
-            BeanDefinitionBuilder configBuilder = createBeanBuilder(ReliableIdGeneratorConfig.class);
+        private void handleFlakeIdGenerator(Node node) {
+            BeanDefinitionBuilder configBuilder = createBeanBuilder(FlakeIdGeneratorConfig.class);
             fillAttributeValues(node, configBuilder);
             String name = getAttribute(node, "name");
-            reliableIdGeneratorConfigMap.put(name, configBuilder.getBeanDefinition());
+            flakeIdGeneratorConfigMap.put(name, configBuilder.getBeanDefinition());
         }
 
         private void handleQuorum(Node node) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
@@ -45,7 +45,7 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
                 "ringBuffer",
                 "cardinalityEstimator",
                 "idGenerator",
-                "reliableIdGenerator",
+                "flakeIdGenerator",
                 "atomicLong",
                 "atomicReference",
                 "countDownLatch",

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -1677,7 +1677,7 @@
                             </xs:complexType>
                         </xs:element>
                         <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="reliable-id-generator" type="reliable-id-generator" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0" maxOccurs="1"/>
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -1800,7 +1800,7 @@
                         <xs:element name="query-caches" type="query-caches-client" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="connection-strategy" type="connection-strategy" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="user-code-deployment" type="user-code-deployment-client" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="reliable-id-generator" type="reliable-id-generator" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0" maxOccurs="1"/>
                     </xs:choice>
                     <xs:attribute name="executor-pool-size" type="xs:int" use="optional"/>
                     <xs:attribute name="credentials-ref" type="xs:string" use="optional"/>
@@ -1990,10 +1990,10 @@
             </xs:appinfo>
         </xs:annotation>
     </xs:element>
-    <xs:element name="reliableIdGenerator" type="hazelcast-type">
+    <xs:element name="flakeIdGenerator" type="hazelcast-type">
         <xs:annotation>
             <xs:documentation>
-                Retrieve a Hazelcast ReliableIdGenerator instance
+                Retrieve a Hazelcast FlakeIdGenerator instance
             </xs:documentation>
             <xs:appinfo>
                 <tool:annotation>
@@ -3155,11 +3155,11 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
-    <xs:complexType name="reliable-id-generator">
+    <xs:complexType name="flake-id-generator">
         <xs:attribute name="name" type="xs:string" default="default">
             <xs:annotation>
                 <xs:documentation>
-                    Name of the Reliable ID Generator.
+                    Name of the Flake ID Generator.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -31,7 +31,7 @@ import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCachePreloaderConfig;
@@ -107,7 +107,7 @@ public class TestClientApplicationContext {
     @Resource(name = "client9-user-code-deployment-test")
     private HazelcastClientProxy userCodeDeploymentTestClient;
 
-    @Resource(name = "client10-reliableIdGenerator")
+    @Resource(name = "client10-flakeIdGenerator")
     private HazelcastClientProxy client10;
 
     @Resource(name = "client11-icmp-ping")
@@ -380,10 +380,10 @@ public class TestClientApplicationContext {
     }
 
     @Test
-    public void testReliableIdGeneratorConfig() {
-        Map<String, ReliableIdGeneratorConfig> configMap = client10.getClientConfig().getReliableIdGeneratorConfigMap();
+    public void testFlakeIdGeneratorConfig() {
+        Map<String, FlakeIdGeneratorConfig> configMap = client10.getClientConfig().getFlakeIdGeneratorConfigMap();
         assertEquals(1, configMap.size());
-        ReliableIdGeneratorConfig config = configMap.values().iterator().next();
+        FlakeIdGeneratorConfig config = configMap.values().iterator().next();
         assertEquals("gen1", config.getName());
         assertEquals(3, config.getPrefetchCount());
         assertEquals(3000L, config.getPrefetchValidityMillis());

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -60,7 +60,7 @@ import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -112,7 +112,7 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.ssl.SSLContextFactory;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.spring.serialization.DummyDataSerializableFactory;
 import com.hazelcast.spring.serialization.DummyPortableFactory;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -192,8 +192,8 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     @Resource(name = "idGenerator")
     private IdGenerator idGenerator;
 
-    @Resource(name = "reliableIdGenerator")
-    private ReliableIdGenerator reliableIdGenerator;
+    @Resource(name = "flakeIdGenerator")
+    private FlakeIdGenerator flakeIdGenerator;
 
     @Resource(name = "atomicLong")
     private IAtomicLong atomicLong;
@@ -410,11 +410,11 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     }
 
     @Test
-    public void testMemberReliableIdGeneratorConfig() {
-        ReliableIdGeneratorConfig c = instance.getConfig().findReliableIdGeneratorConfig("reliableIdGenerator");
+    public void testMemberFlakeIdGeneratorConfig() {
+        FlakeIdGeneratorConfig c = instance.getConfig().findFlakeIdGeneratorConfig("flakeIdGenerator");
         assertEquals(3, c.getPrefetchCount());
         assertEquals(10L, c.getPrefetchValidityMillis());
-        assertEquals("reliableIdGenerator*", c.getName());
+        assertEquals("flakeIdGenerator*", c.getName());
     }
 
     @Test
@@ -791,7 +791,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(list);
         assertNotNull(executorService);
         assertNotNull(idGenerator);
-        assertNotNull(reliableIdGenerator);
+        assertNotNull(flakeIdGenerator);
         assertNotNull(atomicLong);
         assertNotNull(atomicReference);
         assertNotNull(countDownLatch);
@@ -806,7 +806,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("set", set.getName());
         assertEquals("list", list.getName());
         assertEquals("idGenerator", idGenerator.getName());
-        assertEquals("reliableIdGenerator", reliableIdGenerator.getName());
+        assertEquals("flakeIdGenerator", flakeIdGenerator.getName());
         assertEquals("testAtomicLong", atomicLong.getName());
         assertEquals("testAtomicReference", atomicReference.getName());
         assertEquals("countDownLatch", countDownLatch.getName());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -594,7 +594,7 @@
                 <hz:backup-dir>/mnt/hot-backup/</hz:backup-dir>
             </hz:hot-restart-persistence>
 
-            <hz:reliable-id-generator name="reliableIdGenerator*" prefetchCount="3" prefetchValidityMillis="10"/>
+            <hz:flake-id-generator name="flakeIdGenerator*" prefetchCount="3" prefetchValidityMillis="10"/>
         </hz:config>
     </hz:hazelcast>
 
@@ -612,7 +612,7 @@
     <hz:list id="list" instance-ref="instance" name="list"/>
     <hz:executorService id="executorService" instance-ref="instance" name="executorService"/>
     <hz:idGenerator id="idGenerator" instance-ref="instance" name="idGenerator"/>
-    <hz:reliableIdGenerator id="reliableIdGenerator" instance-ref="instance" name="reliableIdGenerator"/>
+    <hz:flakeIdGenerator id="flakeIdGenerator" instance-ref="instance" name="flakeIdGenerator"/>
     <hz:atomicLong id="atomicLong" instance-ref="instance" name="testAtomicLong"/>
     <hz:atomicReference id="atomicReference" instance-ref="instance" name="testAtomicReference"/>
     <hz:countDownLatch id="countDownLatch" instance-ref="instance" name="countDownLatch"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -274,12 +274,12 @@
         </hz:user-code-deployment>
     </hz:client>
 
-    <hz:client id="client10-reliableIdGenerator" credentials-ref="credentials">
+    <hz:client id="client10-flakeIdGenerator" credentials-ref="credentials">
         <hz:network connection-attempt-limit="0">
             <hz:member>127.0.0.1:5700</hz:member>
             <hz:member>127.0.0.1:5701</hz:member>
         </hz:network>
-        <hz:reliable-id-generator name="gen1" prefetchCount="3" prefetchValidityMillis="3000"/>
+        <hz:flake-id-generator name="gen1" prefetchCount="3" prefetchValidityMillis="3000"/>
     </hz:client>
 
     <hz:client id="client11-icmp-ping" credentials-ref="credentials">
@@ -310,7 +310,7 @@
     <hz:list id="list" instance-ref="client" name="list"/>
     <hz:executorService id="executorService" instance-ref="client" name="executorService"/>
     <hz:idGenerator id="idGenerator" instance-ref="client" name="idGenerator"/>
-    <hz:reliableIdGenerator id="reliableIdGenerator" instance-ref="client" name="reliableIdGenerator"/>
+    <hz:flakeIdGenerator id="flakeIdGenerator" instance-ref="client" name="flakeIdGenerator"/>
     <hz:atomicLong id="atomicLong" instance-ref="client" name="atomicLong"/>
     <hz:atomicReference id="atomicReference" instance-ref="client" name="atomicReference"/>
     <hz:countDownLatch id="countDownLatch" instance-ref="client" name="countDownLatch"/>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.impl.protocol.codec.ErrorCodec;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
-import com.hazelcast.reliableidgen.impl.NodeIdOutOfRangeException;
+import com.hazelcast.flakeidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.DuplicateInstanceNameException;
@@ -638,7 +638,7 @@ public class ClientExceptionFactory {
                 return new IndeterminateOperationStateException(message, cause);
             }
         });
-        register(ClientProtocolErrorCodes.RELIABLE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION, NodeIdOutOfRangeException.class, new ExceptionFactory() {
+        register(ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION, NodeIdOutOfRangeException.class, new ExceptionFactory() {
             @Override
             public Throwable createException(String message, Throwable cause) {
                 return new NodeIdOutOfRangeException(message);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -107,7 +107,7 @@ public final class ClientProtocolErrorCodes {
     public static final int STALE_TASK = 82;
     public static final int LOCAL_MEMBER_RESET = 83;
     public static final int INDETERMINATE_OPERATION_STATE = 84;
-    public static final int RELIABLE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION = 85;
+    public static final int FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION = 85;
 
     // These exception codes are reserved to by used by hazelcast-jet project
     public static final int JET_EXCEPTIONS_RANGE_START = 500;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -34,7 +34,7 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddLockConfigMessag
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMultiMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddQueueConfigMessageTask;
-import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableIdGeneratorConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddFlakeIdGeneratorConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableTopicConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReplicatedMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddRingbufferConfigMessageTask;
@@ -72,7 +72,7 @@ import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecut
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorTaskIsDoneFromPartitionMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.reliableidgen.impl.client.NewIdBatchMessageTask;
+import com.hazelcast.flakeidgen.impl.client.NewIdBatchMessageTask;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -2052,14 +2052,14 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 return new AddEventJournalConfigMessageTask(clientMessage, node, connection);
             }
         };
-        factories[com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableIdGeneratorConfigCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+        factories[com.hazelcast.client.impl.protocol.codec.DynamicConfigAddFlakeIdGeneratorConfigCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
-                return new AddReliableIdGeneratorConfigMessageTask(clientMessage, node, connection);
+                return new AddFlakeIdGeneratorConfigMessageTask(clientMessage, node, connection);
             }
         };
 //endregion
-// region ----------- REGISTRATION FOR reliable id generator
-        factories[com.hazelcast.client.impl.protocol.codec.ReliableIdGeneratorNewIdBatchCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+// region ----------- REGISTRATION FOR flake id generator
+        factories[com.hazelcast.client.impl.protocol.codec.FlakeIdGeneratorNewIdBatchCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new NewIdBatchMessageTask(clientMessage, node, connection);
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
@@ -17,32 +17,32 @@
 package com.hazelcast.client.impl.protocol.task.dynamicconfig;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddReliableIdGeneratorConfigCodec;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.client.impl.protocol.codec.DynamicConfigAddFlakeIdGeneratorConfigCodec;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class AddReliableIdGeneratorConfigMessageTask
-        extends AbstractAddConfigMessageTask<DynamicConfigAddReliableIdGeneratorConfigCodec.RequestParameters> {
+public class AddFlakeIdGeneratorConfigMessageTask
+        extends AbstractAddConfigMessageTask<DynamicConfigAddFlakeIdGeneratorConfigCodec.RequestParameters> {
 
-    public AddReliableIdGeneratorConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    public AddFlakeIdGeneratorConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected DynamicConfigAddReliableIdGeneratorConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return DynamicConfigAddReliableIdGeneratorConfigCodec.decodeRequest(clientMessage);
+    protected DynamicConfigAddFlakeIdGeneratorConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return DynamicConfigAddFlakeIdGeneratorConfigCodec.decodeRequest(clientMessage);
     }
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return DynamicConfigAddReliableIdGeneratorConfigCodec.encodeResponse();
+        return DynamicConfigAddFlakeIdGeneratorConfigCodec.encodeResponse();
     }
 
     @Override
     protected IdentifiedDataSerializable getConfig() {
-        ReliableIdGeneratorConfig config = new ReliableIdGeneratorConfig(parameters.name);
+        FlakeIdGeneratorConfig config = new FlakeIdGeneratorConfig(parameters.name);
         config.setPrefetchCount(parameters.prefetchCount);
         config.setPrefetchValidityMillis(parameters.prefetchValidity);
         return config;
@@ -50,6 +50,6 @@ public class AddReliableIdGeneratorConfigMessageTask
 
     @Override
     public String getMethodName() {
-        return "addReliableIdGeneratorConfig";
+        return "addFlakeIdGeneratorConfig";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
@@ -120,8 +120,8 @@ public class Config {
 
     private final Map<String, EventJournalConfig> cacheEventJournalConfigs = new ConcurrentHashMap<String, EventJournalConfig>();
 
-    private final Map<String, ReliableIdGeneratorConfig> reliableIdGeneratorConfigMap =
-            new ConcurrentHashMap<String, ReliableIdGeneratorConfig>();
+    private final Map<String, FlakeIdGeneratorConfig> flakeIdGeneratorConfigMap =
+            new ConcurrentHashMap<String, FlakeIdGeneratorConfig>();
 
     private final Map<String, AtomicLongConfig> atomicLongConfigs = new ConcurrentHashMap<String, AtomicLongConfig>();
 
@@ -3079,42 +3079,42 @@ public class Config {
     }
 
     /**
-     * Returns the map of {@link ReliableIdGenerator} configurations,
+     * Returns the map of {@link FlakeIdGenerator} configurations,
      * mapped by config name. The config name may be a pattern with which the
      * configuration was initially obtained.
      *
      * @return the map configurations mapped by config name
      */
-    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs() {
-        return reliableIdGeneratorConfigMap;
+    public Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigs() {
+        return flakeIdGeneratorConfigMap;
     }
 
     /**
-     * Returns a {@link ReliableIdGeneratorConfig} configuration for the given reliable ID generator name.
+     * Returns a {@link FlakeIdGeneratorConfig} configuration for the given flake ID generator name.
      * <p>
      * The name is matched by pattern to the configuration and by stripping the
      * partition ID qualifier from the given {@code name}.
      * If there is no config found by the name, it will return the configuration
      * with the name {@code "default"}.
      *
-     * @param name name of the reliable ID generator config
-     * @return the reliable ID generator configuration
+     * @param name name of the flake ID generator config
+     * @return the flake ID generator configuration
      * @throws ConfigurationException if ambiguous configurations are found
      * @see com.hazelcast.partition.strategy.StringPartitioningStrategy#getBaseName(java.lang.String)
      * @see #setConfigPatternMatcher(ConfigPatternMatcher)
      * @see #getConfigPatternMatcher()
      */
-    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String name) {
         String baseName = getBaseName(name);
-        ReliableIdGeneratorConfig config = lookupByPattern(configPatternMatcher, reliableIdGeneratorConfigMap, baseName);
+        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
         if (config != null) {
             return config;
         }
-        return getReliableIdGeneratorConfig("default");
+        return getFlakeIdGeneratorConfig("default");
     }
 
     /**
-     * Returns the {@link ReliableIdGeneratorConfig} for the given name, creating
+     * Returns the {@link FlakeIdGeneratorConfig} for the given name, creating
      * one if necessary and adding it to the collection of known configurations.
      * <p>
      * The configuration is found by matching the the configuration name
@@ -3126,62 +3126,62 @@ public class Config {
      * <p>
      * This method is intended to easily and fluently create and add
      * configurations more specific than the default configuration without
-     * explicitly adding it by invoking {@link #addReliableIdGeneratorConfig(ReliableIdGeneratorConfig)}.
+     * explicitly adding it by invoking {@link #addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig)}.
      * <p>
      * Because it adds new configurations if they are not already present,
      * this method is intended to be used before this config is used to
      * create a hazelcast instance. Afterwards, newly added configurations
      * may be ignored.
      *
-     * @param name name of the reliable ID generator config
+     * @param name name of the flake ID generator config
      * @return the cache configuration
      * @throws ConfigurationException if ambiguous configurations are found
      * @see com.hazelcast.partition.strategy.StringPartitioningStrategy#getBaseName(java.lang.String)
      * @see #setConfigPatternMatcher(ConfigPatternMatcher)
      * @see #getConfigPatternMatcher()
      */
-    public ReliableIdGeneratorConfig getReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig getFlakeIdGeneratorConfig(String name) {
         String baseName = getBaseName(name);
-        ReliableIdGeneratorConfig config = lookupByPattern(configPatternMatcher, reliableIdGeneratorConfigMap, baseName);
+        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
         if (config != null) {
             return config;
         }
-        ReliableIdGeneratorConfig defConfig = reliableIdGeneratorConfigMap.get("default");
+        FlakeIdGeneratorConfig defConfig = flakeIdGeneratorConfigMap.get("default");
         if (defConfig == null) {
-            defConfig = new ReliableIdGeneratorConfig("default");
-            reliableIdGeneratorConfigMap.put(defConfig.getName(), defConfig);
+            defConfig = new FlakeIdGeneratorConfig("default");
+            flakeIdGeneratorConfigMap.put(defConfig.getName(), defConfig);
         }
-        config = new ReliableIdGeneratorConfig(defConfig);
+        config = new FlakeIdGeneratorConfig(defConfig);
         config.setName(name);
-        reliableIdGeneratorConfigMap.put(config.getName(), config);
+        flakeIdGeneratorConfigMap.put(config.getName(), config);
         return config;
     }
 
     /**
-     * Adds a reliable ID generator configuration. The configuration is saved under the config
+     * Adds a flake ID generator configuration. The configuration is saved under the config
      * name, which may be a pattern with which the configuration will be
      * obtained in the future.
      *
-     * @param config the reliable ID generator configuration
+     * @param config the flake ID generator configuration
      * @return this config instance
      */
-    public Config addReliableIdGeneratorConfig(ReliableIdGeneratorConfig config) {
-        reliableIdGeneratorConfigMap.put(config.getName(), config);
+    public Config addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig config) {
+        flakeIdGeneratorConfigMap.put(config.getName(), config);
         return this;
     }
 
     /**
-     * Sets the map of {@link ReliableIdGenerator} configurations,
+     * Sets the map of {@link FlakeIdGenerator} configurations,
      * mapped by config name. The config name may be a pattern with which the
      * configuration will be obtained in the future.
      *
-     * @param map the ReliableIdGenerator configuration map to set
+     * @param map the FlakeIdGenerator configuration map to set
      * @return this config instance
      */
-    public Config setReliableIdGeneratorConfigs(Map<String, ReliableIdGeneratorConfig> map) {
-        reliableIdGeneratorConfigMap.clear();
-        reliableIdGeneratorConfigMap.putAll(map);
-        for (Entry<String, ReliableIdGeneratorConfig> entry : map.entrySet()) {
+    public Config setFlakeIdGeneratorConfigs(Map<String, FlakeIdGeneratorConfig> map) {
+        flakeIdGeneratorConfigMap.clear();
+        flakeIdGeneratorConfigMap.putAll(map);
+        for (Entry<String, FlakeIdGeneratorConfig> entry : map.entrySet()) {
             entry.getValue().setName(entry.getKey());
         }
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -87,7 +87,7 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int QUORUM_LISTENER_CONFIG = 45;
     public static final int CACHE_PARTITION_LOST_LISTENER_CONFIG = 46;
     public static final int SIMPLE_CACHE_ENTRY_LISTENER_CONFIG = 47;
-    public static final int RELIABLE_ID_GENERATOR_CONFIG = 48;
+    public static final int FLAKE_ID_GENERATOR_CONFIG = 48;
     public static final int ATOMIC_LONG_CONFIG = 49;
     public static final int ATOMIC_REFERENCE_CONFIG = 50;
     public static final int MERGE_POLICY_CONFIG = 51;
@@ -396,11 +396,11 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                         return new CacheSimpleEntryListenerConfig();
                     }
                 };
-        constructors[RELIABLE_ID_GENERATOR_CONFIG] =
+        constructors[FLAKE_ID_GENERATOR_CONFIG] =
                 new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
-                        return new ReliableIdGeneratorConfig();
+                        return new FlakeIdGeneratorConfig();
                     }
                 };
         constructors[ATOMIC_LONG_CONFIG] =

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -131,7 +131,7 @@ public class ConfigXmlGenerator {
         nativeMemoryXmlGenerator(gen, config);
         servicesXmlGenerator(gen, config);
         hotRestartXmlGenerator(gen, config);
-        reliableIdGeneratorXmlGenerator(gen, config);
+        flakeIdGeneratorXmlGenerator(gen, config);
 
         xml.append("</hazelcast>");
 
@@ -1023,9 +1023,9 @@ public class ConfigXmlGenerator {
                 .close();
     }
 
-    private static void reliableIdGeneratorXmlGenerator(XmlGenerator gen, Config config) {
-        for (ReliableIdGeneratorConfig m : config.getReliableIdGeneratorConfigs().values()) {
-            gen.open("reliable-id-generator", "name", m.getName())
+    private static void flakeIdGeneratorXmlGenerator(XmlGenerator gen, Config config) {
+        for (FlakeIdGeneratorConfig m : config.getFlakeIdGeneratorConfigs().values()) {
+            gen.open("flake-id-generator", "name", m.getName())
                     .node("prefetch-count", m.getPrefetchCount())
                     .node("prefetch-validity-millis", m.getPrefetchValidityMillis());
             gen.close();

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -25,15 +25,15 @@ import com.hazelcast.util.Preconditions;
 import java.io.IOException;
 
 /**
- * The {@code ReliableIdGeneratorConfig} contains the configuration for the member
- * regarding {@link com.hazelcast.core.HazelcastInstance#getReliableIdGenerator(String)
- * Reliable ID Generator}.
+ * The {@code FlakeIdGeneratorConfig} contains the configuration for the member
+ * regarding {@link com.hazelcast.core.HazelcastInstance#getFlakeIdGenerator(String)
+ * Flake ID Generator}.
  * <p>
  * Settings here only apply when ID generator is used from member, not when clients
  * connect to this member to generate IDs - each client has its own settings in {@code
  * ClientConfig}.
  */
-public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
+public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
 
     /**
      * Default value for {@link #getPrefetchCount()}.
@@ -49,20 +49,20 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
     private int prefetchCount = DEFAULT_PREFETCH_COUNT;
     private long prefetchValidityMillis = DEFAULT_PREFETCH_VALIDITY_MILLIS;
 
-    private transient ReliableIdGeneratorConfigReadOnly readOnly;
+    private transient FlakeIdGeneratorConfigReadOnly readOnly;
 
     // for deserialization
-    ReliableIdGeneratorConfig() {
+    FlakeIdGeneratorConfig() {
     }
 
-    public ReliableIdGeneratorConfig(String name) {
+    public FlakeIdGeneratorConfig(String name) {
         this.name = name;
     }
 
     /**
      * Copy-constructor
      */
-    public ReliableIdGeneratorConfig(ReliableIdGeneratorConfig other) {
+    public FlakeIdGeneratorConfig(FlakeIdGeneratorConfig other) {
         this.name = other.name;
         this.prefetchCount = other.prefetchCount;
         this.prefetchValidityMillis = other.prefetchValidityMillis;
@@ -74,9 +74,9 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
      * @return immutable version of this configuration
      * @deprecated this method will be removed in 4.0; it is meant for internal usage only
      */
-    public ReliableIdGeneratorConfigReadOnly getAsReadOnly() {
+    public FlakeIdGeneratorConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
-            readOnly = new ReliableIdGeneratorConfigReadOnly(this);
+            readOnly = new FlakeIdGeneratorConfigReadOnly(this);
         }
         return readOnly;
     }
@@ -106,13 +106,13 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
 
     /**
      * How many IDs are pre-fetched on the background when one call to
-     * {@link ReliableIdGenerator#newId()} is made.
+     * {@link FlakeIdGenerator#newId()} is made.
      * <p>
      * Value must be >= 1, default is 100.
      *
      * @return this instance for fluent API
      */
-    public ReliableIdGeneratorConfig setPrefetchCount(int prefetchCount) {
+    public FlakeIdGeneratorConfig setPrefetchCount(int prefetchCount) {
         Preconditions.checkPositive(prefetchCount, "prefetch-count must be >=1, not " + prefetchCount);
         this.prefetchCount = prefetchCount;
         return this;
@@ -138,7 +138,7 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
      *
      * @return this instance for fluent API
      */
-    public ReliableIdGeneratorConfig setPrefetchValidityMillis(long prefetchValidityMs) {
+    public FlakeIdGeneratorConfig setPrefetchValidityMillis(long prefetchValidityMs) {
         this.prefetchValidityMillis = prefetchValidityMs;
         return this;
     }
@@ -152,7 +152,7 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
             return false;
         }
 
-        ReliableIdGeneratorConfig that = (ReliableIdGeneratorConfig) o;
+        FlakeIdGeneratorConfig that = (FlakeIdGeneratorConfig) o;
 
         if (prefetchCount != that.prefetchCount) {
             return false;
@@ -173,7 +173,7 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        return "ReliableIdGeneratorConfig{"
+        return "FlakeIdGeneratorConfig{"
                 + "name='" + name + '\''
                 + ", prefetchCount=" + prefetchCount
                 + ", prefetchValidityMillis=" + prefetchValidityMillis
@@ -187,7 +187,7 @@ public class ReliableIdGeneratorConfig implements IdentifiedDataSerializable {
 
     @Override
     public int getId() {
-        return ConfigDataSerializerHook.RELIABLE_ID_GENERATOR_CONFIG;
+        return ConfigDataSerializerHook.FLAKE_ID_GENERATOR_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfigReadOnly.java
@@ -17,13 +17,13 @@
 package com.hazelcast.config;
 
 /**
- * See {@link ReliableIdGeneratorConfig}
+ * See {@link FlakeIdGeneratorConfig}
  *
  * @deprecated this class will be removed in 4.0; it is meant for internal usage only.
  */
-public class ReliableIdGeneratorConfigReadOnly extends ReliableIdGeneratorConfig {
+public class FlakeIdGeneratorConfigReadOnly extends FlakeIdGeneratorConfig {
 
-    ReliableIdGeneratorConfigReadOnly(ReliableIdGeneratorConfig config) {
+    FlakeIdGeneratorConfigReadOnly(FlakeIdGeneratorConfig config) {
         super(config);
     }
 
@@ -33,12 +33,12 @@ public class ReliableIdGeneratorConfigReadOnly extends ReliableIdGeneratorConfig
     }
 
     @Override
-    public ReliableIdGeneratorConfig setPrefetchCount(int prefetchCount) {
+    public FlakeIdGeneratorConfig setPrefetchCount(int prefetchCount) {
         throw throwReadOnly();
     }
 
     @Override
-    public ReliableIdGeneratorConfig setPrefetchValidityMillis(long prefetchValidityMs) {
+    public FlakeIdGeneratorConfig setPrefetchValidityMillis(long prefetchValidityMs) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -83,9 +83,9 @@ public class PermissionConfig {
          */
         ID_GENERATOR("id-generator-permission"),
         /**
-         * Reliable ID generator
+         * Flake ID generator
          */
-        RELIABLE_ID_GENERATOR("reliable-id-generator-permission"),
+        FLAKE_ID_GENERATOR("flake-id-generator-permission"),
         /**
          * Lock
          */

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -90,7 +90,7 @@ import static com.hazelcast.config.XmlElements.PARTITION_GROUP;
 import static com.hazelcast.config.XmlElements.PROPERTIES;
 import static com.hazelcast.config.XmlElements.QUEUE;
 import static com.hazelcast.config.XmlElements.QUORUM;
-import static com.hazelcast.config.XmlElements.RELIABLE_ID_GENERATOR;
+import static com.hazelcast.config.XmlElements.FLAKE_ID_GENERATOR;
 import static com.hazelcast.config.XmlElements.RELIABLE_TOPIC;
 import static com.hazelcast.config.XmlElements.REPLICATED_MAP;
 import static com.hazelcast.config.XmlElements.RINGBUFFER;
@@ -387,8 +387,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleUserCodeDeployment(node);
         } else if (CARDINALITY_ESTIMATOR.isEqual(nodeName)) {
             handleCardinalityEstimator(node);
-        } else if (RELIABLE_ID_GENERATOR.isEqual(nodeName)) {
-            handleReliableIdGenerator(node);
+        } else if (FLAKE_ID_GENERATOR.isEqual(nodeName)) {
+            handleFlakeIdGenerator(node);
         } else {
             return true;
         }
@@ -652,9 +652,9 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         handleViaReflection(node, config, cardinalityEstimatorConfig);
     }
 
-    private void handleReliableIdGenerator(Node node) {
+    private void handleFlakeIdGenerator(Node node) {
         String name = getAttribute(node, "name");
-        ReliableIdGeneratorConfig generatorConfig = new ReliableIdGeneratorConfig(name);
+        FlakeIdGeneratorConfig generatorConfig = new FlakeIdGeneratorConfig(name);
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             String value = getTextContent(child).trim();
@@ -664,7 +664,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 generatorConfig.setPrefetchValidityMillis(Long.parseLong(value));
             }
         }
-        config.addReliableIdGeneratorConfig(generatorConfig);
+        config.addFlakeIdGeneratorConfig(generatorConfig);
     }
 
     private void handleGroup(Node node) {
@@ -2319,8 +2319,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 type = PermissionType.SEMAPHORE;
             } else if ("id-generator-permission".equals(nodeName)) {
                 type = PermissionType.ID_GENERATOR;
-            } else if ("reliable-id-generator-permission".equals(nodeName)) {
-                type = PermissionType.RELIABLE_ID_GENERATOR;
+            } else if ("flake-id-generator-permission".equals(nodeName)) {
+                type = PermissionType.FLAKE_ID_GENERATOR;
             } else if ("executor-service-permission".equals(nodeName)) {
                 type = PermissionType.EXECUTOR_SERVICE;
             } else if ("transaction-permission".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -58,7 +58,7 @@ enum XmlElements {
     HOT_RESTART_PERSISTENCE("hot-restart-persistence", false),
     USER_CODE_DEPLOYMENT("user-code-deployment", false),
     CARDINALITY_ESTIMATOR("cardinality-estimator", false),
-    RELIABLE_ID_GENERATOR("reliable-id-generator", true),
+    FLAKE_ID_GENERATOR("flake-id-generator", true),
     ;
 
     final String name;

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -22,7 +22,7 @@ import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.quorum.QuorumService;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
@@ -263,7 +263,7 @@ public interface HazelcastInstance {
      *
      * @deprecated The implementation can produce duplicate IDs in case of network split, even
      * with split-brain protection enabled (during short window while split-brain is detected).
-     * Use {@link #getReliableIdGenerator(String)} for an alternative implementation which does not
+     * Use {@link #getFlakeIdGenerator(String)} for an alternative implementation which does not
      * suffer from this problem.
      */
     @Deprecated
@@ -279,15 +279,15 @@ public interface HazelcastInstance {
      * members, which makes the generator safe even in split-brain scenario (for caveats,
      * {@link com.hazelcast.internal.cluster.ClusterService#getMemberListJoinVersion() see here}).
      * <p>
-     * For more details and caveats, see class documentation for {@link ReliableIdGenerator}.
+     * For more details and caveats, see class documentation for {@link FlakeIdGenerator}.
      * <p>
      * Note: this implementation doesn't share namespace with {@link #getIdGenerator(String)}.
-     * That is, {@code getIdGenerator("a")} is distinct from {@code getReliableIdGenerator("a")}.
+     * That is, {@code getIdGenerator("a")} is distinct from {@code getFlakeIdGenerator("a")}.
      *
-     * @param name name of the {@link IdGenerator}
-     * @return ReliableIdGenerator for the given name
+     * @param name name of the {@link FlakeIdGenerator}
+     * @return FlakeIdGenerator for the given name
      */
-    ReliableIdGenerator getReliableIdGenerator(String name);
+    FlakeIdGenerator getFlakeIdGenerator(String name);
 
     /**
      * Creates cluster-wide atomic long. Hazelcast {@link IAtomicLong} is distributed

--- a/hazelcast/src/main/java/com/hazelcast/core/IdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IdGenerator.java
@@ -52,7 +52,7 @@ package com.hazelcast.core;
  *
  * @deprecated The implementation can produce duplicate IDs in case of network split, even with split-brain
  * protection enabled (during short window while split-brain is detected). Use {@link
- * HazelcastInstance#getReliableIdGenerator(String)} for an alternative implementation which does not suffer
+ * HazelcastInstance#getFlakeIdGenerator(String)} for an alternative implementation which does not suffer
  * from this problem.
  */
 @Deprecated

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/FlakeIdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/FlakeIdGenerator.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen;
+package com.hazelcast.flakeidgen;
 
-import com.hazelcast.reliableidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.flakeidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.internal.cluster.ClusterService;
 
 /**
@@ -39,8 +39,8 @@ import com.hazelcast.internal.cluster.ClusterService;
  * Operation on member is typically local. On client, the {@link #newId()} method goes to a random
  * member and gets a batch of IDs, which will then be returned locally for limited time. The pre-fetch
  * size and the validity time can be configured for each client and member, see {@link
- * com.hazelcast.config.Config#addReliableIdGeneratorConfig(com.hazelcast.config.ReliableIdGeneratorConfig)
- * here} for member config and {@code ClientConfig.addReliableIdGeneratorConfig()} for client config.
+ * com.hazelcast.config.Config#addFlakeIdGeneratorConfig(com.hazelcast.config.FlakeIdGeneratorConfig)
+ * here} for member config and {@code ClientConfig.addFlakeIdGeneratorConfig()} for client config.
  *
  * <h4>Node ID overflow</h4>
  * Node ID component of the ID has 16 bits. Members with member list join version higher than
@@ -52,7 +52,7 @@ import com.hazelcast.internal.cluster.ClusterService;
  *
  * @since 3.10
  */
-public interface ReliableIdGenerator extends DistributedObject {
+public interface FlakeIdGenerator extends DistributedObject {
 
     /**
      * Generates and returns a cluster-wide unique ID.
@@ -65,7 +65,7 @@ public interface ReliableIdGenerator extends DistributedObject {
      * @return new cluster-wide unique ID
      *
      * @throws NodeIdOutOfRangeException if node ID for all members in the cluster is out of valid range.
-     *      See "Node ID overflow" in {@link ReliableIdGenerator class documentation} for more details.
+     *      See "Node ID overflow" in {@link FlakeIdGenerator class documentation} for more details.
      * @throws UnsupportedOperationException if the cluster version is below 3.10
      */
     long newId();

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/AutoBatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/AutoBatcher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.util.Clock;
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorDataSerializerHook.java
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.RELIABLE_ID_GENERATOR_DS_FACTORY;
-import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.RELIABLE_ID_GENERATOR_DS_FACTORY_ID;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.FLAKE_ID_GENERATOR_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.FLAKE_ID_GENERATOR_DS_FACTORY_ID;
 
-public final class ReliableIdGeneratorDataSerializerHook implements DataSerializerHook {
+public final class FlakeIdGeneratorDataSerializerHook implements DataSerializerHook {
 
-    static final int F_ID = FactoryIdHelper.getFactoryId(RELIABLE_ID_GENERATOR_DS_FACTORY, RELIABLE_ID_GENERATOR_DS_FACTORY_ID);
+    static final int F_ID = FactoryIdHelper.getFactoryId(FLAKE_ID_GENERATOR_DS_FACTORY, FLAKE_ID_GENERATOR_DS_FACTORY_ID);
 
     static final int NEW_ID_BATCH_OPERATION = 0;
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
-import com.hazelcast.config.ReliableIdGeneratorConfig;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
@@ -36,9 +36,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import static com.hazelcast.util.Preconditions.checkPositive;
 import static java.util.Collections.newSetFromMap;
 
-public class ReliableIdGeneratorProxy
-        extends AbstractDistributedObject<ReliableIdGeneratorService>
-        implements ReliableIdGenerator {
+public class FlakeIdGeneratorProxy
+        extends AbstractDistributedObject<FlakeIdGeneratorService>
+        implements FlakeIdGenerator {
 
     public static final int BITS_TIMESTAMP = 42;
     public static final int BITS_SEQUENCE = 6;
@@ -76,22 +76,22 @@ public class ReliableIdGeneratorProxy
      */
     private final Set<String> outOfRangeMembers = newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
-    ReliableIdGeneratorProxy(String name, NodeEngine nodeEngine, ReliableIdGeneratorService service) {
+    FlakeIdGeneratorProxy(String name, NodeEngine nodeEngine, FlakeIdGeneratorService service) {
         super(nodeEngine, service);
         this.name = name;
         this.logger = nodeEngine.getLogger(getClass());
 
-        ReliableIdGeneratorConfig config = nodeEngine.getConfig().findReliableIdGeneratorConfig(getName());
+        FlakeIdGeneratorConfig config = nodeEngine.getConfig().findFlakeIdGeneratorConfig(getName());
         batcher = new AutoBatcher(config.getPrefetchCount(), config.getPrefetchValidityMillis(),
                 new AutoBatcher.IdBatchSupplier() {
                     @Override
                     public IdBatch newIdBatch(int batchSize) {
-                        return ReliableIdGeneratorProxy.this.newIdBatch(batchSize);
+                        return FlakeIdGeneratorProxy.this.newIdBatch(batchSize);
                     }
                 });
 
         if (logger.isFinestEnabled()) {
-            logger.finest("Created ReliableIdGeneratorProxy, name='" + name + "'");
+            logger.finest("Created FlakeIdGeneratorProxy, name='" + name + "'");
         }
     }
 
@@ -223,6 +223,6 @@ public class ReliableIdGeneratorProxy
 
     @Override
     public String getServiceName() {
-        return ReliableIdGeneratorService.SERVICE_NAME;
+        return FlakeIdGeneratorService.SERVICE_NAME;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.spi.ManagedService;
@@ -23,13 +23,13 @@ import com.hazelcast.spi.RemoteService;
 
 import java.util.Properties;
 
-public class ReliableIdGeneratorService implements ManagedService, RemoteService {
+public class FlakeIdGeneratorService implements ManagedService, RemoteService {
 
-    public static final String SERVICE_NAME = "hz:impl:reliableIdGeneratorService";
+    public static final String SERVICE_NAME = "hz:impl:flakeIdGeneratorService";
 
     private NodeEngine nodeEngine;
 
-    public ReliableIdGeneratorService(NodeEngine nodeEngine) {
+    public FlakeIdGeneratorService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
     }
 
@@ -49,7 +49,7 @@ public class ReliableIdGeneratorService implements ManagedService, RemoteService
 
     @Override
     public DistributedObject createDistributedObject(String name) {
-        return new ReliableIdGeneratorProxy(name, nodeEngine, this);
+        return new FlakeIdGeneratorProxy(name, nodeEngine, this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/IdBatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/IdBatch.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 
 import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * Set of IDs returned from {@link ReliableIdGenerator}.
+ * Set of IDs returned from {@link FlakeIdGenerator}.
  * <p>
  * IDs can be iterated using a foreach loop:
  * <pre>{@code
- *    IdBatch idBatch = myReliableIdGenerator.newIdBatch(100);
+ *    IdBatch idBatch = myFlakeIdGenerator.newIdBatch(100);
  *    for (Long id : idBatch) {
  *        // ... use the id
  *    }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/NewIdBatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/NewIdBatchOperation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 class NewIdBatchOperation extends Operation implements IdentifiedDataSerializable {
 
-    private String reliableIdGenName;
+    private String flakeIdGenName;
     private int batchSize;
     private long returnValue;
 
@@ -34,14 +34,14 @@ class NewIdBatchOperation extends Operation implements IdentifiedDataSerializabl
     }
 
     public NewIdBatchOperation(String genName, int batchSize) {
-        this.reliableIdGenName = genName;
+        this.flakeIdGenName = genName;
         this.batchSize = batchSize;
     }
 
     @Override
     public void run() throws Exception {
-        ReliableIdGeneratorProxy proxy = (ReliableIdGeneratorProxy) getNodeEngine().getProxyService()
-                .getDistributedObject(getServiceName(), reliableIdGenName);
+        FlakeIdGeneratorProxy proxy = (FlakeIdGeneratorProxy) getNodeEngine().getProxyService()
+                .getDistributedObject(getServiceName(), flakeIdGenName);
         returnValue = proxy.newIdBaseLocal(batchSize);
     }
 
@@ -52,28 +52,28 @@ class NewIdBatchOperation extends Operation implements IdentifiedDataSerializabl
 
     @Override
     public String getServiceName() {
-        return ReliableIdGeneratorService.SERVICE_NAME;
+        return FlakeIdGeneratorService.SERVICE_NAME;
     }
 
     @Override
     public int getFactoryId() {
-        return ReliableIdGeneratorDataSerializerHook.F_ID;
+        return FlakeIdGeneratorDataSerializerHook.F_ID;
     }
 
     @Override
     public int getId() {
-        return ReliableIdGeneratorDataSerializerHook.NEW_ID_BATCH_OPERATION;
+        return FlakeIdGeneratorDataSerializerHook.NEW_ID_BATCH_OPERATION;
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        reliableIdGenName = in.readUTF();
+        flakeIdGenName = in.readUTF();
         batchSize = in.readInt();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(reliableIdGenName);
+        out.writeUTF(flakeIdGenName);
         out.writeInt(batchSize);
     }
 
@@ -81,7 +81,7 @@ class NewIdBatchOperation extends Operation implements IdentifiedDataSerializabl
     protected void toString(StringBuilder sb) {
         super.toString(sb);
 
-        sb.append(", reliableIdGenName=").append(reliableIdGenName);
+        sb.append(", flakeIdGenName=").append(flakeIdGenName);
         sb.append(", batchSize=").append(batchSize);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/NodeIdOutOfRangeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/NodeIdOutOfRangeException.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.core.HazelcastException;
 
 /**
- * Exception thrown from member if that member is not able to generate IDs using Reliable ID generator
+ * Exception thrown from member if that member is not able to generate IDs using Flake ID generator
  * because its node ID is too big.
  */
 public class NodeIdOutOfRangeException extends HazelcastException {

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/client/NewIdBatchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/client/NewIdBatchMessageTask.java
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl.client;
+package com.hazelcast.flakeidgen.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.ReliableIdGeneratorNewIdBatchCodec;
-import com.hazelcast.client.impl.protocol.codec.ReliableIdGeneratorNewIdBatchCodec.RequestParameters;
+import com.hazelcast.client.impl.protocol.codec.FlakeIdGeneratorNewIdBatchCodec;
+import com.hazelcast.client.impl.protocol.codec.FlakeIdGeneratorNewIdBatchCodec.RequestParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
-import com.hazelcast.reliableidgen.impl.IdBatch;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorProxy;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
+import com.hazelcast.flakeidgen.impl.IdBatch;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorProxy;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
-import com.hazelcast.security.permission.ReliableIdGeneratorPermission;
+import com.hazelcast.security.permission.FlakeIdGeneratorPermission;
 
 import java.security.Permission;
 
@@ -38,31 +38,31 @@ public class NewIdBatchMessageTask
     }
 
     @Override
-    protected ReliableIdGeneratorNewIdBatchCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ReliableIdGeneratorNewIdBatchCodec.decodeRequest(clientMessage);
+    protected FlakeIdGeneratorNewIdBatchCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return FlakeIdGeneratorNewIdBatchCodec.decodeRequest(clientMessage);
     }
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
         IdBatch idBatch = (IdBatch) response;
-        return ReliableIdGeneratorNewIdBatchCodec.encodeResponse(idBatch.base(), idBatch.increment(), idBatch.batchSize());
+        return FlakeIdGeneratorNewIdBatchCodec.encodeResponse(idBatch.base(), idBatch.increment(), idBatch.batchSize());
     }
 
     @Override
     protected IdBatch call() throws Exception {
-        ReliableIdGeneratorProxy proxy = (ReliableIdGeneratorProxy) nodeEngine.getProxyService()
-                .getDistributedObject(getServiceName(), parameters.name);
+        FlakeIdGeneratorProxy proxy = (FlakeIdGeneratorProxy) nodeEngine.getProxyService()
+                                                                        .getDistributedObject(getServiceName(), parameters.name);
         return proxy.newIdBatch(parameters.batchSize);
     }
 
     @Override
     public String getServiceName() {
-        return ReliableIdGeneratorService.SERVICE_NAME;
+        return FlakeIdGeneratorService.SERVICE_NAME;
     }
 
     @Override
     public Permission getRequiredPermission() {
-        return new ReliableIdGeneratorPermission(parameters.name, ActionConstants.ACTION_MODIFY);
+        return new FlakeIdGeneratorPermission(parameters.name, ActionConstants.ACTION_MODIFY);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * This package contains Reliable ID Generator functionality for Hazelcast.
+ * This package contains Flake ID Generator functionality for Hazelcast.
  *
  * @since 3.10
  */
- package com.hazelcast.reliableidgen;
+ package com.hazelcast.flakeidgen;

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -25,7 +25,8 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -34,7 +35,6 @@ import com.hazelcast.core.ClientService;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IAtomicLong;
@@ -282,9 +282,9 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     }
 
     @Override
-    public ReliableIdGenerator getReliableIdGenerator(String name) {
-        checkNotNull(name, "Retrieving a Reliable ID-generator instance with a null name is not allowed!");
-        return getDistributedObject(ReliableIdGeneratorService.SERVICE_NAME, name);
+    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+        checkNotNull(name, "Retrieving a Flake ID-generator instance with a null name is not allowed!");
+        return getDistributedObject(FlakeIdGeneratorService.SERVICE_NAME, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.ClientService;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IAtomicLong;
@@ -178,8 +178,8 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
-    public ReliableIdGenerator getReliableIdGenerator(String name) {
-        return getOriginal().getReliableIdGenerator(name);
+    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+        return getOriginal().getFlakeIdGenerator(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ClusterWideConfigurationService.java
@@ -26,7 +26,7 @@ import com.hazelcast.config.CountDownLatchConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.MapConfig;
@@ -121,8 +121,8 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
             new ConcurrentHashMap<String, EventJournalConfig>();
     private final ConcurrentMap<String, EventJournalConfig> mapEventJournalConfigs =
             new ConcurrentHashMap<String, EventJournalConfig>();
-    private final ConcurrentMap<String, ReliableIdGeneratorConfig> reliableIdGeneratorConfigs =
-            new ConcurrentHashMap<String, ReliableIdGeneratorConfig>();
+    private final ConcurrentMap<String, FlakeIdGeneratorConfig> flakeIdGeneratorConfigs =
+            new ConcurrentHashMap<String, FlakeIdGeneratorConfig>();
 
     private final ConfigPatternMatcher configPatternMatcher;
     private final ILogger logger;
@@ -150,7 +150,7 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
             cacheSimpleConfigs,
             cacheEventJournalConfigs,
             mapEventJournalConfigs,
-            reliableIdGeneratorConfigs,
+            flakeIdGeneratorConfigs,
     };
 
     private volatile Version version;
@@ -325,9 +325,9 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
         } else if (newConfig instanceof SemaphoreConfig) {
             SemaphoreConfig semaphoreConfig = (SemaphoreConfig) newConfig;
             currentConfig = semaphoreConfigs.putIfAbsent(semaphoreConfig.getName(), semaphoreConfig);
-        } else if (newConfig instanceof ReliableIdGeneratorConfig) {
-            ReliableIdGeneratorConfig config = (ReliableIdGeneratorConfig) newConfig;
-            currentConfig = reliableIdGeneratorConfigs.putIfAbsent(config.getName(), config);
+        } else if (newConfig instanceof FlakeIdGeneratorConfig) {
+            FlakeIdGeneratorConfig config = (FlakeIdGeneratorConfig) newConfig;
+            currentConfig = flakeIdGeneratorConfigs.putIfAbsent(config.getName(), config);
         } else {
             throw new UnsupportedOperationException("Unsupported config type: " + newConfig);
         }
@@ -597,13 +597,13 @@ public class ClusterWideConfigurationService implements PreJoinAwareService,
     }
 
     @Override
-    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String baseName) {
-        return lookupByPattern(configPatternMatcher, reliableIdGeneratorConfigs, baseName);
+    public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String baseName) {
+        return lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigs, baseName);
     }
 
     @Override
-    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs() {
-        return reliableIdGeneratorConfigs;
+    public Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigs() {
+        return flakeIdGeneratorConfigs;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
@@ -29,7 +29,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.QueueConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -226,12 +226,12 @@ public interface ConfigurationService {
     EventJournalConfig findMapEventJournalConfig(String name);
 
     /**
-     * Finds existing ReliableIdGeneratorConfig config.
+     * Finds existing FlakeIdGeneratorConfig config.
      *
      * @param name name of the config
-     * @return ReliableIdGenerator config or {@code null} when requested ReliableIdGenerator configuration does not exist
+     * @return FlakeIdGenerator config or {@code null} when requested FlakeIdGenerator configuration does not exist
      */
-    ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String name);
+    FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String name);
 
     /**
      * Returns all registered map configurations.
@@ -381,9 +381,9 @@ public interface ConfigurationService {
     Map<String, EventJournalConfig> getMapEventJournalConfigs();
 
     /**
-     * Returns all registered ReliableIdGenerator configurations.
+     * Returns all registered FlakeIdGenerator configurations.
      *
-     * @return registered ReliableIdGenerator configurations
+     * @return registered FlakeIdGenerator configurations
      */
-    Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs();
+    Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigs();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.CountDownLatchConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.JobTrackerConfig;
@@ -42,7 +43,6 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -1165,44 +1165,44 @@ public class DynamicConfigurationAwareConfig extends Config {
     }
 
     @Override
-    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs() {
-        Map<String, ReliableIdGeneratorConfig> staticMapConfigs = staticConfig.getReliableIdGeneratorConfigs();
-        Map<String, ReliableIdGeneratorConfig> dynamicMapConfigs = configurationService.getReliableIdGeneratorConfigs();
+    public Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigs() {
+        Map<String, FlakeIdGeneratorConfig> staticMapConfigs = staticConfig.getFlakeIdGeneratorConfigs();
+        Map<String, FlakeIdGeneratorConfig> dynamicMapConfigs = configurationService.getFlakeIdGeneratorConfigs();
         return aggregate(staticMapConfigs, dynamicMapConfigs);
     }
 
     @Override
-    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String name) {
-        return getReliableIdGeneratorConfigInternal(name, "default").getAsReadOnly();
+    public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String name) {
+        return getFlakeIdGeneratorConfigInternal(name, "default").getAsReadOnly();
     }
 
     @Override
-    public ReliableIdGeneratorConfig getReliableIdGeneratorConfig(String name) {
-        return getReliableIdGeneratorConfigInternal(name, name);
+    public FlakeIdGeneratorConfig getFlakeIdGeneratorConfig(String name) {
+        return getFlakeIdGeneratorConfigInternal(name, name);
     }
 
-    private ReliableIdGeneratorConfig getReliableIdGeneratorConfigInternal(String name, String fallbackName) {
+    private FlakeIdGeneratorConfig getFlakeIdGeneratorConfigInternal(String name, String fallbackName) {
         String baseName = getBaseName(name);
-        Map<String, ReliableIdGeneratorConfig> staticMapConfigs = staticConfig.getReliableIdGeneratorConfigs();
-        ReliableIdGeneratorConfig config = lookupByPattern(configPatternMatcher, staticMapConfigs, baseName);
+        Map<String, FlakeIdGeneratorConfig> staticMapConfigs = staticConfig.getFlakeIdGeneratorConfigs();
+        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, staticMapConfigs, baseName);
         if (config == null) {
-            config = configurationService.findReliableIdGeneratorConfig(baseName);
+            config = configurationService.findFlakeIdGeneratorConfig(baseName);
         }
         if (config == null) {
-            config = staticConfig.getReliableIdGeneratorConfig(fallbackName);
+            config = staticConfig.getFlakeIdGeneratorConfig(fallbackName);
         }
         return config;
     }
 
     @Override
-    public Config addReliableIdGeneratorConfig(ReliableIdGeneratorConfig config) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getReliableIdGeneratorConfigs(), config.getName(), config);
+    public Config addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig config) {
+        checkStaticConfigurationDoesNotExist(staticConfig.getFlakeIdGeneratorConfigs(), config.getName(), config);
         configurationService.broadcastConfig(config);
         return this;
     }
 
     @Override
-    public Config setReliableIdGeneratorConfigs(Map<String, ReliableIdGeneratorConfig> map) {
+    public Config setFlakeIdGeneratorConfigs(Map<String, FlakeIdGeneratorConfig> map) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
@@ -24,7 +24,7 @@ import com.hazelcast.config.CountDownLatchConfig;
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.ExecutorConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.MapConfig;
@@ -260,12 +260,12 @@ class EmptyConfigurationService implements ConfigurationService {
     }
 
     @Override
-    public ReliableIdGeneratorConfig findReliableIdGeneratorConfig(String baseName) {
+    public FlakeIdGeneratorConfig findFlakeIdGeneratorConfig(String baseName) {
         return null;
     }
 
     @Override
-    public Map<String, ReliableIdGeneratorConfig> getReliableIdGeneratorConfigs() {
+    public Map<String, FlakeIdGeneratorConfig> getFlakeIdGeneratorConfigs() {
         return emptyMap();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -140,8 +140,8 @@ public final class FactoryIdHelper {
     public static final String EVENT_JOURNAL_DS_FACTORY = "hazelcast.serialization.ds.event_journal";
     public static final int EVENT_JOURNAL_DS_FACTORY_ID = -45;
 
-    public static final String RELIABLE_ID_GENERATOR_DS_FACTORY = "hazelcast.serialization.ds.reliable_id_generator";
-    public static final int RELIABLE_ID_GENERATOR_DS_FACTORY_ID = -46;
+    public static final String FLAKE_ID_GENERATOR_DS_FACTORY = "hazelcast.serialization.ds.flake_id_generator";
+    public static final int FLAKE_ID_GENERATOR_DS_FACTORY_ID = -46;
 
     public static final String SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY = "hazelcast.serialization.ds.split.brain.merge.policy";
     public static final int SPLIT_BRAIN_MERGE_POLICY_DS_FACTORY_ID = -47;

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.Endpoint;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
@@ -189,8 +189,8 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
-    public ReliableIdGenerator getReliableIdGenerator(String name) {
-        return delegatedInstance.getReliableIdGenerator(name);
+    public FlakeIdGenerator getFlakeIdGenerator(String name) {
+        return delegatedInstance.getFlakeIdGenerator(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ActionConstants.java
@@ -24,7 +24,7 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -143,10 +143,10 @@ public final class ActionConstants {
                 return new AtomicLongPermission(IdGeneratorService.ATOMIC_LONG_NAME + name, actions);
             }
         });
-        PERMISSION_FACTORY_MAP.put(ReliableIdGeneratorService.SERVICE_NAME, new PermissionFactory() {
+        PERMISSION_FACTORY_MAP.put(FlakeIdGeneratorService.SERVICE_NAME, new PermissionFactory() {
             @Override
             public Permission create(String name, String... actions) {
-                return new ReliableIdGeneratorPermission(name, actions);
+                return new FlakeIdGeneratorPermission(name, actions);
             }
         });
         PERMISSION_FACTORY_MAP.put(MapReduceService.SERVICE_NAME, new PermissionFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/FlakeIdGeneratorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/FlakeIdGeneratorPermission.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.security.permission;
 
-public class ReliableIdGeneratorPermission extends InstancePermission {
+public class FlakeIdGeneratorPermission extends InstancePermission {
 
     private static final int MODIFY = 4;
 
     private static final int ALL = MODIFY | CREATE | DESTROY;
 
-    public ReliableIdGeneratorPermission(String name, String... actions) {
+    public FlakeIdGeneratorPermission(String name, String... actions) {
         super(name, actions);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -26,7 +26,7 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
@@ -157,7 +157,7 @@ public final class ServiceManagerImpl implements ServiceManager {
         registerService(CountDownLatchService.SERVICE_NAME, new CountDownLatchService());
         registerService(SemaphoreService.SERVICE_NAME, new SemaphoreService(nodeEngine));
         registerService(IdGeneratorService.SERVICE_NAME, new IdGeneratorService(nodeEngine));
-        registerService(ReliableIdGeneratorService.SERVICE_NAME, new ReliableIdGeneratorService(nodeEngine));
+        registerService(FlakeIdGeneratorService.SERVICE_NAME, new FlakeIdGeneratorService(nodeEngine));
         registerService(MapReduceService.SERVICE_NAME, new MapReduceService(nodeEngine));
         registerService(ReplicatedMapService.SERVICE_NAME, new ReplicatedMapService(nodeEngine));
         registerService(RingbufferService.SERVICE_NAME, new RingbufferService(nodeEngine));

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -31,5 +31,5 @@ com.hazelcast.aggregation.impl.AggregatorDataSerializerHook
 com.hazelcast.projection.impl.ProjectionDataSerializerHook
 com.hazelcast.config.ConfigDataSerializerHook
 com.hazelcast.journal.EventJournalDataSerializerHook
-com.hazelcast.reliableidgen.impl.ReliableIdGeneratorDataSerializerHook
+com.hazelcast.flakeidgen.impl.FlakeIdGeneratorDataSerializerHook
 com.hazelcast.spi.merge.SplitBrainMergePolicyDataSerializerHook

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -71,7 +71,7 @@
                 <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="user-code-deployment" type="user-code-deployment" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="cardinality-estimator" type="cardinality-estimator" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="reliable-id-generator" type="reliable-id-generator" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -3578,7 +3578,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:complexType name="reliable-id-generator">
+    <xs:complexType name="flake-id-generator">
         <xs:all>
             <xs:element name="prefetch-count" minOccurs="0" default="100">
                 <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -269,10 +269,10 @@
         <in-memory-format>BINARY</in-memory-format>
     </ringbuffer>
 
-    <reliable-id-generator name="default">
+    <flake-id-generator name="default">
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
-    </reliable-id-generator>
+    </flake-id-generator>
 
     <atomic-long name="default">
         <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1599,13 +1599,13 @@ https://hazelcast.org/documentation/.
     </ringbuffer>
 
     <!--
-        ===== HAZELCAST RELIABLE ID GENERATOR CONFIGURATION =====
-        Configuration element's name is <reliable-id-generator>. It has the required attribute "name" with which you
-        can specify the name of your Reliable ID generator.
+        ===== HAZELCAST FLAKE ID GENERATOR CONFIGURATION =====
+        Configuration element's name is <flake-id-generator>. It has the required attribute "name" with which you
+        can specify the name of your Flake ID generator.
         It has the following sub-elements:
         * <prefetch-count>:
         How many IDs are pre-fetched on the background when one call to
-        ReliableIdGenerator.newId() is made.
+        FlakeIdGenerator.newId() is made.
         Value must be >= 1, default is 100.
         * <prefetch-validity-millis>:
         For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.
@@ -1615,10 +1615,10 @@ https://hazelcast.org/documentation/.
         is assigned to an event that occurred much later, it will be much out of order. If you don't need
         ordering, set this value to 0.
     -->
-    <reliable-id-generator name="default">
+    <flake-id-generator name="default">
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
-    </reliable-id-generator>
+    </flake-id-generator>
 
     <!--
         ===== HAZELCAST ATOMIC LONG CONFIGURATION =====

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -94,7 +94,7 @@ class ConfigCompatibilityChecker {
         checkCompatibleConfigs("list", c1, c2, c1.getListConfigs(), c2.getListConfigs(), new ListConfigChecker());
         checkCompatibleConfigs("set", c1, c2, c1.getSetConfigs(), c2.getSetConfigs(), new SetConfigChecker());
         checkCompatibleConfigs("job tracker", c1, c2, c1.getJobTrackerConfigs(), c2.getJobTrackerConfigs(), new JobTrackerConfigChecker());
-        checkCompatibleConfigs("reliable id generator", c1, c2, c1.getReliableIdGeneratorConfigs(), c2.getReliableIdGeneratorConfigs(), new ReliableIdGeneratorConfigChecker());
+        checkCompatibleConfigs("flake id generator", c1, c2, c1.getFlakeIdGeneratorConfigs(), c2.getFlakeIdGeneratorConfigs(), new FlakeIdGeneratorConfigChecker());
         checkCompatibleConfigs("count down latch", c1, c2, c1.getCountDownLatchConfigs(), c2.getCountDownLatchConfigs(), new CountDownLatchConfigChecker());
         checkCompatibleConfigs("cardinality estimator", c1, c2, c1.getCardinalityEstimatorConfigs(), c2.getCardinalityEstimatorConfigs(), new CardinalityEstimatorConfigChecker());
 
@@ -576,9 +576,9 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class ReliableIdGeneratorConfigChecker extends ConfigChecker<ReliableIdGeneratorConfig> {
+    private static class FlakeIdGeneratorConfigChecker extends ConfigChecker<FlakeIdGeneratorConfig> {
         @Override
-        boolean check(ReliableIdGeneratorConfig c1, ReliableIdGeneratorConfig c2) {
+        boolean check(FlakeIdGeneratorConfig c1, FlakeIdGeneratorConfig c2) {
             if (c1 == c2) {
                 return true;
             }
@@ -591,8 +591,8 @@ class ConfigCompatibilityChecker {
         }
 
         @Override
-        ReliableIdGeneratorConfig getDefault(Config c) {
-            return c.getReliableIdGeneratorConfig("default");
+        FlakeIdGeneratorConfig getDefault(Config c) {
+            return c.getFlakeIdGeneratorConfig("default");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -145,17 +145,17 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
-    public void testReliableIdGeneratorConfigGenerator() {
-        ReliableIdGeneratorConfig figConfig = new ReliableIdGeneratorConfig("reliable-id-gen1")
+    public void testFlakeIdGeneratorConfigGenerator() {
+        FlakeIdGeneratorConfig figConfig = new FlakeIdGeneratorConfig("flake-id-gen1")
                 .setPrefetchCount(3)
                 .setPrefetchValidityMillis(10L);
 
         Config config = new Config()
-                .addReliableIdGeneratorConfig(figConfig);
+                .addFlakeIdGeneratorConfig(figConfig);
 
         Config xmlConfig = getNewConfigViaXMLGenerator(config);
 
-        ReliableIdGeneratorConfig xmlReplicatedConfig = xmlConfig.getReliableIdGeneratorConfig("reliable-id-gen1");
+        FlakeIdGeneratorConfig xmlReplicatedConfig = xmlConfig.getFlakeIdGeneratorConfig("flake-id-gen1");
         assertEquals(figConfig, xmlReplicatedConfig);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1088,15 +1088,15 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testReliableIdGeneratorConfig() {
+    public void testFlakeIdGeneratorConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<reliable-id-generator name='gen'>"
+                + "<flake-id-generator name='gen'>"
                 + "  <prefetch-count>3</prefetch-count>"
                 + "  <prefetch-validity-millis>10</prefetch-validity-millis>"
-                + "</reliable-id-generator>"
+                + "</flake-id-generator>"
                 + HAZELCAST_END_TAG;
         Config config = buildConfig(xml);
-        ReliableIdGeneratorConfig fConfig = config.findReliableIdGeneratorConfig("gen");
+        FlakeIdGeneratorConfig fConfig = config.findFlakeIdGeneratorConfig("gen");
         assertEquals("gen", fConfig.getName());
         assertEquals(3, fConfig.getPrefetchCount());
         assertEquals(10L, fConfig.getPrefetchValidityMillis());

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/AutoBatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/AutoBatcherTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -26,8 +26,8 @@ import org.junit.runner.RunWith;
 
 import java.util.Set;
 
-import static com.hazelcast.reliableidgen.impl.ReliableIdConcurrencyTestUtil.IDS_IN_THREAD;
-import static com.hazelcast.reliableidgen.impl.ReliableIdConcurrencyTestUtil.NUM_THREADS;
+import static com.hazelcast.flakeidgen.impl.FlakeIdConcurrencyTestUtil.IDS_IN_THREAD;
+import static com.hazelcast.flakeidgen.impl.FlakeIdConcurrencyTestUtil.NUM_THREADS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -66,7 +66,7 @@ public class AutoBatcherTest {
 
     @Test
     public void concurrencySmokeTest() throws Exception {
-        Set<Long> ids = ReliableIdConcurrencyTestUtil.concurrentlyGenerateIds(new Supplier<Long>() {
+        Set<Long> ids = FlakeIdConcurrencyTestUtil.concurrentlyGenerateIds(new Supplier<Long>() {
             @Override
             public Long get() {
                 return batcher.newId();

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdConcurrencyTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdConcurrencyTestUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.util.function.Supplier;
@@ -29,7 +29,7 @@ import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
 
-public class ReliableIdConcurrencyTestUtil {
+public class FlakeIdConcurrencyTestUtil {
     public static final int NUM_THREADS = 4;
     public static final int IDS_IN_THREAD = 100000;
 

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxyTest.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorProxy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -32,9 +31,9 @@ import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static com.hazelcast.reliableidgen.impl.ReliableIdGeneratorProxy.BITS_NODE_ID;
-import static com.hazelcast.reliableidgen.impl.ReliableIdGeneratorProxy.BITS_TIMESTAMP;
-import static com.hazelcast.reliableidgen.impl.ReliableIdGeneratorProxy.EPOCH_START;
+import static com.hazelcast.flakeidgen.impl.FlakeIdGeneratorProxy.BITS_NODE_ID;
+import static com.hazelcast.flakeidgen.impl.FlakeIdGeneratorProxy.BITS_TIMESTAMP;
+import static com.hazelcast.flakeidgen.impl.FlakeIdGeneratorProxy.EPOCH_START;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -42,7 +41,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReliableIdGeneratorProxyTest {
+public class FlakeIdGeneratorProxyTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -67,19 +66,19 @@ public class ReliableIdGeneratorProxyTest {
 
     @Test
     public void test_timeInNegativeRange() {
-        ReliableIdGeneratorProxy gen = createGenerator();
+        FlakeIdGeneratorProxy gen = createGenerator();
         assertEquals(-9112343572002110254L, gen.newIdBaseLocal(1509700048830L, 1234, 10));
     }
 
     @Test
     public void test_timeInPositiveRange() {
-        ReliableIdGeneratorProxy gen = createGenerator();
+        FlakeIdGeneratorProxy gen = createGenerator();
         assertEquals(41798522940425426L, gen.newIdBaseLocal(3692217600000L, 1234, 10));
     }
 
     @Test
     public void test_idsOrdered() {
-        ReliableIdGeneratorProxy gen = createGenerator();
+        FlakeIdGeneratorProxy gen = createGenerator();
         long lastId = Long.MIN_VALUE;
         for (
                 long now = EPOCH_START - (1L << BITS_TIMESTAMP - 1);
@@ -94,7 +93,7 @@ public class ReliableIdGeneratorProxyTest {
 
     @Test
     public void when_currentTimeBeforeAllowedRange_then_fail() {
-        ReliableIdGeneratorProxy gen = createGenerator();
+        FlakeIdGeneratorProxy gen = createGenerator();
         gen.newIdBaseLocal(EPOCH_START - (1L << BITS_TIMESTAMP - 1), 0, 1);
         exception.expect(AssertionError.class);
         exception.expectMessage("Current time out of allowed range");
@@ -103,7 +102,7 @@ public class ReliableIdGeneratorProxyTest {
 
     @Test
     public void when_currentTimeAfterAllowedRange_then_fail() {
-        ReliableIdGeneratorProxy gen = createGenerator();
+        FlakeIdGeneratorProxy gen = createGenerator();
         gen.newIdBaseLocal(EPOCH_START + (1L << BITS_TIMESTAMP - 1) - 1, 0, 1);
         exception.expect(AssertionError.class);
         exception.expectMessage("Current time out of allowed range");
@@ -112,14 +111,14 @@ public class ReliableIdGeneratorProxyTest {
 
     @Test
     public void when_twoIdsAtTheSameMoment_then_higherSeq() {
-        ReliableIdGeneratorProxy gen = createGenerator();
+        FlakeIdGeneratorProxy gen = createGenerator();
         long id1 = gen.newIdBaseLocal(1509700048830L, 1234, 1);
         long id2 = gen.newIdBaseLocal(1509700048830L, 1234, 1);
         assertEquals(-9112343572002110254L, id1);
         assertEquals(id1 + (1 << BITS_NODE_ID), id2);
     }
 
-    private ReliableIdGeneratorProxy createGenerator() {
-        return new ReliableIdGeneratorProxy("foo", nodeEngine, null);
+    private FlakeIdGeneratorProxy createGenerator() {
+        return new FlakeIdGeneratorProxy("foo", nodeEngine, null);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_IdBatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_IdBatchTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
-import com.hazelcast.reliableidgen.impl.IdBatch;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -35,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReliableIdGenerator_IdBatchTest {
+public class FlakeIdGenerator_IdBatchTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -37,7 +37,7 @@ import static com.hazelcast.internal.cluster.Versions.V3_9;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReliableIdGenerator_MemberIntegrationTest extends HazelcastTestSupport {
+public class FlakeIdGenerator_MemberIntegrationTest extends HazelcastTestSupport {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -58,8 +58,8 @@ public class ReliableIdGenerator_MemberIntegrationTest extends HazelcastTestSupp
     @Test
     public void smokeTest() throws Exception {
         HazelcastInstance instance = factory.newHazelcastInstance();
-        final ReliableIdGenerator generator = instance.getReliableIdGenerator("gen");
-        ReliableIdConcurrencyTestUtil.concurrentlyGenerateIds(new Supplier<Long>() {
+        final FlakeIdGenerator generator = instance.getFlakeIdGenerator("gen");
+        FlakeIdConcurrencyTestUtil.concurrentlyGenerateIds(new Supplier<Long>() {
             @Override
             public Long get() {
                 return generator.newId();
@@ -68,11 +68,11 @@ public class ReliableIdGenerator_MemberIntegrationTest extends HazelcastTestSupp
     }
 
     @Test
-    public void when_310MemberJoinsWith39Mode_reliableIdGeneratorDoesNotWork() {
+    public void when_310MemberJoinsWith39Mode_flakeIdGeneratorDoesNotWork() {
         System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, V3_9.toString());
         HazelcastInstance instance = factory.newHazelcastInstance();
 
-        ReliableIdGenerator gen = instance.getReliableIdGenerator("gen");
+        FlakeIdGenerator gen = instance.getFlakeIdGenerator("gen");
         exception.expect(UnsupportedOperationException.class);
         gen.newId();
     }

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.hazelcast.reliableidgen.impl;
+package com.hazelcast.flakeidgen.impl;
 
-import com.hazelcast.reliableidgen.ReliableIdGenerator;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.MemberImpl;
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReliableIdGenerator_NodeIdOverflowIntegrationTest {
+public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -52,7 +52,7 @@ public class ReliableIdGenerator_NodeIdOverflowIntegrationTest {
         assignOutOfRangeNodeId(instance2);
 
         // let's use the instance with out-of-range node ID to generate IDs, it should succeed
-        ReliableIdGenerator gen = instance2.getReliableIdGenerator("gen");
+        FlakeIdGenerator gen = instance2.getFlakeIdGenerator("gen");
         gen.newId();
     }
 
@@ -63,7 +63,7 @@ public class ReliableIdGenerator_NodeIdOverflowIntegrationTest {
         assignOutOfRangeNodeId(instance1);
         assignOutOfRangeNodeId(instance2);
 
-        ReliableIdGenerator gen = instance1.getReliableIdGenerator("gen");
+        FlakeIdGenerator gen = instance1.getFlakeIdGenerator("gen");
 
         exception.expect(HazelcastException.class);
         exception.expectMessage("All members have node ID out of range");

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ItemListenerConfig;
@@ -47,7 +48,6 @@ import com.hazelcast.config.PredicateConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
-import com.hazelcast.config.ReliableIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -531,11 +531,11 @@ public class DynamicConfigTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testReliableIdGeneratorConfig() {
-        ReliableIdGeneratorConfig config = new ReliableIdGeneratorConfig(randomName())
+    public void testFlakeIdGeneratorConfig() {
+        FlakeIdGeneratorConfig config = new FlakeIdGeneratorConfig(randomName())
                 .setPrefetchCount(123)
                 .setPrefetchValidityMillis(456);
-        driver.getConfig().addReliableIdGeneratorConfig(config);
+        driver.getConfig().addFlakeIdGeneratorConfig(config);
         assertConfigurationsEqualsOnAllMembers(config);
     }
 
@@ -757,9 +757,9 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         }
     }
 
-    private void assertConfigurationsEqualsOnAllMembers(ReliableIdGeneratorConfig config) {
+    private void assertConfigurationsEqualsOnAllMembers(FlakeIdGeneratorConfig config) {
         for (HazelcastInstance instance : members) {
-            ReliableIdGeneratorConfig registeredConfig = instance.getConfig().getReliableIdGeneratorConfig(config.getName());
+            FlakeIdGeneratorConfig registeredConfig = instance.getConfig().getFlakeIdGeneratorConfig(config.getName());
             assertEquals(config, registeredConfig);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/security/permission/ActionConstantsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/permission/ActionConstantsTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.reliableidgen.impl.ReliableIdGeneratorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -142,11 +142,11 @@ public class ActionConstantsTest {
     }
 
     @Test
-    public void getPermission_ReliableIdGenerator() {
-        Permission permission = ActionConstants.getPermission("foo", ReliableIdGeneratorService.SERVICE_NAME);
+    public void getPermission_FlakeIdGenerator() {
+        Permission permission = ActionConstants.getPermission("foo", FlakeIdGeneratorService.SERVICE_NAME);
 
         assertNotNull(permission);
-        assertTrue(permission instanceof ReliableIdGeneratorPermission);
+        assertTrue(permission instanceof FlakeIdGeneratorPermission);
     }
 
     @Test

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -583,10 +583,10 @@
         </hot-restart>
     </cache>
 
-    <reliable-id-generator name="default">
+    <flake-id-generator name="default">
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>10000</prefetch-validity-millis>
-    </reliable-id-generator>
+    </flake-id-generator>
 
     <listeners>
         <listener>com.hazelcast.examples.MembershipListener</listener>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.6.0-5</client.protocol.version>
+        <client.protocol.version>1.6.0-6</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
Should compile after https://github.com/hazelcast/hazelcast-client-protocol/pull/112 is released.