### PR TITLE
Introduce ICMP config on member side

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -2183,6 +2183,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="failure-detector" type="failure-detector" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
         <xs:attribute name="public-address" type="xs:string" use="optional"/>
         <xs:attribute name="port" type="xs:string" use="required"/>
@@ -2533,6 +2534,66 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="icmp">
+        <xs:annotation>
+            <xs:documentation>
+                ICMP can be used in addition to the other detectors. It operates at layer 3 detects network
+                and hardware issues more quickly
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="timeout-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Timeout in Milliseconds before declaring a failed ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ttl" type="xs:integer" minOccurs="0" maxOccurs="1" default="255">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of times the IP Datagram (ping) can be forwarded, in most cases
+                        all Hazelcast cluster members would be within one network switch/router therefore
+                        default of 0 is usually sufficient
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="parallel-mode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>Run ICMP detection in parallel with the Heartbeat failure detector</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="fail-fast-on-startup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cluster Member will fail to start if it is unable to action an ICMP ping command when ICMP is enabled.
+                        Failure is usually due to OS level restrictions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-attempts" type="xs:integer" minOccurs="0" maxOccurs="1" default="2">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of consecutive failed attempts before declaring a member suspect
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="interval-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Time in milliseconds between each ICMP ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" default="false">
+            <xs:annotation>
+                <xs:documentation>Enables ICMP Pings to detect and suspect dead members</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="failure-detector">
+        <xs:all>
+            <xs:element name="icmp" type="icmp" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
     </xs:complexType>
 
     <xs:complexType name="hibernate-cache">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -31,10 +31,12 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.HostVerificationConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.config.IcmpFailureDetectorConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListConfig;
@@ -60,7 +62,6 @@ import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.config.RingbufferConfig;
@@ -105,6 +106,7 @@ import com.hazelcast.core.QueueStoreFactory;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.core.RingbufferStoreFactory;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
@@ -112,7 +114,6 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.ssl.SSLContextFactory;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.spring.serialization.DummyDataSerializableFactory;
 import com.hazelcast.spring.serialization.DummyPortableFactory;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -717,6 +718,15 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertFalse(memberAddressProviderConfig.getProperties().isEmpty());
         assertEquals("value", memberAddressProviderConfig.getProperties().getProperty("dummy.property"));
         assertEquals("value2", memberAddressProviderConfig.getProperties().getProperty("dummy.property.2"));
