### PR TITLE
Small cleanup of quorum related tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/PartitionedClusterClients.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/PartitionedClusterClients.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -27,10 +43,9 @@ public class PartitionedClusterClients {
 
     public void terminateAll() {
         for (HazelcastInstance client : clients) {
-            if(client != null) {
+            if (client != null) {
                 client.shutdown();
             }
         }
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/QuorumTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/QuorumTestUtil.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.Address;
 
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 
+@SuppressWarnings("WeakerAccess")
 public class QuorumTestUtil {
 
     private QuorumTestUtil() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.cache;
 
 import com.hazelcast.cache.ICache;
@@ -5,17 +21,19 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.cache.CacheQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheQuorumReadTest extends CacheQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientCacheQuorumReadTest extends CacheQuorumReadTest {
     protected ICache<Integer, String> cache(int index) {
         return clients.client(index).getCacheManager().getCache(CACHE_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.cache;
 
 import com.hazelcast.cache.ICache;
@@ -5,17 +21,19 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.cache.CacheQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheQuorumWriteTest extends CacheQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientCacheQuorumWriteTest extends CacheQuorumWriteTest {
     protected ICache<Integer, String> cache(int index) {
         return clients.client(index).getCacheManager().getCache(CACHE_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.cardinality;
 
 import com.hazelcast.cardinality.CardinalityEstimator;
@@ -5,17 +21,19 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.cardinality.CardinalityEstimatorQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCardinalityEstimatorQuorumReadTest extends CardinalityEstimatorQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientCardinalityEstimatorQuorumReadTest extends CardinalityEstimat
     protected CardinalityEstimator estimator(int index) {
         return clients.client(index).getCardinalityEstimator(ESTIMATOR_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.cardinality;
 
 import com.hazelcast.cardinality.CardinalityEstimator;
@@ -5,17 +21,19 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.cardinality.CardinalityEstimatorQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCardinalityEstimatorQuorumWriteTest extends CardinalityEstimatorQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientCardinalityEstimatorQuorumWriteTest extends CardinalityEstima
     protected CardinalityEstimator estimator(int index) {
         return clients.client(index).getCardinalityEstimator(ESTIMATOR_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumReadTest.java
@@ -1,23 +1,39 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.countdownlatch;
 
-import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ICountDownLatch;
-import com.hazelcast.quorum.cardinality.CardinalityEstimatorQuorumReadTest;
 import com.hazelcast.quorum.countdownlatch.CountDownLatchQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCountDownLatchQuorumReadTest extends CountDownLatchQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -39,5 +55,4 @@ public class ClientCountDownLatchQuorumReadTest extends CountDownLatchQuorumRead
     protected ICountDownLatch latch(int index) {
         return clients.client(index).getCountDownLatch(LATCH_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.countdownlatch;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.quorum.countdownlatch.CountDownLatchQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCountDownLatchQuorumWriteTest extends CountDownLatchQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientCountDownLatchQuorumWriteTest extends CountDownLatchQuorumWri
     protected ICountDownLatch latch(int index) {
         return clients.client(index).getCountDownLatch(LATCH_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.durableexecutor;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -6,17 +22,19 @@ import com.hazelcast.config.Config;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.durableexecutor.DurableExecutorQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientDurableExecutorQuorumReadTest extends DurableExecutorQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +56,4 @@ public class ClientDurableExecutorQuorumReadTest extends DurableExecutorQuorumRe
     protected DurableExecutorService durableExec(int index, QuorumType quorumType) {
         return clients.client(index).getDurableExecutorService(DURABLE_EXEC_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.durableexecutor;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -6,17 +22,19 @@ import com.hazelcast.config.Config;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.durableexecutor.DurableExecutorQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientDurableExecutorQuorumWriteTest extends DurableExecutorQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +56,4 @@ public class ClientDurableExecutorQuorumWriteTest extends DurableExecutorQuorumW
     protected DurableExecutorService durableExec(int index, QuorumType quorumType) {
         return clients.client(index).getDurableExecutorService(DURABLE_EXEC_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.executor;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -6,17 +22,19 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.executor.ExecutorQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientExecutorQuorumReadTest extends ExecutorQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +56,4 @@ public class ClientExecutorQuorumReadTest extends ExecutorQuorumReadTest {
     protected IExecutorService exec(int index, QuorumType quorumType) {
         return clients.client(index).getExecutorService(EXEC_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.executor;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -6,17 +22,19 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.executor.ExecutorQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientExecutorQuorumWriteTest extends ExecutorQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -43,5 +61,4 @@ public class ClientExecutorQuorumWriteTest extends ExecutorQuorumWriteTest {
     protected IExecutorService exec(int index, QuorumType quorumType, String postfix) {
         return clients.client(index).getExecutorService(EXEC_NAME + quorumType.name() + postfix);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.list;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.IList;
 import com.hazelcast.quorum.list.ListQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientListQuorumReadTest extends ListQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientListQuorumReadTest extends ListQuorumReadTest {
     protected IList list(int index) {
         return clients.client(index).getList(LIST_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.list;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,7 +21,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.IList;
 import com.hazelcast.quorum.list.ListQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -13,9 +29,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientListQuorumWriteTest extends ListQuorumWriteTest {
 
@@ -38,5 +55,4 @@ public class ClientListQuorumWriteTest extends ListQuorumWriteTest {
     protected IList list(int index) {
         return clients.client(index).getList(LIST_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumReadTest.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.list;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.list.TransactionalListQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -12,10 +29,12 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalListQuorumReadTest extends TransactionalListQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +56,4 @@ public class ClientTransactionalListQuorumReadTest extends TransactionalListQuor
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumWriteTest.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.list;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.list.TransactionalListQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
@@ -13,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalListQuorumWriteTest extends TransactionalListQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +55,4 @@ public class ClientTransactionalListQuorumWriteTest extends TransactionalListQuo
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.lock;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ILock;
 import com.hazelcast.quorum.lock.LockQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientLockQuorumReadTest extends LockQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientLockQuorumReadTest extends LockQuorumReadTest {
     protected ILock lock(int index) {
         return clients.client(index).getLock(LOCK_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.lock;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ILock;
 import com.hazelcast.quorum.lock.LockQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientLockQuorumWriteTest extends LockQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientLockQuorumWriteTest extends LockQuorumWriteTest {
     protected ILock lock(int index) {
         return clients.client(index).getLock(LOCK_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumReadTest.java
@@ -21,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.IMap;
 import com.hazelcast.quorum.map.MapQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientMapQuorumReadTest extends MapQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientMapQuorumReadTest extends MapQuorumReadTest {
     protected IMap map(int index) {
         return clients.client(index).getMap(MAP_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumWriteTest.java
@@ -21,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.IMap;
 import com.hazelcast.quorum.map.MapQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientMapQuorumWriteTest extends MapQuorumWriteTest {
 
     private static PartitionedClusterClients clients;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumReadTest.java
@@ -20,7 +20,8 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.map.TransactionalMapQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -28,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalMapQuorumReadTest extends TransactionalMapQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientTransactionalMapQuorumReadTest extends TransactionalMapQuorum
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumWriteTest.java
@@ -20,7 +20,8 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.map.TransactionalMapQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -28,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalMapQuorumWriteTest extends TransactionalMapQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientTransactionalMapQuorumWriteTest extends TransactionalMapQuoru
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.multimap;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.quorum.multimap.MultiMapQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientMultiMapQuorumReadTest extends MultiMapQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientMultiMapQuorumReadTest extends MultiMapQuorumReadTest {
     protected MultiMap map(int index) {
         return clients.client(index).getMultiMap(MULTI_MAP_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.multimap;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,7 +21,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.quorum.multimap.MultiMapQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -13,9 +29,10 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMultiMapQuorumWriteTest extends MultiMapQuorumWriteTest {
 
@@ -38,5 +55,4 @@ public class ClientMultiMapQuorumWriteTest extends MultiMapQuorumWriteTest {
     protected MultiMap map(int index) {
         return clients.client(index).getMultiMap(MULTI_MAP_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumReadTest.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.multimap;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.multimap.TransactionalMultiMapQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -12,11 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalMultiMapQuorumReadTest extends TransactionalMultiMapQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +55,4 @@ public class ClientTransactionalMultiMapQuorumReadTest extends TransactionalMult
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumWriteTest.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.multimap;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.multimap.TransactionalMultiMapQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -12,11 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalMultiMapQuorumWriteTest extends TransactionalMultiMapQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +55,4 @@ public class ClientTransactionalMultiMapQuorumWriteTest extends TransactionalMul
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumReadTest.java
@@ -21,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.quorum.queue.QueueQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientQueueQuorumReadTest extends QueueQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientQueueQuorumReadTest extends QueueQuorumReadTest {
     protected IQueue queue(int index) {
         return clients.client(index).getQueue(QUEUE_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumWriteTest.java
@@ -21,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.quorum.queue.QueueQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientQueueQuorumWriteTest extends QueueQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientQueueQuorumWriteTest extends QueueQuorumWriteTest {
     protected IQueue queue(int index) {
         return clients.client(index).getQueue(QUEUE_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumReadTest.java
@@ -20,7 +20,8 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.queue.TransactionalQueueQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -28,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalQueueQuorumReadTest extends TransactionalQueueQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientTransactionalQueueQuorumReadTest extends TransactionalQueueQu
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumWriteTest.java
@@ -20,7 +20,8 @@ import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.queue.TransactionalQueueQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -28,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalQueueQuorumWriteTest extends TransactionalQueueQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -53,5 +55,4 @@ public class ClientTransactionalQueueQuorumWriteTest extends TransactionalQueueQ
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.replicatedmap;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.quorum.replicatedmap.ReplicatedMapQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientReplicatedMapQuorumReadTest extends ReplicatedMapQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientReplicatedMapQuorumReadTest extends ReplicatedMapQuorumReadTe
     protected ReplicatedMap map(int index) {
         return clients.client(index).getReplicatedMap(REPLICATED_MAP_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.replicatedmap;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.quorum.replicatedmap.ReplicatedMapQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientReplicatedMapQuorumWriteTest extends ReplicatedMapQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientReplicatedMapQuorumWriteTest extends ReplicatedMapQuorumWrite
     protected ReplicatedMap map(int index) {
         return clients.client(index).getReplicatedMap(REPLICATED_MAP_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.ringbuffer;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.ringbuffer.RingbufferQuorumReadTest;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientRingbufferQuorumReadTest extends RingbufferQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientRingbufferQuorumReadTest extends RingbufferQuorumReadTest {
     protected Ringbuffer ring(int index) {
         return clients.client(index).getRingbuffer(RINGBUFFER_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.ringbuffer;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.ringbuffer.RingbufferQuorumWriteTest;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientRingbufferQuorumWriteTest extends RingbufferQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientRingbufferQuorumWriteTest extends RingbufferQuorumWriteTest {
     protected Ringbuffer ring(int index) {
         return clients.client(index).getRingbuffer(RINGBUFFER_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.scheduledexecutor;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.scheduledexecutor.ScheduledExecutorQuorumReadTest;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientScheduledExecutorQuorumReadTest extends ScheduledExecutorQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientScheduledExecutorQuorumReadTest extends ScheduledExecutorQuor
     protected IScheduledExecutorService exec(int index) {
         return clients.client(index).getScheduledExecutorService(SCHEDULED_EXEC_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.scheduledexecutor;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.scheduledexecutor.ScheduledExecutorQuorumWriteTest;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientScheduledExecutorQuorumWriteTest extends ScheduledExecutorQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -42,5 +60,4 @@ public class ClientScheduledExecutorQuorumWriteTest extends ScheduledExecutorQuo
     protected IScheduledExecutorService exec(int index, String postfix) {
         return clients.client(index).getScheduledExecutorService(SCHEDULED_EXEC_NAME + quorumType.name() + postfix);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumReadTest.java
@@ -1,21 +1,39 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.semaphore;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.quorum.semaphore.SemaphoreQuorumReadTest;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ISemaphore;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.quorum.semaphore.SemaphoreQuorumReadTest;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientSemaphoreQuorumReadTest extends SemaphoreQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientSemaphoreQuorumReadTest extends SemaphoreQuorumReadTest {
     protected ISemaphore semaphore(int index) {
         return clients.client(index).getSemaphore(SEMAPHORE + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.semaphore;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ISemaphore;
 import com.hazelcast.quorum.semaphore.SemaphoreQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientSemaphoreQuorumWriteTest extends SemaphoreQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientSemaphoreQuorumWriteTest extends SemaphoreQuorumWriteTest {
     protected ISemaphore semaphore(int index) {
         return clients.client(index).getSemaphore(SEMAPHORE + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.set;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ISet;
 import com.hazelcast.quorum.set.SetQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientSetQuorumReadTest extends SetQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientSetQuorumReadTest extends SetQuorumReadTest {
     protected ISet set(int index) {
         return clients.client(index).getSet(SET_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.set;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
@@ -5,17 +21,19 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ISet;
 import com.hazelcast.quorum.set.SetQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientSetQuorumWriteTest extends SetQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientSetQuorumWriteTest extends SetQuorumWriteTest {
     protected ISet set(int index) {
         return clients.client(index).getSet(SET_NAME + quorumType.name());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumReadTest.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.set;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.set.TransactionalSetQuorumReadTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.AfterClass;
@@ -12,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalSetQuorumReadTest extends TransactionalSetQuorumReadTest {
 
     private static PartitionedClusterClients clients;
@@ -37,5 +55,4 @@ public class ClientTransactionalSetQuorumReadTest extends TransactionalSetQuorum
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumWriteTest.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.quorum.set;
 
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.quorum.set.TransactionalSetQuorumWriteTest;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
@@ -13,10 +29,11 @@ import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientTransactionalSetQuorumWriteTest extends TransactionalSetQuorumWriteTest {
 
     private static PartitionedClusterClients clients;
@@ -38,5 +55,4 @@ public class ClientTransactionalSetQuorumWriteTest extends TransactionalSetQuoru
     public TransactionContext newTransactionContext(int index) {
         return clients.client(index).newTransactionContext(options);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumListenerTest.java
@@ -20,14 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.QuorumListenerConfig;
 import com.hazelcast.core.Member;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
@@ -35,8 +30,6 @@ import java.util.concurrent.CountDownLatch;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
 public abstract class AbstractQuorumListenerTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumTest.java
@@ -51,12 +51,15 @@ import static java.util.Arrays.asList;
 
 /**
  * Base class for all quorum tests.
- *
+ * <p>
  * It defines quorum and data-structures that use it. Then it initialises and splits the cluster into two parts:
- * - 3 nodes -> this sub-cluster matches the quorum requirements
- * - 2 nodes -> this sub-cluster DOES NOT match the quorum requirements
+ * <ul>
+ * <li>3 nodes -> this sub-cluster matches the quorum requirements</li>
+ * <li>2 nodes -> this sub-cluster DOES NOT match the quorum requirements</li>
+ * </ul>
  */
-public class AbstractQuorumTest {
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractQuorumTest {
 
     protected static final String SEMAPHORE = "quorum" + randomString();
     protected static final String REFERENCE_NAME = "reference" + "quorum" + randomString();
@@ -254,7 +257,7 @@ public class AbstractQuorumTest {
         return cluster.instance[index].getSemaphore(SEMAPHORE + quorumType.name());
     }
 
-    protected IAtomicReference aref(int index, QuorumType quorumType) {
+    protected IAtomicReference<QuorumTestClass> aref(int index, QuorumType quorumType) {
         return cluster.instance[index].getAtomicReference(REFERENCE_NAME + quorumType.name());
     }
 
@@ -330,14 +333,8 @@ public class AbstractQuorumTest {
         return cluster.instance[index].getSet(SET_NAME + quorumType.name());
     }
 
-    public static class Objekt implements Serializable {
-        public static Objekt object() {
-            return new Objekt();
-        }
-    }
-
     protected static IFunction function() {
-        return new IFunction() {
+        return new IFunction<Object, Object>() {
             @Override
             public Object apply(Object input) {
                 return input;
@@ -345,4 +342,10 @@ public class AbstractQuorumTest {
         };
     }
 
+    public static class QuorumTestClass implements Serializable {
+
+        public static QuorumTestClass object() {
+            return new QuorumTestClass();
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumRollingUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumRollingUpgradeTest.java
@@ -22,10 +22,10 @@ import static com.hazelcast.quorum.executor.ExecutorQuorumWriteTest.ExecRunnable
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 
 /**
- * Quorum test proving that newly supported quorum-aware structures do not respect quorum below version 3.10
+ * Quorum test proving that newly supported quorum-aware structures do not respect quorum below version 3.10.
  */
-@Category({QuickTest.class})
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
 public class QuorumRollingUpgradeTest extends AbstractQuorumTest {
 
     private static final int NO_QUORUM_CLUSTER = 3;
@@ -157,5 +157,4 @@ public class QuorumRollingUpgradeTest extends AbstractQuorumTest {
     public void map() {
         map(NO_QUORUM_CLUSTER, TYPE).put("foo", "bar");
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
@@ -47,6 +47,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests quorum related configurations.
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QuorumTest extends HazelcastTestSupport {
@@ -80,7 +83,7 @@ public class QuorumTest extends HazelcastTestSupport {
         final Quorum quorum2 = hazelcastInstance.getQuorumService().getQuorum(quorumName2);
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertTrue(quorum1.isPresent());
                 assertFalse(quorum2.isPresent());
             }
@@ -105,7 +108,7 @@ public class QuorumTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertTrue(function.wasCalled);
             }
         });

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,22 +33,25 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class AtomicLongQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -83,7 +87,7 @@ public class AtomicLongQuorumReadTest extends AbstractQuorumTest {
         along(3).getAsync().get();
     }
 
-    protected IAtomicLong along(int index) {
+    private IAtomicLong along(int index) {
         return along(index, quorumType);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicLongQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,6 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
@@ -39,17 +43,17 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -65,12 +69,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void addAndGet() throws Exception {
+    public void addAndGet() {
         along(0).addAndGet(1);
     }
 
     @Test(expected = QuorumException.class)
-    public void addAndGet_noQuorum() throws Exception {
+    public void addAndGet_noQuorum() {
         along(3).addAndGet(1);
     }
 
@@ -86,12 +90,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void alter() throws Exception {
+    public void alter() {
         along(0).alter(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void alter_noQuorum() throws Exception {
+    public void alter_noQuorum() {
         along(3).alter(function());
     }
 
@@ -107,12 +111,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void alterAndGet() throws Exception {
+    public void alterAndGet() {
         along(0).alterAndGet(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void alterAndGet_noQuorum() throws Exception {
+    public void alterAndGet_noQuorum() {
         along(3).alterAndGet(function());
     }
 
@@ -128,12 +132,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void apply() throws Exception {
+    public void apply() {
         along(0).apply(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void apply_noQuorum() throws Exception {
+    public void apply_noQuorum() {
         along(3).apply(function());
     }
 
@@ -149,12 +153,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void compareAndSet() throws Exception {
+    public void compareAndSet() {
         along(0).compareAndSet(1L, 2L);
     }
 
     @Test(expected = QuorumException.class)
-    public void compareAndSet_noQuorum() throws Exception {
+    public void compareAndSet_noQuorum() {
         along(3).compareAndSet(1L, 2L);
     }
 
@@ -170,12 +174,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void decrementAndGet() throws Exception {
+    public void decrementAndGet() {
         along(0).decrementAndGet();
     }
 
     @Test(expected = QuorumException.class)
-    public void decrementAndGet_noQuorum() throws Exception {
+    public void decrementAndGet_noQuorum() {
         along(3).decrementAndGet();
     }
 
@@ -191,12 +195,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void getAndAdd() throws Exception {
+    public void getAndAdd() {
         along(0).getAndAdd(1L);
     }
 
     @Test(expected = QuorumException.class)
-    public void getAndAdd_noQuorum() throws Exception {
+    public void getAndAdd_noQuorum() {
         along(3).getAndAdd(1L);
     }
 
@@ -212,12 +216,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void getAndAlter() throws Exception {
+    public void getAndAlter() {
         along(0).getAndAlter(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void getAndAlter_noQuorum() throws Exception {
+    public void getAndAlter_noQuorum() {
         along(3).getAndAlter(function());
     }
 
@@ -233,12 +237,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void getAndIncrement() throws Exception {
+    public void getAndIncrement() {
         along(0).getAndIncrement();
     }
 
     @Test(expected = QuorumException.class)
-    public void getAndIncrement_noQuorum() throws Exception {
+    public void getAndIncrement_noQuorum() {
         along(3).getAndIncrement();
     }
 
@@ -254,12 +258,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void getAndSet() throws Exception {
+    public void getAndSet() {
         along(0).getAndSet(2L);
     }
 
     @Test(expected = QuorumException.class)
-    public void getAndSet_noQuorum() throws Exception {
+    public void getAndSet_noQuorum() {
         along(3).getAndSet(2L);
     }
 
@@ -275,12 +279,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void incrementAndGet() throws Exception {
+    public void incrementAndGet() {
         along(0).incrementAndGet();
     }
 
     @Test(expected = QuorumException.class)
-    public void incrementAndGet_noQuorum() throws Exception {
+    public void incrementAndGet_noQuorum() {
         along(3).incrementAndGet();
     }
 
@@ -296,12 +300,12 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void set() throws Exception {
+    public void set() {
         along(0).set(2L);
     }
 
     @Test(expected = QuorumException.class)
-    public void set_noQuorum() throws Exception {
+    public void set_noQuorum() {
         along(3).set(2L);
     }
 
@@ -316,8 +320,7 @@ public class AtomicLongQuorumWriteTest extends AbstractQuorumTest {
         along(3).setAsync(2L).get();
     }
 
-    protected IAtomicLong along(int index) {
+    private IAtomicLong along(int index) {
         return along(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,23 +33,26 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import static com.hazelcast.quorum.AbstractQuorumTest.Objekt.object;
+import static com.hazelcast.quorum.AbstractQuorumTest.QuorumTestClass.object;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class AtomicReferenceQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -126,7 +130,7 @@ public class AtomicReferenceQuorumReadTest extends AbstractQuorumTest {
         aref(3).containsAsync(object()).get();
     }
 
-    protected IAtomicReference aref(int index) {
+    private IAtomicReference<QuorumTestClass> aref(int index) {
         return aref(index, quorumType);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/atomic/AtomicReferenceQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,25 +33,28 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import static com.hazelcast.quorum.AbstractQuorumTest.Objekt.object;
+import static com.hazelcast.quorum.AbstractQuorumTest.QuorumTestClass.object;
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -98,12 +102,12 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void alterAndGet_quorum() throws Exception {
+    public void alterAndGet_quorum() {
         aref(0).alterAndGet(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void alterAndGet_noQuorum() throws Exception {
+    public void alterAndGet_noQuorum() {
         aref(3).alterAndGet(function());
     }
 
@@ -119,12 +123,12 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void alter_quorum() throws Exception {
+    public void alter_quorum() {
         aref(0).alter(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void alter_noQuorum() throws Exception {
+    public void alter_noQuorum() {
         aref(3).alter(function());
     }
 
@@ -140,12 +144,12 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void apply_quorum() throws Exception {
+    public void apply_quorum() {
         aref(0).apply(function());
     }
 
     @Test(expected = QuorumException.class)
-    public void apply_noQuorum() throws Exception {
+    public void apply_noQuorum() {
         aref(3).apply(function());
     }
 
@@ -161,12 +165,12 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void clear_quorum() throws Exception {
+    public void clear_quorum() {
         aref(0).clear();
     }
 
     @Test(expected = QuorumException.class)
-    public void clear_noQuorum() throws Exception {
+    public void clear_noQuorum() {
         aref(3).clear();
     }
 
@@ -182,12 +186,12 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void compareAndSet_quorum() throws Exception {
+    public void compareAndSet_quorum() {
         aref(0).compareAndSet(object(), object());
     }
 
     @Test(expected = QuorumException.class)
-    public void compareAndSet_noQuorum() throws Exception {
+    public void compareAndSet_noQuorum() {
         aref(3).compareAndSet(object(), object());
     }
 
@@ -203,22 +207,22 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void getAndSet_quorum() throws Exception {
+    public void getAndSet_quorum() {
         aref(0).getAndSet(object());
     }
 
     @Test(expected = QuorumException.class)
-    public void getAndSet_noQuorum() throws Exception {
+    public void getAndSet_noQuorum() {
         aref(3).getAndSet(object());
     }
 
     @Test
-    public void setAndGet_quorum() throws Exception {
+    public void setAndGet_quorum() {
         aref(0).setAndGet(object());
     }
 
     @Test(expected = QuorumException.class)
-    public void setAndGet_noQuorum() throws Exception {
+    public void setAndGet_noQuorum() {
         aref(3).setAndGet(object());
     }
 
@@ -234,16 +238,16 @@ public class AtomicReferenceQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void set_quorum() throws Exception {
+    public void set_quorum() {
         aref(0).set(object());
     }
 
     @Test(expected = QuorumException.class)
-    public void set_noQuorum() throws Exception {
+    public void set_noQuorum() {
         aref(3).set(object());
     }
 
-    protected IAtomicReference aref(int index) {
+    private IAtomicReference aref(int index) {
         return aref(index, quorumType);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.quorum.QuorumEvent;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumFunction;
 import com.hazelcast.quorum.QuorumListener;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CacheQuorumListenerTest extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,6 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.HashSet;
 import java.util.concurrent.ExecutionException;
@@ -39,20 +43,20 @@ import java.util.concurrent.ExecutionException;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
+    @Parameters(name = "quorumType:{0}")
+    public static Iterable<Object[]> parameters() {
+        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
+    }
+
+    @Parameter
     public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
-    public static Iterable<Object[]> parameters() {
-        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
-    }
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,6 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
@@ -49,17 +53,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -70,9 +77,6 @@ public class CacheQuorumWriteTest extends AbstractQuorumTest {
     public static void tearDown() {
         shutdownTestEnvironment();
     }
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void put_quorum() {
@@ -299,5 +303,4 @@ public class CacheQuorumWriteTest extends AbstractQuorumTest {
     protected ICache<Integer, String> cache(int index) {
         return cache(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,25 +33,28 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CardinalityEstimatorQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
+    @Parameters(name = "quorumType:{0}")
+    public static Iterable<Object[]> parameters() {
+        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
+    }
+
+    @Parameter
     public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
-    public static Iterable<Object[]> parameters() {
-        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
-    }
 
     @BeforeClass
     public static void setUp() {
@@ -63,12 +67,12 @@ public class CardinalityEstimatorQuorumReadTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void estimate_quorum() throws Exception {
+    public void estimate_quorum() {
         estimator(0).estimate();
     }
 
     @Test(expected = QuorumException.class)
-    public void estimate_noQuorum() throws Exception {
+    public void estimate_noQuorum() {
         estimator(3).estimate();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cardinality/CardinalityEstimatorQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,6 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
@@ -39,17 +43,20 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CardinalityEstimatorQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -60,9 +67,6 @@ public class CardinalityEstimatorQuorumWriteTest extends AbstractQuorumTest {
     public static void tearDown() {
         shutdownTestEnvironment();
     }
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void add_quorum() {
@@ -88,5 +92,4 @@ public class CardinalityEstimatorQuorumWriteTest extends AbstractQuorumTest {
     protected CardinalityEstimator estimator(int index) {
         return estimator(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,23 +31,26 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CountDownLatchQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/countdownlatch/CountDownLatchQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,23 +31,26 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CountDownLatchQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -81,5 +85,4 @@ public class CountDownLatchQuorumWriteTest extends AbstractQuorumTest {
     protected ICountDownLatch latch(int index) {
         return latch(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumReadTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,26 +32,29 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ExecutorQuorumReadTest extends AbstractQuorumTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -63,22 +67,22 @@ public class ExecutorQuorumReadTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void isShutdown_quorum() throws Exception {
+    public void isShutdown_quorum() {
         exec(0).isShutdown();
     }
 
     @Test
-    public void isShutdown_noQuorum() throws Exception {
+    public void isShutdown_noQuorum() {
         exec(3).isShutdown();
     }
 
     @Test
-    public void isTerminated_quorum() throws Exception {
+    public void isTerminated_quorum() {
         exec(0).isTerminated();
     }
 
     @Test
-    public void isTerminated_noQuorum() throws Exception {
+    public void isTerminated_noQuorum() {
         exec(3).isTerminated();
     }
 
@@ -95,6 +99,4 @@ public class ExecutorQuorumReadTest extends AbstractQuorumTest {
     protected IExecutorService exec(int index) {
         return exec(index, quorumType);
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
@@ -25,8 +25,9 @@ import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -36,6 +37,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -62,20 +66,20 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.WRITE}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -88,72 +92,72 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void executeOnAllMembers_quorum() throws Exception {
+    public void executeOnAllMembers_quorum() {
         exec(0).executeOnAllMembers(runnable());
     }
 
     @Test
-    public void executeOnAllMembers_noQuorum() throws Exception {
+    public void executeOnAllMembers_noQuorum() {
         // fire and forget operation, no quorum exception propagation
         // expectedException.expectCause(isA(QuorumException.class));
         exec(3).executeOnAllMembers(runnable());
     }
 
     @Test
-    public void executeOnKeyOwner_quorum() throws Exception {
+    public void executeOnKeyOwner_quorum() {
         exec(0).executeOnKeyOwner(runnable(), key(0));
     }
 
     @Test
-    public void executeOnKeyOwner_noQuorum() throws Exception {
+    public void executeOnKeyOwner_noQuorum() {
         // fire and forget operation, no quorum exception propagation
         // expectedException.expectCause(isA(QuorumException.class));
         exec(3).executeOnKeyOwner(runnable(), key(3));
     }
 
     @Test
-    public void executeOnMember_quorum() throws Exception {
+    public void executeOnMember_quorum() {
         exec(0).executeOnMember(runnable(), member(0));
     }
 
     @Test
-    public void executeOnMember_noQuorum() throws Exception {
+    public void executeOnMember_noQuorum() {
         // fire and forget operation, no quorum exception propagation
         // expectedException.expectCause(isA(QuorumException.class));
         exec(3).executeOnMember(runnable(), member(3));
     }
 
     @Test
-    public void executeOnMembers_collection_quorum() throws Exception {
+    public void executeOnMembers_collection_quorum() {
         exec(0).executeOnMembers(runnable(), asList(member(0)));
     }
 
     @Test
-    public void executeOnMembers_collection_noQuorum() throws Exception {
+    public void executeOnMembers_collection_noQuorum() {
         // fire and forget operation, no quorum exception propagation
         // expectedException.expectCause(isA(QuorumException.class));
         exec(3).executeOnMembers(runnable(), asList(member(3)));
     }
 
     @Test
-    public void executeOnMembers_selector_quorum() throws Exception {
+    public void executeOnMembers_selector_quorum() {
         exec(0).executeOnMembers(runnable(), selector(0));
     }
 
     @Test
-    public void executeOnMembers_selector_noQuorum() throws Exception {
+    public void executeOnMembers_selector_noQuorum() {
         // fire and forget operation, no quorum exception propagation
         // expectedException.expectCause(isA(QuorumException.class));
         exec(3).executeOnMembers(runnable(), selector(3));
     }
 
     @Test
-    public void execute_quorum() throws Exception {
+    public void execute_quorum() {
         exec(0).execute(runnable());
     }
 
     @Test
-    public void execute_noQuorum() throws Exception {
+    public void execute_noQuorum() {
         // fire and forget operation, no quorum exception propagation
         // expectedException.expectCause(isA(QuorumException.class));
         exec(3).execute(runnable());
@@ -193,14 +197,14 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submit_runnable_selector_callback_quorum() throws Exception {
+    public void submit_runnable_selector_callback_quorum() {
         Callback callback = callback();
         exec(0).submit(runnable(), selector(0), callback);
         callback.get();
     }
 
     @Test
-    public void submit_runnable_selector_callback_noQuorum() throws Exception {
+    public void submit_runnable_selector_callback_noQuorum() {
         Callback callback = callback();
         exec(3).submit(runnable(), selector(3), callback());
         expectQuorumException(callback);
@@ -229,14 +233,14 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submit_callable_selector_callback_quorum() throws Exception {
+    public void submit_callable_selector_callback_quorum() {
         Callback callback = callback();
         exec(0).submit(callable(), selector(0), callback);
         callback.get();
     }
 
     @Test
-    public void submit_callable_selector_callback_noQuorum() throws Exception {
+    public void submit_callable_selector_callback_noQuorum() {
         Callback callback = callback();
         exec(3).submit(callable(), selector(3), callback());
         expectQuorumException(callback);
@@ -254,28 +258,28 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submitToAllMembers_callable_multiCallback_quorum() throws Exception {
+    public void submitToAllMembers_callable_multiCallback_quorum() {
         MultiCallback multiCallback = multiCallback();
         exec(0).submitToAllMembers(callable(), multiCallback);
         multiCallback.get();
     }
 
     @Test
-    public void submitToAllMembers_callable_multiCallback_noQuorum() throws Exception {
+    public void submitToAllMembers_callable_multiCallback_noQuorum() {
         MultiCallback multiCallback = multiCallback();
         exec(3).submitToAllMembers(callable(), multiCallback);
         expectQuorumException(multiCallback);
     }
 
     @Test
-    public void submitToAllMembers_runnable_multiCallback_quorum() throws Exception {
+    public void submitToAllMembers_runnable_multiCallback_quorum() {
         MultiCallback multiCallback = multiCallback();
         exec(0).submitToAllMembers(runnable(), multiCallback);
         multiCallback.get();
     }
 
     @Test
-    public void submitToAllMembers_runnable_multiCallback_noQuorum() throws Exception {
+    public void submitToAllMembers_runnable_multiCallback_noQuorum() {
         MultiCallback multiCallback = multiCallback();
         exec(3).submitToAllMembers(runnable(), multiCallback);
         expectQuorumException(multiCallback);
@@ -293,28 +297,28 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submitToKeyOwner_runnable_callback_quorum() throws Exception {
+    public void submitToKeyOwner_runnable_callback_quorum() {
         Callback callback = callback();
         exec(0).submitToKeyOwner(runnable(), key(0), callback);
         callback.get();
     }
 
     @Test
-    public void submitToKeyOwner_runnable_callback_noQuorum() throws Exception {
+    public void submitToKeyOwner_runnable_callback_noQuorum() {
         Callback callback = callback();
         exec(3).submitToKeyOwner(runnable(), key(3), callback);
         expectQuorumException(callback);
     }
 
     @Test
-    public void submitToKeyOwner_callable_callback_quorum() throws Exception {
+    public void submitToKeyOwner_callable_callback_quorum() {
         Callback callback = callback();
         exec(0).submitToKeyOwner(callable(), key(0), callback);
         callback.get();
     }
 
     @Test
-    public void submitToKeyOwner_callable_callback_noQuorum() throws Exception {
+    public void submitToKeyOwner_callable_callback_noQuorum() {
         Callback callback = callback();
         exec(3).submitToKeyOwner(callable(), key(3), callback);
         expectQuorumException(callback);
@@ -332,28 +336,28 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submitToMember_runnable_callback_quorum() throws Exception {
+    public void submitToMember_runnable_callback_quorum() {
         Callback callback = callback();
         exec(0).submitToMember(runnable(), member(0), callback);
         callback.get();
     }
 
     @Test
-    public void submitToMember_runnable_callback_noQuorum() throws Exception {
+    public void submitToMember_runnable_callback_noQuorum() {
         Callback callback = callback();
         exec(3).submitToMember(runnable(), member(3), callback);
         expectQuorumException(callback);
     }
 
     @Test
-    public void submitToMember_callable_callback_quorum() throws Exception {
+    public void submitToMember_callable_callback_quorum() {
         Callback callback = callback();
         exec(0).submitToMember(callable(), member(0), callback);
         callback.get();
     }
 
     @Test
-    public void submitToMember_callable_callback_noQuorum() throws Exception {
+    public void submitToMember_callable_callback_noQuorum() {
         Callback callback = callback();
         exec(3).submitToMember(callable(), member(3), callback);
         expectQuorumException(callback);
@@ -371,14 +375,14 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submitToMembers_callable_member_callback_quorum() throws Exception {
+    public void submitToMembers_callable_member_callback_quorum() {
         MultiCallback multiCallback = multiCallback();
         exec(0).submitToMembers(callable(), asList(member(0)), multiCallback);
         multiCallback.get();
     }
 
     @Test
-    public void submitToMembers_callable_member_callback_noQuorum() throws Exception {
+    public void submitToMembers_callable_member_callback_noQuorum() {
         MultiCallback multiCallback = multiCallback();
         exec(3).submitToMembers(callable(), asList(member(3)), multiCallback);
         expectQuorumException(multiCallback);
@@ -396,7 +400,7 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submitToMembers_callable_selector_callback_quorum() throws Exception {
+    public void submitToMembers_callable_selector_callback_quorum() {
         MultiCallback multiCallback = multiCallback();
         exec(0).submitToMembers(callable(), selector(0), multiCallback);
         multiCallback.get();
@@ -404,35 +408,35 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void submitToMembers_callable_selector_callback_noQuorum() throws Exception {
+    public void submitToMembers_callable_selector_callback_noQuorum() {
         MultiCallback multiCallback = multiCallback();
         exec(3).submitToMembers(callable(), selector(3), multiCallback);
         expectQuorumException(multiCallback);
     }
 
     @Test
-    public void submitToMembers_runnable_selector_callback_quorum() throws Exception {
+    public void submitToMembers_runnable_selector_callback_quorum() {
         MultiCallback multiCallback = multiCallback();
         exec(0).submitToMembers(runnable(), selector(0), multiCallback);
         multiCallback.get();
     }
 
     @Test
-    public void submitToMembers_runnable_selector_callback_noQuorum() throws Exception {
+    public void submitToMembers_runnable_selector_callback_noQuorum() {
         MultiCallback multiCallback = multiCallback();
         exec(3).submitToMembers(runnable(), selector(3), multiCallback);
         expectQuorumException(multiCallback);
     }
 
     @Test
-    public void submitToMembers_runnable_member_callback_quorum() throws Exception {
+    public void submitToMembers_runnable_member_callback_quorum() {
         MultiCallback multiCallback = multiCallback();
         exec(0).submitToMembers(runnable(), asList(member(0)), multiCallback);
         multiCallback.get();
     }
 
     @Test
-    public void submitToMembers_runnable_member_callback_noQuorum() throws Exception {
+    public void submitToMembers_runnable_member_callback_noQuorum() {
         MultiCallback multiCallback = multiCallback();
         exec(3).submitToMembers(runnable(), asList(member(3)), multiCallback);
         expectQuorumException(multiCallback);
@@ -485,12 +489,12 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void shutdown_quorum() throws Exception {
+    public void shutdown_quorum() {
         exec(0, "shutdown").shutdown();
     }
 
     @Test
-    public void shutdown_noQuorum() throws Exception {
+    public void shutdown_noQuorum() {
         try {
             exec(3, "shutdown").shutdown();
         } catch(QuorumException ex) {
@@ -499,12 +503,12 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void shutdownNow_quorum() throws Exception {
+    public void shutdownNow_quorum() {
         exec(0, "shutdownNow").shutdownNow();
     }
 
     @Test
-    public void shutdownNow_noQuorum() throws Exception {
+    public void shutdownNow_noQuorum() {
         try {
             exec(3, "shutdownNow").shutdownNow();
         } catch(QuorumException ex) {
@@ -518,116 +522,6 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
 
     protected IExecutorService exec(int index, String postfix) {
         return exec(index, quorumType, postfix);
-    }
-
-    public static class ExecRunnable implements Runnable, Callable, Serializable {
-        @Override
-        public Object call() throws Exception {
-            return "response";
-        }
-
-        public void run() {
-        }
-
-        public static Runnable runnable() {
-            return new ExecRunnable();
-        }
-
-        public static Callable callable() {
-            return new ExecRunnable();
-        }
-    }
-
-    static class Selector implements MemberSelector {
-
-        private int index;
-
-        public Selector(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public boolean select(Member member) {
-            return member.getAddress().getPort() % (getNode(cluster.getInstance(0)).getThisAddress().getPort() + index) == 0;
-        }
-
-        public static MemberSelector selector(int index) {
-            return new Selector(index);
-        }
-    }
-
-    static class Callback implements ExecutionCallback {
-        static Semaphore finished;
-        static Throwable throwable;
-
-        public Callback() {
-            finished = new Semaphore(0);
-            throwable = null;
-        }
-
-        @Override
-        public void onResponse(Object response) {
-            finished.release();
-        }
-
-        @Override
-        public void onFailure(Throwable t) {
-            finished.release();
-            throwable = t;
-        }
-
-        public void get() {
-            while (true) {
-                try {
-                    finished.tryAcquire(5, TimeUnit.SECONDS);
-                    if (throwable != null) {
-                        sneakyThrow(throwable);
-                    }
-                    return;
-                } catch (InterruptedException e) {
-                }
-            }
-        }
-
-        public static Callback callback() {
-            return new Callback();
-        }
-    }
-
-    static class MultiCallback implements MultiExecutionCallback {
-        Semaphore finished = new Semaphore(0);
-        Throwable throwable;
-
-        @Override
-        public void onResponse(Member member, Object response) {
-            if (response instanceof Throwable) {
-                throwable = (Throwable) response;
-            }
-        }
-
-        @Override
-        public void onComplete(Map<Member, Object> values) {
-            finished.release();
-        }
-
-        public void get() {
-            while (true) {
-                try {
-                    if (finished.tryAcquire(5, TimeUnit.SECONDS) == false) {
-                        sneakyThrow(new TimeoutException());
-                    }
-                    if (throwable != null) {
-                        sneakyThrow(throwable);
-                    }
-                    return;
-                } catch (InterruptedException e) {
-                }
-            }
-        }
-
-        public static MultiCallback multiCallback() {
-            return new MultiCallback();
-        }
     }
 
     private void wait(Map<Member, Future<?>> futures) throws Exception {
@@ -676,6 +570,118 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     private void wait(Collection<Future<?>> futures) throws ExecutionException, InterruptedException {
         for (Future f : futures) {
             f.get();
+        }
+    }
+
+    public static class ExecRunnable implements Runnable, Callable, Serializable {
+
+        @Override
+        public Object call() throws Exception {
+            return "response";
+        }
+
+        public void run() {
+        }
+
+        public static Runnable runnable() {
+            return new ExecRunnable();
+        }
+
+        public static Callable callable() {
+            return new ExecRunnable();
+        }
+    }
+
+    static class Selector implements MemberSelector {
+
+        private int index;
+
+        Selector(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean select(Member member) {
+            return member.getAddress().getPort() % (getNode(cluster.getInstance(0)).getThisAddress().getPort() + index) == 0;
+        }
+
+        public static MemberSelector selector(int index) {
+            return new Selector(index);
+        }
+    }
+
+    static class Callback implements ExecutionCallback {
+        static Semaphore finished;
+        static Throwable throwable;
+
+        Callback() {
+            finished = new Semaphore(0);
+            throwable = null;
+        }
+
+        @Override
+        public void onResponse(Object response) {
+            finished.release();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            finished.release();
+            throwable = t;
+        }
+
+        public void get() {
+            while (true) {
+                try {
+                    finished.tryAcquire(5, TimeUnit.SECONDS);
+                    if (throwable != null) {
+                        sneakyThrow(throwable);
+                    }
+                    return;
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+
+        public static Callback callback() {
+            return new Callback();
+        }
+    }
+
+    static class MultiCallback implements MultiExecutionCallback {
+
+        Semaphore finished = new Semaphore(0);
+        Throwable throwable;
+
+        @Override
+        public void onResponse(Member member, Object response) {
+            if (response instanceof Throwable) {
+                throwable = (Throwable) response;
+            }
+        }
+
+        @Override
+        public void onComplete(Map<Member, Object> values) {
+            finished.release();
+        }
+
+        public void get() {
+            while (true) {
+                try {
+                    if (finished.tryAcquire(5, TimeUnit.SECONDS) == false) {
+                        sneakyThrow(new TimeoutException());
+                    }
+                    if (throwable != null) {
+                        sneakyThrow(throwable);
+                    }
+                    return;
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+
+        static MultiCallback multiCallback() {
+            return new MultiCallback();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,21 +31,24 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ListQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,23 +31,26 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ListQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -136,5 +140,4 @@ public class ListQuorumWriteTest extends AbstractQuorumTest {
     protected IList list(int index) {
         return list(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumReadTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,17 +46,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalListQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -68,6 +66,12 @@ public class TransactionalListQuorumReadTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/TransactionalListQuorumWriteTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,17 +46,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalListQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -69,6 +67,12 @@ public class TransactionalListQuorumWriteTest extends AbstractQuorumTest {
         );
     }
 
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
+
     @BeforeClass
     public static void setUp() {
         initTestEnvironment(new Config(), new TestHazelcastInstanceFactory());
@@ -78,7 +82,6 @@ public class TransactionalListQuorumWriteTest extends AbstractQuorumTest {
     public static void tearDown() {
         shutdownTestEnvironment();
     }
-
 
     @Test
     public void txAdd_successful_whenQuorumSize_met() {
@@ -119,5 +122,4 @@ public class TransactionalListQuorumWriteTest extends AbstractQuorumTest {
     public TransactionContext newTransactionContext(int index) {
         return cluster.instance[index].newTransactionContext(options);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumListenerTest.java
@@ -33,6 +33,11 @@ import java.util.concurrent.CountDownLatch;
 @Category({QuickTest.class, ParallelTest.class})
 public class LockQuorumListenerTest extends AbstractQuorumListenerTest {
 
+    @Override
+    protected void addQuorumConfig(Config config, String distributedObjectName, String quorumName) {
+        config.getLockConfig(distributedObjectName).setQuorumName(quorumName);
+    }
+
     @Test
     public void testQuorumFailureEventFiredWhenNodeCountBelowThreshold() {
         CountDownLatch quorumNotPresent = new CountDownLatch(1);
@@ -46,10 +51,5 @@ public class LockQuorumListenerTest extends AbstractQuorumListenerTest {
             expected.printStackTrace();
         }
         assertOpenEventually(quorumNotPresent, 15);
-    }
-
-    @Override
-    protected void addQuorumConfig(Config config, String distributedObjectName, String quorumName) {
-        config.getLockConfig(distributedObjectName).setQuorumName(quorumName);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,24 +33,27 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LockQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
+    @Parameters(name = "quorumType:{0}")
+    public static Iterable<Object[]> parameters() {
+        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
+    }
+
+    @Parameter
     public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
-    public static Iterable<Object[]> parameters() {
-        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
-    }
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,6 +33,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -40,17 +44,20 @@ import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LockQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -61,9 +68,6 @@ public class LockQuorumWriteTest extends AbstractQuorumTest {
     public static void tearDown() {
         shutdownTestEnvironment();
     }
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void tryLock_quorum() {
@@ -161,5 +165,4 @@ public class LockQuorumWriteTest extends AbstractQuorumTest {
     protected ILock lock(int index) {
         return lock(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumLiteMemberTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MapQuorumLiteMemberTest extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumReadTest.java
@@ -23,8 +23,9 @@ import com.hazelcast.projection.Projections;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -34,6 +35,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.HashSet;
 
@@ -41,17 +45,17 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MapQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -146,7 +150,7 @@ public class MapQuorumReadTest extends AbstractQuorumTest {
     public void localKeySet_successful_whenQuorumSize_met() {
         try {
             map(0).localKeySet();
-        } catch (UnsupportedOperationException ex) {
+        } catch (UnsupportedOperationException ignored) {
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapQuorumWriteTest.java
@@ -22,8 +22,9 @@ import com.hazelcast.map.TestLoggingEntryProcessor;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,6 +32,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,17 +45,17 @@ import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MapQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.WRITE}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -33,6 +34,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,17 +47,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalMapQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -69,6 +67,12 @@ public class TransactionalMapQuorumReadTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -227,5 +231,4 @@ public class TransactionalMapQuorumReadTest extends AbstractQuorumTest {
     public TransactionContext newTransactionContext(int index) {
         return cluster.instance[index].newTransactionContext(options);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapQuorumWriteTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -33,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,17 +47,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class TransactionalMapQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -70,6 +67,12 @@ public class TransactionalMapQuorumWriteTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumReadTest.java
@@ -23,8 +23,9 @@ import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,21 +33,24 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MultiMapQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -122,7 +126,7 @@ public class MultiMapQuorumReadTest extends AbstractQuorumTest {
     public void localKeySet_successful_whenQuorumSize_met() {
         try {
             map(0).localKeySet();
-        } catch (UnsupportedOperationException ex) {
+        } catch (UnsupportedOperationException ignored) {
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/MultiMapQuorumWriteTest.java
@@ -22,8 +22,9 @@ import com.hazelcast.core.MultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,6 +32,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -40,17 +44,17 @@ import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -61,7 +65,6 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     public static void tearDown() {
         shutdownTestEnvironment();
     }
-
 
     @Test
     public void put_successful_whenQuorumSize_met() {
@@ -74,32 +77,32 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void lock_successful_whenQuorumSize_met() throws InterruptedException {
+    public void lock_successful_whenQuorumSize_met() {
         map(0).lock(UUID.randomUUID().toString());
     }
 
     @Test(expected = QuorumException.class)
-    public void lock_failing_whenQuorumSize_notMet() throws InterruptedException {
+    public void lock_failing_whenQuorumSize_notMet() {
         map(3).lock(UUID.randomUUID().toString());
     }
 
     @Test
-    public void lockWithTime_successful_whenQuorumSize_met() throws InterruptedException {
+    public void lockWithTime_successful_whenQuorumSize_met() {
         map(0).lock(UUID.randomUUID().toString(), 5, TimeUnit.SECONDS);
     }
 
     @Test(expected = QuorumException.class)
-    public void lockWithTime_failing_whenQuorumSize_notMet() throws InterruptedException {
+    public void lockWithTime_failing_whenQuorumSize_notMet() {
         map(3).lock(UUID.randomUUID().toString(), 5, TimeUnit.SECONDS);
     }
 
     @Test
-    public void tryLock_successful_whenQuorumSize_met() throws InterruptedException {
+    public void tryLock_successful_whenQuorumSize_met() {
         map(0).tryLock(UUID.randomUUID().toString());
     }
 
     @Test(expected = QuorumException.class)
-    public void tryLock_failing_whenQuorumSize_notMet() throws InterruptedException {
+    public void tryLock_failing_whenQuorumSize_notMet() {
         map(3).tryLock(UUID.randomUUID().toString());
     }
 
@@ -124,7 +127,7 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void unlock_successful_whenQuorumSize_met() throws InterruptedException {
+    public void unlock_successful_whenQuorumSize_met() {
         try {
             map(0).unlock("foo");
         } catch (IllegalMonitorStateException ex) {
@@ -133,7 +136,7 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test(expected = QuorumException.class)
-    public void unlock_failing_whenQuorumSize_notMet() throws InterruptedException {
+    public void unlock_failing_whenQuorumSize_notMet() {
         try {
             map(3).unlock("foo");
         } catch (IllegalMonitorStateException ex) {
@@ -142,12 +145,12 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void forceUnlock_successful_whenQuorumSize_met() throws InterruptedException {
+    public void forceUnlock_successful_whenQuorumSize_met() {
         map(0).forceUnlock("foo");
     }
 
     @Test(expected = QuorumException.class)
-    public void forceUnlock_failing_whenQuorumSize_notMet() throws InterruptedException {
+    public void forceUnlock_failing_whenQuorumSize_notMet() {
         map(3).forceUnlock("foo");
     }
 
@@ -185,7 +188,7 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     public void addLocalEntryListener_successful_whenQuorumSize_met() {
         try {
             map(0).addLocalEntryListener(new EntryAdapter());
-        } catch (UnsupportedOperationException ex) {
+        } catch (UnsupportedOperationException ignored) {
         }
     }
 
@@ -193,7 +196,7 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     public void addLocalEntryListener_successful_whenQuorumSize_notMet() {
         try {
             map(3).addLocalEntryListener(new EntryAdapter());
-        } catch (UnsupportedOperationException ex) {
+        } catch (UnsupportedOperationException ignored) {
         }
     }
 
@@ -230,5 +233,4 @@ public class MultiMapQuorumWriteTest extends AbstractQuorumTest {
     protected MultiMap map(int index) {
         return multimap(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumReadTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalMultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,17 +46,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalMultiMapQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -68,6 +66,12 @@ public class TransactionalMultiMapQuorumReadTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -136,5 +140,4 @@ public class TransactionalMultiMapQuorumReadTest extends AbstractQuorumTest {
     public TransactionContext newTransactionContext(int index) {
         return cluster.instance[index].newTransactionContext(options);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/multimap/TransactionalMultiMapQuorumWriteTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalMultiMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,17 +46,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalMultiMapQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -68,6 +66,12 @@ public class TransactionalMultiMapQuorumWriteTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -136,5 +140,4 @@ public class TransactionalMultiMapQuorumWriteTest extends AbstractQuorumTest {
     public TransactionContext newTransactionContext(int index) {
         return cluster.instance[index].newTransactionContext(options);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,24 +33,27 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class QueueQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
+    @Parameters(name = "quorumType:{0}")
+    public static Iterable<Object[]> parameters() {
+        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
+    }
+
+    @Parameter
     public static QuorumType quorumType;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
-    public static Iterable<Object[]> parameters() {
-        return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
-    }
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/QueueQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,23 +33,29 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class QueueQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -59,9 +66,6 @@ public class QueueQuorumWriteTest extends AbstractQuorumTest {
     public static void tearDown() {
         shutdownTestEnvironment();
     }
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void put_quorum() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumReadTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,17 +47,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalQueueQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -69,6 +67,12 @@ public class TransactionalQueueQuorumReadTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -103,7 +107,7 @@ public class TransactionalQueueQuorumReadTest extends AbstractQuorumTest {
         TransactionContext transactionContext = newTransactionContext(0);
         transactionContext.beginTransaction();
         TransactionalQueue<Object> q = transactionContext.getQueue(QUEUE_NAME + quorumType.name());
-        q.peek(10l, TimeUnit.MILLISECONDS);
+        q.peek(10L, TimeUnit.MILLISECONDS);
         transactionContext.commitTransaction();
     }
 
@@ -112,7 +116,7 @@ public class TransactionalQueueQuorumReadTest extends AbstractQuorumTest {
         TransactionContext transactionContext = newTransactionContext(3);
         transactionContext.beginTransaction();
         TransactionalQueue<Object> q = transactionContext.getQueue(QUEUE_NAME + quorumType.name());
-        q.peek(10l, TimeUnit.MILLISECONDS);
+        q.peek(10L, TimeUnit.MILLISECONDS);
         transactionContext.commitTransaction();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/queue/TransactionalQueueQuorumWriteTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,17 +47,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -69,6 +67,12 @@ public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -103,7 +107,7 @@ public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
         TransactionContext transactionContext = newTransactionContext(0);
         transactionContext.beginTransaction();
         TransactionalQueue<Object> q = transactionContext.getQueue(QUEUE_NAME + quorumType.name());
-        q.offer("object", 10l, TimeUnit.MILLISECONDS);
+        q.offer("object", 10L, TimeUnit.MILLISECONDS);
         transactionContext.commitTransaction();
     }
 
@@ -112,7 +116,7 @@ public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
         TransactionContext transactionContext = newTransactionContext(3);
         transactionContext.beginTransaction();
         TransactionalQueue<Object> q = transactionContext.getQueue(QUEUE_NAME + quorumType.name());
-        q.offer("object", 10l, TimeUnit.MILLISECONDS);
+        q.offer("object", 10L, TimeUnit.MILLISECONDS);
         transactionContext.commitTransaction();
     }
 
@@ -139,7 +143,7 @@ public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
         TransactionContext transactionContext = newTransactionContext(0);
         transactionContext.beginTransaction();
         TransactionalQueue<Object> q = transactionContext.getQueue(QUEUE_NAME + quorumType.name());
-        q.poll(10l, TimeUnit.MILLISECONDS);
+        q.poll(10L, TimeUnit.MILLISECONDS);
         transactionContext.commitTransaction();
     }
 
@@ -148,7 +152,7 @@ public class TransactionalQueueQuorumWriteTest extends AbstractQuorumTest {
         TransactionContext transactionContext = newTransactionContext(3);
         transactionContext.beginTransaction();
         TransactionalQueue<Object> q = transactionContext.getQueue(QUEUE_NAME + quorumType.name());
-        q.poll(10l, TimeUnit.MILLISECONDS);
+        q.poll(10L, TimeUnit.MILLISECONDS);
         transactionContext.commitTransaction();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,23 +31,26 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Comparator;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/replicatedmap/ReplicatedMapQuorumWriteTest.java
@@ -22,8 +22,9 @@ import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,6 +32,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
@@ -40,17 +44,17 @@ import static com.hazelcast.quorum.QuorumType.WRITE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -131,5 +135,4 @@ public class ReplicatedMapQuorumWriteTest extends AbstractQuorumTest {
     protected ReplicatedMap map(int index) {
         return replmap(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
@@ -22,8 +22,9 @@ import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -33,25 +34,28 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class RingbufferQuorumReadTest extends AbstractQuorumTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -115,23 +119,23 @@ public class RingbufferQuorumReadTest extends AbstractQuorumTest {
 
     @Test
     public void readOne_quorum() throws InterruptedException {
-        ring(0).readOne(1l);
+        ring(0).readOne(1L);
     }
 
     @Test(expected = QuorumException.class)
     public void readOne_noQuorum() throws InterruptedException {
-        ring(3).readOne(1l);
+        ring(3).readOne(1L);
     }
 
     @Test
     public void readManyAsync_quorum() throws Exception {
-        ring(0).readManyAsync(1l, 1, 1, new Filter()).get();
+        ring(0).readManyAsync(1L, 1, 1, new Filter()).get();
     }
 
     @Test
-    public void readManyAsync_noQuorum() throws Exception {
+    public void readManyAsync_noQuorum() {
         try {
-            ring(3).readManyAsync(1l, 1, 1, new Filter()).get();
+            ring(3).readManyAsync(1L, 1, 1, new Filter()).get();
         } catch (Exception ex) {
             if (ex instanceof QuorumException || ex.getCause() instanceof QuorumException) {
                 return;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumWriteTest.java
@@ -22,8 +22,9 @@ import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -33,6 +34,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.quorum.QuorumType.READ_WRITE;
 import static com.hazelcast.quorum.QuorumType.WRITE;
@@ -40,20 +44,20 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.isA;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class RingbufferQuorumWriteTest extends AbstractQuorumTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{WRITE}, {READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -100,5 +104,4 @@ public class RingbufferQuorumWriteTest extends AbstractQuorumTest {
     protected Ringbuffer ring(int index) {
         return ring(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,24 +33,27 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ScheduledExecutorQuorumReadTest extends AbstractQuorumTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -62,12 +66,12 @@ public class ScheduledExecutorQuorumReadTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void getAllScheduledFutures_quorum() throws Exception {
+    public void getAllScheduledFutures_quorum() {
         exec(0).getAllScheduledFutures();
     }
 
     @Test(expected = QuorumException.class)
-    public void getAllScheduledFutures_noQuorum() throws Exception {
+    public void getAllScheduledFutures_noQuorum() {
         exec(3).getAllScheduledFutures();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
@@ -23,8 +23,9 @@ import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.IScheduledFuture;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -34,6 +35,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -47,20 +51,20 @@ import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.WRITE}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -93,7 +97,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void scheduleAtFixedRate_callable_quorum() throws Exception {
+    public void scheduleAtFixedRate_callable_quorum() {
         exec(0).scheduleAtFixedRate(runnable(), 10, 10, TimeUnit.MILLISECONDS).cancel(false);
     }
 
@@ -123,7 +127,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void scheduleOnMemberAtFixedRate_runnable_quorum() throws Exception {
+    public void scheduleOnMemberAtFixedRate_runnable_quorum() {
         exec(0).scheduleOnMemberAtFixedRate(runnable(), member(0), 10, 10, TimeUnit.MILLISECONDS).cancel(false);
     }
 
@@ -153,7 +157,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void scheduleOnKeyOwnerAtFixedRate_runnable_quorum() throws Exception {
+    public void scheduleOnKeyOwnerAtFixedRate_runnable_quorum() {
         exec(0).scheduleOnKeyOwnerAtFixedRate(runnable(), key(0), 10, 10, TimeUnit.MILLISECONDS).cancel(false);
     }
 
@@ -183,7 +187,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void scheduleOnAllMembersAtFixedRate_runnable_quorum() throws Exception {
+    public void scheduleOnAllMembersAtFixedRate_runnable_quorum() {
         cancel(exec(0).scheduleOnAllMembersAtFixedRate(runnable(), 10, 10, TimeUnit.MILLISECONDS));
     }
 
@@ -213,7 +217,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void scheduleOnMembersAtFixedRate_runnable_quorum() throws Exception {
+    public void scheduleOnMembersAtFixedRate_runnable_quorum() {
         cancel(exec(0).scheduleOnMembersAtFixedRate(runnable(), asList(member(0)), 10, 10, TimeUnit.MILLISECONDS));
     }
 
@@ -223,12 +227,12 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void shutdown_quorum() throws Exception {
+    public void shutdown_quorum() {
         exec(0, "shutdown").shutdown();
     }
 
     @Test(expected = QuorumException.class)
-    public void shutdown_noQuorum() throws Exception {
+    public void shutdown_noQuorum() {
         exec(3, "shutdown").shutdown();
     }
 
@@ -264,7 +268,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
         }
     }
 
-    private void cancel(Map<Member, IScheduledFuture<?>> futures) throws Exception {
+    private void cancel(Map<Member, IScheduledFuture<?>> futures) {
         for (IScheduledFuture f : futures.values()) {
             f.cancel(false);
         }
@@ -277,5 +281,4 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     protected IScheduledExecutorService exec(int index, String postfix) {
         return scheduledExec(index, quorumType, postfix);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumReadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.quorum.semaphore;
 
 import com.hazelcast.config.Config;
@@ -5,8 +21,9 @@ import com.hazelcast.core.ISemaphore;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -14,21 +31,24 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SemaphoreQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "classLoaderType:{0}")
+    @Parameters(name = "classLoaderType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -41,17 +61,16 @@ public class SemaphoreQuorumReadTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void availablePermits_successful_whenQuorumSize_met() throws InterruptedException {
+    public void availablePermits_successful_whenQuorumSize_met() {
         semaphore(0).availablePermits();
     }
 
     @Test(expected = QuorumException.class)
-    public void availablePermits_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void availablePermits_successful_whenQuorumSize_notMet() {
         semaphore(3).availablePermits();
     }
 
     protected ISemaphore semaphore(int index) {
         return semaphore(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumWriteTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.quorum.semaphore;
 
 import com.hazelcast.config.Config;
@@ -5,8 +21,9 @@ import com.hazelcast.core.ISemaphore;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -14,23 +31,26 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "classLoaderType:{0}")
+    @Parameters(name = "classLoaderType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.WRITE}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -43,12 +63,12 @@ public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void init_successful_whenQuorumSize_met() throws InterruptedException {
+    public void init_successful_whenQuorumSize_met() {
         semaphore(0).init(10);
     }
 
     @Test(expected = QuorumException.class)
-    public void init_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void init_successful_whenQuorumSize_notMet() {
         semaphore(3).init(10);
     }
 
@@ -75,7 +95,7 @@ public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
-    public void drainPermits_successful_whenQuorumSize_met() throws InterruptedException {
+    public void drainPermits_successful_whenQuorumSize_met() {
         int drained = 0;
         try {
             drained = semaphore(0).drainPermits();
@@ -85,60 +105,60 @@ public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test(expected = QuorumException.class)
-    public void drainPermits_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void drainPermits_successful_whenQuorumSize_notMet() {
         semaphore(3).drainPermits();
     }
 
     @Test
-    public void reducePermits_successful_whenQuorumSize_met() throws InterruptedException {
+    public void reducePermits_successful_whenQuorumSize_met() {
         semaphore(0).release();
         semaphore(0).reducePermits(1);
     }
 
     @Test(expected = QuorumException.class)
-    public void reducePermits_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void reducePermits_successful_whenQuorumSize_notMet() {
         semaphore(3).reducePermits(1);
     }
 
     @Test
-    public void release_successful_whenQuorumSize_met() throws InterruptedException {
+    public void release_successful_whenQuorumSize_met() {
         semaphore(0).release();
     }
 
     @Test(expected = QuorumException.class)
-    public void release_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void release_successful_whenQuorumSize_notMet() {
         semaphore(3).release();
     }
 
     @Test
-    public void releasePermits_successful_whenQuorumSize_met() throws InterruptedException {
+    public void releasePermits_successful_whenQuorumSize_met() {
         semaphore(0).release(2);
     }
 
     @Test(expected = QuorumException.class)
-    public void releasePermits_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void releasePermits_successful_whenQuorumSize_notMet() {
         semaphore(3).release(2);
     }
 
     @Test
-    public void tryAcquire_successful_whenQuorumSize_met() throws InterruptedException {
+    public void tryAcquire_successful_whenQuorumSize_met() {
         semaphore(0).release();
         semaphore(0).tryAcquire();
     }
 
     @Test(expected = QuorumException.class)
-    public void tryAcquire_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void tryAcquire_successful_whenQuorumSize_notMet() {
         semaphore(3).tryAcquire();
     }
 
     @Test
-    public void tryAcquirePermits_successful_whenQuorumSize_met() throws InterruptedException {
+    public void tryAcquirePermits_successful_whenQuorumSize_met() {
         semaphore(0).release(2);
         semaphore(0).tryAcquire(2);
     }
 
     @Test(expected = QuorumException.class)
-    public void tryAcquirePermits_successful_whenQuorumSize_notMet() throws InterruptedException {
+    public void tryAcquirePermits_successful_whenQuorumSize_notMet() {
         semaphore(3).tryAcquire(2);
     }
 
@@ -167,5 +187,4 @@ public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
     protected ISemaphore semaphore(int index) {
         return semaphore(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ISet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,21 +31,24 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SetQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.READ}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -129,5 +133,4 @@ public class SetQuorumReadTest extends AbstractQuorumTest {
     protected ISet set(int index) {
         return set(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumWriteTest.java
@@ -21,8 +21,9 @@ import com.hazelcast.core.ISet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -30,21 +31,24 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SetQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "quorumType:{0}")
+    @Parameters(name = "quorumType:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[][]{{QuorumType.WRITE}, {QuorumType.READ_WRITE}});
     }
+
+    @Parameter
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -119,5 +123,4 @@ public class SetQuorumWriteTest extends AbstractQuorumTest {
     protected ISet set(int index) {
         return set(index, quorumType);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumReadTest.java
@@ -20,8 +20,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -32,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,17 +46,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TransactionalSetQuorumReadTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -68,6 +66,12 @@ public class TransactionalSetQuorumReadTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/TransactionalSetQuorumWriteTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.quorum.AbstractQuorumTest;
 import com.hazelcast.quorum.QuorumType;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
@@ -32,6 +32,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,17 +45,11 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class})
 public class TransactionalSetQuorumWriteTest extends AbstractQuorumTest {
 
-    @Parameterized.Parameter(0)
-    public static TransactionOptions options;
-
-    @Parameterized.Parameter(1)
-    public static QuorumType quorumType;
-
-    @Parameterized.Parameters(name = "Executing: {0} {1}")
+    @Parameters(name = "Executing: {0} {1}")
     public static Collection<Object[]> parameters() {
 
         TransactionOptions onePhaseOption = TransactionOptions.getDefault();
@@ -68,6 +65,12 @@ public class TransactionalSetQuorumWriteTest extends AbstractQuorumTest {
                 new Object[]{twoPhaseOption, READ_WRITE}
         );
     }
+
+    @Parameter(0)
+    public static TransactionOptions options;
+
+    @Parameter(1)
+    public static QuorumType quorumType;
 
     @BeforeClass
     public static void setUp() {
@@ -118,5 +121,4 @@ public class TransactionalSetQuorumWriteTest extends AbstractQuorumTest {
     public TransactionContext newTransactionContext(int index) {
         return cluster.instance[index].newTransactionContext(options);
     }
-
 }


### PR DESCRIPTION
* made quorum tests parallel on class level and serial on method level
* added missing header
* aligned order or `@Parameters`, `@Parameter` and `@Rule` annotations

The combination
```java
@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
@Category({QuickTest.class, ParallelTest.class})
```
executes a parameterized test with serial method execution (one `@Test` after another), but parallel test class execution (multiple test classes in parallel).