### PR TITLE
Introduced NioEventLoopGroup.Context

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioEventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioEventLoopGroupFactory.java
@@ -17,10 +17,8 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelFactory;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.EventLoopGroupFactory;
 import com.hazelcast.nio.tcp.MockIOService;
 import com.hazelcast.nio.tcp.MemberChannelInitializer;
@@ -35,19 +33,21 @@ public class SelectNow_NioEventLoopGroupFactory implements EventLoopGroupFactory
 
     @Override
     public NioEventLoopGroup create(MockIOService ioService, MetricsRegistry metricsRegistry) {
-
-        LoggingServiceImpl loggingService = ioService.loggingService;
-        NioEventLoopGroup threadingModel = new NioEventLoopGroup(
-                loggingService,
-                metricsRegistry,
-                ioService.getHazelcastName(),
-                new TcpIpConnectionChannelErrorHandler(loggingService.getLogger(TcpIpConnectionChannelErrorHandler.class)),
-                ioService.getInputSelectorThreadCount(),
-                ioService.getOutputSelectorThreadCount(),
-                ioService.getBalancerIntervalSeconds(),
-                new MemberChannelInitializer(loggingService.getLogger(MemberChannelInitializer.class), ioService)
-        );
-        threadingModel.setSelectorMode(SelectorMode.SELECT_NOW);
-        return threadingModel;
+        LoggingService loggingService = ioService.loggingService;
+        return new NioEventLoopGroup(
+                new NioEventLoopGroup.Context()
+                        .loggingService(loggingService)
+                        .metricsRegistry(metricsRegistry)
+                        .threadNamePrefix(ioService.getHazelcastName())
+                        .errorHandler(
+                                new TcpIpConnectionChannelErrorHandler(
+                                        loggingService.getLogger(TcpIpConnectionChannelErrorHandler.class)))
+                        .inputThreadCount(ioService.getInputSelectorThreadCount())
+                        .outputThreadCount(ioService.getOutputSelectorThreadCount())
+                        .balancerIntervalSeconds(ioService.getBalancerIntervalSeconds())
+                        .channelInitializer(
+                                new MemberChannelInitializer(
+                                        loggingService.getLogger(MemberChannelInitializer.class), ioService))
+                        .selectorMode(SelectorMode.SELECT_NOW));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioEventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioEventLoopGroupFactory.java
@@ -17,17 +17,14 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelFactory;
-import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.EventLoopGroupFactory;
 import com.hazelcast.nio.tcp.MemberChannelInitializer;
 import com.hazelcast.nio.tcp.MockIOService;
 import com.hazelcast.nio.tcp.TcpIpConnectionChannelErrorHandler;
 
-public class SelectWithSelectorFix_NioEventLoopGroupFactory
-        implements EventLoopGroupFactory {
+public class SelectWithSelectorFix_NioEventLoopGroupFactory implements EventLoopGroupFactory {
 
     @Override
     public ChannelFactory createChannelFactory() {
@@ -35,21 +32,23 @@ public class SelectWithSelectorFix_NioEventLoopGroupFactory
     }
 
     @Override
-    public NioEventLoopGroup create(
-            MockIOService ioService, MetricsRegistry metricsRegistry) {
-        LoggingServiceImpl loggingService = ioService.loggingService;
-        NioEventLoopGroup threadingModel = new NioEventLoopGroup(
-                loggingService,
-                metricsRegistry,
-                "hzName",
-                new TcpIpConnectionChannelErrorHandler(loggingService.getLogger(TcpIpConnectionChannelErrorHandler.class)),
-                ioService.getInputSelectorThreadCount(),
-                ioService.getOutputSelectorThreadCount(),
-                ioService.getBalancerIntervalSeconds(),
-                new MemberChannelInitializer(loggingService.getLogger(MemberChannelInitializer.class), ioService)
-        );
-        threadingModel.setSelectorMode(SelectorMode.SELECT_WITH_FIX);
-        threadingModel.setSelectorWorkaroundTest(true);
-        return threadingModel;
+    public NioEventLoopGroup create(MockIOService ioService, MetricsRegistry metricsRegistry) {
+        LoggingService loggingService = ioService.loggingService;
+        return new NioEventLoopGroup(
+                new NioEventLoopGroup.Context()
+                        .loggingService(loggingService)
+                        .metricsRegistry(metricsRegistry)
+                        .threadNamePrefix(ioService.getHazelcastName())
+                        .errorHandler(
+                                new TcpIpConnectionChannelErrorHandler(
+                                        loggingService.getLogger(TcpIpConnectionChannelErrorHandler.class)))
+                        .inputThreadCount(ioService.getInputSelectorThreadCount())
+                        .outputThreadCount(ioService.getOutputSelectorThreadCount())
+                        .balancerIntervalSeconds(ioService.getBalancerIntervalSeconds())
+                        .channelInitializer(
+                                new MemberChannelInitializer(
+                                        loggingService.getLogger(MemberChannelInitializer.class), ioService))
+                        .selectorMode(SelectorMode.SELECT_WITH_FIX)
+                        .selectorWorkaroundTest(true));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioEventLoopGroupFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioEventLoopGroupFactory.java
@@ -17,8 +17,6 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelFactory;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.EventLoopGroupFactory;
@@ -36,17 +34,20 @@ public class Select_NioEventLoopGroupFactory implements EventLoopGroupFactory {
     @Override
     public NioEventLoopGroup create(MockIOService ioService, MetricsRegistry metricsRegistry) {
         LoggingService loggingService = ioService.loggingService;
-        NioEventLoopGroup threadingModel = new NioEventLoopGroup(
-                loggingService,
-                metricsRegistry,
-                ioService.getHazelcastName(),
-                new TcpIpConnectionChannelErrorHandler(loggingService.getLogger(TcpIpConnectionChannelErrorHandler.class)),
-                ioService.getInputSelectorThreadCount(),
-                ioService.getOutputSelectorThreadCount(),
-                ioService.getBalancerIntervalSeconds(),
-                new MemberChannelInitializer(loggingService.getLogger(MemberChannelInitializer.class),ioService)
-        );
-        threadingModel.setSelectorMode(SelectorMode.SELECT);
-        return threadingModel;
+        return new NioEventLoopGroup(
+                new NioEventLoopGroup.Context()
+                        .loggingService(loggingService)
+                        .metricsRegistry(metricsRegistry)
+                        .threadNamePrefix(ioService.getHazelcastName())
+                        .errorHandler(
+                                new TcpIpConnectionChannelErrorHandler(
+                                        loggingService.getLogger(TcpIpConnectionChannelErrorHandler.class)))
+                        .inputThreadCount(ioService.getInputSelectorThreadCount())
+                        .outputThreadCount(ioService.getOutputSelectorThreadCount())
+                        .balancerIntervalSeconds(ioService.getBalancerIntervalSeconds())
+                        .channelInitializer(
+                                new MemberChannelInitializer(
+                                        loggingService.getLogger(MemberChannelInitializer.class), ioService))
+                        .selectorMode(SelectorMode.SELECT));
     }
 }


### PR DESCRIPTION
This prevents having a very long constructor with too many arguments. It also removes on the fly behavior discovery into the context and makes a lot more fields on the NioEventLoopGroup final