### PR TITLE
[BACKPORT] Fix OS process & system load metrics display issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -361,7 +361,7 @@ public class HealthMonitor {
                 sb.append("load.systemAverage").append("=n/a ");
             } else {
                 sb.append("load.systemAverage").append('=')
-                        .append(format("%.2f", osSystemLoadAverage.read())).append("%, ");
+                        .append(format("%.2f", osSystemLoadAverage.read())).append(", ");
             }
         }
 


### PR DESCRIPTION
- os.systemLoadAverage is not a percentage, removed `%` sign.
- os.processCpuLoad & os.systemCpuLoad are reported between [0, 1] range.
Multiplied their results with 100.

(cherry picked from commit e5f6cf780eb4b68f8de35a02f7c60ff9b3ecf83a)

Backport of https://github.com/hazelcast/hazelcast/pull/12199