### PR TITLE
Renamed Inbound/OutboundHandler impls to Decoder/Encoder.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.ClientMessageChannelInboundHandler;
+import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelInitializer;
@@ -52,8 +52,8 @@ class ClientChannelInitializer implements ChannelInitializer {
 
         final ClientConnection connection = (ClientConnection) channel.attributeMap().get(ClientConnection.class);
 
-        ChannelInboundHandler inboundHandler = new ClientMessageChannelInboundHandler(
-                new ClientMessageChannelInboundHandler.ClientMessageHandler() {
+        ChannelInboundHandler inboundHandler = new ClientMessageDecoder(
+                new ClientMessageDecoder.ClientMessageHandler() {
                     @Override
                     public void handle(ClientMessage message) {
                         connection.handleClientMessage(message);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -29,14 +29,14 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.END_FLAG;
 /**
  * Builds {@link ClientMessage}s from byte chunks. Fragmented messages are merged into single messages before processed.
  */
-public class ClientMessageChannelInboundHandler extends ChannelInboundHandlerWithCounters {
+public class ClientMessageDecoder extends ChannelInboundHandlerWithCounters {
 
     private final Long2ObjectHashMap<BufferBuilder> builderBySessionIdMap = new Long2ObjectHashMap<BufferBuilder>();
 
     private final ClientMessageHandler messageHandler;
     private ClientMessage message = ClientMessage.create();
 
-    public ClientMessageChannelInboundHandler(ClientMessageHandler messageHandler) {
+    public ClientMessageDecoder(ClientMessageHandler messageHandler) {
         this.messageHandler = messageHandler;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -70,8 +70,8 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
-import com.hazelcast.nio.tcp.MemberChannelInboundHandler;
-import com.hazelcast.nio.tcp.MemberChannelOutboundHandler;
+import com.hazelcast.nio.tcp.PacketDecoder;
+import com.hazelcast.nio.tcp.PacketEncoder;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.security.SecurityContext;
@@ -258,12 +258,12 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public ChannelInboundHandler createInboundHandler(TcpIpConnection connection, IOService ioService) {
         NodeEngineImpl nodeEngine = node.nodeEngine;
-        return new MemberChannelInboundHandler(connection, nodeEngine.getPacketDispatcher());
+        return new PacketDecoder(connection, nodeEngine.getPacketDispatcher());
     }
 
     @Override
     public ChannelOutboundHandler createOutboundHandler(TcpIpConnection connection, IOService ioService) {
-        return new MemberChannelOutboundHandler();
+        return new PacketEncoder();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
+import com.hazelcast.nio.ascii.TextEncoder;
 
 public abstract class AbstractTextCommand implements TextCommand {
     protected final TextCommandConstants.TextCommandType type;
-    private TextChannelInboundHandler readHandler;
-    private TextChannelOutboundHandler writeHandler;
+    private TextDecoder decoder;
+    private TextEncoder encoder;
     private long requestId = -1;
 
     protected AbstractTextCommand(TextCommandConstants.TextCommandType type) {
@@ -35,13 +35,13 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public TextChannelInboundHandler getReadHandler() {
-        return readHandler;
+    public TextDecoder getDecoder() {
+        return decoder;
     }
 
     @Override
-    public TextChannelOutboundHandler getWriteHandler() {
-        return writeHandler;
+    public TextEncoder getEncoder() {
+        return encoder;
     }
 
     @Override
@@ -50,10 +50,10 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public void init(TextChannelInboundHandler textReadHandler, long requestId) {
-        this.readHandler = textReadHandler;
+    public void init(TextDecoder decoder, long requestId) {
+        this.decoder = decoder;
         this.requestId = requestId;
-        this.writeHandler = textReadHandler.getOutboundHandler();
+        this.encoder = decoder.getEncoder();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 public interface CommandParser  {
-    TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space);
+    TextCommand parser(TextDecoder decoder, String cmd, int space);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.ascii;
 
 import com.hazelcast.internal.networking.OutboundFrame;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
+import com.hazelcast.nio.ascii.TextEncoder;
 
 import java.nio.ByteBuffer;
 
@@ -26,11 +26,11 @@ public interface TextCommand extends OutboundFrame {
 
     TextCommandConstants.TextCommandType getType();
 
-    void init(TextChannelInboundHandler textReadHandler, long requestId);
+    void init(TextDecoder decoder, long requestId);
 
-    TextChannelInboundHandler getReadHandler();
+    TextDecoder getDecoder();
 
-    TextChannelOutboundHandler getWriteHandler();
+    TextEncoder getEncoder();
 
     long getRequestId();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -38,7 +38,7 @@ import com.hazelcast.internal.ascii.rest.HttpHeadCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpPostCommandProcessor;
 import com.hazelcast.internal.ascii.rest.RestValue;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextEncoder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
@@ -393,7 +393,7 @@ public class TextCommandServiceImpl implements TextCommandService {
                             stopObject.notify();
                         }
                     } else {
-                        TextChannelOutboundHandler textWriteHandler = textCommand.getWriteHandler();
+                        TextEncoder textWriteHandler = textCommand.getEncoder();
                         textWriteHandler.enqueue(textCommand);
                     }
                 } catch (InterruptedException e) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
@@ -18,13 +18,13 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
 public class DeleteCommandParser implements CommandParser {
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,11 +27,11 @@ import java.util.StringTokenizer;
 public class GetCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         String key = cmd.substring(space + 1);
         if (key.indexOf(' ') == -1) {
             GetCommand r = new GetCommand(key);
-            readHandler.publishRequest(r);
+            decoder.publishRequest(r);
         } else {
             StringTokenizer st = new StringTokenizer(key);
             List<String> keys = new ArrayList<String>();
@@ -39,7 +39,7 @@ public class GetCommandParser implements CommandParser {
                 String singleKey = st.nextToken();
                 keys.add(singleKey);
             }
-            readHandler.publishRequest(new BulkGetCommand(keys));
+            decoder.publishRequest(new BulkGetCommand(keys));
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
@@ -20,7 +20,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -33,7 +33,7 @@ public class IncrementCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -32,7 +32,7 @@ public class SetCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.QUIT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.STATS;
@@ -33,7 +33,7 @@ public class SimpleCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         if (type == QUIT) {
             return new SimpleCommand(type);
         } else if (type == STATS) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandProcessor.java
@@ -37,7 +37,7 @@ public class SimpleCommandProcessor extends MemcacheCommandProcessor<SimpleComma
     public void handle(SimpleCommand command) {
         if (command.getType() == QUIT) {
             try {
-                command.getReadHandler().closeConnection();
+                command.getDecoder().closeConnection();
             } catch (Exception e) {
                 logger.warning(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -32,7 +32,7 @@ public class TouchCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpDeleteCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpGetCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpHeadCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.NoOpCommand;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 import com.hazelcast.util.StringUtil;
 
 import java.nio.BufferOverflowException;
@@ -38,7 +38,7 @@ public class HttpPostCommand extends HttpCommand {
     private static final byte LINE_FEED = 0x0A;
     private static final byte CARRIAGE_RETURN = 0x0D;
 
-    private final TextChannelInboundHandler readHandler;
+    private final TextDecoder decoder;
 
     private boolean chunked;
     private boolean nextLine;
@@ -47,9 +47,9 @@ public class HttpPostCommand extends HttpCommand {
     private String contentType;
     private ByteBuffer lineBuffer = ByteBuffer.allocate(INITIAL_CAPACITY);
 
-    public HttpPostCommand(TextChannelInboundHandler readHandler, String uri) {
+    public HttpPostCommand(TextDecoder decoder, String uri) {
         super(HTTP_POST, uri);
-        this.readHandler = readHandler;
+        this.decoder = decoder;
     }
 
     /**
@@ -230,7 +230,7 @@ public class HttpPostCommand extends HttpCommand {
         } else if (!chunked && currentLine.startsWith(HEADER_CHUNKED)) {
             chunked = true;
         } else if (currentLine.startsWith(HEADER_EXPECT_100)) {
-            readHandler.sendResponse(new NoOpCommand(RES_100));
+            decoder.sendResponse(new NoOpCommand(RES_100));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpPostCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextDecoder decoder, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;
@@ -37,6 +37,6 @@ public class HttpPostCommandParser implements CommandParser {
         } else {
             return new ErrorCommand(ERROR_CLIENT);
         }
-        return new HttpPostCommand(readHandler, uri);
+        return new HttpPostCommand(decoder, uri);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInboundHandler.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking;
 
-import com.hazelcast.nio.tcp.MemberChannelInboundHandler;
+import com.hazelcast.nio.tcp.PacketDecoder;
 
 import java.nio.ByteBuffer;
 
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
  * <h1>Pipelining & Encryption</h1>
  * The ChannelInboundHandler/ChannelOutboundHandler can also form a pipeline. For example for SSL there could be a initial
  * ChannelInboundHandler that decryption the ByteBuffer and passes the decrypted ByteBuffer to the next ChannelInboundHandler;
- * which could be a {@link MemberChannelInboundHandler} that reads out any Packet from the decrypted ByteBuffer. Using this
+ * which could be a {@link PacketDecoder} that reads out any Packet from the decrypted ByteBuffer. Using this
  * approach encryption can easily be added to any type of communication, not only member 2 member communication.
  *
  * Currently security is added by using a {@link Channel}, but this is not needed if the handlers form a pipeline.
@@ -60,6 +60,10 @@ import java.nio.ByteBuffer;
  *
  * For encryption is similar approach can be followed where the DecryptingWriteHandler is the last ChannelOutboundHandler in
  * the pipeline.
+ *
+ *
+ * If the main task of a ChannelInboundHandler is to decode a message (e.g. a Packet), it is best to call this handler a
+ * decoder. For example PacketDecoder.
  *
  * @see ChannelOutboundHandler
  * @see EventLoopGroup

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelOutboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelOutboundHandler.java
@@ -31,6 +31,9 @@ import java.nio.ByteBuffer;
  * For more information about the ChannelOutboundHandler (and handlers in generally), have a look at the
  * {@link ChannelInboundHandler}.
  *
+ * If the main task of a ChannelOutboundHandler is to encode a message (e.g. a Packet), it is best to call this handler
+ * an encoder. For example PacketEncoder.
+ *
  * @param <F>
  * @see EventLoopGroup
  * @see ChannelInboundHandler

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextDecoder.java
@@ -60,7 +60,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
 
 @PrivateApi
-public class TextChannelInboundHandler implements ChannelInboundHandler {
+public class TextDecoder implements ChannelInboundHandler {
 
     private static final Map<String, CommandParser> MAP_COMMAND_PARSERS = new HashMap<String, CommandParser>();
 
@@ -98,7 +98,7 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
     private TextCommand command;
     private final boolean sslEnabled;
     private final TextCommandService textCommandService;
-    private final TextChannelOutboundHandler outboundHandler;
+    private final TextEncoder encoder;
     private final TcpIpConnection connection;
     private final boolean restEnabled;
     private final boolean memcacheEnabled;
@@ -107,11 +107,11 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
     private long requestIdGen;
     private final ILogger logger;
 
-    public TextChannelInboundHandler(TcpIpConnection connection, TextChannelOutboundHandler outboundHandler) {
+    public TextDecoder(TcpIpConnection connection, TextEncoder encoder) {
         IOService ioService = connection.getConnectionManager().getIoService();
         this.sslEnabled = ioService.getSSLConfig() == null ? false : ioService.getSSLConfig().isEnabled();
         this.textCommandService = ioService.getTextCommandService();
-        this.outboundHandler = outboundHandler;
+        this.encoder = encoder;
         this.connection = connection;
         this.memcacheEnabled = ioService.isMemcacheEnabled();
         this.restEnabled = ioService.isRestEnabled();
@@ -120,7 +120,7 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
     }
 
     public void sendResponse(TextCommand command) {
-        outboundHandler.enqueue(command);
+        encoder.enqueue(command);
     }
 
     @Override
@@ -251,8 +251,8 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
         }
     }
 
-    public TextChannelOutboundHandler getOutboundHandler() {
-        return outboundHandler;
+    public TextEncoder getEncoder() {
+        return encoder;
     }
 
     public void closeConnection() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextEncoder.java
@@ -26,12 +26,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @PrivateApi
-public class TextChannelOutboundHandler implements ChannelOutboundHandler<TextCommand> {
+public class TextEncoder implements ChannelOutboundHandler<TextCommand> {
     private final TcpIpConnection connection;
     private final Map<Long, TextCommand> responses = new ConcurrentHashMap<Long, TextCommand>(100);
     private long currentRequestId;
 
-    public TextChannelOutboundHandler(TcpIpConnection connection) {
+    public TextEncoder(TcpIpConnection connection) {
         this.connection = connection;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageEncoder.java
@@ -16,28 +16,18 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.internal.networking.ChannelOutboundHandler;
-import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.PacketIOHelper;
 
 import java.nio.ByteBuffer;
 
 /**
- * A {@link ChannelOutboundHandler} that for member to member communication.
- *
- * It writes {@link Packet} instances to the {@link ByteBuffer}.
- *
- * It makes use of a flyweight to allow the sharing of a packet-instance over multiple connections. The flyweight contains
- * the actual 'position' state of what has been written.
- *
- * @see MemberChannelInboundHandler
+ * A {@link ChannelOutboundHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
  */
-public class MemberChannelOutboundHandler implements ChannelOutboundHandler<Packet> {
-
-   private final PacketIOHelper packetWriter = new PacketIOHelper();
+public class ClientMessageEncoder implements ChannelOutboundHandler<ClientMessage> {
 
     @Override
-    public boolean onWrite(Packet packet, ByteBuffer dst) {
-        return packetWriter.writeTo(packet, dst);
+    public boolean onWrite(ClientMessage message, ByteBuffer dst) {
+        return message.writeTo(dst);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageHandlerImpl.java
@@ -18,21 +18,19 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.client.ClientEngine;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.ClientMessageChannelInboundHandler;
+import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.nio.Connection;
 
-import java.io.IOException;
-
 /**
- * A {@link ClientMessageChannelInboundHandler.ClientMessageHandler} implementation
+ * A {@link ClientMessageDecoder.ClientMessageHandler} implementation
  * that passes the message to the {@link ClientEngine}.
  */
-public class ClientMessageHandlerImpl implements ClientMessageChannelInboundHandler.ClientMessageHandler {
+public class ClientMessageHandlerImpl implements ClientMessageDecoder.ClientMessageHandler {
 
     private final Connection connection;
     private final ClientEngine clientEngine;
 
-    public ClientMessageHandlerImpl(Connection connection, ClientEngine clientEngine) throws IOException {
+    public ClientMessageHandlerImpl(Connection connection, ClientEngine clientEngine) {
         this.connection = connection;
         this.clientEngine = clientEngine;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.client.impl.protocol.util.ClientMessageChannelInboundHandler;
+import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelInitializer;
@@ -24,8 +24,8 @@ import com.hazelcast.internal.networking.ChannelOutboundHandler;
 import com.hazelcast.internal.networking.InitResult;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOService;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextDecoder;
+import com.hazelcast.nio.ascii.TextEncoder;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -141,7 +141,7 @@ public class MemberChannelInitializer implements ChannelInitializer {
         ByteBuffer inputBuffer = newInputBuffer(channel, ioService.getSocketClientReceiveBufferSize());
 
         ChannelInboundHandler inboundHandler
-                = new ClientMessageChannelInboundHandler(new ClientMessageHandlerImpl(connection, ioService.getClientEngine()));
+                = new ClientMessageDecoder(new ClientMessageHandlerImpl(connection, ioService.getClientEngine()));
 
         return new InitResult<ChannelInboundHandler>(inputBuffer, inboundHandler);
     }
@@ -151,13 +151,13 @@ public class MemberChannelInitializer implements ChannelInitializer {
         TcpIpConnectionManager connectionManager = connection.getConnectionManager();
         connectionManager.incrementTextConnections();
 
-        TextChannelOutboundHandler outboundHandler = new TextChannelOutboundHandler(connection);
+        TextEncoder outboundHandler = new TextEncoder(connection);
         channel.attributeMap().put(TEXT_OUTBOUND_HANDLER, outboundHandler);
 
         ByteBuffer inputBuffer = newInputBuffer(channel, ioService.getSocketReceiveBufferSize());
         inputBuffer.put(stringToBytes(protocol));
 
-        ChannelInboundHandler inboundHandler = new TextChannelInboundHandler(connection, outboundHandler);
+        ChannelInboundHandler inboundHandler = new TextDecoder(connection, outboundHandler);
         return new InitResult<ChannelInboundHandler>(inputBuffer, inboundHandler);
     }
 
@@ -223,7 +223,7 @@ public class MemberChannelInitializer implements ChannelInitializer {
     }
 
     private InitResult<ChannelOutboundHandler> initOutboundClientProtocol(Channel channel) {
-        ChannelOutboundHandler outboundHandler = new ClientChannelOutboundHandler();
+        ChannelOutboundHandler outboundHandler = new ClientMessageEncoder();
 
         ByteBuffer outputBuffer = newOutputBuffer(channel, ioService.getSocketClientSendBufferSize());
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketDecoder.java
@@ -32,15 +32,15 @@ import static com.hazelcast.nio.Packet.FLAG_URGENT;
  * It reads as many packets from the src ByteBuffer as possible, and each of the Packets is send to the {@link PacketHandler}.
  *
  * @see PacketHandler
- * @see MemberChannelOutboundHandler
+ * @see PacketEncoder
  */
-public class MemberChannelInboundHandler extends ChannelInboundHandlerWithCounters {
+public class PacketDecoder extends ChannelInboundHandlerWithCounters {
 
     protected final TcpIpConnection connection;
     private final PacketHandler handler;
     private final PacketIOHelper packetReader = new PacketIOHelper();
 
-    public MemberChannelInboundHandler(TcpIpConnection connection, PacketHandler handler) {
+    public PacketDecoder(TcpIpConnection connection, PacketHandler handler) {
         this.connection = connection;
         this.handler = handler;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketEncoder.java
@@ -16,18 +16,28 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.internal.networking.ChannelOutboundHandler;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.PacketIOHelper;
 
 import java.nio.ByteBuffer;
 
 /**
- * A {@link ChannelOutboundHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
+ * A {@link ChannelOutboundHandler} that for member to member communication.
+ *
+ * It writes {@link Packet} instances to the {@link ByteBuffer}.
+ *
+ * It makes use of a flyweight to allow the sharing of a packet-instance over multiple connections. The flyweight contains
+ * the actual 'position' state of what has been written.
+ *
+ * @see PacketDecoder
  */
-public class ClientChannelOutboundHandler implements ChannelOutboundHandler<ClientMessage> {
+public class PacketEncoder implements ChannelOutboundHandler<Packet> {
+
+    private final PacketIOHelper packetWriter = new PacketIOHelper();
 
     @Override
-    public boolean onWrite(ClientMessage message, ByteBuffer dst) throws Exception {
-        return message.writeTo(dst);
+    public boolean onWrite(Packet packet, ByteBuffer dst) {
+        return packetWriter.writeTo(packet, dst);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageEncoderTest.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.PacketIOHelper;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.util.SafeBuffer;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -36,28 +34,29 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MemberChannelOutboundHandlerTest extends HazelcastTestSupport {
+public class ClientMessageEncoderTest extends HazelcastTestSupport {
 
-    private InternalSerializationService serializationService;
-    private MemberChannelOutboundHandler writeHandler;
+    private ClientMessageEncoder encoder;
 
     @Before
     public void setup() {
-        serializationService = new DefaultSerializationServiceBuilder().build();
-        writeHandler = new MemberChannelOutboundHandler();
+        encoder = new ClientMessageEncoder();
     }
 
     @Test
-    public void test() throws Exception {
-        Packet packet = new Packet(serializationService.toBytes("foobar"));
+    public void test() {
+        ClientMessage message = ClientMessage.createForEncode(1000)
+                .setPartitionId(10)
+                .setMessageType(1);
+
         ByteBuffer bb = ByteBuffer.allocate(1000);
-        boolean result = writeHandler.onWrite(packet, bb);
+        boolean result = encoder.onWrite(message, bb);
 
         assertTrue(result);
-
-        // now we read out the bb and check if we can find the written packet.
         bb.flip();
-        Packet resultPacket = new PacketIOHelper().readFrom(bb);
-        assertEquals(packet, resultPacket);
+        ClientMessage clone = ClientMessage.createForDecode(new SafeBuffer(bb.array()), 0);
+
+        assertEquals(message.getPartitionId(), clone.getPartitionId());
+        assertEquals(message.getMessageType(), clone.getMessageType());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageHandlerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageHandlerImplTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.client.ClientEngine;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.ClientMessageChannelInboundHandler;
+import com.hazelcast.client.impl.protocol.util.ClientMessageDecoder;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.IOService;
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static org.mockito.Matchers.any;
@@ -46,18 +45,18 @@ public class ClientMessageHandlerImplTest {
     private IOService ioService;
     private Connection connection;
     private SwCounter counter;
-    private ClientMessageChannelInboundHandler inboundHandler;
+    private ClientMessageDecoder decoder;
     private ClientEngine clientEngine;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() {
         ioService = mock(IOService.class);
         connection = mock(Connection.class);
         counter = SwCounter.newSwCounter();
         clientEngine = mock(ClientEngine.class);
         messageHandler = new ClientMessageHandlerImpl(connection, clientEngine);
-        inboundHandler = new ClientMessageChannelInboundHandler(messageHandler);
-        inboundHandler.setNormalPacketsRead(counter);
+        decoder = new ClientMessageDecoder(messageHandler);
+        decoder.setNormalPacketsRead(counter);
     }
 
     @Test
@@ -72,7 +71,7 @@ public class ClientMessageHandlerImplTest {
         message.writeTo(bb);
         bb.flip();
 
-        inboundHandler.onRead(bb);
+        decoder.onRead(bb);
 
         verify(clientEngine).handleClientMessage(any(ClientMessage.class), eq(connection));
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -352,7 +352,7 @@ public class MockIOService implements IOService {
 
     @Override
     public ChannelInboundHandler createInboundHandler(final TcpIpConnection connection) {
-        return new MemberChannelInboundHandler(connection, new PacketHandler() {
+        return new PacketDecoder(connection, new PacketHandler() {
             private ILogger logger = loggingService.getLogger("MockIOService");
 
             @Override
@@ -375,7 +375,7 @@ public class MockIOService implements IOService {
 
     @Override
     public ChannelOutboundHandler createOutboundHandler(TcpIpConnection connection) {
-        return new MemberChannelOutboundHandler();
+        return new PacketEncoder();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketDecoderTest.java
@@ -39,10 +39,10 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 @Ignore
-public class MemberChannelInboundHandlerTest extends TcpIpConnection_AbstractTest {
+public class PacketDecoderTest extends TcpIpConnection_AbstractTest {
 
     private MockPacketDispatcher dispatcher;
-    private MemberChannelInboundHandler readHandler;
+    private PacketDecoder readHandler;
     private long oldPriorityPacketsRead;
     private long oldNormalPacketsRead;
     private NioChannelReader channelReader;
@@ -59,7 +59,7 @@ public class MemberChannelInboundHandlerTest extends TcpIpConnection_AbstractTes
         TcpIpConnection connection = connect(connManagerA, addressB);
 
         dispatcher = new MockPacketDispatcher();
-        readHandler = new MemberChannelInboundHandler(connection, dispatcher);
+        readHandler = new PacketDecoder(connection, dispatcher);
 
         channelReader = ((NioChannel) connection.getChannel()).getReader();
         oldNormalPacketsRead = channelReader.getNormalFramesReadCounter().get();

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketEncoderTest.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.SafeBuffer;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.PacketIOHelper;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -34,29 +36,28 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientChannelOutboundHandlerTest extends HazelcastTestSupport {
+public class PacketEncoderTest extends HazelcastTestSupport {
 
-    private ClientChannelOutboundHandler writeHandler;
+    private InternalSerializationService serializationService;
+    private PacketEncoder writeHandler;
 
     @Before
     public void setup() {
-        writeHandler = new ClientChannelOutboundHandler();
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        writeHandler = new PacketEncoder();
     }
 
     @Test
     public void test() throws Exception {
-        ClientMessage message = ClientMessage.createForEncode(1000)
-                .setPartitionId(10)
-                .setMessageType(1);
-
+        Packet packet = new Packet(serializationService.toBytes("foobar"));
         ByteBuffer bb = ByteBuffer.allocate(1000);
-        boolean result = writeHandler.onWrite(message, bb);
+        boolean result = writeHandler.onWrite(packet, bb);
 
         assertTrue(result);
-        bb.flip();
-        ClientMessage clone = ClientMessage.createForDecode(new SafeBuffer(bb.array()), 0);
 
-        assertEquals(message.getPartitionId(), clone.getPartitionId());
-        assertEquals(message.getMessageType(), clone.getMessageType());
+        // now we read out the bb and check if we can find the written packet.
+        bb.flip();
+        Packet resultPacket = new PacketIOHelper().readFrom(bb);
+        assertEquals(packet, resultPacket);
     }
 }


### PR DESCRIPTION
They are encoding/decoding Packets/ClientMessage/Text; so they have
been renamed to reflect that. The long names were a not that easy to
understand as the newer snappier names

This renaming follows from the IO pipeline cleanup. With more
handlers, having many classes with name InboundHandler/OutboundHandler
becomes a bit of a pita.

For enterprise PR see:
https://github.com/hazelcast/hazelcast-enterprise/pull/1897