### PR TITLE
Added unified split-brain healing to ReplicatedMap

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -456,6 +456,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     replicatedMapConfigBuilder.addPropertyValue("listenerConfigs", listeners);
                 } else if ("quorum-ref".equals(nodeName)) {
                     replicatedMapConfigBuilder.addPropertyValue("quorumName", getTextContent(childNode));
+                } else if ("merge-policy".equals(nodeName)) {
+                    handleMergePolicyConfig(childNode, replicatedMapConfigBuilder);
                 }
             }
             replicatedMapManagedMap.put(name, replicatedMapConfigBuilder.getBeanDefinition());

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -1568,6 +1568,7 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
                                 </xs:sequence>
                                 <xs:attribute name="name" type="xs:string" use="optional" default="default"/>
                                 <xs:attribute name="in-memory-format" type="in-memory-format" use="optional"

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1041,11 +1041,17 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig("replicatedMap");
         assertNotNull(replicatedMapConfig);
         assertEquals("replicatedMap", replicatedMapConfig.getName());
+        assertEquals(InMemoryFormat.OBJECT, replicatedMapConfig.getInMemoryFormat());
         assertEquals(200, replicatedMapConfig.getReplicationDelayMillis());
         assertEquals(16, replicatedMapConfig.getConcurrencyLevel());
-        assertEquals(InMemoryFormat.OBJECT, replicatedMapConfig.getInMemoryFormat());
-        assertFalse(replicatedMapConfig.isStatisticsEnabled());
         assertFalse(replicatedMapConfig.isAsyncFillup());
