### PR TITLE
Remove the member list version jump logic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -146,22 +146,14 @@ public interface ClusterService extends CoreService, Cluster {
     /**
      * Returns the member list join version of the local member instance.
      * <p>
-     * The join algorithm is specifically designed to ensure that member list join version is unique for each
-     * member in the cluster, even during a network-split situation:<ul>
-     *     <li>If two members join at the same time, they will appear on different version of member list
-     *     <li>If a new member claims mastership, it makes a jump in the member list version based on its
-     *     index in the member list multiplied by the value of the
-     *     {@link com.hazelcast.spi.properties.GroupProperty#MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT}
-     *     configuration property. This is to protect against the possibility that the original master is still
-     *     running in a separate network partition.
-     * </ul>
-     * The solution provides uniqueness guarantee of member list join version numbers with the following
-     * limitations:<ul>
-     *    <li>When there is a split-brain issue, the number of member list changes that can occur in the
-     *    sub-clusters are capped by the abovementioned configuration parameter.
-     *    <li>When there is a split-brain issue, if further splits occur in the already split sub-clusters, the
-     *    uniqueness guarantee can be lost.
-     * </ul>
+     * The join algorithm assigns different member list join versions to each member in the cluster.
+     * If two members join at the same time, they will appear on different version of member list.
+     * <p>
+     * The uniqueness guarantee of member list join versions is provided except the following scenario:
+     * when there is a split-brain issue, if a new node joins to any sub-cluster,
+     * it can get a duplicate member list join version, i.e., its member list join version
+     * can be assigned to another node in the other sub-cluster(s).
+     * <p>
      * When duplicate member list join version is assigned during network split, the returned value can
      * change to make it unique again. Therefore the caller should call this method repeatedly.
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -66,8 +66,6 @@ import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.MEMBERSHIP_
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SERVICE_NAME;
 import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.spi.properties.GroupProperty.MASTERSHIP_CLAIM_TIMEOUT_SECONDS;
-import static com.hazelcast.spi.properties.GroupProperty.MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT;
-import static java.lang.Math.max;
 import static java.util.Collections.unmodifiableSet;
 
 /**
@@ -706,7 +704,7 @@ public class MembershipManager {
             }
         }
 
-        int finalVersion = getMastershipClaimMemberListVersion(localMemberMap, latestMembersView.getVersion());
+        int finalVersion = latestMembersView.getVersion() + 1;
         return new MembersView(finalVersion, finalMembers);
     }
 
@@ -791,14 +789,6 @@ public class MembershipManager {
                 .createInvocationBuilder(SERVICE_NAME, op, target)
                 .setTryCount(mastershipClaimTimeoutSeconds)
                 .setCallTimeout(TimeUnit.SECONDS.toMillis(mastershipClaimTimeoutSeconds)).invoke();
-    }
-
-    private int getMastershipClaimMemberListVersion(MemberMap localMemberMap, int latestMemberListVersion) {
-        int localMemberIndex = localMemberMap.getMemberIndex(nodeEngine.getLocalMember());
-        int inc = node.getProperties().getInteger(MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT);
-        int versionIncPerMember = max(inc, localMemberMap.size());
-        int newMemberListVersion = latestMemberListVersion + localMemberIndex * versionIncPerMember;
-        return max(newMemberListVersion, localMemberMap.size());
     }
 
     private MembersView generateMissingMemberListJoinVersions(MembersView membersView) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -414,18 +414,6 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.heartbeat.failuredetector.type", "deadline");
 
     /**
-     * The Hazelcast master node increments the member list version for each joining member. Then, member list versions
-     * are used to identify joined members with unique integers. For this algorithm to work under network partitioning scenarios
-     * without generating duplicate member list join versions for different members, a mastership-claiming node increments
-     * the member list version as specified by this parameter, multiplied by its position in the member list.
-     * The value of the parameter must be bigger than the cluster size.
-     * <p>
-     * Introduced in 3.10.
-     */
-    public static final HazelcastProperty MASTERSHIP_CLAIM_MEMBER_LIST_VERSION_INCREMENT =
-            new HazelcastProperty("hazelcast.mastership.claim.member.list.version.increment", 25);
-
-    /**
      * The interval at which the master sends the member lists are sent to other non-master members
      */
     public static final HazelcastProperty MEMBER_LIST_PUBLISH_INTERVAL_SECONDS


### PR DESCRIPTION
The member list version jump logic which is introduced for flake ids is removed. When a node makes a mastership claim, it does not make a jump in the member list version. Instead, it increments the current biggest version by 1.