### PR TITLE
PartitionPredicate support for map operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.proxy;
 
+import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.concurrent.lock.LockProxySupport;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.config.EntryListenerConfig;
@@ -52,7 +53,10 @@ import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.operation.RemoveInterceptorOperation;
 import com.hazelcast.map.impl.query.MapQueryEngine;
+import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryEventFilter;
+import com.hazelcast.map.impl.query.Result;
+import com.hazelcast.map.impl.query.Target;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
@@ -65,6 +69,8 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializableByConvention;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.EventFilter;
@@ -82,6 +88,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.IterableUtil;
+import com.hazelcast.util.IterationType;
 import com.hazelcast.util.MutableLong;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -1129,9 +1136,21 @@ abstract class MapProxySupport<K, V>
      */
     public void executeOnEntriesInternal(EntryProcessor entryProcessor, Predicate predicate, List<Data> result) {
         try {
-            OperationFactory operation
-                    = operationProvider.createPartitionWideEntryWithPredicateOperationFactory(name, entryProcessor, predicate);
-            Map<Integer, Object> results = operationService.invokeOnAllPartitions(SERVICE_NAME, operation);
+            Map<Integer, Object> results;
+            if (predicate instanceof PartitionPredicate) {
+                PartitionPredicate partitionPredicate = (PartitionPredicate) predicate;
+                Data key = toData(partitionPredicate.getPartitionKey());
+                int partitionId = partitionService.getPartitionId(key);
+                handleHazelcastInstanceAwareParams(partitionPredicate.getTarget());
+
+                OperationFactory operation = operationProvider.createPartitionWideEntryWithPredicateOperationFactory(
+                        name, entryProcessor, partitionPredicate.getTarget());
+                results = operationService.invokeOnPartitions(SERVICE_NAME, operation, Collections.singletonList(partitionId));
+            } else {
+                OperationFactory operation = operationProvider.createPartitionWideEntryWithPredicateOperationFactory(
+                        name, entryProcessor, predicate);
+                results = operationService.invokeOnAllPartitions(SERVICE_NAME, operation);
+            }
             for (Object object : results.values()) {
                 if (object != null) {
                     MapEntries mapEntries = (MapEntries) object;
@@ -1209,6 +1228,42 @@ abstract class MapProxySupport<K, V>
     private void publishMapEvent(int numberOfAffectedEntries, EntryEventType eventType) {
         MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();
         mapEventPublisher.publishMapEvent(thisAddress, name, eventType, numberOfAffectedEntries);
+    }
+
+    protected <T extends Result> T executeQueryInternal(Predicate predicate, IterationType iterationType, Target target) {
+        return executeQueryInternal(predicate, null, null, iterationType, target);
+    }
+
+    protected <T extends Result> T executeQueryInternal(Predicate predicate, Aggregator aggregator, Projection projection,
+                                                        IterationType iterationType, Target target) {
+        MapQueryEngine queryEngine = getMapQueryEngine();
+        Predicate userPredicate = predicate;
+
+        if (predicate instanceof PartitionPredicate) {
+            PartitionPredicate partitionPredicate = (PartitionPredicate) predicate;
+            Data key = toData(partitionPredicate.getPartitionKey());
+            int partitionId = partitionService.getPartitionId(key);
+            userPredicate = partitionPredicate.getTarget();
+            target = Target.of().partitionOwner(partitionId).build();
+        }
+        handleHazelcastInstanceAwareParams(userPredicate);
+
+        Query query = Query.of()
+                .mapName(getName())
+                .predicate(userPredicate)
+                .iterationType(iterationType)
+                .aggregator(aggregator)
+                .projection(projection)
+                .build();
+        return queryEngine.execute(query, target);
+    }
+
+    protected void handleHazelcastInstanceAwareParams(Object... objects) {
+        for (Object object : objects) {
+            if (object instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) object).setHazelcastInstance(getNodeEngine().getHazelcastInstance());
+            }
+        }
     }
 
     private class IncrementStatsExecutionCallback<T> implements ExecutionCallback<T> {

--- a/hazelcast/src/test/java/com/hazelcast/map/PartitionPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PartitionPredicateTest.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.aggregation.Aggregators;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projections;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -50,11 +53,17 @@ public class PartitionPredicateTest extends HazelcastTestSupport {
 
     private HazelcastInstance local;
     private IMap<String, Integer> map;
+    private IMap<String, Integer> aggMap;
 
     private String partitionKey;
     private int partitionId;
 
+    private String localPartitionKey;
+    private int localPartitionId;
+
     private Predicate<String, Integer> predicate;
+    private Predicate<String, Integer> aggPredicate;
+    private Predicate<String, Integer> localPredicate;
 
     @Before
     public void setUp() {
@@ -68,9 +77,11 @@ public class PartitionPredicateTest extends HazelcastTestSupport {
         warmUpPartitions(local, remote);
 
         map = local.getMap(randomString());
+        aggMap = local.getMap(randomString());
         for (int p = 0; p < PARTITIONS; p++) {
             for (int k = 0; k < ITEMS_PER_PARTITION; k++) {
                 map.put(generateKeyForPartition(local, p), p);
+                aggMap.put(generateKeyForPartition(local, p), k);
             }
         }
 
@@ -78,6 +89,12 @@ public class PartitionPredicateTest extends HazelcastTestSupport {
         partitionId = local.getPartitionService().getPartition(partitionKey).getPartitionId();
 
         predicate = new PartitionPredicate<String, Integer>(partitionKey, TruePredicate.INSTANCE);
+        aggPredicate = new PartitionPredicate<String, Integer>(partitionKey, Predicates.equal("this", partitionId));
+
+        localPartitionKey = generateKeyOwnedBy(local);
+        localPartitionId = local.getPartitionService().getPartition(localPartitionKey).getPartitionId();
+        localPredicate = new PartitionPredicate<String, Integer>(localPartitionKey, Predicates.equal("this", localPartitionId));
+
     }
 
     @Test
@@ -111,6 +128,43 @@ public class PartitionPredicateTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void localKeySet() {
+        Collection<String> keys = aggMap.localKeySet(localPredicate);
+
+        assertEquals(1, keys.size());
+        for (String key : keys) {
+            assertEquals(localPartitionId, local.getPartitionService().getPartition(key).getPartitionId());
+        }
+    }
+
+    @Test
+    public void aggregate() {
+        Long aggregate = aggMap.aggregate(Aggregators.<Map.Entry<String, Integer>>count(), aggPredicate);
+        assertEquals(1, aggregate.longValue());
+    }
+
+    @Test
+    public void project() {
+        Collection<Integer> values = aggMap.project(Projections.<Map.Entry<String, Integer>, Integer>
+                singleAttribute("this"), aggPredicate);
+        assertEquals(1, values.size());
+        assertEquals(partitionId, values.iterator().next().intValue());
+    }
+
+    @Test
+    public void executeOnEntries() {
+        PartitionPredicate<String, Integer>  lessThan10pp = new PartitionPredicate<String, Integer>(partitionKey,
+                Predicates.lessThan("this", 10));
+        Map<String, Object> result = aggMap.executeOnEntries(new EntryNoop(), lessThan10pp);
+
+        assertEquals(10, result.size());
+        for (Map.Entry<String, Object> entry : result.entrySet()) {
+            assertEquals(partitionId, local.getPartitionService().getPartition(entry.getKey()).getPartitionId());
+            assertEquals(-1, entry.getValue());
+        }
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void apply() {
         assertTrue(predicate.apply(null));
@@ -130,5 +184,12 @@ public class PartitionPredicateTest extends HazelcastTestSupport {
 
         assertEquals(partitionKey, deserialized.getPartitionKey());
         assertEquals(TruePredicate.INSTANCE, deserialized.getTarget());
+    }
+
+    private static class EntryNoop extends AbstractEntryProcessor<String, Integer> {
+        @Override
+        public Object process(Map.Entry<String, Integer> entry) {
+            return -1;
+        }
     }
 }


### PR DESCRIPTION
Fixes #11962

Added `PartitionPredicate` support to `localKeySet`, `aggregate`, `projection` & `executeOnEntries` methods on member side IMap implementation.