+        assertFalse(replicatedMapConfig.isStatisticsEnabled());
+        assertEquals("my-quorum", replicatedMapConfig.getQuorumName());
+
+        MergePolicyConfig mergePolicyConfig = replicatedMapConfig.getMergePolicyConfig();
+        assertNotNull(mergePolicyConfig);
+        assertEquals("PassThroughMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(2342, mergePolicyConfig.getBatchSize());
 
         replicatedMapConfig.getListenerConfigs();
         for (ListenerConfig listener : replicatedMapConfig.getListenerConfigs()) {

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -512,6 +512,7 @@
                     <hz:message-listener class-name="com.hazelcast.spring.DummyMessageListener"/>
                 </hz:message-listeners>
             </hz:topic>
+
             <hz:replicatedmap name="replicatedMap" replication-delay-millis="200" async-fillup="false"
                               concurrency-level="16" statistics-enabled="false" in-memory-format="OBJECT">
                 <hz:entry-listeners>
@@ -519,7 +520,9 @@
                     <hz:entry-listener implementation="dummyEntryListener" local="true"/>
                 </hz:entry-listeners>
                 <hz:quorum-ref>my-quorum</hz:quorum-ref>
+                <hz:merge-policy batch-size="2342">PassThroughMergePolicy</hz:merge-policy>
             </hz:replicatedmap>
+
             <hz:listeners>
                 <hz:listener class-name="com.hazelcast.spring.DummyMembershipListener"/>
                 <hz:listener implementation="dummyMembershipListener"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -173,13 +173,15 @@ public class ConfigXmlGenerator {
     @SuppressWarnings("deprecation")
     private static void replicatedMapConfigXmlGenerator(XmlGenerator gen, Config config) {
         for (ReplicatedMapConfig r : config.getReplicatedMapConfigs().values()) {
+            MergePolicyConfig mergePolicyConfig = r.getMergePolicyConfig();
             gen.open("replicatedmap", "name", r.getName())
                     .node("in-memory-format", r.getInMemoryFormat())
                     .node("concurrency-level", r.getConcurrencyLevel())
                     .node("replication-delay-millis", r.getReplicationDelayMillis())
                     .node("async-fillup", r.isAsyncFillup())
+                    .node("statistics-enabled", r.isStatisticsEnabled())
                     .node("quorum-ref", r.getQuorumName())
-                    .node("statistics-enabled", r.isStatisticsEnabled());
+                    .node("merge-policy", mergePolicyConfig.getPolicy(), "batch-size", mergePolicyConfig.getBatchSize());
 
             if (!r.getListenerConfigs().isEmpty()) {
                 gen.open("entry-listeners");

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -30,10 +30,12 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableList;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableList;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.ReplicatedMap}
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versioned {
 
     /**
@@ -68,7 +70,7 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
     private transient ScheduledExecutorService replicatorExecutorService;
     private boolean asyncFillup = DEFAULT_ASNYC_FILLUP;
     private boolean statisticsEnabled = true;
-    private String mergePolicy = DEFAULT_MERGE_POLICY;
+    private MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
 
     private List<ListenerConfig> listenerConfigs;
 
@@ -95,7 +97,7 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         this.listenerConfigs = new ArrayList<ListenerConfig>(replicatedMapConfig.getListenerConfigs());
         this.asyncFillup = replicatedMapConfig.asyncFillup;
         this.statisticsEnabled = replicatedMapConfig.statisticsEnabled;
-        this.mergePolicy = replicatedMapConfig.mergePolicy;
+        this.mergePolicyConfig = replicatedMapConfig.mergePolicyConfig;
         this.quorumName = replicatedMapConfig.quorumName;
     }
 
@@ -309,26 +311,6 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
     }
 
     /**
-     * Gets the replicated map merge policy {@link com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy}
-     *
-     * @return the updated replicated map configuration
-     */
-    public String getMergePolicy() {
-        return mergePolicy;
-    }
-
-    /**
-     * Sets the replicated map merge policy {@link com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy}
-     *
-     * @param mergePolicy the replicated map merge policy to set
-     * @return the updated replicated map configuration
-     */
-    public ReplicatedMapConfig setMergePolicy(String mergePolicy) {
-        this.mergePolicy = mergePolicy;
-        return this;
-    }
-
-    /**
      * Returns the quorum name for operations.
      *
      * @return the quorum name
@@ -348,6 +330,47 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         return this;
     }
 
+    /**
+     * Gets the replicated map merge policy {@link com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy}
+     *
+     * @return the updated replicated map configuration
+     * @deprecated since 3.10, please use {@link #getMergePolicyConfig()} and {@link MergePolicyConfig#getPolicy()}
+     */
+    public String getMergePolicy() {
+        return mergePolicyConfig.getPolicy();
+    }
+
+    /**
+     * Sets the replicated map merge policy {@link com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy}
+     *
+     * @param mergePolicy the replicated map merge policy to set
+     * @return the updated replicated map configuration
+     * @deprecated since 3.10, please use {@link #setMergePolicyConfig(MergePolicyConfig)}
+     */
+    public ReplicatedMapConfig setMergePolicy(String mergePolicy) {
+        this.mergePolicyConfig.setPolicy(mergePolicy);
+        return this;
+    }
+
+    /**
+     * Gets the {@link MergePolicyConfig} for this replicated map.
+     *
+     * @return the {@link MergePolicyConfig} for this replicated map
+     */
+    public MergePolicyConfig getMergePolicyConfig() {
+        return mergePolicyConfig;
+    }
+
+    /**
+     * Sets the {@link MergePolicyConfig} for this replicated map.
+     *
+     * @return the updated replicated map configuration
+     */
+    public ReplicatedMapConfig setMergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
+        this.mergePolicyConfig = checkNotNull(mergePolicyConfig, "mergePolicyConfig cannot be null!");
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ReplicatedMapConfig{"
@@ -357,8 +380,8 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
                 + ", replicationDelayMillis=" + replicationDelayMillis
                 + ", asyncFillup=" + asyncFillup
                 + ", statisticsEnabled=" + statisticsEnabled
-                + ", mergePolicy='" + mergePolicy + '\''
                 + ", quorumName='" + quorumName + '\''
+                + ", mergePolicyConfig='" + mergePolicyConfig + '\''
                 + '}';
     }
 
@@ -378,10 +401,15 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         out.writeUTF(inMemoryFormat.name());
         out.writeBoolean(asyncFillup);
         out.writeBoolean(statisticsEnabled);
-        out.writeUTF(mergePolicy);
+        // RU_COMPAT_3_9
+        if (out.getVersion().isLessThan(Versions.V3_10)) {
+            out.writeUTF(mergePolicyConfig.getPolicy());
+        }
         writeNullableList(listenerConfigs, out);
+        // RU_COMPAT_3_9
         if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             out.writeUTF(quorumName);
+            out.writeObject(mergePolicyConfig);
         }
     }
 
@@ -391,10 +419,15 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
         asyncFillup = in.readBoolean();
         statisticsEnabled = in.readBoolean();
-        mergePolicy = in.readUTF();
+        // RU_COMPAT_3_9
+        if (in.getVersion().isLessThan(Versions.V3_10)) {
+            mergePolicyConfig.setPolicy(in.readUTF());
+        }
         listenerConfigs = readNullableList(in);
+        // RU_COMPAT_3_9
         if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             quorumName = in.readUTF();
+            mergePolicyConfig = in.readObject();
         }
     }
 
@@ -421,10 +454,10 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         if (inMemoryFormat != that.inMemoryFormat) {
             return false;
         }
-        if (mergePolicy != null ? !mergePolicy.equals(that.mergePolicy) : that.mergePolicy != null) {
+        if (quorumName != null ? !quorumName.equals(that.quorumName) : that.quorumName != null) {
             return false;
         }
-        if (quorumName != null ? !quorumName.equals(that.quorumName) : that.quorumName != null) {
+        if (mergePolicyConfig != null ? !mergePolicyConfig.equals(that.mergePolicyConfig) : that.mergePolicyConfig != null) {
             return false;
         }
         return listenerConfigs != null ? listenerConfigs.equals(that.listenerConfigs) : that.listenerConfigs == null;
@@ -437,9 +470,9 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         result = 31 * result + (inMemoryFormat != null ? inMemoryFormat.hashCode() : 0);
         result = 31 * result + (asyncFillup ? 1 : 0);
         result = 31 * result + (statisticsEnabled ? 1 : 0);
-        result = 31 * result + (mergePolicy != null ? mergePolicy.hashCode() : 0);
         result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
         result = 31 * result + (quorumName != null ? quorumName.hashCode() : 0);
+        result = 31 * result + (mergePolicyConfig != null ? mergePolicyConfig.hashCode() : 0);
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
@@ -69,12 +69,17 @@ class ReplicatedMapConfigReadOnly extends ReplicatedMapConfig {
     }
 
     @Override
+    public ReplicatedMapConfig setQuorumName(String quorumName) {
+        throw throwReadOnly();
+    }
+
+    @Override
     public ReplicatedMapConfig setMergePolicy(String mergePolicy) {
         throw throwReadOnly();
     }
 
     @Override
-    public ReplicatedMapConfig setQuorumName(String quorumName) {
+    public ReplicatedMapConfig setMergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
         throw throwReadOnly();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -70,6 +70,7 @@ import static com.hazelcast.config.XmlElements.COUNT_DOWN_LATCH;
 import static com.hazelcast.config.XmlElements.DURABLE_EXECUTOR_SERVICE;
 import static com.hazelcast.config.XmlElements.EVENT_JOURNAL;
 import static com.hazelcast.config.XmlElements.EXECUTOR_SERVICE;
+import static com.hazelcast.config.XmlElements.FLAKE_ID_GENERATOR;
 import static com.hazelcast.config.XmlElements.GROUP;
 import static com.hazelcast.config.XmlElements.HOT_RESTART_PERSISTENCE;
 import static com.hazelcast.config.XmlElements.IMPORT;
@@ -90,7 +91,6 @@ import static com.hazelcast.config.XmlElements.PARTITION_GROUP;
 import static com.hazelcast.config.XmlElements.PROPERTIES;
 import static com.hazelcast.config.XmlElements.QUEUE;
 import static com.hazelcast.config.XmlElements.QUORUM;
-import static com.hazelcast.config.XmlElements.FLAKE_ID_GENERATOR;
 import static com.hazelcast.config.XmlElements.RELIABLE_TOPIC;
 import static com.hazelcast.config.XmlElements.REPLICATED_MAP;
 import static com.hazelcast.config.XmlElements.RINGBUFFER;
@@ -1224,8 +1224,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             } else if ("in-memory-format".equals(nodeName)) {
                 replicatedMapConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
             } else if ("replication-delay-millis".equals(nodeName)) {
-                replicatedMapConfig.setReplicationDelayMillis(getIntegerValue("replication-delay-millis"
-                        , value));
+                replicatedMapConfig.setReplicationDelayMillis(getIntegerValue("replication-delay-millis", value));
             } else if ("async-fillup".equals(nodeName)) {
                 replicatedMapConfig.setAsyncFillup(getBooleanValue(value));
             } else if ("statistics-enabled".equals(nodeName)) {
@@ -1241,7 +1240,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                     }
                 }
             } else if ("merge-policy".equals(nodeName)) {
-                replicatedMapConfig.setMergePolicy(value);
+                MergePolicyConfig mergePolicyConfig = createMergePolicyConfig(n);
+                replicatedMapConfig.setMergePolicyConfig(mergePolicyConfig);
             } else if ("quorum-ref".equals(nodeName)) {
                 replicatedMapConfig.setQuorumName(value);
             }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
@@ -22,8 +22,7 @@ import com.hazelcast.nio.Address;
 /**
  * Thrown when {@link com.hazelcast.core.HazelcastInstance#getReplicatedMap(String)} is invoked on a lite member.
  */
-public class ReplicatedMapCantBeCreatedOnLiteMemberException
-        extends HazelcastException {
+public class ReplicatedMapCantBeCreatedOnLiteMemberException extends HazelcastException {
 
     public ReplicatedMapCantBeCreatedOnLiteMemberException(Address address) {
         this("Can't create replicated map instance on " + address);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/PartitionContainer.java
@@ -18,29 +18,26 @@ package com.hazelcast.replicatedmap.impl;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ReplicatedMapConfig;
-import com.hazelcast.replicatedmap.impl.record.AbstractReplicatedRecordStore;
 import com.hazelcast.replicatedmap.impl.record.DataReplicatedRecordStore;
 import com.hazelcast.replicatedmap.impl.record.ObjectReplicatedRecordStorage;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
-import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
+
 /**
- * Contains the record storage for the replicated maps which are actual place where the data is stored.
+ * Contains the record storage for the replicated maps which are the actual place where the data is stored.
  */
 public class PartitionContainer {
 
-    private final ReplicatedMapService service;
-
-    private final int partitionId;
-
-    private final ConcurrentHashMap<String, ReplicatedRecordStore> replicatedStorages = initReplicatedRecordStoreMapping();
-
+    private final ConcurrentHashMap<String, ReplicatedRecordStore> replicatedRecordStores = initReplicatedRecordStoreMapping();
     private final ConstructorFunction<String, ReplicatedRecordStore> constructor = buildConstructorFunction();
 
+    private final ReplicatedMapService service;
+    private final int partitionId;
 
     public PartitionContainer(ReplicatedMapService service, int partitionId) {
         this.service = service;
@@ -58,54 +55,47 @@ public class PartitionContainer {
             public ReplicatedRecordStore createNew(String name) {
                 ReplicatedMapConfig replicatedMapConfig = service.getReplicatedMapConfig(name);
                 InMemoryFormat inMemoryFormat = replicatedMapConfig.getInMemoryFormat();
-                AbstractReplicatedRecordStore replicatedRecordStorage = null;
                 switch (inMemoryFormat) {
                     case OBJECT:
-                        replicatedRecordStorage = new ObjectReplicatedRecordStorage(name, service, partitionId);
-                        break;
+                        return new ObjectReplicatedRecordStorage(name, service, partitionId);
                     case BINARY:
-                        replicatedRecordStorage = new DataReplicatedRecordStore(name, service, partitionId);
-                        break;
+                        return new DataReplicatedRecordStore(name, service, partitionId);
                     case NATIVE:
                         throw new IllegalStateException("Native memory not yet supported for replicated map");
                     default:
-                        throw new IllegalStateException("Unhandled in memory format:" + inMemoryFormat);
+                        throw new IllegalStateException("Unsupported in memory format: " + inMemoryFormat);
                 }
-                return replicatedRecordStorage;
             }
         };
     }
 
     public boolean isEmpty() {
-        return replicatedStorages.isEmpty();
+        return replicatedRecordStores.isEmpty();
     }
 
     public ConcurrentMap<String, ReplicatedRecordStore> getStores() {
-        return replicatedStorages;
+        return replicatedRecordStores;
     }
 
     public ReplicatedRecordStore getOrCreateRecordStore(String name) {
-        ReplicatedRecordStore replicatedRecordStore = ConcurrencyUtil
-                .getOrPutSynchronized(replicatedStorages, name, replicatedStorages, constructor);
-        return replicatedRecordStore;
+        return getOrPutSynchronized(replicatedRecordStores, name, replicatedRecordStores, constructor);
     }
 
     public ReplicatedRecordStore getRecordStore(String name) {
-        return replicatedStorages.get(name);
+        return replicatedRecordStores.get(name);
     }
 
     public void shutdown() {
-        for (ReplicatedRecordStore replicatedRecordStore : replicatedStorages.values()) {
+        for (ReplicatedRecordStore replicatedRecordStore : replicatedRecordStores.values()) {
             replicatedRecordStore.destroy();
         }
-        replicatedStorages.clear();
+        replicatedRecordStores.clear();
     }
 
     public void destroy(String name) {
-        ReplicatedRecordStore replicatedRecordStore = replicatedStorages.remove(name);
+        ReplicatedRecordStore replicatedRecordStore = replicatedRecordStores.remove(name);
         if (replicatedRecordStore != null) {
             replicatedRecordStore.destroy();
         }
-
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
@@ -57,11 +57,12 @@ import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME
  */
 public class ReplicatedMapEventPublishingService implements EventPublishingService {
 
+    private final HashMap<String, Boolean> statisticsMap = new HashMap<String, Boolean>();
+
     private final ReplicatedMapService replicatedMapService;
     private final NodeEngine nodeEngine;
     private final Config config;
     private final EventService eventService;
-    private final HashMap<String, Boolean> statisticsMap = new HashMap<String, Boolean>();
 
     public ReplicatedMapEventPublishingService(ReplicatedMapService replicatedMapService) {
         this.replicatedMapService = replicatedMapService;
@@ -122,7 +123,7 @@ public class ReplicatedMapEventPublishingService implements EventPublishingServi
                     entryListener.mapCleared(mapEvent);
                     break;
                 default:
-                    throw new IllegalArgumentException("event type " + type + " not supported");
+                    throw new IllegalArgumentException("Unsupported EntryEventType " + type);
             }
         }
     }
@@ -148,8 +149,7 @@ public class ReplicatedMapEventPublishingService implements EventPublishingServi
 
     public void fireMapClearedEvent(int deletedEntrySize, String name) {
         EventService eventService = nodeEngine.getEventService();
-        Collection<EventRegistration> registrations = eventService.getRegistrations(
-                SERVICE_NAME, name);
+        Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, name);
         if (registrations.isEmpty()) {
             return;
         }
@@ -201,8 +201,8 @@ public class ReplicatedMapEventPublishingService implements EventPublishingServi
             } else {
                 testValue = value;
             }
-            InternalSerializationService serializationService =
-                    (InternalSerializationService) nodeEngine.getSerializationService();
+            InternalSerializationService serializationService
+                    = (InternalSerializationService) nodeEngine.getSerializationService();
             queryEntry = new QueryEntry(serializationService, key, testValue, null);
         }
         return filter == null || filter.eval(queryEntry != null ? queryEntry : key);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -55,6 +55,7 @@ import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
@@ -131,7 +132,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     }
 
     @Override
-    public void init(final NodeEngine nodeEngine, Properties properties) {
+    public void init(NodeEngine nodeEngine, Properties properties) {
         if (config.isLiteMember()) {
             return;
         }
@@ -360,9 +361,9 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
             return null;
         }
 
-        final PartitionContainer container = partitionContainers[event.getPartitionId()];
-        final ReplicationOperation operation = new ReplicationOperation(nodeEngine.getSerializationService(),
-                container, event.getPartitionId());
+        PartitionContainer container = partitionContainers[event.getPartitionId()];
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        ReplicationOperation operation = new ReplicationOperation(serializationService, container, event.getPartitionId());
         operation.setService(this);
         return operation.isEmpty() ? null : operation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableEntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableEntryEvent.java
@@ -82,7 +82,7 @@ public class ReplicatedMapPortableEntryEvent implements Portable {
     public void writePortable(PortableWriter writer) throws IOException {
         writer.writeInt("e", eventType.getType());
         writer.writeUTF("u", uuid);
-        final ObjectDataOutput out = writer.getRawDataOutput();
+        ObjectDataOutput out = writer.getRawDataOutput();
         out.writeData(key);
         out.writeData(value);
         out.writeData(oldValue);
@@ -92,7 +92,7 @@ public class ReplicatedMapPortableEntryEvent implements Portable {
     public void readPortable(PortableReader reader) throws IOException {
         eventType = EntryEventType.getByType(reader.readInt("e"));
         uuid = reader.readUTF("u");
-        final ObjectDataInput in = reader.getRawDataInput();
+        ObjectDataInput in = reader.getRawDataInput();
         key = in.readData();
         value = in.readData();
         oldValue = in.readData();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.MutatingOperation;
 
@@ -77,14 +78,14 @@ public class ClearOperation extends AbstractNamedSerializableOperation implement
     }
 
     private void replicateClearOperation(long version) {
-        final OperationService operationService = getNodeEngine().getOperationService();
+        OperationService operationService = getNodeEngine().getOperationService();
         Collection<Address> members = getMemberAddresses();
         for (Address address : members) {
-            ClearOperation clearOperation = new ClearOperation(mapName, false, version);
-            clearOperation.setPartitionId(getPartitionId());
-            clearOperation.setValidateTarget(false);
+            Operation op = new ClearOperation(mapName, false, version)
+                    .setPartitionId(getPartitionId())
+                    .setValidateTarget(false);
             operationService
-                    .createInvocationBuilder(getServiceName(), clearOperation, address)
+                    .createInvocationBuilder(getServiceName(), op, address)
                     .setTryCount(INVOCATION_TRY_COUNT)
                     .invoke();
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EntrySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EntrySetOperation.java
@@ -36,6 +36,7 @@ import java.util.Map;
 public class EntrySetOperation extends AbstractNamedSerializableOperation implements ReadonlyOperation {
 
     private String name;
+
     private transient Object response;
 
     public EntrySetOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/IsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/IsEmptyOperation.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 public class IsEmptyOperation extends AbstractNamedSerializableOperation implements ReadonlyOperation {
 
     private String name;
+
     private transient boolean response;
 
     public IsEmptyOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/KeySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/KeySetOperation.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class KeySetOperation extends AbstractNamedSerializableOperation implements ReadonlyOperation {
 
     private String name;
+
     private transient Object response;
 
     public KeySetOperation() {
@@ -46,7 +47,7 @@ public class KeySetOperation extends AbstractNamedSerializableOperation implemen
     public void run() throws Exception {
         ReplicatedMapService service = getService();
         Collection<ReplicatedRecordStore> stores = service.getAllReplicatedRecordStores(name);
-        List keys = new ArrayList();
+        List<Object> keys = new ArrayList<Object>();
         for (ReplicatedRecordStore store : stores) {
             keys.addAll(store.keySet(false));
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -16,66 +16,87 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
-import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
-import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
-import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
 
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
- * Merges two replicated map entries with the given merge policy after the split-brain syndrome is recovered.
+ * Contains multiple merging entries for split-brain healing with a {@link SplitBrainMergePolicy}.
+ *
+ * @since 3.10
  */
 public class MergeOperation extends AbstractNamedSerializableOperation {
 
     private String name;
-    private Object key;
-    private ReplicatedMapEntryView entryView;
-    private ReplicatedMapMergePolicy policy;
+    private List<SplitBrainMergeEntryView<Object, Object>> mergeEntries;
+    private SplitBrainMergePolicy mergePolicy;
+
+    private transient boolean hasMergedValues;
 
     public MergeOperation() {
     }
 
-    public MergeOperation(String name, Object key, ReplicatedMapEntryView entryView, ReplicatedMapMergePolicy policy) {
+    MergeOperation(String name, List<SplitBrainMergeEntryView<Object, Object>> mergeEntries, SplitBrainMergePolicy policy) {
         this.name = name;
-        this.key = key;
-        this.entryView = entryView;
-        this.policy = policy;
-    }
-
-    @Override
-    public void run() throws Exception {
-        ReplicatedMapService service = getService();
-        ReplicatedRecordStore store = service.getReplicatedRecordStore(name, true, key);
-        store.merge(key, entryView, policy);
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-        IOUtil.writeObject(out, key);
-        out.writeObject(entryView);
-        out.writeObject(policy);
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
-        key = IOUtil.readObject(in);
-        entryView = in.readObject();
-        policy = in.readObject();
-    }
-
-    @Override
-    public int getId() {
-        return ReplicatedMapDataSerializerHook.MERGE;
+        this.mergeEntries = mergeEntries;
+        this.mergePolicy = policy;
     }
 
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public void run() {
+        ReplicatedMapService service = getService();
+        ReplicatedRecordStore recordStore = service.getReplicatedRecordStore(name, true, getPartitionId());
+
+        for (SplitBrainMergeEntryView<Object, Object> mergingEntry : mergeEntries) {
+            if (recordStore.merge(mergingEntry, mergePolicy)) {
+                hasMergedValues = true;
+            }
+        }
+    }
+
+    @Override
+    public Object getResponse() {
+        return hasMergedValues;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(name);
+        out.writeInt(mergeEntries.size());
+        for (SplitBrainMergeEntryView<Object, Object> mergeEntry : mergeEntries) {
+            out.writeObject(mergeEntry);
+        }
+        out.writeObject(mergePolicy);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        name = in.readUTF();
+        mergeEntries = new LinkedList<SplitBrainMergeEntryView<Object, Object>>();
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            SplitBrainMergeEntryView<Object, Object> mergeEntry = in.readObject();
+            mergeEntries.add(mergeEntry);
+        }
+        mergePolicy = in.readObject();
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.MERGE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Inserts the merging entries for all partitions of a member via locally invoked {@link MergeOperation}.
+ *
+ * @since 3.10
+ */
+public class MergeOperationFactory extends PartitionAwareOperationFactory {
+
+    private String name;
+    private List<SplitBrainMergeEntryView<Object, Object>>[] mergeEntries;
+    private SplitBrainMergePolicy policy;
+
+    public MergeOperationFactory() {
+    }
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public MergeOperationFactory(String name, int[] partitions, List<SplitBrainMergeEntryView<Object, Object>>[] mergeEntries,
+                                 SplitBrainMergePolicy policy) {
+        this.name = name;
+        this.partitions = partitions;
+        this.mergeEntries = mergeEntries;
+        this.policy = policy;
+    }
+
+    @Override
+    public Operation createPartitionOperation(int partitionId) {
+        for (int i = 0; i < partitions.length; i++) {
+            if (partitions[i] == partitionId) {
+                return new MergeOperation(name, mergeEntries[i], policy);
+            }
+        }
+        throw new IllegalArgumentException("Unknown partitionId " + partitionId + " (" + Arrays.toString(partitions) + ")");
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+        out.writeIntArray(partitions);
+        for (List<SplitBrainMergeEntryView<Object, Object>> entry : mergeEntries) {
+            out.writeInt(entry.size());
+            for (SplitBrainMergeEntryView<Object, Object> mergeEntry : entry) {
+                out.writeObject(mergeEntry);
+            }
+        }
+        out.writeObject(policy);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+        partitions = in.readIntArray();
+        //noinspection unchecked
+        mergeEntries = new List[partitions.length];
+        for (int i = 0; i < partitions.length; i++) {
+            List<SplitBrainMergeEntryView<Object, Object>> list = new LinkedList<SplitBrainMergeEntryView<Object, Object>>();
+            int size = in.readInt();
+            for (int j = 0; j < size; j++) {
+                SplitBrainMergeEntryView<Object, Object> mergeEntry = in.readObject();
+                list.add(mergeEntry);
+            }
+            mergeEntries[i] = list;
+        }
+        policy = in.readObject();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.MERGE_FACTORY;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.replicatedmap.impl.ReplicatedMapEventPublishingService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.client.ReplicatedMapEntries;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -42,7 +43,6 @@ public class PutAllOperation extends AbstractNamedSerializableOperation implemen
     private String name;
     private ReplicatedMapEntries entries;
 
-    @SuppressWarnings("unused")
     public PutAllOperation() {
     }
 
@@ -80,11 +80,10 @@ public class PutAllOperation extends AbstractNamedSerializableOperation implemen
             if (address.equals(getNodeEngine().getThisAddress())) {
                 continue;
             }
-            ReplicateUpdateOperation updateOperation = new ReplicateUpdateOperation(name, key, value, 0, response, false,
-                    getCallerAddress());
-            updateOperation.setPartitionId(getPartitionId());
-            updateOperation.setValidateTarget(false);
-            operationService.invokeOnTarget(getServiceName(), updateOperation, address);
+            Operation op = new ReplicateUpdateOperation(name, key, value, 0, response, false, getCallerAddress())
+                    .setPartitionId(getPartitionId())
+                    .setValidateTarget(false);
+            operationService.invokeOnTarget(getServiceName(), op, address);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
@@ -33,7 +33,6 @@ public class PutAllOperationFactory implements OperationFactory {
     private String name;
     private ReplicatedMapEntries entries;
 
-    @SuppressWarnings("unused")
     public PutAllOperationFactory() {
     }
 
@@ -44,9 +43,8 @@ public class PutAllOperationFactory implements OperationFactory {
 
     @Override
     public Operation createOperation() {
-        PutAllOperation putAllOperation = new PutAllOperation(name, entries);
-        putAllOperation.setServiceName(ReplicatedMapService.SERVICE_NAME);
-        return putAllOperation;
+        return new PutAllOperation(name, entries)
+                .setServiceName(ReplicatedMapService.SERVICE_NAME);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -49,7 +49,7 @@ public class RemoveOperation extends AbstractReplicatedMapOperation implements P
         service = getService();
         ReplicatedRecordStore store = service.getReplicatedRecordStore(name, true, getPartitionId());
         Object removed = store.remove(key);
-        this.oldValue = getNodeEngine().toData(removed);
+        oldValue = getNodeEngine().toData(removed);
         response = new VersionResponsePair(removed, store.getVersion());
         Address thisAddress = getNodeEngine().getThisAddress();
         if (!getCallerAddress().equals(thisAddress)) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -32,27 +32,21 @@ import java.util.concurrent.TimeUnit;
 /**
  * Replicates the update happened on the partition owner to the other nodes.
  */
-public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation
-        implements PartitionAwareOperation {
+public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation implements PartitionAwareOperation {
 
-    VersionResponsePair response;
-    boolean isRemove;
-    String name;
-    Data dataKey;
-    Data dataValue;
-    long ttl;
-    Address origin;
+    private VersionResponsePair response;
+    private boolean isRemove;
+    private String name;
+    private Data dataKey;
+    private Data dataValue;
+    private long ttl;
+    private Address origin;
 
     public ReplicateUpdateOperation() {
     }
 
-    public ReplicateUpdateOperation(String name,
-                                    Data dataKey,
-                                    Data dataValue,
-                                    long ttl,
-                                    VersionResponsePair response,
-                                    boolean isRemove,
-                                    Address origin) {
+    public ReplicateUpdateOperation(String name, Data dataKey, Data dataValue, long ttl, VersionResponsePair response,
+                                    boolean isRemove, Address origin) {
         this.name = name;
         this.dataKey = dataKey;
         this.dataValue = dataValue;
@@ -71,8 +65,8 @@ public class ReplicateUpdateOperation extends AbstractNamedSerializableOperation
         if (currentVersion >= updateVersion) {
             ILogger logger = getLogger();
             if (logger.isFineEnabled()) {
-                logger.fine("Rejecting stale update received for replicated map: " + name + "  partitionId="
-                        + getPartitionId() + " current version: " + currentVersion + " update version: " + updateVersion);
+                logger.fine("Rejecting stale update received for replicated map '" + name + "' (partitionId " + getPartitionId()
+                        + ") (current version " + currentVersion + ") (update version " + updateVersion + ")");
             }
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -33,8 +33,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This operation will update the local record store with the update received from local/remote partition owner.
  */
-public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperation
-        implements PartitionAwareOperation {
+public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperation implements PartitionAwareOperation {
 
     private String name;
     private long callId;
@@ -67,10 +66,9 @@ public class ReplicateUpdateToCallerOperation extends AbstractSerializableOperat
         long updateVersion = response.getVersion();
         if (currentVersion >= updateVersion) {
             if (logger.isFineEnabled()) {
-                logger.fine("Rejecting stale update received for replicated map: " + name + "  partitionId="
-                        + getPartitionId() + " current version: " + currentVersion + " update version: " + updateVersion);
+                logger.fine("Rejecting stale update received for replicated map '" + name + "' (partitionId " + getPartitionId()
+                        + ") (current version " + currentVersion + ") (update version " + updateVersion + ")");
             }
-
             return;
         }
         Object key = store.marshall(dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
@@ -47,7 +47,7 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
     public static final int PUT = 6;
     public static final int REMOVE = 7;
     public static final int SIZE = 8;
-    public static final int MERGE = 9;
+    public static final int LEGACY_MERGE = 9;
     public static final int VERSION_RESPONSE_PAIR = 10;
     public static final int GET = 11;
     public static final int CHECK_REPLICA_VERSION = 12;
@@ -68,8 +68,10 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
     public static final int LATEST_UPDATE_MERGE_POLICY = 27;
     public static final int PASS_THROUGH_MERGE_POLICY = 28;
     public static final int PUT_IF_ABSENT_MERGE_POLICY = 29;
+    public static final int MERGE_FACTORY = 30;
+    public static final int MERGE = 31;
 
-    private static final int LEN = PUT_IF_ABSENT_MERGE_POLICY + 1;
+    private static final int LEN = MERGE + 1;
 
     private static final DataSerializableFactory FACTORY = createFactoryInternal();
 
@@ -133,10 +135,10 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
                 return new SizeOperation();
             }
         };
-        constructors[MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+        constructors[LEGACY_MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MergeOperation();
+                return new LegacyMergeOperation();
             }
         };
         constructors[VERSION_RESPONSE_PAIR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
@@ -257,6 +259,18 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return PutIfAbsentMapMergePolicy.INSTANCE;
+            }
+        };
+        constructors[MERGE_FACTORY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MergeOperationFactory();
+            }
+        };
+        constructors[MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MergeOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
@@ -59,9 +59,8 @@ public class ReplicationOperation extends AbstractSerializableOperation {
     public void run() throws Exception {
         ILogger logger = getLogger();
         if (logger.isFineEnabled()) {
-            logger.fine("Moving partitionId=" + getPartitionId()
-                    + " to the new owner: " + getNodeEngine().getThisAddress()
-                    + " from: " + getCallerAddress());
+            logger.fine("Moving replicated map (partitionId " + getPartitionId() + ") from " + getCallerAddress()
+                    + " to the new owner " + getNodeEngine().getThisAddress());
         }
         ReplicatedMapService service = getService();
         if (data == null) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -50,15 +50,17 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractSerializableOp
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void run() throws Exception {
         ILogger logger = getLogger();
         if (logger.isFineEnabled()) {
-            logger.fine("Syncing " + recordSet.size() + " records and version: " + version + " for map: " + name + " partitionId="
-                    + getPartitionId() + " from: " + getCallerAddress() + " to: " + getNodeEngine().getThisAddress());
+            logger.fine("Syncing " + recordSet.size() + " records (version " + version
+                    + ") for replicated map '" + name + "' (partitionId " + getPartitionId()
+                    + ") from " + getCallerAddress() + " to " + getNodeEngine().getThisAddress());
         }
         ReplicatedMapService service = getService();
-        AbstractReplicatedRecordStore store = (AbstractReplicatedRecordStore) service
-                .getReplicatedRecordStore(name, true, getPartitionId());
+        AbstractReplicatedRecordStore store
+                = (AbstractReplicatedRecordStore) service.getReplicatedRecordStore(name, true, getPartitionId());
         InternalReplicatedMapStorage<K, V> newStorage = new InternalReplicatedMapStorage<K, V>();
         for (RecordMigrationInfo record : recordSet) {
             K key = (K) store.marshall(record.getKey());

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/VersionResponsePair.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/VersionResponsePair.java
@@ -28,8 +28,8 @@ import java.io.IOException;
  */
 public class VersionResponsePair implements IdentifiedDataSerializable {
 
-    Object response;
-    long version;
+    private Object response;
+    private long version;
 
     public VersionResponsePair() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -26,6 +26,8 @@ import com.hazelcast.replicatedmap.impl.operation.ReplicateUpdateOperation;
 import com.hazelcast.replicatedmap.impl.operation.VersionResponsePair;
 import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.util.Clock;
 
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.core.EntryEventType.EVICTED;
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
+import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
 import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
@@ -56,26 +59,27 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
 
     @Override
     public Object remove(Object key) {
-        final InternalReplicatedMapStorage<K, V> storage = getStorage();
-        final Object old = remove(storage, key);
+        InternalReplicatedMapStorage<K, V> storage = getStorage();
+        Object old = remove(storage, key);
         storage.incrementVersion();
         return old;
     }
 
     @Override
     public Object removeWithVersion(Object key, long version) {
-        final InternalReplicatedMapStorage<K, V> storage = getStorage();
-        final Object old = remove(storage, key);
+        InternalReplicatedMapStorage<K, V> storage = getStorage();
+        Object old = remove(storage, key);
         storage.setVersion(version);
         return old;
     }
 
+    @SuppressWarnings("unchecked")
     private Object remove(InternalReplicatedMapStorage<K, V> storage, Object key) {
         isNotNull(key, "key");
         long time = Clock.currentTimeMillis();
         V oldValue;
         K marshalledKey = (K) marshall(key);
-        final ReplicatedRecord current = storage.get(marshalledKey);
+        ReplicatedRecord current = storage.get(marshalledKey);
         if (current == null) {
             oldValue = null;
         } else {
@@ -90,6 +94,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void evict(Object key) {
         isNotNull(key, "key");
         long time = Clock.currentTimeMillis();
@@ -140,20 +145,21 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
 
     @Override
     public Object put(Object key, Object value, long ttl, TimeUnit timeUnit, boolean incrementHits) {
-        final InternalReplicatedMapStorage<K, V> storage = getStorage();
-        final Object old = put(storage, key, value, ttl, timeUnit, incrementHits);
+        InternalReplicatedMapStorage<K, V> storage = getStorage();
+        Object old = put(storage, key, value, ttl, timeUnit, incrementHits);
         storage.incrementVersion();
         return old;
     }
 
     @Override
     public Object putWithVersion(Object key, Object value, long ttl, TimeUnit timeUnit, boolean incrementHits, long version) {
-        final InternalReplicatedMapStorage<K, V> storage = getStorage();
-        final Object old = put(storage, key, value, ttl, timeUnit, incrementHits);
+        InternalReplicatedMapStorage<K, V> storage = getStorage();
+        Object old = put(storage, key, value, ttl, timeUnit, incrementHits);
         storage.setVersion(version);
         return old;
     }
 
+    @SuppressWarnings("unchecked")
     private Object put(InternalReplicatedMapStorage<K, V> storage, Object key, Object value,
                        long ttl, TimeUnit timeUnit, boolean incrementHits) {
         isNotNull(key, "key");
@@ -166,8 +172,8 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         V oldValue = null;
         K marshalledKey = (K) marshall(key);
         V marshalledValue = (V) marshall(value);
-        final long ttlMillis = ttl == 0 ? 0 : timeUnit.toMillis(ttl);
-        final ReplicatedRecord<K, V> old = storage.get(marshalledKey);
+        long ttlMillis = ttl == 0 ? 0 : timeUnit.toMillis(ttl);
+        ReplicatedRecord<K, V> old = storage.get(marshalledKey);
         ReplicatedRecord<K, V> record;
         if (old == null) {
             record = buildReplicatedRecord(marshalledKey, marshalledValue, ttlMillis);
@@ -244,7 +250,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     @Override
     public Collection values(Comparator comparator) {
         InternalReplicatedMapStorage<K, V> storage = getStorage();
-        List values = new ArrayList(storage.size());
+        List<Object> values = new ArrayList<Object>(storage.size());
         for (ReplicatedRecord record : storage.values()) {
             values.add(unmarshall(record.getValue()));
         }
@@ -308,13 +314,14 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     }
 
     public void putRecords(Collection<RecordMigrationInfo> records, long version) {
-        final InternalReplicatedMapStorage<K, V> storage = getStorage();
+        InternalReplicatedMapStorage<K, V> storage = getStorage();
         for (RecordMigrationInfo record : records) {
             putRecord(storage, record);
         }
         storage.syncVersion(version);
     }
 
+    @SuppressWarnings("unchecked")
     private void putRecord(InternalReplicatedMapStorage<K, V> storage, RecordMigrationInfo record) {
         K key = (K) marshall(record.getKey());
         V value = (V) marshall(record.getValue());
@@ -334,14 +341,15 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     }
 
     @Override
-    public boolean merge(Object key, ReplicatedMapEntryView mergingEntry, ReplicatedMapMergePolicy policy) {
-        K marshalledKey = (K) marshall(key);
+    @SuppressWarnings("unchecked")
+    public Boolean merge(SplitBrainMergeEntryView<Object, Object> mergingEntry, SplitBrainMergePolicy mergePolicy) {
+        mergePolicy.setSerializationService(serializationService);
+
+        K marshalledKey = (K) marshall(mergingEntry.getKey());
         InternalReplicatedMapStorage<K, V> storage = getStorage();
         ReplicatedRecord<K, V> record = storage.get(marshalledKey);
         if (record == null) {
-            ReplicatedMapEntryView nullEntryView = new ReplicatedMapEntryView<Object, V>()
-                    .setKey(unmarshall(key));
-            V newValue = (V) policy.merge(getName(), mergingEntry, nullEntryView);
+            V newValue = (V) mergePolicy.merge(mergingEntry, null);
             if (newValue == null) {
                 return false;
             }
@@ -351,23 +359,16 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             Data dataKey = serializationService.toData(marshalledKey);
             Data dataValue = serializationService.toData(newValue);
             VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
-            sendReplicationOperation(false, getName(), dataKey, dataValue, record.getTtlMillis(), responsePair);
+            sendReplicationOperation(false, name, dataKey, dataValue, record.getTtlMillis(), responsePair);
         } else {
-            ReplicatedMapEntryView existingEntry = new ReplicatedMapEntryView<Object, Object>()
-                    .setKey(unmarshall(key))
-                    .setValue(unmarshall(record.getValueInternal()))
-                    .setCreationTime(record.getCreationTime())
-                    .setLastUpdateTime(record.getUpdateTime())
-                    .setLastAccessTime(record.getLastAccessTime())
-                    .setHits(record.getHits())
-                    .setTtl(record.getTtlMillis());
-            V newValue = (V) policy.merge(getName(), mergingEntry, existingEntry);
+            SplitBrainMergeEntryView<Object, Object> existingEntry = createSplitBrainMergeEntryView(record);
+            V newValue = (V) mergePolicy.merge(mergingEntry, existingEntry);
             if (newValue == null) {
                 storage.remove(marshalledKey, record);
                 storage.incrementVersion();
                 Data dataKey = serializationService.toData(marshalledKey);
                 VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
-                sendReplicationOperation(true, getName(), dataKey, null, record.getTtlMillis(), responsePair);
+                sendReplicationOperation(true, name, dataKey, null, record.getTtlMillis(), responsePair);
                 return false;
             }
             record.setValueInternal(newValue, record.getTtlMillis());
@@ -375,12 +376,60 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             Data dataKey = serializationService.toData(marshalledKey);
             Data dataValue = serializationService.toData(newValue);
             VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
-            sendReplicationOperation(false, getName(), dataKey, dataValue, record.getTtlMillis(), responsePair);
+            sendReplicationOperation(false, name, dataKey, dataValue, record.getTtlMillis(), responsePair);
         }
         return true;
     }
 
-    protected void sendReplicationOperation(final boolean isRemove, String name, Data key, Data value, long ttl,
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean merge(Object key, ReplicatedMapEntryView mergingEntry, ReplicatedMapMergePolicy policy) {
+        K marshalledKey = (K) marshall(key);
+        InternalReplicatedMapStorage<K, V> storage = getStorage();
+        ReplicatedRecord<K, V> existingRecord = storage.get(marshalledKey);
+        if (existingRecord == null) {
+            ReplicatedMapEntryView nullEntryView = new ReplicatedMapEntryView<Object, V>()
+                    .setKey(unmarshall(key));
+            V newValue = (V) policy.merge(name, mergingEntry, nullEntryView);
+            if (newValue == null) {
+                return false;
+            }
+            existingRecord = buildReplicatedRecord(marshalledKey, newValue, 0);
+            storage.put(marshalledKey, existingRecord);
+            storage.incrementVersion();
+            Data dataKey = serializationService.toData(marshalledKey);
+            Data dataValue = serializationService.toData(newValue);
+            VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
+            sendReplicationOperation(false, name, dataKey, dataValue, existingRecord.getTtlMillis(), responsePair);
+        } else {
+            ReplicatedMapEntryView existingEntry = new ReplicatedMapEntryView<Object, Object>()
+                    .setKey(unmarshall(key))
+                    .setValue(unmarshall(existingRecord.getValueInternal()))
+                    .setCreationTime(existingRecord.getCreationTime())
+                    .setLastUpdateTime(existingRecord.getUpdateTime())
+                    .setLastAccessTime(existingRecord.getLastAccessTime())
+                    .setHits(existingRecord.getHits())
+                    .setTtl(existingRecord.getTtlMillis());
+            V newValue = (V) policy.merge(name, mergingEntry, existingEntry);
+            if (newValue == null) {
+                storage.remove(marshalledKey, existingRecord);
+                storage.incrementVersion();
+                Data dataKey = serializationService.toData(marshalledKey);
+                VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
+                sendReplicationOperation(true, name, dataKey, null, existingRecord.getTtlMillis(), responsePair);
+                return false;
+            }
+            existingRecord.setValueInternal(newValue, existingRecord.getTtlMillis());
+            storage.incrementVersion();
+            Data dataKey = serializationService.toData(marshalledKey);
+            Data dataValue = serializationService.toData(newValue);
+            VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
+            sendReplicationOperation(false, name, dataKey, dataValue, existingRecord.getTtlMillis(), responsePair);
+        }
+        return true;
+    }
+
+    protected void sendReplicationOperation(boolean isRemove, String name, Data key, Data value, long ttl,
                                             VersionResponsePair response) {
         Collection<Member> members = nodeEngine.getClusterService().getMembers(MemberSelectors.DATA_MEMBER_SELECTOR);
         for (Member member : members) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
@@ -32,7 +32,7 @@ class EntrySetIteratorFactory<K, V> implements IteratorFactory<K, V, Map.Entry<K
     }
 
     @Override
-    public Iterator<Map.Entry<K, V>> create(final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+    public Iterator<Map.Entry<K, V>> create(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
         return new EntrySetIterator(iterator);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -31,7 +31,7 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
     }
 
     @Override
-    public Iterator<K> create(final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+    public Iterator<K> create(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
         return new KeySetIterator(iterator);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
@@ -51,7 +51,7 @@ class LazySet<K, V, R> implements Set<R> {
 
     @Override
     public Iterator<R> iterator() {
-        final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator = storage.entrySet().iterator();
+        Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator = storage.entrySet().iterator();
         return iteratorFactory.create(iterator);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedQueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedQueryEventFilter.java
@@ -35,8 +35,8 @@ public class ReplicatedQueryEventFilter extends ReplicatedEntryEventFilter {
     }
 
     public boolean eval(Object arg) {
-        final QueryableEntry entry = (QueryableEntry) arg;
-        final Data keyData = entry.getKeyData();
+        QueryableEntry entry = (QueryableEntry) arg;
+        Data keyData = entry.getKeyData();
         return (key == null || key.equals(keyData)) && predicate.apply((Map.Entry) arg);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
@@ -17,6 +17,7 @@
 package com.hazelcast.replicatedmap.impl.record;
 
 import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
+import com.hazelcast.spi.SplitBrainAwareDataContainer;
 import com.hazelcast.util.scheduler.ScheduledEntry;
 
 import java.util.Collection;
@@ -28,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This interface describes a common record store for replicated maps and their actual records
  */
-public interface ReplicatedRecordStore {
+public interface ReplicatedRecordStore extends SplitBrainAwareDataContainer<Object, Object, Boolean> {
 
     String getName();
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
@@ -31,7 +31,7 @@ class ValuesIteratorFactory<K, V> implements IteratorFactory<K, V, V> {
     }
 
     @Override
-    public Iterator<V> create(final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+    public Iterator<V> create(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
         return new ValuesIterator(iterator);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
@@ -16,15 +16,17 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.util.ConcurrencyUtil;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.nio.ClassLoaderUtil.newInstance;
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -35,8 +37,6 @@ public final class MergePolicyProvider {
     private final ConcurrentMap<String, ReplicatedMapMergePolicy> mergePolicyMap
             = new ConcurrentHashMap<String, ReplicatedMapMergePolicy>();
 
-    private final NodeEngine nodeEngine;
-
     private final ConstructorFunction<String, ReplicatedMapMergePolicy> policyConstructorFunction
             = new ConstructorFunction<String, ReplicatedMapMergePolicy>() {
         @Override
@@ -45,13 +45,17 @@ public final class MergePolicyProvider {
                 return newInstance(nodeEngine.getConfigClassLoader(), className);
             } catch (Exception e) {
                 nodeEngine.getLogger(getClass()).severe(e);
-                throw ExceptionUtil.rethrow(e);
+                throw rethrow(e);
             }
         }
     };
 
+    private final NodeEngine nodeEngine;
+    private final SplitBrainMergePolicyProvider policyProvider;
+
     public MergePolicyProvider(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
+        this.policyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
         addOutOfBoxPolicies();
     }
 
@@ -62,8 +66,23 @@ public final class MergePolicyProvider {
         mergePolicyMap.put(LatestUpdateMapMergePolicy.class.getName(), LatestUpdateMapMergePolicy.INSTANCE);
     }
 
-    public ReplicatedMapMergePolicy getMergePolicy(String className) {
+    /**
+     * Returns an instance of a merge policy by its classname.
+     * <p>
+     * First tries to resolve the classname as {@link com.hazelcast.spi.SplitBrainMergePolicy},
+     * then as {@link ReplicatedMapMergePolicy}.
+     * <p>
+     * If no merge policy matches an exception is thrown.
+     *
+     * @param className the classname of the given merge policy
+     * @return an instance of the merge policy class
+     */
+    public Object getMergePolicy(String className) {
         checkNotNull(className, "Class name is mandatory!");
-        return ConcurrencyUtil.getOrPutIfAbsent(mergePolicyMap, className, policyConstructorFunction);
+        try {
+            return policyProvider.getMergePolicy(className);
+        } catch (InvalidConfigurationException e) {
+            return getOrPutIfAbsent(mergePolicyMap, className, policyConstructorFunction);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
@@ -29,6 +29,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskDescriptor;
 import com.hazelcast.spi.SplitBrainMergeEntryView;
 
@@ -124,6 +125,17 @@ public final class SplitBrainEntryViews {
                 .setExpirationTime(record.getExpirationTime())
                 .setHits(record.getAccessHit())
                 .setLastAccessTime(record.getLastAccessTime());
+    }
+
+    public static SplitBrainMergeEntryView<Object, Object> createSplitBrainMergeEntryView(ReplicatedRecord record) {
+        return new SimpleSplitBrainEntryView<Object, Object>()
+                .setKey(record.getKeyInternal())
+                .setValue(record.getValueInternal())
+                .setCreationTime(record.getCreationTime())
+                .setHits(record.getHits())
+                .setLastAccessTime(record.getLastAccessTime())
+                .setLastUpdateTime(record.getUpdateTime())
+                .setTtl(record.getTtlMillis());
     }
 
     public static SplitBrainMergeEntryView<String, HyperLogLog>

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -1039,6 +1039,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -237,6 +237,13 @@
         <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
     </multimap>
 
+    <replicatedmap name="default">
+        <in-memory-format>OBJECT</in-memory-format>
+        <async-fillup>true</async-fillup>
+        <statistics-enabled>true</statistics-enabled>
+        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
+    </replicatedmap>
+
     <list name="default">
         <backup-count>1</backup-count>
         <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1128,7 +1128,9 @@ https://hazelcast.org/documentation/.
             <entry-listener include-value="true" local="true">com.hazelcast.examples.EntryListener</entry-listener>
         </entry-listeners>
         <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
+        <merge-policy batch-size="100">LatestAccessMergePolicy</merge-policy>
     </replicatedmap>
+
     <!--
         ===== HAZELCAST CACHE CONFIGURATION =====
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -510,10 +510,10 @@ class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getName(), c2.getName())
                     && nullSafeEqual(c1.getInMemoryFormat(), c2.getInMemoryFormat())
                     && nullSafeEqual(c1.getConcurrencyLevel(), c2.getConcurrencyLevel())
-                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
-                    && nullSafeEqual(c1.getQuorumName(), c2.getQuorumName())
                     && nullSafeEqual(c1.isAsyncFillup(), c2.isAsyncFillup())
                     && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
+                    && nullSafeEqual(c1.getQuorumName(), c2.getQuorumName())
+                    && ConfigCompatibilityChecker.isCompatible(c1.getMergePolicyConfig(), c2.getMergePolicyConfig())
                     && isCollectionCompatible(c1.getListenerConfigs(), c2.getListenerConfigs(), new ReplicatedMapListenerConfigChecker());
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigReadOnlyTest.java
@@ -74,7 +74,17 @@ public class ReplicatedMapConfigReadOnlyTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
+    public void testSetQuorumName() {
+        getReadOnlyConfig().setQuorumName("myQuorum");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
     public void testSetMergePolicy() {
         getReadOnlyConfig().setMergePolicy("MyMergePolicy");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetMergePolicyConfig() {
+        getReadOnlyConfig().setMergePolicyConfig(new MergePolicyConfig());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,8 +34,11 @@ public class ReplicatedMapConfigTest {
     @Test
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(ReplicatedMapConfig.class)
-                      .allFieldsShouldBeUsed()
-                      .suppress(Warning.NONFINAL_FIELDS)
-                      .verify();
+                .allFieldsShouldBeUsed()
+                .suppress(Warning.NONFINAL_FIELDS)
+                .withPrefabValues(MergePolicyConfig.class,
+                        new MergePolicyConfig(PutIfAbsentMergePolicy.class.getName(), 100),
+                        new MergePolicyConfig(DiscardMergePolicy.class.getName(), 200))
+                .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1636,16 +1636,26 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     public void testReplicatedMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <replicatedmap name=\"foobar\">\n"
-                + "        <quorum-ref>customQuorumRule</quorum-ref>"
+                + "        <in-memory-format>BINARY</in-memory-format>\n"
+                + "        <async-fillup>false</async-fillup>\n"
+                + "        <statistics-enabled>false</statistics-enabled>\n"
+                + "        <quorum-ref>CustomQuorumRule</quorum-ref>\n"
+                + "        <merge-policy batch-size=\"2342\">CustomMergePolicy</merge-policy>\n"
                 + "    </replicatedmap>\n"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
         ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig("foobar");
 
-        // TODO -> not full config checked
         assertFalse(config.getReplicatedMapConfigs().isEmpty());
-        assertEquals("customQuorumRule", replicatedMapConfig.getQuorumName());
+        assertEquals(InMemoryFormat.BINARY, replicatedMapConfig.getInMemoryFormat());
+        assertFalse(replicatedMapConfig.isAsyncFillup());
+        assertFalse(replicatedMapConfig.isStatisticsEnabled());
+        assertEquals("CustomQuorumRule", replicatedMapConfig.getQuorumName());
+
+        MergePolicyConfig mergePolicyConfig = replicatedMapConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(2342, mergePolicyConfig.getBatchSize());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.replicatedmap.impl.record;
 
 import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -682,6 +684,11 @@ public class LazyIteratorTest extends HazelcastTestSupport {
 
         @Override
         public boolean merge(Object key, ReplicatedMapEntryView entryView, ReplicatedMapMergePolicy policy) {
+            return false;
+        }
+
+        @Override
+        public Boolean merge(SplitBrainMergeEntryView<Object, Object> mergingEntry, SplitBrainMergePolicy mergePolicy) {
             return false;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LegacyReplicatedMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LegacyReplicatedMapSplitBrainTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.merge;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.SplitBrainTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LegacyReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
+
+    @Parameters(name = "mergePolicy:{0}")
+    public static Collection<Object> parameters() {
+        return asList(new Object[]{
+                LatestUpdateMapMergePolicy.class,
+                HigherHitsMapMergePolicy.class,
+                PutIfAbsentMapMergePolicy.class,
+                PassThroughMergePolicy.class,
+                CustomReplicatedMergePolicy.class
+        });
+    }
+
+    @Parameter
+    public Class<? extends ReplicatedMapMergePolicy> mergePolicyClass;
+
+    private String replicatedMapName = randomMapName();
+    private MergeLifecycleListener mergeLifecycleListener;
+    private ReplicatedMap<Object, Object> replicatedMap1;
+    private ReplicatedMap<Object, Object> replicatedMap2;
+    private String key1;
+    private String key2;
+
+    @Override
+    protected Config config() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(mergePolicyClass.getName())
+                .setBatchSize(10);
+
+        Config config = super.config();
+        config.getReplicatedMapConfig(replicatedMapName)
+                .setMergePolicyConfig(mergePolicyConfig);
+        return config;
+    }
+
+    @Override
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
+        warmUpPartitions(instances);
+    }
+
+    @Override
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        mergeLifecycleListener = new MergeLifecycleListener(secondBrain.length);
+        for (HazelcastInstance instance : secondBrain) {
+            instance.getLifecycleService().addLifecycleListener(mergeLifecycleListener);
+        }
+
+        replicatedMap1 = firstBrain[0].getReplicatedMap(replicatedMapName);
+        replicatedMap2 = secondBrain[0].getReplicatedMap(replicatedMapName);
+
+        // since the statistics are not replicated, we have to use keys on the same node like the proxy we are interacting with
+        String[] keys = generateKeysBelongingToSamePartitionsOwnedBy(firstBrain[0], 2);
+        key1 = keys[0];
+        key2 = keys[1];
+
+        if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
+            afterSplitLatestUpdateMapMergePolicy();
+        } else if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
+            afterSplitHigherHitsMapMergePolicy();
+        } else if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
+            afterSplitPutIfAbsentMapMergePolicy();
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
+            afterSplitPassThroughMapMergePolicy();
+        } else if (mergePolicyClass == CustomReplicatedMergePolicy.class) {
+            afterSplitCustomReplicatedMapMergePolicy();
+        } else {
+            fail();
+        }
+    }
+
+    @Override
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
+        // wait until merge completes
+        mergeLifecycleListener.await();
+
+        if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
+            afterMergeLatestUpdateMapMergePolicy();
+        } else if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
+            afterMergeHigherHitsMapMergePolicy();
+        } else if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
+            afterMergePutIfAbsentMapMergePolicy();
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
+            afterMergePassThroughMapMergePolicy();
+        } else if (mergePolicyClass == CustomReplicatedMergePolicy.class) {
+            afterMergeCustomReplicatedMapMergePolicy();
+        } else {
+            fail();
+        }
+    }
+
+    private void afterSplitLatestUpdateMapMergePolicy() {
+        replicatedMap1.put(key1, "value1");
+
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        replicatedMap2.put(key1, "LatestUpdatedValue1");
+        replicatedMap2.put(key2, "value2");
+
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        replicatedMap1.put(key2, "LatestUpdatedValue2");
+    }
+
+    private void afterMergeLatestUpdateMapMergePolicy() {
+        assertEquals("LatestUpdatedValue1", replicatedMap1.get(key1));
+        assertEquals("LatestUpdatedValue1", replicatedMap2.get(key1));
+
+        assertEquals("LatestUpdatedValue2", replicatedMap1.get(key2));
+        assertEquals("LatestUpdatedValue2", replicatedMap2.get(key2));
+    }
+
+    private void afterSplitHigherHitsMapMergePolicy() {
+        replicatedMap1.put(key1, "higherHitsValue1");
+        replicatedMap1.put(key2, "value2");
+
+        // increase hits number
+        assertEquals("higherHitsValue1", replicatedMap1.get(key1));
+        assertEquals("higherHitsValue1", replicatedMap1.get(key1));
+
+        replicatedMap2.put(key1, "value1");
+        replicatedMap2.put(key2, "higherHitsValue2");
+
+        // increase hits number
+        assertEquals("higherHitsValue2", replicatedMap2.get(key2));
+        assertEquals("higherHitsValue2", replicatedMap2.get(key2));
+    }
+
+    private void afterMergeHigherHitsMapMergePolicy() {
+        assertEquals("higherHitsValue1", replicatedMap1.get(key1));
+        assertEquals("higherHitsValue1", replicatedMap2.get(key1));
+
+        assertEquals("higherHitsValue2", replicatedMap1.get(key2));
+        assertEquals("higherHitsValue2", replicatedMap2.get(key2));
+    }
+
+    private void afterSplitPutIfAbsentMapMergePolicy() {
+        replicatedMap1.put(key1, "PutIfAbsentValue1");
+
+        replicatedMap2.put(key1, "value1");
+        replicatedMap2.put(key2, "PutIfAbsentValue2");
+    }
+
+    private void afterMergePutIfAbsentMapMergePolicy() {
+        assertEquals("PutIfAbsentValue1", replicatedMap1.get(key1));
+        assertEquals("PutIfAbsentValue1", replicatedMap2.get(key1));
+
+        assertEquals("PutIfAbsentValue2", replicatedMap1.get(key2));
+        assertEquals("PutIfAbsentValue2", replicatedMap2.get(key2));
+    }
+
+    private void afterSplitPassThroughMapMergePolicy() {
+        replicatedMap1.put(key1, "value");
+        replicatedMap2.put(key1, "passThroughValue");
+    }
+
+    private void afterMergePassThroughMapMergePolicy() {
+        assertEquals("passThroughValue", replicatedMap1.get(key1));
+        assertEquals("passThroughValue", replicatedMap2.get(key1));
+    }
+
+    private void afterSplitCustomReplicatedMapMergePolicy() {
+        replicatedMap1.put(key1, "value");
+        replicatedMap2.put(key1, 1);
+    }
+
+    private void afterMergeCustomReplicatedMapMergePolicy() {
+        assertEquals(1, replicatedMap1.get(key1));
+        assertEquals(1, replicatedMap2.get(key1));
+    }
+
+    private static class CustomReplicatedMergePolicy implements ReplicatedMapMergePolicy {
+
+        @Override
+        public Object merge(String replicatedMapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
+            if (mergingEntry.getValue() instanceof Integer) {
+                return mergingEntry.getValue();
+            }
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/MergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/MergePolicyProviderTest.java
@@ -80,7 +80,7 @@ public class MergePolicyProviderTest extends HazelcastTestSupport {
     }
 
     private void assertMergePolicyCorrectlyInitialised(String mergePolicyName) {
-        ReplicatedMapMergePolicy mergePolicy = mergePolicyProvider.getMergePolicy(mergePolicyName);
+        Object mergePolicy = mergePolicyProvider.getMergePolicy(mergePolicyName);
 
         assertNotNull(mergePolicy);
         assertEquals(mergePolicyName, mergePolicy.getClass().getName());

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/ReplicatedMapSplitBrainTest.java
@@ -17,10 +17,19 @@
 package com.hazelcast.replicatedmap.merge;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
+import com.hazelcast.spi.merge.LatestAccessMergePolicy;
+import com.hazelcast.spi.merge.LatestUpdateMergePolicy;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -33,46 +42,80 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+/**
+ * Tests different split-brain scenarios for {@link IMap}.
+ * <p>
+ * Most merge policies are tested with {@link InMemoryFormat#BINARY} only, since they don't check the value.
+ * <p>
+ * The {@link MergeIntegerValuesMergePolicy} is tested with both in-memory formats, since it's using the value to merge.
+ * <p>
+ * The {@link DiscardMergePolicy}, {@link PassThroughMergePolicy} and {@link PutIfAbsentMergePolicy} are also
+ * tested with a data structure, which is only created in the smaller cluster.
+ */
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
 
-    @Parameters(name = "mergePolicy:{0}")
-    public static Collection<Object> parameters() {
-        return asList(new Object[]{
-                LatestUpdateMapMergePolicy.class,
-                HigherHitsMapMergePolicy.class,
-                PutIfAbsentMapMergePolicy.class,
-                PassThroughMergePolicy.class,
-                CustomReplicatedMergePolicy.class
+    @Parameters(name = "format:{0}, mergePolicy:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {BINARY, DiscardMergePolicy.class},
+                {BINARY, HigherHitsMergePolicy.class},
+                {BINARY, LatestAccessMergePolicy.class},
+                {BINARY, LatestUpdateMergePolicy.class},
+                {BINARY, PassThroughMergePolicy.class},
+                {BINARY, PutIfAbsentMergePolicy.class},
+
+                {BINARY, MergeIntegerValuesMergePolicy.class},
+                {OBJECT, MergeIntegerValuesMergePolicy.class},
         });
     }
 
     @Parameter
-    public Class<? extends ReplicatedMapMergePolicy> mergePolicyClass;
+    public InMemoryFormat inMemoryFormat;
 
-    private String replicatedMapName = randomMapName();
-    private MergeLifecycleListener mergeLifecycleListener;
-    private ReplicatedMap<Object, Object> replicatedMap1;
-    private ReplicatedMap<Object, Object> replicatedMap2;
+    @Parameter(value = 1)
+    public Class<? extends SplitBrainMergePolicy> mergePolicyClass;
+
+    private String replicatedMapNameA = randomMapName("replicatedMapA-");
+    private String replicatedMapNameB = randomMapName("replicatedMapB-");
+    private String key;
     private String key1;
     private String key2;
+    private ReplicatedMap<Object, Object> replicatedMapA1;
+    private ReplicatedMap<Object, Object> replicatedMapA2;
+    private ReplicatedMap<Object, Object> replicatedMapB1;
+    private ReplicatedMap<Object, Object> replicatedMapB2;
+    private MergeLifecycleListener mergeLifecycleListener;
 
     @Override
     protected Config config() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(mergePolicyClass.getName())
+                .setBatchSize(10);
+
         Config config = super.config();
-        config.getReplicatedMapConfig(replicatedMapName)
-                .setMergePolicy(mergePolicyClass.getName());
+        config.getReplicatedMapConfig(replicatedMapNameA)
+                .setInMemoryFormat(inMemoryFormat)
+                .setMergePolicyConfig(mergePolicyConfig);
+        config.getReplicatedMapConfig(replicatedMapNameB)
+                .setInMemoryFormat(inMemoryFormat)
+                .setMergePolicyConfig(mergePolicyConfig);
         return config;
     }
 
     @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
-        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
     }
 
     @Override
@@ -82,28 +125,32 @@ public class ReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
             instance.getLifecycleService().addLifecycleListener(mergeLifecycleListener);
         }
 
-        replicatedMap1 = firstBrain[0].getReplicatedMap(replicatedMapName);
-        replicatedMap2 = secondBrain[0].getReplicatedMap(replicatedMapName);
-
         // since the statistics are not replicated, we have to use keys on the same node like the proxy we are interacting with
-        String[] keys = generateKeysBelongingToSamePartitionsOwnedBy(firstBrain[0], 2);
-        key1 = keys[0];
-        key2 = keys[1];
+        String[] keys = generateKeysBelongingToSamePartitionsOwnedBy(firstBrain[0], 3);
+        key = keys[0];
+        key1 = keys[1];
+        key2 = keys[2];
 
-        if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
-            afterSplitLatestUpdateMapMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
-            afterSplitHigherHitsMapMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
-            afterSplitPutIfAbsentMapMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
-            afterSplitPassThroughMapMergePolicy();
-        }
-        if (mergePolicyClass == CustomReplicatedMergePolicy.class) {
-            afterSplitCustomReplicatedMapMergePolicy();
+        replicatedMapA1 = firstBrain[0].getReplicatedMap(replicatedMapNameA);
+        replicatedMapA2 = secondBrain[0].getReplicatedMap(replicatedMapNameA);
+        replicatedMapB2 = secondBrain[0].getReplicatedMap(replicatedMapNameB);
+
+        if (mergePolicyClass == DiscardMergePolicy.class) {
+            afterSplitDiscardMergePolicy();
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
+            afterSplitHigherHitsMergePolicy();
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
+            afterSplitLatestAccessMergePolicy();
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+            afterSplitLatestUpdateMergePolicy();
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
+            afterSplitPassThroughMergePolicy();
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+            afterSplitPutIfAbsentMergePolicy();
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+            afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -112,113 +159,203 @@ public class ReplicatedMapSplitBrainTest extends SplitBrainTestSupport {
         // wait until merge completes
         mergeLifecycleListener.await();
 
-        if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
-            afterMergeLatestUpdateMapMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
-            afterMergeHigherHitsMapMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
-            afterMergePutIfAbsentMapMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
-            afterMergePassThroughMapMergePolicy();
-        }
-        if (mergePolicyClass == CustomReplicatedMergePolicy.class) {
-            afterMergeCustomReplicatedMapMergePolicy();
+        replicatedMapB1 = instances[0].getReplicatedMap(replicatedMapNameB);
+
+        if (mergePolicyClass == DiscardMergePolicy.class) {
+            afterMergeDiscardMergePolicy();
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
+            afterMergeHigherHitsMergePolicy();
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
+            afterMergeLatestAccessMergePolicy();
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+            afterMergeLatestUpdateMergePolicy();
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
+            afterMergePassThroughMergePolicy();
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+            afterMergePutIfAbsentMergePolicy();
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+            afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
-    private void afterSplitLatestUpdateMapMergePolicy() {
-        replicatedMap1.put(key1, "value1");
+    private void afterSplitDiscardMergePolicy() {
+        replicatedMapA1.put(key1, "value1");
+
+        replicatedMapA2.put(key1, "DiscardedValue1");
+        replicatedMapA2.put(key2, "DiscardedValue2");
+
+        replicatedMapB2.put(key, "DiscardedValue");
+    }
+
+    private void afterMergeDiscardMergePolicy() {
+        assertEquals("value1", replicatedMapA1.get(key1));
+        assertEquals("value1", replicatedMapA2.get(key1));
+
+        assertNull(replicatedMapA1.get(key2));
+        assertNull(replicatedMapA2.get(key2));
+
+        assertEquals(1, replicatedMapA1.size());
+        assertEquals(1, replicatedMapA2.size());
+
+        assertNull(replicatedMapB1.get(key));
+        assertNull(replicatedMapB2.get(key));
+
+        assertTrue(replicatedMapB1.isEmpty());
+        assertTrue(replicatedMapB2.isEmpty());
+    }
+
+    private void afterSplitHigherHitsMergePolicy() {
+        replicatedMapA1.put(key1, "higherHitsValue1");
+        replicatedMapA1.put(key2, "value2");
+
+        // increase hits number
+        assertEquals("higherHitsValue1", replicatedMapA1.get(key1));
+        assertEquals("higherHitsValue1", replicatedMapA1.get(key1));
+
+        replicatedMapA2.put(key1, "value1");
+        replicatedMapA2.put(key2, "higherHitsValue2");
+
+        // increase hits number
+        assertEquals("higherHitsValue2", replicatedMapA2.get(key2));
+        assertEquals("higherHitsValue2", replicatedMapA2.get(key2));
+    }
+
+    private void afterMergeHigherHitsMergePolicy() {
+        assertEquals("higherHitsValue1", replicatedMapA1.get(key1));
+        assertEquals("higherHitsValue1", replicatedMapA2.get(key1));
+
+        assertEquals("higherHitsValue2", replicatedMapA1.get(key2));
+        assertEquals("higherHitsValue2", replicatedMapA2.get(key2));
+
+        assertEquals(2, replicatedMapA1.size());
+        assertEquals(2, replicatedMapA2.size());
+    }
+
+    private void afterSplitLatestAccessMergePolicy() {
+        replicatedMapA1.put(key1, "value1");
+        // access to record
+        assertEquals("value1", replicatedMapA1.get(key1));
 
         // prevent updating at the same time
         sleepAtLeastMillis(100);
 
-        replicatedMap2.put(key1, "LatestUpdatedValue1");
-        replicatedMap2.put(key2, "value2");
+        replicatedMapA2.put(key1, "LatestAccessedValue1");
+        // access to record
+        assertEquals("LatestAccessedValue1", replicatedMapA2.get(key1));
+
+        replicatedMapA2.put(key2, "value2");
+        // access to record
+        assertEquals("value2", replicatedMapA2.get(key2));
 
         // prevent updating at the same time
         sleepAtLeastMillis(100);
 
-        replicatedMap1.put(key2, "LatestUpdatedValue2");
+        replicatedMapA1.put(key2, "LatestAccessedValue2");
+        // access to record
+        assertEquals("LatestAccessedValue2", replicatedMapA1.get(key2));
     }
 
-    private void afterMergeLatestUpdateMapMergePolicy() {
-        assertEquals("LatestUpdatedValue1", replicatedMap1.get(key1));
-        assertEquals("LatestUpdatedValue1", replicatedMap2.get(key1));
+    private void afterMergeLatestAccessMergePolicy() {
+        assertEquals("LatestAccessedValue1", replicatedMapA1.get(key1));
+        assertEquals("LatestAccessedValue1", replicatedMapA2.get(key1));
 
-        assertEquals("LatestUpdatedValue2", replicatedMap1.get(key2));
-        assertEquals("LatestUpdatedValue2", replicatedMap2.get(key2));
+        assertEquals("LatestAccessedValue2", replicatedMapA1.get(key2));
+        assertEquals("LatestAccessedValue2", replicatedMapA2.get(key2));
+
+        assertEquals(2, replicatedMapA1.size());
+        assertEquals(2, replicatedMapA2.size());
     }
 
-    private void afterSplitHigherHitsMapMergePolicy() {
-        replicatedMap1.put(key1, "higherHitsValue1");
-        replicatedMap1.put(key2, "value2");
+    private void afterSplitLatestUpdateMergePolicy() {
+        replicatedMapA1.put(key1, "value1");
 
-        // increase hits number
-        assertEquals("higherHitsValue1", replicatedMap1.get(key1));
-        assertEquals("higherHitsValue1", replicatedMap1.get(key1));
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
 
-        replicatedMap2.put(key1, "value1");
-        replicatedMap2.put(key2, "higherHitsValue2");
+        replicatedMapA2.put(key1, "LatestUpdatedValue1");
+        replicatedMapA2.put(key2, "value2");
 
-        // increase hits number
-        assertEquals("higherHitsValue2", replicatedMap2.get(key2));
-        assertEquals("higherHitsValue2", replicatedMap2.get(key2));
+        // prevent updating at the same time
+        sleepAtLeastMillis(100);
+
+        replicatedMapA1.put(key2, "LatestUpdatedValue2");
     }
 
-    private void afterMergeHigherHitsMapMergePolicy() {
-        assertEquals("higherHitsValue1", replicatedMap1.get(key1));
-        assertEquals("higherHitsValue1", replicatedMap2.get(key1));
+    private void afterMergeLatestUpdateMergePolicy() {
+        assertEquals("LatestUpdatedValue1", replicatedMapA1.get(key1));
+        assertEquals("LatestUpdatedValue1", replicatedMapA2.get(key1));
 
-        assertEquals("higherHitsValue2", replicatedMap1.get(key2));
-        assertEquals("higherHitsValue2", replicatedMap2.get(key2));
+        assertEquals("LatestUpdatedValue2", replicatedMapA1.get(key2));
+        assertEquals("LatestUpdatedValue2", replicatedMapA2.get(key2));
+
+        assertEquals(2, replicatedMapA1.size());
+        assertEquals(2, replicatedMapA2.size());
     }
 
-    private void afterSplitPutIfAbsentMapMergePolicy() {
-        replicatedMap1.put(key1, "PutIfAbsentValue1");
+    private void afterSplitPassThroughMergePolicy() {
+        replicatedMapA1.put(key1, "value1");
 
-        replicatedMap2.put(key1, "value1");
-        replicatedMap2.put(key2, "PutIfAbsentValue2");
+        replicatedMapA2.put(key1, "PassThroughValue1");
+        replicatedMapA2.put(key2, "PassThroughValue2");
+
+        replicatedMapB2.put(key, "PutIfAbsentValue");
     }
 
-    private void afterMergePutIfAbsentMapMergePolicy() {
-        assertEquals("PutIfAbsentValue1", replicatedMap1.get(key1));
-        assertEquals("PutIfAbsentValue1", replicatedMap2.get(key1));
+    private void afterMergePassThroughMergePolicy() {
+        assertEquals("PassThroughValue1", replicatedMapA1.get(key1));
+        assertEquals("PassThroughValue1", replicatedMapA2.get(key1));
 
-        assertEquals("PutIfAbsentValue2", replicatedMap1.get(key2));
-        assertEquals("PutIfAbsentValue2", replicatedMap2.get(key2));
+        assertEquals("PassThroughValue2", replicatedMapA1.get(key2));
+        assertEquals("PassThroughValue2", replicatedMapA2.get(key2));
+
+        assertEquals(2, replicatedMapA1.size());
+        assertEquals(2, replicatedMapA2.size());
+
+        assertEquals("PutIfAbsentValue", replicatedMapB1.get(key));
+        assertEquals("PutIfAbsentValue", replicatedMapB2.get(key));
+
+        assertEquals(1, replicatedMapB1.size());
+        assertEquals(1, replicatedMapB2.size());
     }
 
-    private void afterSplitPassThroughMapMergePolicy() {
-        replicatedMap1.put(key1, "value");
-        replicatedMap2.put(key1, "passThroughValue");
+    private void afterSplitPutIfAbsentMergePolicy() {
+        replicatedMapA1.put(key1, "PutIfAbsentValue1");
+
+        replicatedMapA2.put(key1, "value");
+        replicatedMapA2.put(key2, "PutIfAbsentValue2");
+
+        replicatedMapB2.put(key, "PutIfAbsentValue");
     }
 
-    private void afterMergePassThroughMapMergePolicy() {
-        assertEquals("passThroughValue", replicatedMap1.get(key1));
-        assertEquals("passThroughValue", replicatedMap2.get(key1));
+    private void afterMergePutIfAbsentMergePolicy() {
+        assertEquals("PutIfAbsentValue1", replicatedMapA1.get(key1));
+        assertEquals("PutIfAbsentValue1", replicatedMapA2.get(key1));
+
+        assertEquals("PutIfAbsentValue2", replicatedMapA1.get(key2));
+        assertEquals("PutIfAbsentValue2", replicatedMapA2.get(key2));
+
+        assertEquals(2, replicatedMapA1.size());
+        assertEquals(2, replicatedMapA2.size());
+
+        assertEquals("PutIfAbsentValue", replicatedMapB1.get(key));
+        assertEquals("PutIfAbsentValue", replicatedMapB2.get(key));
+
+        assertEquals(1, replicatedMapB1.size());
+        assertEquals(1, replicatedMapB2.size());
     }
 
-    private void afterSplitCustomReplicatedMapMergePolicy() {
-        replicatedMap1.put(key1, "value");
-        replicatedMap2.put(key1, 1);
+    private void afterSplitCustomMergePolicy() {
+        replicatedMapA1.put(key, "value");
+        replicatedMapA2.put(key, 1);
     }
 
-    private void afterMergeCustomReplicatedMapMergePolicy() {
-        assertEquals(1, replicatedMap1.get(key1));
-        assertEquals(1, replicatedMap2.get(key1));
-    }
+    private void afterMergeCustomMergePolicy() {
+        assertEquals(1, replicatedMapA1.get(key));
+        assertEquals(1, replicatedMapA2.get(key));
 
-    private static class CustomReplicatedMergePolicy implements ReplicatedMapMergePolicy {
-
-        @Override
-        public Object merge(String replicatedMapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
-            if (mergingEntry.getValue() instanceof Integer) {
-                return mergingEntry.getValue();
-            }
-            return null;
-        }
+        assertEquals(1, replicatedMapA1.size());
+        assertEquals(1, replicatedMapA2.size());
     }
 }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -476,10 +476,11 @@
         <replication-delay-millis>12</replication-delay-millis>
         <async-fillup>false</async-fillup>
         <statistics-enabled>false</statistics-enabled>
+        <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
+        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
         <entry-listeners>
             <entry-listener include-value="false" local="true">DummyListener</entry-listener>
         </entry-listeners>
-        <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
     </replicatedmap>
 
     <list name="default">


### PR DESCRIPTION
The old merge policy configuration was missing completely in the XSD and Spring. It was added to the `XmlConfigBuilder` though, so for XML users it was a kind of hidden feature. This is fixed along with adding the new merge policies with batching support to the ReplicatedMap.

I hope you can forgive me the general cleanup I did. I had some trouble getting the test setup correct, since the statistics are not replicated. While figuring out which operation is used for what I browsed a lot of code and aligned it a bit with our actual coding style.