### PR TITLE
Define MapStore/Loader contracts in IMap javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -123,7 +123,7 @@ import java.util.concurrent.TimeUnit;
  * <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#specifying-merge-policies">
  * specify their own map merge policies</a>, these policies when used in concert with
  * <a href="http://hal.upmc.fr/inria-00555588/document">CRDTs (Convergent and Commutative
- Replicated Data Types)</a> can ensure against data loss during a split-brain.
+ * Replicated Data Types)</a> can ensure against data loss during a split-brain.
  * <p>
  * As a defensive mechanism against such inconsistency, consider using the in-built
  * <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#split-brain-protection">
@@ -131,7 +131,13 @@ import java.util.concurrent.TimeUnit;
  * partitioned clusters. It should be noted that there is still an inconsistency window between the time of
  * the split and the actual detection. Therefore using this reduces the window of inconsistency but can never
  * completely eliminate it.
+ *
+ * <p><b>Interactions with the map store</b>
  * <p>
+ * Maps can be configured to be backed by a map store to persist the
+ * entries. In this case many of the IMap methods call {@link MapLoader} or
+ * {@link MapStore} methods to load, store or remove data. Each method's
+ * javadoc describes the way of its interaction with the map store.
  *
  * @param <K> key
  * @param <V> value
@@ -149,6 +155,30 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
      * expire when the initial TTL has elapsed.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * For each element not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map, which may come at a significant
