### PR TITLE
[#12203] Throw an initialization exception when Symmetric Encryption is configured on Hazelcast OS version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -22,6 +22,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.PartitioningStrategy;
@@ -122,6 +123,12 @@ public class DefaultNodeExtension implements NodeExtension {
         if (securityConfig != null && securityConfig.isEnabled()) {
             if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
                 throw new IllegalStateException("Security requires Hazelcast Enterprise Edition");
+            }
+        }
+        SymmetricEncryptionConfig symmetricEncryptionConfig = node.getConfig().getNetworkConfig().getSymmetricEncryptionConfig();
+        if (symmetricEncryptionConfig != null && symmetricEncryptionConfig.isEnabled()) {
+            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
+                throw new IllegalStateException("Symmetric Encryption requires Hazelcast Enterprise Edition");
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/security/SecurityWithoutEnterpriseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/security/SecurityWithoutEnterpriseTest.java
@@ -1,14 +1,16 @@
 package com.hazelcast.security;
 
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SecurityConfig;
+import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -22,6 +24,15 @@ public class SecurityWithoutEnterpriseTest extends HazelcastTestSupport {
         Config config = new Config()
                 .setSecurityConfig(securityConfig);
 
+        createHazelcastInstance(config);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSymmetricEncryption() {
+        SymmetricEncryptionConfig symmetricEncryptionConfig = new SymmetricEncryptionConfig()
+                .setEnabled(true);
+        Config config = new Config();
+        config.getNetworkConfig().setSymmetricEncryptionConfig(symmetricEncryptionConfig);
         createHazelcastInstance(config);
     }
 }


### PR DESCRIPTION
Fixes #12203.

This commit applies the fail-fast approach on symmetric-encryption configuration for OS Hazelcast edition.