### PR TITLE
Complete coverage in Spring namespace handler

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
@@ -27,24 +27,24 @@ import org.w3c.dom.Node;
  * BeanDefinitionParser for Hazelcast Instance Configuration.
  * <p>
  * <b>Sample Spring XML for Hazelcast Instance:</b>
- * <pre>
- * &lt;hz:hazelcast id="instance"&gt;
- *      &lt;hz:config&gt;
- *          &lt;hz:group name="dev" password="password"/&gt;
- *          &lt;hz:network port="5701" port-auto-increment="false"&gt;
- *              &lt;hz:join&gt;
- *                  &lt;hz:multicast enabled="false" multicast-group="224.2.2.3" multicast-port="54327"/&gt;
- *                   &lt;hz:tcp-ip enabled="true"&gt;
- *                      &lt;hz:members&gt;10.10.1.2, 10.10.1.3&lt;/hz:members&gt;
- *                   &lt;/hz:tcp-ip&gt;
- *              &lt;/hz:join&gt;
- *          &lt;/hz:network&gt;
- *          &lt;hz:map name="map" backup-count="2" max-size="0" eviction-percentage="30"
+ * <pre>{@code
+ * <hz:hazelcast id="instance">
+ *      <hz:config>
+ *          <hz:group name="dev" password="password"/>
+ *          <hz:network port="5701" port-auto-increment="false">
+ *              <hz:join>
+ *                  <hz:multicast enabled="false" multicast-group="224.2.2.3" multicast-port="54327"/>
+ *                   <hz:tcp-ip enabled="true">
+ *                      <hz:members>10.10.1.2, 10.10.1.3</hz:members>
+ *                   </hz:tcp-ip>
+ *              </hz:join>
+ *          </hz:network>
+ *          <hz:map name="map" backup-count="2" max-size="0" eviction-percentage="30"
  *              read-backup-data="true" eviction-policy="NONE"
- *          merge-policy="com.hazelcast.map.merge.PassThroughMergePolicy"/&gt;
- *      &lt;/hz:config&gt;
- * &lt;/hz:hazelcast&gt;
- * </pre>
+ *          merge-policy="com.hazelcast.map.merge.PassThroughMergePolicy"/>
+ *      </hz:config>
+ * </hz:hazelcast>
+ * }</pre>
  */
 public class HazelcastInstanceDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
@@ -42,7 +42,7 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
                 "executorService",
                 "durableExecutorService",
                 "scheduledExecutorService",
-                "ringBuffer",
+                "ringbuffer",
                 "cardinalityEstimator",
                 "idGenerator",
                 "flakeIdGenerator",
@@ -51,7 +51,8 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
                 "countDownLatch",
                 "semaphore",
                 "lock",
-        };
+                "reliableTopic",
+                };
         for (String type : types) {
             registerBeanDefinitionParser(type, new HazelcastTypeBeanDefinitionParser(type));
         }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -1921,6 +1921,18 @@
             </xs:appinfo>
         </xs:annotation>
     </xs:element>
+    <xs:element name="reliableTopic" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ITopic instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ITopic"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="set" type="hazelcast-type">
         <xs:annotation>
             <xs:documentation>
@@ -2008,23 +2020,11 @@
     <xs:element name="cardinalityEstimator" type="hazelcast-type">
         <xs:annotation>
             <xs:documentation>
-                Retrieve a Hazelcast CardinalityEstimartor instance
+                Retrieve a Hazelcast CardinalityEstimator instance
             </xs:documentation>
             <xs:appinfo>
                 <tool:annotation>
                     <tool:exports type="com.hazelcast.cardinality.CardinalityEstimator"/>
-                </tool:annotation>
-            </xs:appinfo>
-        </xs:annotation>
-    </xs:element>
-    <xs:element name="ringBuffer" type="hazelcast-type">
-        <xs:annotation>
-            <xs:documentation>
-                Retrieve a Hazelcast CardinalityEstimartor instance
-            </xs:documentation>
-            <xs:appinfo>
-                <tool:annotation>
-                    <tool:exports type="com.hazelcast.ringbuffer.Ringbuffer"/>
                 </tool:annotation>
             </xs:appinfo>
         </xs:annotation>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -626,6 +626,8 @@
     <hz:set id="set" instance-ref="instance" name="set"/>
     <hz:list id="list" instance-ref="instance" name="list"/>
     <hz:executorService id="executorService" instance-ref="instance" name="executorService"/>
+    <hz:scheduledExecutorService id="scheduledExec" instance-ref="instance" name="scheduledExec"/>
+    <hz:durableExecutorService id="durableExec" instance-ref="instance" name="durableExec"/>
     <hz:idGenerator id="idGenerator" instance-ref="instance" name="idGenerator"/>
     <hz:flakeIdGenerator id="flakeIdGenerator" instance-ref="instance" name="flakeIdGenerator"/>
     <hz:atomicLong id="atomicLong" instance-ref="instance" name="testAtomicLong"/>
@@ -633,7 +635,9 @@
     <hz:countDownLatch id="countDownLatch" instance-ref="instance" name="countDownLatch"/>
     <hz:semaphore id="semaphore" instance-ref="instance" name="semaphore"/>
     <hz:lock id="lock" instance-ref="instance" name="lock"/>
-    <!--<hz:cardinality-estimator id="cardinality" instance-ref="instance" name="cardinality"/>-->
+    <hz:cardinalityEstimator id="cardinality" instance-ref="instance" name="cardinality"/>
+    <hz:ringbuffer id="testRingbuffer" instance-ref="instance" name="testRingbuffer"/>
+    <hz:reliableTopic id="testReliableTopic" instance-ref="instance" name="testReliableTopic"/>
 
     <bean id="dummyMapStore" class="com.hazelcast.spring.DummyStore"/>
     <bean id="dummyMapStoreFactory" class="com.hazelcast.spring.DummyStoreFactory"/>


### PR DESCRIPTION
Coverage of data structures in hazelcast-spring-3.10.xsd was incomplete.
This PR completes it with the following changes:
- Rename ringBuffer to ringbuffer - ringBuffer was failing as there is no HazelcastInstance.getRingBuffer()
- Add reliableTopic
- Add missing structures to test spring appcontext xml

Fixes #12121
Related reference-manual pull request: hazelcast/hazelcast-reference-manual#482