### PR TITLE
Compensate backup in case  on replica loss

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -355,27 +355,15 @@ public class InvocationMonitor implements PacketHandler, MetricsProvider {
             heartbeatPerMember.remove(leftMember.getAddress());
 
             for (Invocation invocation : invocationRegistry) {
-                // Notify only if invocation's target is left member and invocation's member-list-version
-                // is lower than member-list-version at time of member removal.
-                //
-                // Comparison of invocation's target and left member is done using member UUID.
-                // Normally Hazelcast does not support crash-recover, a left member cannot rejoin
-                // with the same UUID. Hence UUID comparison is enough.
-                //
-                // But Hot-Restart breaks this limitation and when Hot-Restart is enabled a member
-                // can restore its UUID and it's allowed to rejoin when cluster state is FROZEN or PASSIVE.
-                //
-                // That's why another ordering property is needed. Invocation keeps member-list-version before
-                // operation is submitted to the target. If a member restarts with the same identity (UUID),
-                // by comparing member-list-version during member removal with the invocation's member-list-version
-                // we can determine whether invocation is submitted before member left or after restart.
-                if (hasMemberLeft(invocation) && invocation.memberListVersion < memberListVersion) {
-                    invocation.notifyError(new MemberLeftException(leftMember));
+                if (hasTargetLeft(invocation)) {
+                    onTargetLoss(invocation);
+                } else {
+                    onPotentialBackupLoss(invocation);
                 }
             }
         }
 
-        private boolean hasMemberLeft(Invocation invocation) {
+        private boolean hasTargetLeft(Invocation invocation) {
             MemberImpl targetMember = invocation.targetMember;
             if (targetMember == null) {
                 Address invTarget = invocation.invTarget;
@@ -383,6 +371,30 @@ public class InvocationMonitor implements PacketHandler, MetricsProvider {
             } else {
                 return leftMember.getUuid().equals(targetMember.getUuid());
             }
+        }
+
+        private void onTargetLoss(Invocation invocation) {
+            // Notify only if invocation's target is left member and invocation's member-list-version
+            // is lower than member-list-version at time of member removal.
+            //
+            // Comparison of invocation's target and left member is done using member UUID.
+            // Normally Hazelcast does not support crash-recover, a left member cannot rejoin
+            // with the same UUID. Hence UUID comparison is enough.
+            //
+            // But Hot-Restart breaks this limitation and when Hot-Restart is enabled a member
+            // can restore its UUID and it's allowed to rejoin when cluster state is FROZEN or PASSIVE.
+            //
+            // That's why another ordering property is needed. Invocation keeps member-list-version before
+            // operation is submitted to the target. If a member restarts with the same identity (UUID),
+            // by comparing member-list-version during member removal with the invocation's member-list-version
+            // we can determine whether invocation is submitted before member left or after restart.
+            if (invocation.memberListVersion < memberListVersion) {
+                invocation.notifyError(new MemberLeftException(leftMember));
+            }
+        }
+
+        private void onPotentialBackupLoss(Invocation invocation) {
+            invocation.notifyBackupComplete();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -286,7 +286,6 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         return true;
     }
 
-
     private void afterRun(Operation op) {
         try {
             op.afterRun();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
+import static java.util.Collections.newSetFromMap;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
+
+    private final static Set<String> backupRunning = newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+    // We use 20 seconds so we don't get spurious build failures.
+    public static final int COMPLETION_TIMEOUT_SECONDS = 20;
+
+    private OperationServiceImpl localOperationService;
+    private HazelcastInstance remote;
+    private TestHazelcastInstanceFactory instanceFactory;
+    private HazelcastInstance local;
+
+    @Before
+    public void setup() {
+        instanceFactory = createHazelcastInstanceFactory();
+        Config config = new Config()
+                // a long timeout is configured to verify that the fast timeout is kicking in
+                .setProperty(GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS.getName(), "100000")
+                .setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+
+        HazelcastInstance[] cluster = instanceFactory.newInstances(config, 2);
+        local = cluster[0];
+        remote = cluster[1];
+        warmUpPartitions(local, remote);
+        localOperationService = getOperationServiceImpl(cluster[0]);
+    }
+
+    @Test
+    public void whenPrimaryResponseNotYetReceived() {
+        String backupId = newUnsecureUuidString();
+        int responseDelaySeconds = 5;
+        Operation op = new PrimaryOperation(backupId)
+                .setPrimaryResponseDelaySeconds(responseDelaySeconds)
+                .setPartitionId(getPartitionId(local));
+        InvocationFuture f = (InvocationFuture) localOperationService.invokeOnPartition(op);
+
+        waitForBackupRunning(backupId);
+
+        remote.getLifecycleService().terminate();
+
+        assertCompletesEventually(f, responseDelaySeconds + COMPLETION_TIMEOUT_SECONDS);
+    }
+
+    @Test
+    public void whenPrimaryResponseAlreadyReceived() {
+        String backupId = newUnsecureUuidString();
+        Operation op = new PrimaryOperation(backupId)
+                .setPartitionId(getPartitionId(local));
+        InvocationFuture f = (InvocationFuture) localOperationService.invokeOnPartition(op);
+
+        waitForPrimaryResponse(f);
+
+        waitForBackupRunning(backupId);
+
+        remote.getLifecycleService().terminate();
+
+        assertCompletesEventually(f, COMPLETION_TIMEOUT_SECONDS);
+    }
+
+    private void waitForBackupRunning(final String backupId) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue(backupRunning.contains(backupId));
+            }
+        });
+    }
+
+    private void waitForPrimaryResponse(final InvocationFuture f) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertNotNull(f.invocation.pendingResponse);
+            }
+        });
+    }
+
+    static class PrimaryOperation extends Operation implements BackupAwareOperation {
+        private String backupId;
+        private int primaryResponseDelaySeconds;
+
+        public PrimaryOperation() {
+        }
+
+        public PrimaryOperation(String backupId) {
+            this.backupId = backupId;
+        }
+
+        public PrimaryOperation setPrimaryResponseDelaySeconds(int delaySeconds) {
+            this.primaryResponseDelaySeconds = delaySeconds;
+            return this;
+        }
+
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            return 1;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new SlowBackupOperation(backupId);
+        }
+
+        @Override
+        public Object getResponse() {
+            // backups are send before the response is send, and we stall sending a response so we can trigger
+            // a slow primary response while the backup is running.
+            sleepSeconds(primaryResponseDelaySeconds);
+            return super.getResponse();
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            out.writeUTF(backupId);
+            out.writeInt(primaryResponseDelaySeconds);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            backupId = in.readUTF();
+            primaryResponseDelaySeconds = in.readInt();
+        }
+    }
+
+    // the backup operation is going to be terribly slow with sending a backup
+    static class SlowBackupOperation extends Operation {
+        private String backupId;
+
+        public SlowBackupOperation() {
+        }
+
+        public SlowBackupOperation(String backupId) {
+            this.backupId = backupId;
+        }
+
+        @Override
+        public void run() throws Exception {
+            backupRunning.add(backupId);
+            sleepSeconds(120);
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            out.writeUTF(backupId);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            backupId = in.readUTF();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -895,6 +895,15 @@ public abstract class HazelcastTestSupport {
         });
     }
 
+    public static void assertCompletesEventually(final Future future, long timeoutSeconds) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue("Future has not completed", future.isDone());
+            }
+        }, timeoutSeconds);
+    }
+
     public static void assertSizeEventually(int expectedSize, Collection collection) {
         assertSizeEventually(expectedSize, collection, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }


### PR DESCRIPTION
If a member fails that isn't the primary, the number of
acked backups is increased by 1 to compensate for the failed member.