### PR TITLE
Small cleanup and minor fixes in CardinalityEstimator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/CardinalityEstimator.java
@@ -23,10 +23,10 @@ import com.hazelcast.spi.annotation.Beta;
 /**
  * CardinalityEstimator is a redundant and highly available distributed data-structure used
  * for probabilistic cardinality estimation purposes, on unique items, in significantly sized data cultures.
- *
+ * <p>
  * CardinalityEstimator is internally based on a HyperLogLog++ data-structure,
  * and uses P^2 byte registers for storage and computation. (Default P = 14)
- *
+ * <p>
  * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
  */
 @Beta
@@ -35,7 +35,7 @@ public interface CardinalityEstimator extends DistributedObject {
     /**
      * Add a new object in the estimation set. This is the method you want to
      * use to feed objects into the estimator.
-     *
+     * <p>
      * Objects are considered identical if they are serialized into the same binary blob.
      * In other words: It does <strong>not</strong> use Java equality.
      *
@@ -44,7 +44,6 @@ public interface CardinalityEstimator extends DistributedObject {
      * @since 3.8
      */
     void add(Object obj);
-
 
     /**
      * Estimates the cardinality of the aggregation so far.
@@ -58,21 +57,18 @@ public interface CardinalityEstimator extends DistributedObject {
     /**
      * Add a new object in the estimation set. This is the method you want to
      * use to feed objects into the estimator.
-     *
+     * <p>
      * Objects are considered identical if they are serialized into the same binary blob.
      * In other words: It does <strong>not</strong> use Java equality.
-     *
+     * <p>
      * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
      * The operations result can be obtained in a blocking way, or a
      * callback can be provided for execution upon completion, as demonstrated in the following examples:
-     * <p>
      * <pre>
      *     ICompletableFuture&lt;Void&gt; future = estimator.addAsync();
      *     // do something else, then read the result
      *     Boolean result = future.get(); // this method will block until the result is available
      * </pre>
-     * </p>
-     * <p>
      * <pre>
      *     ICompletableFuture&lt;Void&gt; future = estimator.addAsync();
      *     future.andThen(new ExecutionCallback&lt;Void&gt;() {
@@ -85,7 +81,7 @@ public interface CardinalityEstimator extends DistributedObject {
      *          }
      *     });
      * </pre>
-     * </p>
+     *
      * @param obj object to add in the estimation set.
      * @return an {@link ICompletableFuture} API consumers can use to track execution of this request.
      * @throws NullPointerException if obj is null
@@ -96,18 +92,15 @@ public interface CardinalityEstimator extends DistributedObject {
     /**
      * Estimates the cardinality of the aggregation so far.
      * If it was previously estimated and never invalidated, then a cached version is used.
-     *
+     * <p>
      * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
      * The operations result can be obtained in a blocking way, or a
      * callback can be provided for execution upon completion, as demonstrated in the following examples:
-     * <p>
      * <pre>
      *     ICompletableFuture&lt;Long&gt; future = estimator.estimateAsync();
      *     // do something else, then read the result
      *     Long result = future.get(); // this method will block until the result is available
      * </pre>
-     * </p>
-     * <p>
      * <pre>
      *     ICompletableFuture&lt;Long&gt; future = estimator.estimateAsync();
      *     future.andThen(new ExecutionCallback&lt;Long&gt;() {
@@ -120,10 +113,9 @@ public interface CardinalityEstimator extends DistributedObject {
      *          }
      *     });
      * </pre>
-     * </p>
+     *
      * @return {@link ICompletableFuture} bearing the response, the estimate.
      * @since 3.8
      */
     ICompletableFuture<Long> estimateAsync();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -32,13 +32,11 @@ import static com.hazelcast.config.CardinalityEstimatorConfig.DEFAULT_SYNC_BACKU
 import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
 
 public class CardinalityEstimatorContainer
-        implements SplitBrainAwareDataContainer<String, HyperLogLog, HyperLogLog>,
-                   IdentifiedDataSerializable {
+        implements SplitBrainAwareDataContainer<String, HyperLogLog, HyperLogLog>, IdentifiedDataSerializable {
 
     HyperLogLog hll;
 
     private int backupCount;
-
     private int asyncBackupCount;
 
     public CardinalityEstimatorContainer() {
@@ -72,12 +70,10 @@ public class CardinalityEstimatorContainer
     }
 
     @Override
-    public HyperLogLog merge(SplitBrainMergeEntryView<String, HyperLogLog> mergingEntry,
-                                               SplitBrainMergePolicy mergePolicy) {
+    public HyperLogLog merge(SplitBrainMergeEntryView<String, HyperLogLog> mergingEntry, SplitBrainMergePolicy mergePolicy) {
         String name = mergingEntry.getKey();
         if (hll.estimate() != 0) {
-            SplitBrainMergeEntryView<String, HyperLogLog> existing =
-                    createSplitBrainMergeEntryView(name, hll);
+            SplitBrainMergeEntryView<String, HyperLogLog> existing = createSplitBrainMergeEntryView(name, hll);
             HyperLogLog newValue = mergePolicy.merge(mergingEntry, existing);
             if (newValue != null && !newValue.equals(hll)) {
                 setValue(newValue);
@@ -90,7 +86,6 @@ public class CardinalityEstimatorContainer
                 return hll;
             }
         }
-
         return null;
     }
 
@@ -132,7 +127,6 @@ public class CardinalityEstimatorContainer
         }
 
         CardinalityEstimatorContainer that = (CardinalityEstimatorContainer) o;
-
         return hll.equals(that.hll);
     }
 
@@ -140,5 +134,4 @@ public class CardinalityEstimatorContainer
     public int hashCode() {
         return hll.hashCode();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorDataSerializerHook.java
@@ -24,7 +24,7 @@ import com.hazelcast.cardinality.impl.operations.AggregateOperation;
 import com.hazelcast.cardinality.impl.operations.EstimateOperation;
 import com.hazelcast.cardinality.impl.operations.MergeOperation;
 import com.hazelcast.cardinality.impl.operations.ReplicationOperation;
-import com.hazelcast.cardinality.impl.operations.SyncBackupOperation;
+import com.hazelcast.cardinality.impl.operations.MergeBackupOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
@@ -48,7 +48,7 @@ public final class CardinalityEstimatorDataSerializerHook
     public static final int HLL_DENSE_ENC = 6;
     public static final int HLL_SPARSE_ENC = 7;
     public static final int MERGE = 8;
-    public static final int SYNC_BACKUP = 9;
+    public static final int MERGE_BACKUP = 9;
 
     @Override
     public int getFactoryId() {
@@ -79,8 +79,8 @@ public final class CardinalityEstimatorDataSerializerHook
                         return new SparseHyperLogLogEncoder();
                     case MERGE:
                         return new MergeOperation();
-                    case SYNC_BACKUP:
-                        return new SyncBackupOperation();
+                    case MERGE_BACKUP:
+                        return new MergeBackupOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -19,8 +19,8 @@ package com.hazelcast.cardinality.impl;
 import com.hazelcast.cardinality.impl.operations.MergeOperation;
 import com.hazelcast.cardinality.impl.operations.ReplicationOperation;
 import com.hazelcast.config.CardinalityEstimatorConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
@@ -56,8 +56,7 @@ import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class CardinalityEstimatorService
-        implements ManagedService, RemoteService, MigrationAwareService,
-                   SplitBrainHandlerService, QuorumAwareService {
+        implements ManagedService, RemoteService, MigrationAwareService, QuorumAwareService, SplitBrainHandlerService {
 
     public static final String SERVICE_NAME = "hz:impl:cardinalityEstimatorService";
 
@@ -209,8 +208,7 @@ public class CardinalityEstimatorService
         if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
             return null;
         }
-        Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
-                quorumConfigConstructor);
+        Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory, quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }
 
@@ -229,8 +227,8 @@ public class CardinalityEstimatorService
             this.snapshot = snapshot;
         }
 
-        @SuppressWarnings({"checkstyle:methodlength"})
         @Override
+        @SuppressWarnings({"checkstyle:methodlength"})
         public void run() {
             // we cannot merge into a 3.9 cluster, since not all members may understand the CollectionMergeOperation
             if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
@@ -257,7 +255,7 @@ public class CardinalityEstimatorService
             int operationCount = 0;
 
             try {
-                //TODO tkountis - Batching support
+                // TODO: Batching support (tkountis)
                 for (Map.Entry<String, CardinalityEstimatorContainer> entry : snapshot.entrySet()) {
                     String containerName = entry.getKey();
                     CardinalityEstimatorContainer container = entry.getValue();
@@ -269,17 +267,15 @@ public class CardinalityEstimatorService
                     MergeOperation operation = new MergeOperation(containerName, mergePolicy, container.hll);
                     try {
                         nodeEngine.getOperationService()
-                                  .invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                                  .andThen(mergeCallback);
+                                .invokeOnPartition(SERVICE_NAME, operation, partitionId)
+                                .andThen(mergeCallback);
                     } catch (Throwable t) {
                         throw rethrow(t);
                     }
                     size++;
-
                 }
 
                 snapshot.clear();
-
             } catch (Exception ex) {
                 logger.warning("CardinalityEstimatorService merging didn't complete successfully.", ex);
                 throw rethrow(ex);
@@ -293,4 +289,3 @@ public class CardinalityEstimatorService
         }
     }
 }
-

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/HyperLogLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/HyperLogLog.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cardinality.impl.hyperloglog;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 /**
  * HyperLogLog is a redundant and highly available distributed data-structure used for cardinality estimation
@@ -30,7 +31,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
  * </ul>
  *
  */
-public interface HyperLogLog extends IdentifiedDataSerializable {
+public interface HyperLogLog extends IdentifiedDataSerializable, Versioned {
 
     /**
      * Computes a new estimate for the current status of the registers.

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/DenseHyperLogLogConstants.java
@@ -23,9 +23,8 @@ package com.hazelcast.cardinality.impl.hyperloglog.impl;
 final class DenseHyperLogLogConstants {
 
     /**
-     * The following tables list the empirically determined thresholds & bias data,
-     * used in HLL++ implementation.
-     *
+     * The following tables list the empirically determined thresholds and bias data, used in HLL++ implementation.
+     * <p>
      * As found at https://docs.google.com/document/d/1gyjfMHy43U9OWBXxfaeG-3MjGzejW1dlpyMwEYAAWEI/view?fullscreen#
      */
     static final int[] THRESHOLD = {

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogEncoder.java
@@ -29,7 +29,7 @@ public interface HyperLogLogEncoder extends IdentifiedDataSerializable {
 
     /**
      * Aggregates the hash value in the HyperLogLog registers, and returns a hint if the
-     * operation migth have affected the cardinality, it is just a hint, and it relies to
+     * operation might have affected the cardinality, it is just a hint, and it relies to
      * the respective implementation.
      *
      * @param hash the value to aggregate
@@ -47,6 +47,7 @@ public interface HyperLogLogEncoder extends IdentifiedDataSerializable {
 
     /**
      * Returns the encoding type of this instance; see: {@link HyperLogLogEncoding}
+     *
      * @return {@link HyperLogLogEncoding}
      */
     HyperLogLogEncoding getEncodingType();

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
@@ -37,8 +37,8 @@ public class HyperLogLogImpl implements HyperLogLog {
     private static final int DEFAULT_P_PRIME = 25;
 
     private int m;
-    private Long cachedEstimate;
     private HyperLogLogEncoder encoder;
+    private Long cachedEstimate;
 
     public HyperLogLogImpl() {
         this(DEFAULT_P, DEFAULT_P_PRIME);
@@ -63,7 +63,6 @@ public class HyperLogLogImpl implements HyperLogLog {
         if (cachedEstimate == null) {
             cachedEstimate = encoder.estimate();
         }
-
         return cachedEstimate;
     }
 
@@ -106,7 +105,6 @@ public class HyperLogLogImpl implements HyperLogLog {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(encoder);
-
         if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             out.writeInt(m);
         }
@@ -115,8 +113,6 @@ public class HyperLogLogImpl implements HyperLogLog {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         encoder = in.readObject();
-
-
         if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             m = in.readInt();
         }
@@ -129,5 +125,4 @@ public class HyperLogLogImpl implements HyperLogLog {
             encoder = ((SparseHyperLogLogEncoder) encoder).asDense();
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AbstractCardinalityEstimatorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AbstractCardinalityEstimatorOperation.java
@@ -62,14 +62,12 @@ public abstract class AbstractCardinalityEstimatorOperation
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out)
-            throws IOException {
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in)
-            throws IOException {
+    protected void readInternal(ObjectDataInput in) throws IOException {
         this.name = in.readUTF();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateBackupOperation.java
@@ -60,5 +60,4 @@ public class AggregateBackupOperation
         super.readInternal(in);
         hash = in.readLong();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/AggregateOperation.java
@@ -25,11 +25,13 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
 public class AggregateOperation
-        extends CardinalityEstimatorBackupAwareOperation implements MutatingOperation {
+        extends CardinalityEstimatorBackupAwareOperation
+        implements MutatingOperation {
 
     private long hash;
 
-    public AggregateOperation() { }
+    public AggregateOperation() {
+    }
 
     public AggregateOperation(String name, long hash) {
         super(name);

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
@@ -45,5 +45,4 @@ public abstract class CardinalityEstimatorBackupAwareOperation
     public int getAsyncBackupCount() {
         return getCardinalityEstimatorContainer().getAsyncBackupCount();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/EstimateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/EstimateOperation.java
@@ -20,11 +20,13 @@ import com.hazelcast.cardinality.impl.CardinalityEstimatorDataSerializerHook;
 import com.hazelcast.spi.ReadonlyOperation;
 
 public class EstimateOperation
-        extends AbstractCardinalityEstimatorOperation implements ReadonlyOperation {
+        extends AbstractCardinalityEstimatorOperation
+        implements ReadonlyOperation {
 
     private long estimate;
 
-    public EstimateOperation() { }
+    public EstimateOperation() {
+    }
 
     public EstimateOperation(String name) {
         super(name);
@@ -44,5 +46,4 @@ public class EstimateOperation
     public Object getResponse() {
         return estimate;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeBackupOperation.java
@@ -23,21 +23,22 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
-public class SyncBackupOperation
+public class MergeBackupOperation
         extends AbstractCardinalityEstimatorOperation {
 
     private HyperLogLog value;
 
-    public SyncBackupOperation() { }
+    public MergeBackupOperation() {
+    }
 
-    public SyncBackupOperation(String name, HyperLogLog value) {
+    public MergeBackupOperation(String name, HyperLogLog value) {
         super(name);
         this.value = value;
     }
 
     @Override
     public int getId() {
-        return CardinalityEstimatorDataSerializerHook.SYNC_BACKUP;
+        return CardinalityEstimatorDataSerializerHook.MERGE_BACKUP;
     }
 
     @Override
@@ -46,15 +47,13 @@ public class SyncBackupOperation
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in)
-            throws IOException {
+    protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         value = in.readObject();
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out)
-            throws IOException {
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeOperation.java
@@ -28,10 +28,10 @@ import java.io.IOException;
 import static com.hazelcast.cardinality.impl.CardinalityEstimatorDataSerializerHook.MERGE;
 import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
 
-public class MergeOperation extends CardinalityEstimatorBackupAwareOperation {
+public class MergeOperation
+        extends CardinalityEstimatorBackupAwareOperation {
 
     private SplitBrainMergePolicy mergePolicy;
-
     private HyperLogLog value;
 
     private transient HyperLogLog backupValue;
@@ -47,8 +47,7 @@ public class MergeOperation extends CardinalityEstimatorBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        SplitBrainMergeEntryView<String, HyperLogLog> mergingEntry =
-                createSplitBrainMergeEntryView(name, value);
+        SplitBrainMergeEntryView<String, HyperLogLog> mergingEntry = createSplitBrainMergeEntryView(name, value);
         backupValue = getCardinalityEstimatorContainer().merge(mergingEntry, mergePolicy);
     }
 
@@ -64,20 +63,18 @@ public class MergeOperation extends CardinalityEstimatorBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new SyncBackupOperation(name, backupValue);
+        return new MergeBackupOperation(name, backupValue);
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in)
-            throws IOException {
+    protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         mergePolicy = in.readObject();
         value = in.readObject();
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out)
-            throws IOException {
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(mergePolicy);
         out.writeObject(value);

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/ReplicationOperation.java
@@ -29,7 +29,8 @@ import java.util.Map;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
 
-public class ReplicationOperation extends Operation
+public class ReplicationOperation
+        extends Operation
         implements IdentifiedDataSerializable {
 
     private Map<String, CardinalityEstimatorContainer> migrationData;


### PR DESCRIPTION
* added missing `Versioned` to `HyperLogLog` (used by implementation)
* renamed `SyncBackupOperation` to `MergeBackupOperation`
* fixed typo and paragraphs in JavaDoc
* aligned code style after split-brain protection and healing have been implemented