+
+        IcmpFailureDetectorConfig icmpFailureDetectorConfig = networkConfig.getIcmpFailureDetectorConfig();
+        assertFalse(icmpFailureDetectorConfig.isEnabled());
+        assertTrue(icmpFailureDetectorConfig.isParallelMode());
+        assertTrue(icmpFailureDetectorConfig.isFailFastOnStartup());
+        assertEquals(500, icmpFailureDetectorConfig.getTimeoutMilliseconds());
+        assertEquals(1002, icmpFailureDetectorConfig.getIntervalMilliseconds());
+        assertEquals(2, icmpFailureDetectorConfig.getMaxAttempts());
+        assertEquals(1, icmpFailureDetectorConfig.getTtl());
     }
 
     private void assertAwsConfig(AwsConfig aws) {

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -187,6 +187,16 @@
                         <hz:property name="dummy.property.2">value2</hz:property>
                     </hz:properties>
                 </hz:member-address-provider>
+                <hz:failure-detector>
+                    <hz:icmp enabled="false">
+                        <hz:fail-fast-on-startup>true</hz:fail-fast-on-startup>
+                        <hz:interval-milliseconds>1002</hz:interval-milliseconds>
+                        <hz:max-attempts>2</hz:max-attempts>
+                        <hz:parallel-mode>true</hz:parallel-mode>
+                        <hz:timeout-milliseconds>500</hz:timeout-milliseconds>
+                        <hz:ttl>1</hz:ttl>
+                    </hz:icmp>
+                </hz:failure-detector>
             </hz:network>
             <hz:partition-group enabled="true" group-type="CUSTOM">
                 <hz:member-group>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -565,6 +565,7 @@ public class ConfigXmlGenerator {
         socketInterceptorConfigXmlGenerator(gen, netCfg);
         symmetricEncInterceptorConfigXmlGenerator(gen, netCfg);
         memberAddressProviderConfigXmlGenerator(gen, netCfg);
+        failureDetectorConfigXmlGenerator(gen, netCfg);
         gen.close();
     }
 
@@ -1003,6 +1004,24 @@ public class ConfigXmlGenerator {
                 .node("class-name", className)
                 .appendProperties(memberAddressProviderConfig.getProperties())
                 .close();
+    }
+
+    private static void failureDetectorConfigXmlGenerator(XmlGenerator gen, NetworkConfig networkConfig) {
+        IcmpFailureDetectorConfig icmpFailureDetectorConfig = networkConfig.getIcmpFailureDetectorConfig();
+        if (icmpFailureDetectorConfig == null) {
+            return;
+        }
+
+        gen.open("failure-detector");
+        gen.open("icmp", "enabled", icmpFailureDetectorConfig.isEnabled())
+           .node("ttl", icmpFailureDetectorConfig.getTtl())
+           .node("interval-milliseconds", icmpFailureDetectorConfig.getIntervalMilliseconds())
+           .node("max-attempts", icmpFailureDetectorConfig.getMaxAttempts())
+           .node("timeout-milliseconds", icmpFailureDetectorConfig.getTimeoutMilliseconds())
+           .node("fail-fast-on-startup", icmpFailureDetectorConfig.isFailFastOnStartup())
+           .node("parallel-mode", icmpFailureDetectorConfig.isParallelMode())
+           .close();
+        gen.close();
     }
 
     private static void hotRestartXmlGenerator(XmlGenerator gen, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/IcmpFailureDetectorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/IcmpFailureDetectorConfig.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static com.hazelcast.util.Preconditions.checkPositive;
+import static java.lang.String.format;
+
+/**
+ * This Failure Detector may be configured in addition to one of Deadline and Phi Accual Failure Detectors.<br/>
+ * It operates at Layer 3 of the OSI protocol, and provides much quicker and more deterministic detection of hardware<br/>
+ * and other lower level events. This detector may be configured to perform an extra check after a member is suspected by one<br/>
+ * of the other detectors, or it can work in parallel, which is the default. This way hardware and network level issues<br/>
+ * will be detected more quickly.
+ *
+ * <p>This failure detector is based on InetAddress.isReachable().
+ * When the JVM process has enough permissions to create RAW sockets, the implementation will choose to rely on
+ * ICMP Echo requests. This is preferred.
+ * However, if there are not enough permissions, it can be configured to fallback on attempting a TCP Echo on port 7.
+ * In the latter case, both a successful connection or an explicit rejection will be treated as "Host is Reachable".
+ * This is not preferred as each call creates a heavy weight socket and moreover the Echo service is typically disabled.
+ *
+ * <p>For the Ping Failure Detector to rely only on ICMP (RAW sockets) Echo requests, there are some criteria
+ * that need to be met. Please consult the Hazelcast Reference Manual on how to configure and what the OS requirements are.
+ */
+public class IcmpFailureDetectorConfig {
+
+    /**
+     * Default timeout for detection in millis see {@link #timeoutMilliseconds}
+     */
+    private static final int DEFAULT_TIMEOUT_MILLISECONDS = 1000;
+
+    /**
+     * Default interval between ping attempts see {@link #intervalMilliseconds}
+     */
+    private static final int DEFAULT_INTERVAL_MILLISECONDS = 1000;
+
+    private static final int MIN_INTERVAL_MILLIS = 1000;
+
+    /**
+     * Default ttl for ping packets {@link #ttl}.
+     */
+    private static final int DEFAULT_TTL = 255;
+
+    /**
+     * Default max number of attempts {@link #maxAttempts}
+     */
+    private static final int DEFAULT_MAX_ATTEMPT = 2;
+
+    private static final boolean DEFAULT_ENABLED = false;
+
+    private static final boolean DEFAULT_PARALLEL_MODE = true;
+
+    private int timeoutMilliseconds = DEFAULT_TIMEOUT_MILLISECONDS;
+
+    private int intervalMilliseconds = DEFAULT_INTERVAL_MILLISECONDS;
+
+    private boolean failFastOnStartup = true;
+
+    private int ttl = DEFAULT_TTL;
+
+    private int maxAttempts = DEFAULT_MAX_ATTEMPT;
+
+    private boolean enabled = DEFAULT_ENABLED;
+
+    private boolean parallelMode = DEFAULT_PARALLEL_MODE;
+    /**
+     * @return the timeout in Milliseconds before declaring a failed ping
+     */
+    public int getTimeoutMilliseconds() {
+        return timeoutMilliseconds;
+    }
+
+    /**
+     * Sets the timeout in Milliseconds before declaring a failed ping
+     * This cannot be more than the interval value. Should always be smaller.
+     *
+     * @param timeoutMilliseconds the timeout for each ping in millis
+     * @return this {@link IcmpFailureDetectorConfig} instance
+     */
+    public IcmpFailureDetectorConfig setTimeoutMilliseconds(int timeoutMilliseconds) {
+        checkPositive(timeoutMilliseconds, "Timeout must be a positive value");
+        this.timeoutMilliseconds = timeoutMilliseconds;
+        return this;
+    }
+
+    /**
+     * @return the time in milliseconds between each ping
+     */
+    public int getIntervalMilliseconds() {
+        return intervalMilliseconds;
+    }
+
+    /**
+     * Sets the time in milliseconds between each ping
+     * This value can not be smaller than 1000 milliseconds
+     *
+     * @param intervalMilliseconds the interval millis between each ping
+     * @return this {@link IcmpFailureDetectorConfig} instance
+     */
+    public IcmpFailureDetectorConfig setIntervalMilliseconds(int intervalMilliseconds) {
+        if (intervalMilliseconds < MIN_INTERVAL_MILLIS) {
+            throw new ConfigurationException(format("Interval can't be set to less than %d milliseconds.", MIN_INTERVAL_MILLIS));
+        }
+
+        this.intervalMilliseconds = intervalMilliseconds;
+        return this;
+    }
+
+    /**
+     * @return whether the member should fail-fast on startup if ICMP is not allowed by the underlying OS.
+     */
+    public boolean isFailFastOnStartup() {
+        return failFastOnStartup;
+    }
+
+    /**
+     * Sets whether the member should fail-fast on startup if ICMP is not allowed by the underlying OS.
+     * Failure is usually due to OS level restrictions.
+     *
+     * @param failFastOnStartup the fail-fast flag
+     * @return this {@link IcmpFailureDetectorConfig} instance
+     */
+    public IcmpFailureDetectorConfig setFailFastOnStartup(boolean failFastOnStartup) {
+        this.failFastOnStartup = failFastOnStartup;
+        return this;
+    }
+
+    /**
+     * @return the maximum number of times the IP Datagram (ping) can be forwarded
+     */
+    public int getTtl() {
+        return ttl;
+    }
+
+    /**
+     * Sets the maximum number of times the IP Datagram (ping) can be forwarded, in most cases
+     * all Hazelcast cluster members would be within one network switch/router therefore
+     *
+     * @param ttl the new time-to-live value
+     * @return this {@link IcmpFailureDetectorConfig} instance
+     */
+    public IcmpFailureDetectorConfig setTtl(int ttl) {
+        checkNotNegative(ttl, "TTL must not be a negative value");
+        this.ttl = ttl;
+        return this;
+    }
+
+    /**
+     * @return max ping attempts before suspecting a member
+     */
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * Set the max ping attempts before suspecting a member
+     *
+     * @param maxAttempts the max attempts before suspecting a member
+     * @return this {@link IcmpFailureDetectorConfig} instance
+     */
+    public IcmpFailureDetectorConfig setMaxAttempts(int maxAttempts) {
+        checkNotNegative(maxAttempts, "Max attempts must not be a negative value");
+        this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    /**
+     * @return whether the ICMP detector is enabled or not.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Set whether the ICMP failure detector should be enabled or not.
+     * When set to true, this member will use icmp ping failure detector to detect unavailable members
+     */
+    public IcmpFailureDetectorConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * @return whether the ICMP detector is set in parallel mode, or in legacy (flag value = <code>false</code>).
+     */
+    public boolean isParallelMode() {
+        return parallelMode;
+    }
+
+    /**
+     * Set the ICMP detector to run in parallel mode, independent from the other failure detectors.
+     * If set to false (default) then the detector runs in legacy mode, with similar behavior as to Hazelcast version less than
+     * 3.9.
+     *
+     * @param mode the mode representing whether the detector should work in parallel or not
+     * @return this {@link IcmpFailureDetectorConfig} instance
+     */
+    public IcmpFailureDetectorConfig setParallelMode(boolean mode) {
+        this.parallelMode = mode;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "IcmpFailureDetectorConfig{"
+                + "timeoutMilliseconds=" + timeoutMilliseconds
+                + ", intervalMilliseconds=" + intervalMilliseconds
+                + ", echoFailFastOnStartup=" + failFastOnStartup
+                + ", ttl=" + ttl
+                + ", maxAttempts=" + maxAttempts
+                + ", enabled=" + enabled
+                + ", parallelMode=" + parallelMode
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 /**
  * Contains configuration for Network.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class NetworkConfig {
 
     /**
@@ -60,6 +61,8 @@ public class NetworkConfig {
     private SSLConfig sslConfig;
 
     private MemberAddressProviderConfig memberAddressProviderConfig = new MemberAddressProviderConfig();
+
+    private IcmpFailureDetectorConfig icmpFailureDetectorConfig;
 
     public NetworkConfig() {
         String os = StringUtil.lowerCaseInternal(System.getProperty("os.name"));
@@ -334,6 +337,29 @@ public class NetworkConfig {
         return this;
     }
 
+    /**
+     * Sets the {@link IcmpFailureDetectorConfig}. The value can be {@code null} if this detector isn't needed.
+     *
+     * @param icmpFailureDetectorConfig the IcmpFailureDetectorConfig to set
+     * @return the updated NetworkConfig
+     * @see #getIcmpFailureDetectorConfig()
+     */
+    public NetworkConfig setIcmpFailureDetectorConfig(final IcmpFailureDetectorConfig icmpFailureDetectorConfig) {
+        this.icmpFailureDetectorConfig = icmpFailureDetectorConfig;
+        return this;
+    }
+
+    /**
+     * Returns the current {@link IcmpFailureDetectorConfig}. It is possible that null is returned if no
+     * IcmpFailureDetectorConfig has been set.
+     *
+     * @return the IcmpFailureDetectorConfig
+     * @see #setIcmpFailureDetectorConfig(IcmpFailureDetectorConfig)
+     */
+    public IcmpFailureDetectorConfig getIcmpFailureDetectorConfig() {
+        return icmpFailureDetectorConfig;
+    }
+
     @Override
     public String toString() {
         return "NetworkConfig{"
@@ -346,6 +372,7 @@ public class NetworkConfig {
                 + ", sslConfig=" + sslConfig
                 + ", socketInterceptorConfig=" + socketInterceptorConfig
                 + ", symmetricEncryptionConfig=" + symmetricEncryptionConfig
+                + ", icmpFailureDetectorConfig=" + icmpFailureDetectorConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -440,12 +440,20 @@ public final class GroupProperty {
     /**
      * If a member should be pinged when a sufficient amount of heartbeats have passed and the member has not sent any
      * heartbeats. If the member is not reachable, it will be removed.
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_ENABLED
             = new HazelcastProperty("hazelcast.icmp.enabled", false);
 
     /**
      * Run ICMP detection in parallel with the Heartbeat failure detector.
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_PARALLEL_MODE
             = new HazelcastProperty("hazelcast.icmp.parallel.mode", true);
@@ -453,24 +461,40 @@ public final class GroupProperty {
     /**
      * Enforce ICMP Echo Request mode for ping-detector. If OS is not supported,
      * or not configured correctly as per reference-manual, hazelcast will fail to start.
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_ECHO_FAIL_FAST
             = new HazelcastProperty("hazelcast.icmp.echo.fail.fast.on.startup", true);
 
     /**
      * Ping timeout in milliseconds. This cannot be more than the interval value. Should always be smaller.
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_TIMEOUT
             = new HazelcastProperty("hazelcast.icmp.timeout", 1000, MILLISECONDS);
 
     /**
      * Interval between ping attempts in milliseconds. Default and min allowed, 1 second.
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_INTERVAL
             = new HazelcastProperty("hazelcast.icmp.interval", 1000, MILLISECONDS);
 
     /**
      * Max ping attempts before suspecting a member
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_MAX_ATTEMPTS
             = new HazelcastProperty("hazelcast.icmp.max.attempts", 3);
@@ -478,6 +502,10 @@ public final class GroupProperty {
     /**
      * Ping TTL, the maximum number of hops the packets should go through or 0 for the default.
      * Zero in this case means unlimited hops.
+     *
+     * @deprecated as of 3.10 this can be configured through {@link com.hazelcast.config.IcmpFailureDetectorConfig}
+     * This will be removed in future versions. Until this is done,
+     * if the {@link com.hazelcast.config.IcmpFailureDetectorConfig} is null we will still fall back to this
      */
     public static final HazelcastProperty ICMP_TTL
             = new HazelcastProperty("hazelcast.icmp.ttl", 0);

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -1613,6 +1613,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="failure-detector" type="failure-detector" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="tcp-ip">
@@ -2143,6 +2144,65 @@
                 <xs:documentation>
                     True to enable symmetric encryption, false to disable.
                 </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="failure-detector">
+        <xs:all>
+            <xs:element name="icmp" type="icmp"/>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="icmp">
+        <xs:annotation>
+            <xs:documentation>
+                ICMP can be used in addition to the other detectors. It operates at layer 3 detects network
+                and hardware issues more quickly
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="timeout-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Timeout in Milliseconds before declaring a failed ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ttl" type="xs:integer" minOccurs="0" maxOccurs="1" default="255">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of times the IP Datagram (ping) can be forwarded, in most cases
+                        all Hazelcast cluster members would be within one network switch/router therefore
+                        default of 0 is usually sufficient
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="parallel-mode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>Run ICMP detection in parallel with the Heartbeat failure detector</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="fail-fast-on-startup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cluster Member will fail to start if it is unable to action an ICMP ping command when ICMP is enabled.
+                        Failure is usually due to OS level restrictions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-attempts" type="xs:integer" minOccurs="0" maxOccurs="1" default="2">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of consecutive failed attempts before declaring a member suspect
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="interval-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Time in milliseconds between each ICMP ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" default="false">
+            <xs:annotation>
+                <xs:documentation>Enables ICMP Pings to detect and suspect dead members</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -88,6 +88,9 @@
             <!-- iteration count to use when generating the secret key -->
             <iteration-count>19</iteration-count>
         </symmetric-encryption>
+        <failure-detector>
+            <icmp enabled="false"></icmp>
+        </failure-detector>
     </network>
     <partition-group enabled="false"/>
     <executor-service name="default">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -486,6 +486,16 @@ https://hazelcast.org/documentation/.
                 <property name="prop2">prop2-value</property>
             </properties>
         </member-address-provider>
+        <failure-detector>
+            <icmp enabled="true">
+                <timeout-milliseconds>1000</timeout-milliseconds>
+                <fail-fast-on-startup>true</fail-fast-on-startup>
+                <interval-milliseconds>1000</interval-milliseconds>
+                <max-attempts>2</max-attempts>
+                <parallel-mode>true</parallel-mode>
+                <ttl>255</ttl>
+            </icmp>
+        </failure-detector>
     </network>
     <!--
         ===== PARTITION GROUPING CONFIGURATION =====

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -92,6 +92,31 @@ public class ConfigXmlGeneratorTest {
     }
 
     @Test
+    public void testFailureDetectorConfigGenerator() {
+        Config cfg = new Config();
+        IcmpFailureDetectorConfig expected = new IcmpFailureDetectorConfig();
+        expected.setEnabled(true)
+                .setIntervalMilliseconds(1001)
+                .setTimeoutMilliseconds(1002)
+                .setMaxAttempts(4)
+                .setTtl(300)
+                .setParallelMode(false) // Defaults to false
+                .setFailFastOnStartup(false); // Defaults to false
+
+        cfg.getNetworkConfig().setIcmpFailureDetectorConfig(expected);
+
+        Config newConfigViaXMLGenerator = getNewConfigViaXMLGenerator(cfg);
+        IcmpFailureDetectorConfig actual = newConfigViaXMLGenerator.getNetworkConfig().getIcmpFailureDetectorConfig();
+
+        assertEquals(expected.isEnabled(), actual.isEnabled());
+        assertEquals(expected.getIntervalMilliseconds(), actual.getIntervalMilliseconds());
+        assertEquals(expected.getTimeoutMilliseconds(), actual.getTimeoutMilliseconds());
+        assertEquals(expected.getTtl(), actual.getTtl());
+        assertEquals(expected.getMaxAttempts(), actual.getMaxAttempts());
+        assertEquals(expected.isFailFastOnStartup(), actual.isFailFastOnStartup());
+        assertEquals(expected.isParallelMode(), actual.isParallelMode());
+    }
+    @Test
     public void testManagementCenterConfigGenerator() {
         ManagementCenterConfig managementCenterConfig = new ManagementCenterConfig()
                 .setEnabled(true)

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -202,6 +202,16 @@
                 <property name="foo">bar</property>
             </properties>
         </member-address-provider>
+        <failure-detector>
+            <icmp enabled="false">
+                <timeout-milliseconds>1000</timeout-milliseconds>
+                <fail-fast-on-startup>true</fail-fast-on-startup>
+                <interval-milliseconds>1000</interval-milliseconds>
+                <max-attempts>2</max-attempts>
+                <parallel-mode>true</parallel-mode>
+                <ttl>255</ttl>
+            </icmp>
+        </failure-detector>
     </network>
     <partition-group enabled="true" group-type="CUSTOM">
         <member-group>


### PR DESCRIPTION
Property based configuration is now deprecated, and will be removed in future versions.
If both properties and configs are in use, the config is taking precedence. Defaults have
been changed to match those of the Client config. However, property defaults stayed the same,
therefore users migrating from 3.9.3 shouldn't see any difference, until the enable the config.

Due to the nature of the implementation (private & internal logic) this was tested manually.