### PR TITLE
Fail if MapLoader.loadAll loads unexpected keys

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -72,6 +72,9 @@ public interface MapLoader<K, V> {
      *
      * The given collection should not contain any <code>null</code> keys.
      * The returned Map should not contain any <code>null</code> keys or values.
+     * <p>
+     * Loading other items than what provided in <code>keys</code>
+     * prevents the map from being filled from the map store.
      *
      * @param keys keys of the values entries to load
      * @return map of loaded key-value pairs.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
@@ -64,7 +64,6 @@ public class MapStoreWrapper implements MapStore, MapLoaderLifecycleSupport {
         this.mapStore = store;
     }
 
-
     public MapStore getMapStore() {
         return mapStore;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -46,6 +46,7 @@ import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.ExceptionUtil;
@@ -76,6 +77,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     protected final ILogger logger;
     protected final RecordStoreLoader recordStoreLoader;
     protected final MapKeyLoader keyLoader;
+
     /**
      * A collection of futures representing pending completion of the key and
      * value loading tasks.
@@ -100,6 +102,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
      */
     private boolean loadedOnPreMigration;
 
+    private final IPartitionService partitionService;
+
     public DefaultRecordStore(MapContainer mapContainer, int partitionId,
                               MapKeyLoader keyLoader, ILogger logger) {
         super(mapContainer, partitionId);
@@ -107,6 +111,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         this.logger = logger;
         this.keyLoader = keyLoader;
         this.recordStoreLoader = createRecordStoreLoader(mapStoreContext);
+        this.partitionService = mapServiceContext.getNodeEngine().getPartitionService();
     }
 
     @Override
@@ -896,6 +901,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (value == null) {
             logger.warning("Found an attempt to load a null value from map-store, ignoring it.");
             return false;
+        }
+
+        if (partitionService.getPartitionId(key) != partitionId) {
+            throw new IllegalStateException("MapLoader loaded an item belongs to a different partition");
         }
 
         return true;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderUnexpectedLoadedItemsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderUnexpectedLoadedItemsTest.java
@@ -1,0 +1,110 @@
+package com.hazelcast.map.impl.mapstore;
+
+import com.google.common.collect.Lists;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.LAZY;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapLoaderUnexpectedLoadedItemsTest extends HazelcastTestSupport {
+
+    private static final boolean LOAD_ALL_KEYS = false;
+    private static final boolean LOAD_PROVIDED_KEYS = true;
+    private static final Integer[] KEYS_TO_LOAD = {0, 1, 2, 3, 4, 5};
+
+    @Test
+    public void loadAllAbortsIfItemFromOtherPartitionIsLoaded() {
+        String mapName = randomString();
+        DummyMapLoader mapLoader = new DummyMapLoader(LOAD_ALL_KEYS);
+        Config config = getConfig(mapName, mapLoader);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<?, ?> map = instance.getMap(mapName);
+        map.clear();
+
+        map.loadAll(true);
+
+        assertThat(map.size(), lessThan(KEYS_TO_LOAD.length));
+
+        instance.shutdown();
+    }
+
+    @Test
+    public void loadAllLoadsAllIfProvidedKeysLoadedFromStore() {
+        String mapName = randomString();
+        DummyMapLoader mapLoader = new DummyMapLoader(LOAD_PROVIDED_KEYS);
+        Config config = getConfig(mapName, mapLoader);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<?, ?> map = instance.getMap(mapName);
+        map.clear();
+
+        map.loadAll(true);
+
+        assertThat(map.size(), equalTo(KEYS_TO_LOAD.length));
+
+        instance.shutdown();
+    }
+
+    private Config getConfig(String mapName1, DummyMapLoader mapLoader) {
+        Config config = getConfig();
+        config.getMapConfig(mapName1).getMapStoreConfig()
+              .setEnabled(true)
+              .setInitialLoadMode(LAZY)
+              .setImplementation(mapLoader);
+        return config;
+    }
+
+    public static class DummyMapLoader implements MapLoader<Integer, String> {
+
+        private final boolean useProvidedKeys;
+
+        private DummyMapLoader(boolean useProvidedKeys) {
+            this.useProvidedKeys = useProvidedKeys;
+        }
+
+        public String load(Integer key) {
+            return key.toString();
+        }
+
+        public Map<Integer, String> loadAll(Collection<Integer> keys) {
+            Map<Integer, String> map = new HashMap<Integer, String>();
+
+            for (Integer key : getKeysToLoad(keys)) {
+                map.put(key, load(key));
+            }
+
+            return map;
+        }
+
+        private Iterable<Integer> getKeysToLoad(Collection<Integer> keys) {
+            if (useProvidedKeys) {
+                return keys;
+            }
+            return loadAllKeys();
+        }
+
+        public Iterable<Integer> loadAllKeys() {
+            return Lists.newArrayList(KEYS_TO_LOAD);
+        }
+    }
+
+}


### PR DESCRIPTION
Contract of MapLoader.loadAll(keys) defines exactly which items should be loaded from the map store.
Loading other items may lead to duplications in the map and to wasted resources in form of increased memory usage, load time and replication costs.
This fix makes loadAll failing fast if keys other than the given ones are loaded.

Fixes #11462