### PR TITLE
Client authentication retry logic fixed

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AuthenticationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AuthenticationFuture.java
@@ -20,8 +20,6 @@ import com.hazelcast.nio.Connection;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 class AuthenticationFuture {
 
@@ -39,10 +37,8 @@ class AuthenticationFuture {
         countDownLatch.countDown();
     }
 
-    Connection get(int timeout) throws Throwable {
-        if (!countDownLatch.await(timeout, TimeUnit.MILLISECONDS)) {
-            throw new TimeoutException("Authentication response did not come back in " + timeout + " millis");
-        }
+    Connection get() throws Throwable {
+        countDownLatch.await();
         if (connection != null) {
             return connection;
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -18,7 +18,10 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
@@ -26,6 +29,10 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipAdapter;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -36,8 +43,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -164,5 +173,113 @@ public class ClientReconnectTest extends HazelcastTestSupport {
                 .setConnectionAttemptLimit(Integer.MAX_VALUE);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         client.shutdown();
+    }
+
+    public static abstract class CustomCredentials extends UsernamePasswordCredentials {
+
+        public CustomCredentials() {
+        }
+
+        CustomCredentials(String username, String password) {
+            super(username, password);
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+
+        @Override
+        public int getClassId() {
+            return 1;
+        }
+
+    }
+
+    public static class CustomCredentials_takesLong extends CustomCredentials {
+
+        private static AtomicInteger count = new AtomicInteger();
+
+        public CustomCredentials_takesLong() {
+        }
+
+        CustomCredentials_takesLong(String username, String password) {
+            super(username, password);
+        }
+
+        @Override
+        protected void readPortableInternal(PortableReader reader) throws IOException {
+            if (count.incrementAndGet() == 1) {
+                try {
+                    Thread.sleep(30000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            super.readPortableInternal(reader);
+        }
+    }
+
+    @Test
+    public void testClientConnected_withFirstAuthenticationTakingLong() throws InterruptedException {
+        SerializationConfig serializationConfig = new SerializationConfig();
+        serializationConfig.addPortableFactory(1, new PortableFactory() {
+            @Override
+            public Portable create(int classId) {
+                return new CustomCredentials_takesLong();
+            }
+        });
+
+        Config config = new Config();
+        config.setSerializationConfig(serializationConfig);
+        hazelcastFactory.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setCredentials(new CustomCredentials_takesLong("dev", "dev-pass"));
+        clientConfig.setSerializationConfig(serializationConfig);
+        hazelcastFactory.newHazelcastClient(clientConfig);
+    }
+
+    public static class CustomCredentials_retried extends CustomCredentials {
+
+        private static AtomicInteger count = new AtomicInteger();
+
+        public CustomCredentials_retried() {
+        }
+
+        CustomCredentials_retried(String username, String password) {
+            super(username, password);
+        }
+
+        @Override
+        public String getPassword() {
+            if (count.incrementAndGet() == 1) {
+                throw new HazelcastInstanceNotActiveException();
+            }
+            return super.getPassword();
+        }
+    }
+
+    @Test
+    public void testClientConnected_withFirstAuthenticationRetried() throws InterruptedException {
+        SerializationConfig serializationConfig = new SerializationConfig();
+        serializationConfig.addPortableFactory(1, new PortableFactory() {
+            @Override
+            public Portable create(int classId) {
+                return new CustomCredentials_retried();
+            }
+        });
+
+        Config config = new Config();
+        config.setSerializationConfig(serializationConfig);
+        hazelcastFactory.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        //first authentication should be able to retried by invocation system. No need to do a second invocation.
+        //By setting attempt limit to one, we are expecting client to connect in first attempt.
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        clientConfig.setCredentials(new CustomCredentials_retried("dev", "dev-pass"));
+        clientConfig.setSerializationConfig(serializationConfig);
+        hazelcastFactory.newHazelcastClient(clientConfig);
     }
 }


### PR DESCRIPTION
We introduced a logic in #9506 to prevent a late coming
authentication response to alter client principal
incorrectly. Failure in #11737, showed that using correlation
id as solution is not suitable because correlation id can change
when an invocation is retried.

As a solution, as soon as connection timeout happens, related
future is completed. This way,a late response will not be
processed.

fixes https://github.com/hazelcast/hazelcast/issues/11737