+     * performance cost. Exceptions thrown by load fail the operation
+     * and are propagated to the caller. The elements which were added
+     * before the exception was thrown will remain in the map, the rest
+     * will not be added.
+     * <p>
+     * If write-through persistence mode is configured,
+     * {@link MapStore#store(Object, Object)} is invoked for each element
+     * before the element is added in memory, which may come at a
+     * significant performance cost. Exceptions thrown by store fail the
+     * operation and are propagated to the caller. The elements which
+     * were added before the exception was thrown will remain in the map,
+     * the rest will not be added.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      */
     void putAll(Map<? extends K, ? extends V> m);
 
@@ -159,8 +189,13 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * This method uses {@code hashCode} and {@code equals} of the binary form of the {@code key},
      * not the actual implementations of {@code hashCode} and {@code equals} defined in the {@code key}'s class.
-     * The {@code key} will first be searched for in memory. If the key is not found, and if a key is attributed,
-     * a {@link MapLoader} will then attempt to load the key.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If {@code key} is not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
      *
      * @throws NullPointerException if the specified key is null
      */
@@ -192,14 +227,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If value with {@code key} is not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     *
      * @throws NullPointerException if the specified key is null
      */
     V get(Object key);
 
     /**
      * {@inheritDoc}
-     * <p>Consider usage of {@link #delete(Object)} if you don't need the returned value. This will trim the serialization
-     * costs.
      * <p>
      * <b>Warning 1:</b>
      * <p>
@@ -219,6 +259,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * <p><b>Note:</b>
      * Use {@link #set(Object, Object)} if you don't need the return value, it's slightly more efficient.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @throws NullPointerException if the specified key or value is null
      */
@@ -241,6 +299,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * This method returns a clone of the previous value, not the original (identically equal) value
      * previously put into the map.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is removed from the memory, {@link MapStore#delete(Object)} is
+     * called to remove the value from the map store. Exceptions thrown
+     * by delete fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @throws NullPointerException if the specified key is null
      * @see #delete(Object)
      */
@@ -255,6 +331,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is removed from the memory, {@link MapStore#delete(Object)} is
+     * called to remove the value from the map store. Exceptions thrown
+     * by delete fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @throws NullPointerException if the specified key or value is null
      */
     boolean remove(Object key, Object value);
@@ -266,6 +360,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * otherwise they will be found by full-scan.
      * <p>
      * Note that calling this method also removes all entries from callers Near Cache.
+     *
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before a value
+     * is removed from the memory, {@link MapStore#delete(Object)} is
+     * called to remove the value from the map store. Exceptions thrown
+     * by delete fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param predicate matching entries with this predicate will be removed from this map
      * @throws NullPointerException if the specified predicate is null
@@ -289,6 +397,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * Also, a listener with predicates will have null values, so only keys can be queried via predicates.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is removed from the the memory, {@link MapStore#delete(Object)}
+     * is called to remove the value from the map store. Exceptions
+     * thrown by delete fail the operation and are propagated to the
+     * caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key key whose mapping is to be removed from the map
      * @throws ClassCastException   if the key is of an inappropriate type for this map (optional)
      * @throws NullPointerException if the specified key is null
@@ -298,24 +420,42 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
 
     /**
      * If this map has a MapStore, this method flushes
-     * all the local dirty entries by calling MapStore.storeAll() and/or MapStore.deleteAll().
+     * all the local dirty entries.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * Calls {@link MapStore#storeAll(Map)} and/or
+     * {@link MapStore#deleteAll(Collection)} with elements marked dirty.
+     *
+     * Please note that this method has effect only if write-behind
+     * persistence mode is configured. If the persistence mode is
+     * write-through calling this method has no practical effect, but an
+     * operation is executed on all partitions wasting resources.
      */
     void flush();
 
     /**
-     * Returns the entries for the given keys. If any keys are not present in the Map, it will
-     * call {@link MapStore#loadAll(java.util.Collection)}.
+     * Returns the entries for the given keys.
      * <p>
      * <b>Warning 1:</b>
      * <p>
-     * The returned map is <b>NOT</b> backed by the original map,
-     * so changes to the original map are <b>NOT</b> reflected in the returned map, and vice-versa.
+     * The returned map is <b>NOT</b> backed by the original map, so
+     * changes to the original map are <b>NOT</b> reflected in the
+     * returned map, and vice-versa.
      * <p>
      * <b>Warning 2:</b>
      * <p>
-     * This method uses {@code hashCode} and {@code equals} of the binary form of
-     * the {@code keys}, not the actual implementations of {@code hashCode} and {@code equals}
-     * defined in the {@code key}'s class.
+     * This method uses {@code hashCode} and {@code equals} of the
+     * binary form of the {@code keys}, not the actual implementations
+     * of {@code hashCode} and {@code equals} defined in the
+     * {@code key}'s class.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If any keys are not found in memory,
+     * {@link MapLoader#loadAll(java.util.Collection)} is called with
+     * the missing keys. Exceptions thrown by loadAll fail the operation
+     * and are propagated to the caller.
      *
      * @param keys keys to get (keys inside the collection cannot be null)
      * @return map of entries
@@ -324,19 +464,33 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     Map<K, V> getAll(Set<K> keys);
 
     /**
-     * Loads all keys into the store. This is a batch load operation so that an implementation can
-     * optimize the multiple loads.
+     * Loads all keys into the store. This is a batch load operation so
+     * that an implementation can optimize multiple loads.
      *
-     * @param replaceExistingValues when {@code true}, existing values in the Map will
-     *                              be replaced by those loaded from the MapLoader
-     *                              void loadAll(boolean replaceExistingValues));
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * Calls {@link MapLoader#loadAllKeys()} and with the loaded keys
+     * calls {@link MapLoader#loadAll(java.util.Collection)} on each
+     * partition. Exceptions thrown by loadAllKeys() or loadAll() are
+     * not propagated to the caller.
+     *
+     * @param replaceExistingValues when {@code true}, existing values
+     *                              in the Map will be replaced by those
+     *                              loaded from the MapLoader
+     *                              {@link #loadAll(boolean)}
      * @since 3.3
      */
     void loadAll(boolean replaceExistingValues);
 
     /**
      * Loads the given keys. This is a batch load operation so that an implementation can
-     * optimize the multiple loads.
+     * optimize multiple loads.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * Calls {@link MapLoader#loadAll(java.util.Collection)} on the
+     * partitions storing the values with the keys. Exceptions thrown by
+     * loadAll() are not propagated to the caller.
      *
      * @param keys                  keys of the values entries to load (keys inside the collection cannot be null)
      * @param replaceExistingValues when {@code true}, existing values in the Map will
@@ -346,13 +500,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     void loadAll(Set<K> keys, boolean replaceExistingValues);
 
     /**
-     * Clears the map and invokes {@link MapStore#deleteAll} which,
-     * if connected to a database, will delete the records from the database.
+     * Clears the map and deletes the items from the backing map store.
      * <p>
      * The MAP_CLEARED event is fired for any registered listeners.
      * See {@link com.hazelcast.core.EntryListener#mapCleared(MapEvent)}.
      * <p>
-     * To clear a map without calling {@link MapStore#deleteAll}, use {@link #evictAll}.
+     * To clear the map without removing the items from the map store,
+     * use {@link #evictAll}.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * Calls {@link MapStore#deleteAll(Collection)} on each partition
+     * with the keys that the given partition stores. Exceptions thrown
+     * by deleteAll() are not propagated to the caller.
      *
      * @see #evictAll
      */
@@ -381,10 +541,10 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * completion of the {@code ICompletableFuture} via
      * {@link ICompletableFuture#andThen(ExecutionCallback)} or
      * {@link ICompletableFuture#andThen(ExecutionCallback, Executor)}:
-     * <pre>
-     *   // assuming a IMap&lt;String, String&gt;
-     *   ICompletableFuture&lt;String&gt; future = map.getAsync("a");
-     *   future.andThen(new ExecutionCallback&lt;String&gt;() {
+     * <pre>{@code
+     *   // assuming an IMap<String, String>
+     *   ICompletableFuture<String> future = map.getAsync("a");
+     *   future.andThen(new ExecutionCallback<String>() {
      *     public void onResponse(String response) {
      *       // do something with value in response
      *     }
@@ -393,7 +553,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      *       // handle failure
      *     }
      *   });
-     * </pre>
+     * }</pre>
      * ExecutionException is never thrown.
      * <p>
      * <b>Warning:</b>
@@ -401,6 +561,13 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If value with {@code key} is not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
      *
      * @param key the key of the map entry
      * @return ICompletableFuture from which the value of the key can be retrieved
@@ -430,10 +597,10 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * Additionally, the client can schedule an {@link ExecutionCallback} to be invoked upon
      * completion of the {@code ICompletableFuture} via {@link ICompletableFuture#andThen(ExecutionCallback)} or
      * {@link ICompletableFuture#andThen(ExecutionCallback, Executor)}:
-     * <pre>
-     *   // assuming a IMap&lt;String, String&gt;
-     *   ICompletableFuture&lt;String&gt; future = map.putAsync("a", "b");
-     *   future.andThen(new ExecutionCallback&lt;String&gt;() {
+     * <pre>{@code
+     *   // assuming an IMap<String, String>
+     *   ICompletableFuture<String> future = map.putAsync("a", "b");
+     *   future.andThen(new ExecutionCallback<String>() {
      *     public void onResponse(String response) {
      *       // do something with the old value returned by put operation
      *     }
@@ -442,7 +609,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      *       // handle failure
      *     }
      *   });
-     * </pre>
+     * }</pre>
      * ExecutionException is never thrown.
      * <p>
      * <b>Warning 1:</b>
@@ -459,11 +626,30 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p><b>Note:</b>
      * Use {@link #setAsync(Object, Object)} if you don't need the return value, it's slightly more efficient.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key   the key of the map entry
      * @param value the new value of the map entry
      * @return ICompletableFuture from which the old value of the key can be retrieved
      * @throws NullPointerException if the specified key or value is null
      * @see ICompletableFuture
+     * @see #setAsync(Object, Object)
      */
     ICompletableFuture<V> putAsync(K key, V value);
 
@@ -492,10 +678,10 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * The client can schedule an {@link ExecutionCallback} to be invoked upon
      * completion of the {@code ICompletableFuture} via {@link ICompletableFuture#andThen(ExecutionCallback)} or
      * {@link ICompletableFuture#andThen(ExecutionCallback, Executor)}:
-     * <pre>
-     *   // assuming a IMap&lt;String, String&gt;
-     *   ICompletableFuture&lt;String&gt; future = map.putAsync("a", "b", 5, TimeUnit.MINUTES);
-     *   future.andThen(new ExecutionCallback&lt;String&gt;() {
+     * <pre>{@code
+     *   // assuming an IMap<String, String>
+     *   ICompletableFuture<String> future = map.putAsync("a", "b", 5, TimeUnit.MINUTES);
+     *   future.andThen(new ExecutionCallback<String>() {
      *     public void onResponse(String response) {
      *       // do something with old value returned by put operation
      *     }
@@ -504,7 +690,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      *       // handle failure
      *     }
      *   });
-     * </pre>
+     * }</pre>
      * ExecutionException is never thrown.
      * <p>
      * <b>Warning 1:</b>
@@ -521,6 +707,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * Use {@link #setAsync(Object, Object, long, TimeUnit)} if you don't need the return value, it's slightly
      * more efficient.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key      the key of the map entry
      * @param value    the new value of the map entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
@@ -528,36 +732,37 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @return ICompletableFuture from which the old value of the key can be retrieved
      * @throws NullPointerException if the specified key or value is null
      * @see ICompletableFuture
+     * @see #setAsync(Object, Object, long, TimeUnit)
      */
     ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit);
 
     /**
      * Asynchronously puts the given key and value.
-     * the entry lives forever.
+     * The entry lives forever.
      * Similar to the put operation except that set
      * doesn't return the old value, which is more efficient.
-     * <pre>
-     *   ICompletableFuture&lt;Void&gt; future = map.setAsync(key, value);
+     * <pre>{@code
+     *   ICompletableFuture<Void> future = map.setAsync(key, value);
      *   // do some other stuff, when ready wait for completion
      *   future.get();
-     * </pre>
+     * }</pre>
      * ICompletableFuture.get() will block until the actual map.set() operation completes.
      * If your application requires a timely response,
      * then you can use ICompletableFuture.get(timeout, timeunit).
-     * <pre>
+     * <pre>{@code
      *   try {
-     *     ICompletableFuture&lt;Void&gt; future = map.setAsync(key, newValue);
+     *     ICompletableFuture<Void> future = map.setAsync(key, newValue);
      *     future.get(40, TimeUnit.MILLISECOND);
      *   } catch (TimeoutException t) {
      *     // time wasn't enough
      *   }
-     * </pre>
+     * }</pre>
      * You can also schedule an {@link ExecutionCallback} to be invoked upon
      * completion of the {@code ICompletableFuture} via {@link ICompletableFuture#andThen(ExecutionCallback)} or
      * {@link ICompletableFuture#andThen(ExecutionCallback, Executor)}:
-     * <pre>
-     *   ICompletableFuture&lt;Void&gt; future = map.setAsync("a", "b");
-     *   future.andThen(new ExecutionCallback&lt;String&gt;() {
+     * <pre>{@code
+     *   ICompletableFuture<Void> future = map.setAsync("a", "b");
+     *   future.andThen(new ExecutionCallback<String>() {
      *     public void onResponse(Void response) {
      *       // Set operation was completed
      *     }
@@ -566,7 +771,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      *       // handle failure
      *     }
      *   });
-     * </pre>
+     * }</pre>
      * ExecutionException is never thrown.
      * <p>
      * <b>Warning 1:</b>
@@ -579,6 +784,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
      * expire when the initial TTL has elapsed.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param key   the key of the map entry
      * @param value the new value of the map entry
@@ -639,6 +857,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller..
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key      the key of the map entry
      * @param value    the new value of the map entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
@@ -661,6 +892,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is removed from the the memory, {@link MapStore#delete(Object)}
+     * is called to remove the value from the map store. Exceptions
+     * thrown by delete fail the operation and are propagated to the
+     * caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key The key of the map entry to remove
      * @return {@link ICompletableFuture} from which the value removed from the map can be retrieved
      * @throws NullPointerException if the specified key is null
@@ -679,6 +924,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is removed from the the memory, {@link MapStore#delete(Object)}
+     * is called to remove the value from the map store. Exceptions
+     * thrown by delete fail the operation and are propagated to the
+     * caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param key      key of the entry
      * @param timeout  maximum time to wait for acquiring the lock for the key
@@ -704,6 +963,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
      * expire when the initial TTL has elapsed.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param key      key of the entry
      * @param value    value of the entry
@@ -738,6 +1015,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * <p><b>Note:</b>
      * Use {@link #set(Object, Object, long, TimeUnit)} if you don't need the return value, it's slightly more efficient.
+     * <p>
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param key      key of the entry
      * @param value    value of the entry
@@ -749,8 +1044,9 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     V put(K key, V value, long ttl, TimeUnit timeunit);
 
     /**
-     * Same as {@link #put(K, V, long, java.util.concurrent.TimeUnit)} except that the MapStore, if defined,
-     * will not be called to store/persist the entry.
+     * Same as {@link #put(K, V, long, java.util.concurrent.TimeUnit)}
+     * except that the map store, if defined, will not be called to
+     * load/store/persist the entry.
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
@@ -786,6 +1082,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * Also, this method returns a clone of the previous value, not the original (identically equal) value
      * previously put into the map.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @return a clone of the previous value
      * @throws NullPointerException if the specified key or value is null
      */
@@ -814,6 +1128,24 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key      key of the entry
      * @param value    value of the entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
@@ -828,9 +1160,23 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * <b>Warning:</b>
      * <p>
-     * This method uses {@code hashCode} and {@code equals} of the binary form of
-     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
-     * defined in the {@code key}'s class.
+     * This method uses {@code hashCode} and {@code equals} of the
+     * binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s
+     * class.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @throws NullPointerException if any of the specified parameters are null
      */
@@ -853,6 +1199,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <b>Warning 3:</b>
      * <p>
      * If you have previously set a TTL for the key, the same TTL will be again set on the new value.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @throws NullPointerException if the specified key or value is null
      */
@@ -878,6 +1237,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
      * expire when the initial TTL has elapsed.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key   key of the entry
      * @param value value of the entry
      * @throws NullPointerException if the specified key or value is null
@@ -901,6 +1273,19 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <b>Warning 2:</b>
      * <p>
      * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param key      key of the entry
      * @param value    value of the entry
@@ -1428,27 +1813,34 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     /**
      * Evicts the specified key from this map.
      * <p>
-     * If a {@code MapStore} is defined for this map, then the entry is not
-     * deleted from the underlying {@code MapStore}, evict only removes
-     * the entry from the memory.
+     * If a {@code MapStore} is defined for this map, then the entry is
+     * not deleted from the underlying {@code MapStore}, evict only
+     * removes the entry from the memory. Use {@link #delete(Object)} or
+     * {@link #remove(Object)} if {@link MapStore#delete(Object)} needs
+     * to be called.
      * <p>
      * <b>Warning:</b>
      * <p>
-     * This method uses {@code hashCode} and {@code equals} of the binary form of
-     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
-     * defined in the {@code key}'s class.
+     * This method uses {@code hashCode} and {@code equals} of the
+     * binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s
+     * class.
      *
      * @param key the specified key to evict from this map
      * @return {@code true} if the key is evicted, {@code false} otherwise
      * @throws NullPointerException if the specified key is null
+     * @see #delete(Object)
+     * @see #remove(Object)
      */
     boolean evict(K key);
 
     /**
      * Evicts all keys from this map except the locked ones.
      * <p>
-     * If a {@code MapStore} is defined for this map, deleteAll is <strong>not</strong> called by this method.
-     * If you do want to deleteAll to be called use the {@link #clear()} method.
+     * If a {@code MapStore} is defined for this map, deleteAll is
+     * <strong>not</strong> called by this method. If you do want to
+     * {@link MapStore#deleteAll(Collection)} to be called use the
+     * {@link #clear()} method.
      * <p>
      * The EVICT_ALL event is fired for any registered listeners.
      * See {@link com.hazelcast.core.EntryListener#mapEvicted(MapEvent)} .
@@ -1731,6 +2123,31 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * See {@link #submitToKey(Object, EntryProcessor)} for an async version of this method.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If value with {@code key} is not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If the entryProcessor updates the entry and write-through
+     * persistence mode is configured, before the value is stored
+     * in memory, {@link MapStore#store(Object, Object)} is called to
+     * write the value into the map store. Exceptions thrown by store
+     * fail the operation are propagated to the caller.
+     * <p>
+     * If the entryProcessor updates the entry's value to null value and
+     * write-through persistence mode is configured, before the value is
+     * removed from the memory, {@link MapStore#delete(Object)} is
+     * called to delete the value from the map store. Exceptions thrown
+     * by delete fail the operation are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @return result of {@link EntryProcessor#process(Entry)}
      * @throws NullPointerException if the specified key is {@code null}
      * @see Offloadable
@@ -1743,6 +2160,31 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * The operation is not lock-aware. The {@code EntryProcessor} will process the entries no matter if the keys are
      * locked or not. For more details check <b>Entry Processing</b> section on {@link IMap} documentation.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * For each entry not found in memory {@link MapLoader#load(Object)}
+     * is invoked to load the value from the map store backing the map.
+     * Exceptions thrown by load fail the operation and are propagated
+     * to the caller.
+     * <p>
+     * If write-through persistence mode is configured, for each entry
+     * updated by the entryProcessor, before the updated value is stored
+     * in memory, {@link MapStore#store(Object, Object)} is called to
+     * write the value into the map store. Exceptions thrown by store
+     * fail the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, for each entry
+     * updated to null value, before the value is removed from the
+     * memory, {@link MapStore#delete(Object)} is called to delete the
+     * value from the map store. Exceptions thrown by delete fail the
+     * operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @return results of {@link EntryProcessor#process(Entry)}
      * @throws NullPointerException     if the specified key is {@code null}
@@ -1791,6 +2233,34 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * so that the EntryBackupProcessor does not have to calculate the "delta" but it may just apply it.
      * <p>
      * See {@link #executeOnKey(Object, EntryProcessor)} for sync version of this method.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If value with {@code key} is not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the provided callback via
+     * {@link ExecutionCallback#onFailure(Throwable)}.
+     * <p>
+     * If the entryProcessor updates the entry and write-through
+     * persistence mode is configured, before the value is stored
+     * in memory, {@link MapStore#store(Object, Object)} is called to
+     * write the value into the map store. Exceptions thrown by store
+     * fail the operation and are propagated to the provided callback via
+     * {@link ExecutionCallback#onFailure(Throwable)}.
+     * <p>
+     * If the entryProcessor updates the entry's value to null value and
+     * write-through persistence mode is configured, before the value is
+     * removed from the memory, {@link MapStore#delete(Object)} is
+     * called to delete the value from the map store. Exceptions thrown
+     * by delete fail the operation and are propagated to the provided
+     * callback via {@link ExecutionCallback#onFailure(Throwable)}.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      *
      * @param key            key to be processed
      * @param entryProcessor processor to process the key
@@ -1845,6 +2315,31 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * See {@link #executeOnKey(Object, EntryProcessor)} for sync version of this method.
      *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If value with {@code key} is not found in memory
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If the entryProcessor updates the entry and write-through
+     * persistence mode is configured, before the value is stored
+     * in memory, {@link MapStore#store(Object, Object)} is called to
+     * write the value into the map store. Exceptions thrown by store
+     * fail the operation are propagated to the caller.
+     * <p>
+     * If the entryProcessor updates the entry's value to null value and
+     * write-through persistence mode is configured, before the value is
+     * removed from the memory, {@link MapStore#delete(Object)} is
+     * called to delete the value from the map store. Exceptions thrown
+     * by delete fail the operation are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
      * @param key            key to be processed
      * @param entryProcessor processor to process the key
      * @return ICompletableFuture from which the result of the operation can be retrieved
@@ -1860,6 +2355,31 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * The operation is not lock-aware. The {@code EntryProcessor} will process the entries no matter if the keys are
      * locked or not. For more details check <b>Entry Processing</b> section on {@link IMap} documentation.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * For each entry not found in memory {@link MapLoader#load(Object)}
+     * is invoked to load the value from the map store backing the map.
+     * Exceptions thrown by load fail the operation and are propagated
+     * to the caller.
+     * <p>
+     * If write-through persistence mode is configured, for each entry
+     * updated by the entryProcessor, before the updated value is stored
+     * in memory, {@link MapStore#store(Object, Object)} is called to
+     * write the value into the map store. Exceptions thrown by store
+     * fail the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, for each entry
+     * updated to null value, before the value is removed from the
+     * memory, {@link MapStore#delete(Object)} is called to delete the
+     * value from the map store. Exceptions thrown by delete fail the
+     * operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      */
     Map<K, Object> executeOnEntries(EntryProcessor entryProcessor);
 
@@ -1869,6 +2389,31 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * The operation is not lock-aware. The {@code EntryProcessor} will process the entries no matter if the keys are
      * locked or not. For more details check <b>Entry Processing</b> section on {@link IMap} documentation.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * For each entry not found in memory {@link MapLoader#load(Object)}
+     * is invoked to load the value from the map store backing the map.
+     * Exceptions thrown by load fail the operation and are propagated
+     * to the caller.
+     * <p>
+     * If write-through persistence mode is configured, for each entry
+     * updated by the entryProcessor, before the updated value is stored
+     * in memory, {@link MapStore#store(Object, Object)} is called to
+     * write the value into the map store. Exceptions thrown by store
+     * fail the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, for each entry
+     * updated to null value, before the value is removed from the
+     * memory, {@link MapStore#delete(Object)} is called to delete the
+     * value from the map store. Exceptions thrown by delete fail the
+     * operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
      */
     Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate);
 


### PR DESCRIPTION
Define for each IMap method in its javadoc that
- how the given method interacts with MapStore and MapLoader if there is any interaction
- whether the exceptions from MapStore/MapLoader implementations are propagated or not
- if there is a significant performance impact to be aware of when calling the method on an IMap backed by a data store
- if there is an alternative method that does similar work but with different data store interactions

Fixes #10969