### PR TITLE
Test attribute generation in ConfigXmlGeneratorTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/GlobalSerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GlobalSerializerConfig.java
@@ -59,6 +59,34 @@ public class GlobalSerializerConfig {
     }
 
     @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof GlobalSerializerConfig)) {
+            return false;
+        }
+
+        GlobalSerializerConfig that = (GlobalSerializerConfig) o;
+
+        if (overrideJavaSerialization != that.overrideJavaSerialization) {
+            return false;
+        }
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        return implementation != null ? implementation.equals(that.implementation) : that.implementation == null;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = className != null ? className.hashCode() : 0;
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + (overrideJavaSerialization ? 1 : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "GlobalSerializerConfig{"
                 + "className='" + className + '\''

--- a/hazelcast/src/main/java/com/hazelcast/config/HostVerificationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HostVerificationConfig.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.config;
 
-import java.util.Properties;
-
 import com.hazelcast.nio.ssl.TlsHostVerifier;
+
+import java.util.Properties;
 
 /**
  * TLS host verification configuration holder.
@@ -116,4 +116,36 @@ public class HostVerificationConfig {
                 + ", properties=" + properties + "}";
     }
 
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof HostVerificationConfig)) {
+            return false;
+        }
+
+        HostVerificationConfig that = (HostVerificationConfig) o;
+
+        if (enabledOnServer != that.enabledOnServer) {
+            return false;
+        }
+        if (policyClassName != null ? !policyClassName.equals(that.policyClassName) : that.policyClassName != null) {
+            return false;
+        }
+        if (implementation != null ? !implementation.equals(that.implementation) : that.implementation != null) {
+            return false;
+        }
+        return properties != null ? properties.equals(that.properties) : that.properties == null;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = policyClassName != null ? policyClassName.hashCode() : 0;
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + (enabledOnServer ? 1 : 0);
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
@@ -201,4 +201,49 @@ public class HotRestartPersistenceConfig {
         this.dataLoadTimeoutSeconds = dataLoadTimeoutSeconds;
         return this;
     }
+
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof HotRestartPersistenceConfig)) {
+            return false;
+        }
+
+        HotRestartPersistenceConfig that = (HotRestartPersistenceConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (parallelism != that.parallelism) {
+            return false;
+        }
+        if (validationTimeoutSeconds != that.validationTimeoutSeconds) {
+            return false;
+        }
+        if (dataLoadTimeoutSeconds != that.dataLoadTimeoutSeconds) {
+            return false;
+        }
+        if (baseDir != null ? !baseDir.equals(that.baseDir) : that.baseDir != null) {
+            return false;
+        }
+        if (backupDir != null ? !backupDir.equals(that.backupDir) : that.backupDir != null) {
+            return false;
+        }
+        return clusterDataRecoveryPolicy == that.clusterDataRecoveryPolicy;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (baseDir != null ? baseDir.hashCode() : 0);
+        result = 31 * result + (backupDir != null ? backupDir.hashCode() : 0);
+        result = 31 * result + parallelism;
+        result = 31 * result + validationTimeoutSeconds;
+        result = 31 * result + dataLoadTimeoutSeconds;
+        result = 31 * result + (clusterDataRecoveryPolicy != null ? clusterDataRecoveryPolicy.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/IcmpFailureDetectorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/IcmpFailureDetectorConfig.java
@@ -227,4 +227,49 @@ public class IcmpFailureDetectorConfig {
                 + ", parallelMode=" + parallelMode
                 + '}';
     }
+
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof IcmpFailureDetectorConfig)) {
+            return false;
+        }
+
+        IcmpFailureDetectorConfig that = (IcmpFailureDetectorConfig) o;
+
+        if (timeoutMilliseconds != that.timeoutMilliseconds) {
+            return false;
+        }
+        if (intervalMilliseconds != that.intervalMilliseconds) {
+            return false;
+        }
+        if (failFastOnStartup != that.failFastOnStartup) {
+            return false;
+        }
+        if (ttl != that.ttl) {
+            return false;
+        }
+        if (maxAttempts != that.maxAttempts) {
+            return false;
+        }
+        if (enabled != that.enabled) {
+            return false;
+        }
+        return parallelMode == that.parallelMode;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = timeoutMilliseconds;
+        result = 31 * result + intervalMilliseconds;
+        result = 31 * result + (failFastOnStartup ? 1 : 0);
+        result = 31 * result + ttl;
+        result = 31 * result + maxAttempts;
+        result = 31 * result + (enabled ? 1 : 0);
+        result = 31 * result + (parallelMode ? 1 : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/InterfacesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InterfacesConfig.java
@@ -82,6 +82,30 @@ public class InterfacesConfig {
     }
 
     @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof InterfacesConfig)) {
+            return false;
+        }
+
+        InterfacesConfig that = (InterfacesConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        return interfaceSet.equals(that.interfaceSet);
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + interfaceSet.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "InterfacesConfig{enabled=" + enabled + ", interfaces=" + interfaceSet + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberGroupConfig.java
@@ -88,6 +88,25 @@ public class MemberGroupConfig {
     }
 
     @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof MemberGroupConfig)) {
+            return false;
+        }
+
+        MemberGroupConfig that = (MemberGroupConfig) o;
+
+        return interfaces.equals(that.interfaces);
+    }
+
+    @Override
+    public final int hashCode() {
+        return interfaces.hashCode();
+    }
+
+    @Override
     public String toString() {
         return "MemberGroupConfig{interfaces=" + interfaces + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MulticastConfig.java
@@ -266,6 +266,51 @@ public class MulticastConfig {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof MulticastConfig)) {
+            return false;
+        }
+
+        MulticastConfig that = (MulticastConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (multicastPort != that.multicastPort) {
+            return false;
+        }
+        if (multicastTimeoutSeconds != that.multicastTimeoutSeconds) {
+            return false;
+        }
+        if (multicastTimeToLive != that.multicastTimeToLive) {
+            return false;
+        }
+        if (loopbackModeEnabled != that.loopbackModeEnabled) {
+            return false;
+        }
+        if (multicastGroup != null ? !multicastGroup.equals(that.multicastGroup) : that.multicastGroup != null) {
+            return false;
+        }
+        return trustedInterfaces.equals(that.trustedInterfaces);
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (multicastGroup != null ? multicastGroup.hashCode() : 0);
+        result = 31 * result + multicastPort;
+        result = 31 * result + multicastTimeoutSeconds;
+        result = 31 * result + multicastTimeToLive;
+        result = 31 * result + trustedInterfaces.hashCode();
+        result = 31 * result + (loopbackModeEnabled ? 1 : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "MulticastConfig [enabled=" + enabled
                 + ", multicastGroup=" + multicastGroup

--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -131,11 +131,55 @@ public class NativeMemoryConfig {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof NativeMemoryConfig)) {
+            return false;
+        }
+
+        NativeMemoryConfig that = (NativeMemoryConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (minBlockSize != that.minBlockSize) {
+            return false;
+        }
+        if (pageSize != that.pageSize) {
+            return false;
+        }
+        if (Float.compare(that.metadataSpacePercentage, metadataSpacePercentage) != 0) {
+            return false;
+        }
+        if (size != null ? !size.equals(that.size) : that.size != null) {
+            return false;
+        }
+        return allocatorType == that.allocatorType;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (size != null ? size.hashCode() : 0);
+        result = 31 * result + (allocatorType != null ? allocatorType.hashCode() : 0);
+        result = 31 * result + minBlockSize;
+        result = 31 * result + pageSize;
+        result = 31 * result + (metadataSpacePercentage != +0.0f ? Float.floatToIntBits(metadataSpacePercentage) : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "NativeMemoryConfig{"
                 + "enabled=" + enabled
                 + ", size=" + size
                 + ", allocatorType=" + allocatorType
+                + ", minBlockSize=" + minBlockSize
+                + ", pageSize=" + pageSize
+                + ", metadataSpacePercentage=" + metadataSpacePercentage
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -256,6 +256,34 @@ public class PartitionGroupConfig {
     }
 
     @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof PartitionGroupConfig)) {
+            return false;
+        }
+
+        PartitionGroupConfig that = (PartitionGroupConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (groupType != that.groupType) {
+            return false;
+        }
+        return memberGroupConfigs.equals(that.memberGroupConfigs);
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (groupType != null ? groupType.hashCode() : 0);
+        result = 31 * result + memberGroupConfigs.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "PartitionGroupConfig{"
                 + "enabled=" + enabled

--- a/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
@@ -133,6 +133,39 @@ public class SerializerConfig {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof SerializerConfig)) {
+            return false;
+        }
+
+        SerializerConfig that = (SerializerConfig) o;
+
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        if (implementation != null ? !implementation.equals(that.implementation) : that.implementation != null) {
+            return false;
+        }
+        if (typeClass != null ? !typeClass.equals(that.typeClass) : that.typeClass != null) {
+            return false;
+        }
+        return typeClassName != null ? typeClassName.equals(that.typeClassName) : that.typeClassName == null;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = className != null ? className.hashCode() : 0;
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + (typeClass != null ? typeClass.hashCode() : 0);
+        result = 31 * result + (typeClassName != null ? typeClassName.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "SerializerConfig{"
                 + "className='" + className + '\''

--- a/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
@@ -120,6 +120,48 @@ public class ServiceConfig {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof ServiceConfig)) {
+            return false;
+        }
+
+        ServiceConfig that = (ServiceConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        if (serviceImpl != null ? !serviceImpl.equals(that.serviceImpl) : that.serviceImpl != null) {
+            return false;
+        }
+        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
+            return false;
+        }
+        return configObject != null ? configObject.equals(that.configObject) : that.configObject == null;
+    }
+
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        result = 31 * result + (serviceImpl != null ? serviceImpl.hashCode() : 0);
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        result = 31 * result + (configObject != null ? configObject.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "ServiceConfig{"
                 + "enabled=" + enabled

--- a/hazelcast/src/main/java/com/hazelcast/config/ServicesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServicesConfig.java
@@ -69,6 +69,30 @@ public class ServicesConfig {
     }
 
     @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof ServicesConfig)) {
+            return false;
+        }
+
+        ServicesConfig that = (ServicesConfig) o;
+
+        if (enableDefaults != that.enableDefaults) {
+            return false;
+        }
+        return services.equals(that.services);
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enableDefaults ? 1 : 0);
+        result = 31 * result + services.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "ServicesConfig{enableDefaults=" + enableDefaults + ", services=" + services + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/SocketInterceptorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SocketInterceptorConfig.java
@@ -136,6 +136,39 @@ public class SocketInterceptorConfig {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof SocketInterceptorConfig)) {
+            return false;
+        }
+
+        SocketInterceptorConfig that = (SocketInterceptorConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        if (implementation != null ? !implementation.equals(that.implementation) : that.implementation != null) {
+            return false;
+        }
+        return properties != null ? properties.equals(that.properties) : that.properties == null;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "SocketInterceptorConfig{"
                 + "className='" + className + '\''

--- a/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TcpIpConfig.java
@@ -193,6 +193,39 @@ public class TcpIpConfig {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof TcpIpConfig)) {
+            return false;
+        }
+
+        TcpIpConfig that = (TcpIpConfig) o;
+
+        if (connectionTimeoutSeconds != that.connectionTimeoutSeconds) {
+            return false;
+        }
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (members != null ? !members.equals(that.members) : that.members != null) {
+            return false;
+        }
+        return requiredMember != null ? requiredMember.equals(that.requiredMember) : that.requiredMember == null;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = connectionTimeoutSeconds;
+        result = 31 * result + (enabled ? 1 : 0);
+        result = 31 * result + (members != null ? members.hashCode() : 0);
+        result = 31 * result + (requiredMember != null ? requiredMember.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "TcpIpConfig [enabled=" + enabled
                 + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -220,24 +220,48 @@ public class TopicConfig implements IdentifiedDataSerializable {
         return this;
     }
 
-    public int hashCode() {
-        return 31 * (name != null ? name.hashCode() : 0);
-    }
-
-    /**
-     * Checks if the given object is equal to this topic.
-     *
-     * @return {@code true} if the object is equal to this topic, {@code false} otherwise
-     */
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (!(obj instanceof TopicConfig)) {
+        if (o == null || !(o instanceof TopicConfig)) {
             return false;
         }
-        TopicConfig other = (TopicConfig) obj;
-        return (this.name != null ? this.name.equals(other.name) : other.name == null);
+
+        TopicConfig that = (TopicConfig) o;
+
+        if (globalOrderingEnabled != that.globalOrderingEnabled) {
+            return false;
+        }
+        if (statisticsEnabled != that.statisticsEnabled) {
+            return false;
+        }
+        if (multiThreadingEnabled != that.multiThreadingEnabled) {
+            return false;
+        }
+        if (listenerConfigs != null && that.listenerConfigs != null && !listenerConfigs.equals(that.listenerConfigs)) {
+            return false;
+        }
+        if (listenerConfigs != null && that.listenerConfigs == null && !listenerConfigs.isEmpty()) {
+            return false;
+        }
+        if (listenerConfigs == null && that.listenerConfigs != null && !that.listenerConfigs.isEmpty()) {
+            return false;
+        }
+        return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public final int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (globalOrderingEnabled ? 1 : 0);
+        result = 31 * result + (statisticsEnabled ? 1 : 0);
+        result = 31 * result + (multiThreadingEnabled ? 1 : 0);
+        result = 31 * result + (listenerConfigs != null ? listenerConfigs.hashCode() : 0);
+        return result;
     }
 
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemorySize.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemorySize.java
@@ -209,4 +209,28 @@ public final class MemorySize {
         }
         return size + " bytes";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MemorySize that = (MemorySize) o;
+
+        if (value != that.value) {
+            return false;
+        }
+        return unit == that.unit;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (value ^ (value >>> 32));
+        result = 31 * result + (unit != null ? unit.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class GlobalSerializerConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(GlobalSerializerConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/HostVerificationConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HostVerificationConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class HostVerificationConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(HostVerificationConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class HotRestartPersistenceConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(HotRestartPersistenceConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class IcmpFailureDetectorConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(IcmpFailureDetectorConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class InterfacesConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(InterfacesConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class MemberGroupConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MemberGroupConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .verify();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class MulticastConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MulticastConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .verify();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class NativeMemoryConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(NativeMemoryConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class PartitionGroupConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(PartitionGroupConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class SerializerConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(SerializerConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
@@ -21,6 +21,8 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -62,6 +64,14 @@ public class ServiceConfigTest extends HazelcastTestSupport {
         factory.newHazelcastInstance(config);
 
         assertTrue(configObject == service.config);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(ServiceConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .verify();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class ServicesConfigTest {
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(ServicesConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                      .verify();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class SocketInterceptorConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(SocketInterceptorConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class TcpIpConfigTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(TcpIpConfig.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -101,5 +103,17 @@ public class TopicConfigTest {
             // anticipated..
         }
         assertFalse(topicConfig.isGlobalOrderingEnabled());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(TopicConfig.class)
+                      .withPrefabValues(TopicConfigReadOnly.class,
+                              new TopicConfigReadOnly(new TopicConfig("Topic1")),
+                              new TopicConfigReadOnly(new TopicConfig("Topic2")))
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/memory/MemorySizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/MemorySizeTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.memory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.Test;
+
+public class MemorySizeTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        EqualsVerifier.forClass(MemorySize.class)
+                      .allFieldsShouldBeUsed()
+                      .suppress(Warning.NONFINAL_FIELDS)
+                      .verify();
+    }
+}


### PR DESCRIPTION
Many attributes for multiple data structures were missing in ConfigXmlGeneratorTest. This change adds them.
Also, some attributes and nodes were not generated before this change, those are added:
- Query caches in map config
- InitialMode in MapStore config
- SerializeKeys in NearCache config

To perform stricter validation in the tests, `equals()` and `hashCode()` methods are added to config classes where these were missing.

Fixes #12119