### PR TITLE
Client cache config creation exception handling fixed

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -17,21 +17,25 @@
 package com.hazelcast.client.cache.impl;
 
 import com.hazelcast.cache.impl.CacheProxyUtil;
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheCreateConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheGetConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheManagementConfigCodec;
+import com.hazelcast.client.spi.impl.AbstractClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.LegacyCacheConfig;
 import com.hazelcast.core.Member;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil;
 
 import java.io.IOException;
@@ -42,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static com.hazelcast.util.StringUtil.timeToString;
 
 /**
  * Helper class for some client cache related stuff.
@@ -121,7 +126,7 @@ final class ClientCacheHelper {
             String nameWithPrefix = newCacheConfig.getNameWithPrefix();
             int partitionId = client.getClientPartitionService().getPartitionId(nameWithPrefix);
 
-            Object resolvedConfig = resolveCacheConfig(client, newCacheConfig, partitionId);
+            Object resolvedConfig = resolveCacheConfigWithRetry(client, newCacheConfig, partitionId);
 
             Data configData = client.getSerializationService().toData(resolvedConfig);
             ClientMessage request = CacheCreateConfigCodec.encodeRequest(configData, createAlsoOnOthers);
@@ -185,6 +190,59 @@ final class ClientCacheHelper {
         }
         return address;
     }
+
+    private static <K, V> Object resolveCacheConfigWithRetry(HazelcastClientInstanceImpl client,
+                                                             CacheConfig<K, V> newCacheConfig, int partitionId) {
+        AbstractClientInvocationService invocationService = (AbstractClientInvocationService) client.getInvocationService();
+        long invocationRetryPauseMillis = invocationService.getInvocationRetryPauseMillis();
+        long invocationTimeoutMillis = invocationService.getInvocationTimeoutMillis();
+        long startMillis = System.currentTimeMillis();
+        Exception lastException;
+        do {
+            try {
+                return resolveCacheConfig(client, newCacheConfig, partitionId);
+            } catch (Exception e) {
+                lastException = e;
+            }
+
+            timeOutOrSleepBeforeNextTry(startMillis, invocationRetryPauseMillis, invocationTimeoutMillis, lastException);
+
+        } while (client.getLifecycleService().isRunning());
+        throw new HazelcastClientNotActiveException("Client is shut down");
+    }
+
+    private static void sleepBeforeNextTry(long invocationRetryPauseMillis) {
+        try {
+            Thread.sleep(invocationRetryPauseMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw ExceptionUtil.rethrow(e);
+        }
+    }
+
+    private static void timeOutOrSleepBeforeNextTry(long startMillis, long invocationRetryPauseMillis,
+                                                    long invocationTimeoutMillis, Exception lastException) {
+        long nowInMillis = System.currentTimeMillis();
+        long elapsedMillis = nowInMillis - startMillis;
+        boolean timedOut = elapsedMillis > invocationTimeoutMillis;
+
+        if (timedOut) {
+            throwOperationTimeoutException(startMillis, nowInMillis, elapsedMillis, invocationTimeoutMillis, lastException);
+        } else {
+            sleepBeforeNextTry(invocationRetryPauseMillis);
+        }
+    }
+
+    private static void throwOperationTimeoutException(long startMillis, long nowInMillis,
+                                                       long elapsedMillis, long invocationTimeoutMillis,
+                                                       Exception lastException) {
+        throw new OperationTimeoutException("Creating cache config is timed out."
+                + " Current time: " + timeToString(nowInMillis) + ", "
+                + " Start time : " + timeToString(startMillis) + ", "
+                + " Client invocation timeout : " + invocationTimeoutMillis + " ms, "
+                + " Elapsed time : " + elapsedMillis + " ms. ", lastException);
+    }
+
 
     /**
      * Enables/disables statistics or management support of cache on the all servers in the cluster.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -20,8 +20,11 @@ import com.hazelcast.cache.CacheCreationTest;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Ignore;
@@ -29,7 +32,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.cache.CacheManager;
+import javax.cache.configuration.MutableConfiguration;
 import javax.cache.spi.CachingProvider;
+
+import java.util.concurrent.CountDownLatch;
 
 import static java.util.Collections.singletonList;
 
@@ -48,6 +55,50 @@ public class ClientCacheCreationTest extends CacheCreationTest {
             clientConfig.getNetworkConfig().setAddresses(singletonList("127.0.0.1"));
         }
         return HazelcastClientCachingProvider.createCachingProvider(HazelcastClient.newHazelcastClient(clientConfig));
+    }
+
+    @Test(expected = OperationTimeoutException.class)
+    public void createSingleCache_whenMemberDown_throwsOperationTimeoutException() {
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "2");
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        HazelcastClientCachingProvider cachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        hazelcastInstance.shutdown();
+        MutableConfiguration configuration = new MutableConfiguration();
+        cacheManager.createCache("xmlCache", configuration);
+    }
+
+    @Test
+    public void createSingleCache_whenMemberBounce() throws InterruptedException {
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+        HazelcastClientCachingProvider cachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+        final CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        hazelcastInstance.shutdown();
+
+        final CountDownLatch cacheCreated = new CountDownLatch(1);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                MutableConfiguration configuration = new MutableConfiguration();
+                cacheManager.createCache("xmlCache", configuration);
+                cacheCreated.countDown();
+            }
+        }).start();
+
+        //leave some gap to let create cache to start and retry
+        Thread.sleep(2000);
+        Hazelcast.newHazelcastInstance();
+        assertOpenEventually(cacheCreated);
     }
 
     @Test


### PR DESCRIPTION
If cluster is not available while creating cache, we were failing
immediately. Since client invocations should at least wait for
`client.invocation.timeout.seconds` , I have added retry logic
with OperationTimeoutException as failure exception.

Expcetion type also get fixed.
related to https://github.com/hazelcast/hazelcast/issues/11439