### PR TITLE
Fix indexed query consistency during migration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -36,6 +36,8 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.partition.membergroup.MemberGroup;
 import com.hazelcast.partition.membergroup.MemberGroupFactory;
 import com.hazelcast.partition.membergroup.MemberGroupFactoryFactory;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 
 import java.util.Collection;
 import java.util.Set;
@@ -310,18 +312,31 @@ public class PartitionStateManager {
         return newState;
     }
 
-    public void setMigratingFlag(int partitionId) {
+    /**
+     * Sets migrating flag for the partition with the given {@code partitionId}.
+     *
+     * @param partitionId the partition ID to set the flag of.
+     * @param endpoint    tells on which side the migration is going on.
+     * @see IPartition#isMigrating()
+     */
+    public void setMigratingFlag(int partitionId, MigrationEndpoint endpoint) {
         if (logger.isFinestEnabled()) {
             logger.finest("Setting partition-migrating flag. partitionId=" + partitionId);
         }
-        partitions[partitionId].setMigrating(true);
+        partitions[partitionId].setMigratingFlag(endpoint);
     }
 
+    /**
+     * Clears migrating flag for the partition with the given {@code partitionId}.
+     *
+     * @param partitionId the partition ID to set the flag for.
+     * @see IPartition#isMigrating()
+     */
     public void clearMigratingFlag(int partitionId) {
         if (logger.isFinestEnabled()) {
             logger.finest("Clearing partition-migrating flag. partitionId=" + partitionId);
         }
-        partitions[partitionId].setMigrating(false);
+        partitions[partitionId].clearMigratingFlag();
     }
 
     /** Sets the replica addresses for the {@code partitionId}. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -37,6 +37,7 @@ import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
@@ -135,8 +136,12 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
         }
     }
 
-    /** Sets the active migration and the partition migration flag. */
-    void setActiveMigration() {
+    /**
+     * Sets the active migration and the partition migration flag.
+     *
+     * @param endpoint tells on which side the migration is going on.
+     */
+    void setActiveMigration(MigrationEndpoint endpoint) {
         InternalPartitionServiceImpl partitionService = getService();
         MigrationManager migrationManager = partitionService.getMigrationManager();
         MigrationInfo currentActiveMigration = migrationManager.setActiveMigration(migrationInfo);
@@ -150,7 +155,7 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
                     + ". Current active migration is " + currentActiveMigration);
         }
         PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
-        partitionStateManager.setMigratingFlag(migrationInfo.getPartitionId());
+        partitionStateManager.setMigratingFlag(migrationInfo.getPartitionId(), endpoint);
     }
 
     void onMigrationStart() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PartitionMigrationEvent;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 
 import static com.hazelcast.core.MigrationEvent.MigrationStatus.STARTED;
 
@@ -54,7 +55,7 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
 
         InternalPartitionServiceImpl service = getService();
         PartitionStateManager partitionStateManager = service.getPartitionStateManager();
-        partitionStateManager.setMigratingFlag(getPartitionId());
+        partitionStateManager.setMigratingFlag(getPartitionId(), MigrationEndpoint.DESTINATION);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -69,7 +70,7 @@ public class MigrationOperation extends BaseMigrationDestinationOperation {
     @Override
     public void run() throws Exception {
         verifyMasterOnMigrationDestination();
-        setActiveMigration();
+        setActiveMigration(MigrationEndpoint.DESTINATION);
 
         try {
             doRun();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -41,6 +41,7 @@ import com.hazelcast.spi.impl.SimpleExecutionCallback;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -92,7 +93,7 @@ public class MigrationRequestOperation extends BaseMigrationSourceOperation {
         InternalPartition partition = getPartition();
         verifySource(nodeEngine.getThisAddress(), partition);
 
-        setActiveMigration();
+        setActiveMigration(MigrationEndpoint.SOURCE);
 
         if (!migrationInfo.startProcessing()) {
             getLogger().warning("Migration is cancelled -> " + migrationInfo);

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartition.java
@@ -36,7 +36,7 @@ public interface IPartition {
 
     /**
      * Checks if the partition is local.
-     *
+     * <p>
      * A partition is local if and only if the {@link #getOwnerOrNull()} returns the same address as 'this' address of the
      * {@link ClusterService#getThisAddress()}. If the address is {@code null} or a different address, {@code false}
      * is returned.
@@ -72,8 +72,16 @@ public interface IPartition {
      * The returned value could be stale when it is returned.
      *
      * @return {@code true} if there is a migration going on, {@code false} otherwise
+     * @see #getMigrationEndpoint()
      */
     boolean isMigrating();
+
+    /**
+     * @return the migration endpoint of this partition or {@code null} if this partition is not migrating at the moment.
+     * The returned value could be stale when it is returned.
+     * @see #isMigrating()
+     */
+    MigrationEndpoint getMigrationEndpoint();
 
     /**
      * Returns the address of the replica.

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -328,7 +329,7 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
         final int leaseTime = 1000;
 
         lock.lock(leaseTime, TimeUnit.MILLISECONDS);
-        partition.setMigrating(true);
+        partition.setMigratingFlag(MigrationEndpoint.SOURCE);
 
         spawn(new Runnable() {
             @Override
@@ -338,7 +339,7 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
-                partition.setMigrating(false);
+                partition.clearMigratingFlag();
             }
         });
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -77,7 +78,7 @@ public class StaleReadDuringMigrationTest extends HazelcastTestSupport {
         final int partitionId = 0;
         final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(instance);
         final InternalPartitionImpl partition = (InternalPartitionImpl) partitionService.getPartition(partitionId);
-        partition.setMigrating(true);
+        partition.setMigratingFlag(MigrationEndpoint.SOURCE);
 
         final InternalOperationService operationService = getOperationService(instance);
         final InvocationBuilder invocationBuilder = operationService

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/DummyInternalPartition.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/DummyInternalPartition.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.partition.MigrationEndpoint;
 
 public class DummyInternalPartition implements InternalPartition {
     private Address[] replicas;
@@ -45,6 +46,11 @@ public class DummyInternalPartition implements InternalPartition {
 
     @Override
     public boolean isMigrating() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MigrationEndpoint getMigrationEndpoint() {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
There is a short window during partition migration when partition
table is already updated on the destination member, but indexes are
not populated yet. To avoid consulting empty indexes while executing
queries the check for migration status of partitions is performed and
migrating partitions are skipped.

During the last step of query processing skipped partitions are asked
again for the results, see `AbstractMapQueryMessageTask#invokeOnMissingPartitions`.
Usually this works well, but there is a chance that some of the
partitions are still migrating and their indexes are still empty. There
was no check for this situation.

This change brings following:

1. Allows queries to run on a migrating partition if it's a source of
the migration operation since indexes are guaranteed to be available in
this case. This is an optimization.

2. Adds check for migration status of the partition in
`QueryRunner#runPartitionIndexOrPartitionScanQueryOnGivenOwnedPartition`
and fall backs to full scan if partition is a migration destination.
This is the fix.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1851
See also: https://github.com/hazelcast/hazelcast/issues/8385