### PR TITLE
Compilation with Java 6 and above

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/SortingUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SortingUtil.java
@@ -128,9 +128,9 @@ public final class SortingUtil {
         };
     }
 
-    public static Comparator<Map.Entry> newComparator(final PagingPredicate pagingPredicate) {
-        return new Comparator<Map.Entry>() {
-            public int compare(Map.Entry entry1, Map.Entry entry2) {
+    private static Comparator<QueryableEntry> newComparator(final PagingPredicate pagingPredicate) {
+        return new Comparator<QueryableEntry>() {
+            public int compare(QueryableEntry entry1, QueryableEntry entry2) {
                 return SortingUtil.compare(pagingPredicate.getComparator(),
                         pagingPredicate.getIterationType(), entry1, entry2);
             }
@@ -142,7 +142,7 @@ public final class SortingUtil {
         if (pagingPredicate == null || list.isEmpty()) {
             return list;
         }
-        Comparator<Map.Entry> comparator = SortingUtil.newComparator(pagingPredicate);
+        Comparator<QueryableEntry> comparator = newComparator(pagingPredicate);
         Collections.sort(list, comparator);
         int nearestPage = nearestAnchorEntry.getKey();
         int pageSize = pagingPredicate.getPageSize();

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCreateDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCreateDestroyTest.java
@@ -62,7 +62,7 @@ public class ExecutorServiceCreateDestroyTest extends HazelcastTestSupport {
     public void test_createSubmit_thenDestroy() throws Exception {
         test_createUse_thenDestroy(new ExecutorServiceCommand() {
             @Override
-            Collection<Future> submit(IExecutorService ex, Callable task) {
+            <T> Collection<Future<T>> submit(IExecutorService ex, Callable<T> task) {
                 return Collections.singleton(ex.submit(task));
             }
         });
@@ -72,8 +72,8 @@ public class ExecutorServiceCreateDestroyTest extends HazelcastTestSupport {
     public void test_createSubmitAllMembers_thenDestroy() throws Exception {
         test_createUse_thenDestroy(new ExecutorServiceCommand() {
             @Override
-            Collection<Future> submit(IExecutorService ex, Callable task) {
-                Map<Member, Future> futures = ex.submitToAllMembers(task);
+            <T> Collection<Future<T>> submit(IExecutorService ex, Callable<T> task) {
+                Map<Member, Future<T>> futures = ex.submitToAllMembers(task);
                 return futures.values();
             }
         });
@@ -107,8 +107,8 @@ public class ExecutorServiceCreateDestroyTest extends HazelcastTestSupport {
     private static abstract class ExecutorServiceCommand {
         final void run(IExecutorService ex) throws Exception {
             try {
-                Collection<Future> futures = submit(ex, new VoidCallableTask());
-                for (Future future : futures) {
+                Collection<Future<Void>> futures = submit(ex, new VoidCallableTask());
+                for (Future<Void> future : futures) {
                     future.get();
                 }
             } catch (RejectedExecutionException ignored) {
@@ -121,7 +121,7 @@ public class ExecutorServiceCreateDestroyTest extends HazelcastTestSupport {
             }
         }
 
-        abstract Collection<Future> submit(IExecutorService ex, Callable task);
+        abstract <T> Collection<Future<T>> submit(IExecutorService ex, Callable<T> task);
     }
 
     private static class VoidCallableTask implements Callable<Void>, Serializable {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -378,7 +378,6 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
                     return 0;
                 }
 
-                @Override
                 @SuppressWarnings("ComparatorMethodParameterNotUsed")
                 public int compare(Object o1, Object o2) {
                     return 0;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/durableexecutor/DurableExecutorQuorumWriteTest.java
@@ -262,8 +262,8 @@ public class DurableExecutorQuorumWriteTest extends AbstractQuorumTest {
         return generateKeyOwnedBy(cluster.getInstance(index), true);
     }
 
-    private void wait(Collection<Future<?>> futures) throws ExecutionException, InterruptedException {
-        for (Future f : futures) {
+    private void wait(Collection<? extends Future<?>> futures) throws ExecutionException, InterruptedException {
+        for (Future<?> f : futures) {
             f.get();
         }
     }
@@ -286,4 +286,5 @@ public class DurableExecutorQuorumWriteTest extends AbstractQuorumTest {
             return new ExecRunnable();
         }
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
@@ -456,7 +456,7 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
 
     @Test
     public void invokeAll_timeout_quorum_short_timeout() throws Exception {
-        List<Future<?>> futures = exec(0).invokeAll(Arrays.<Callable<Object>>asList(callable(), callable()), 10l, TimeUnit.SECONDS);
+        List<? extends Future<?>> futures = exec(0).invokeAll(Arrays.<Callable<Object>>asList(callable(), callable()), 10l, TimeUnit.SECONDS);
 
         // 10s is relatively short timeout -> there is some chance the task will be cancelled before it
         // had a chance to be executed. especially in slow environments -> we have to tolerate the CancellationException
@@ -531,7 +531,7 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
         return exec(index, quorumType, postfix);
     }
 
-    private void wait(Map<Member, Future<?>> futures) throws Exception {
+    private void wait(Map<Member, ? extends Future<?>> futures) throws Exception {
         for (Future f : futures.values()) {
             f.get();
         }
@@ -555,12 +555,12 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
         }
     }
 
-    private void expectQuorumException(Collection<Future<?>> futures) {
+    private void expectQuorumException(Collection<? extends Future<?>> futures) {
         assertAllowedException(futures, QuorumException.class);
     }
 
-    private void assertAllowedException(Collection<Future<?>> futures, Class<?> allowedException) {
-        for (Future f : futures) {
+    private void assertAllowedException(Collection<? extends Future<?>> futures, Class<?> allowedException) {
+        for (Future<?> f : futures) {
             try {
                 f.get();
             } catch (Exception e) {
@@ -581,8 +581,8 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
         }
     }
 
-    private void wait(Collection<Future<?>> futures) throws ExecutionException, InterruptedException {
-        for (Future f : futures) {
+    private void wait(Collection<? extends Future<?>> futures) throws ExecutionException, InterruptedException {
+        for (Future<?> f : futures) {
             f.get();
         }
     }
@@ -698,4 +698,5 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
             return new MultiCallback();
         }
     }
+
 }


### PR DESCRIPTION
Changed or added generics that would otherwise cause compilation errors with newer Java versions.
The generics as they are now should be fine with both Java 6 and above.

There a still **a lot** of raw types...

Please add more/other reviews that you think fit.