### PR TITLE
adds go client as a known client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
@@ -59,6 +59,11 @@ public final class ClientTypes {
      */
     public static final String NODEJS = "NJS";
 
+    /**
+     * Go client protocol ID
+     */
+    public static final String GO = "GOO";
+
     private ClientTypes() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -178,6 +178,9 @@ public final class ClientEndpointImpl implements ClientEndpoint {
             case NODEJS_CLIENT:
                 type = ClientType.NODEJS;
                 break;
+            case GO_CLIENT:
+                type = ClientType.GO;
+                break;
             case BINARY_CLIENT:
                 type = ClientType.OTHER;
                 break;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -244,6 +244,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
             connection.setType(ConnectionType.RUBY_CLIENT);
         } else if (ClientTypes.NODEJS.equals(type)) {
             connection.setType(ConnectionType.NODEJS_CLIENT);
+        } else if (ClientTypes.GO.equals(type)) {
+            connection.setType(ConnectionType.GO_CLIENT);
         } else {
             clientEngine.getLogger(getClass()).info("Unknown client type: " + type);
             connection.setType(ConnectionType.BINARY_CLIENT);

--- a/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
@@ -26,5 +26,6 @@ public enum ClientType {
     PYTHON,
     RUBY,
     NODEJS,
+    GO,
     OTHER
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionType.java
@@ -32,6 +32,7 @@ public enum ConnectionType {
     PYTHON_CLIENT(false, true),
     RUBY_CLIENT(false, true),
     NODEJS_CLIENT(false, true),
+    GO_CLIENT(false, true),
     BINARY_CLIENT(false, true),
     REST_CLIENT(false, false),
     MEMCACHE_CLIENT(false, false);


### PR DESCRIPTION
This PR adds our go client as a recognized client. Go clients are logged as `GO_CLIENT` rather than `BINARY_CLIENT` in server logs.
