### PR TITLE
Unified split-brain healing for WAN replication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -43,7 +43,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.SplitBrainAwareDataContainer;
 import com.hazelcast.spi.SplitBrainMergeEntryView;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -86,7 +85,7 @@ import static java.util.Collections.emptySet;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extends SampleableCacheRecordMap<Data, R>>
-        implements ICacheRecordStore, EvictionListener<Data, R>, SplitBrainAwareDataContainer<Data, Data, CacheRecord> {
+        implements ICacheRecordStore, EvictionListener<Data, R> {
 
     public static final String SOURCE_NOT_AVAILABLE = "<NA>";
     protected static final int DEFAULT_INITIAL_CAPACITY = 256;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.SplitBrainAwareDataContainer;
 
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
@@ -45,7 +46,7 @@ import java.util.Set;
  * @see com.hazelcast.cache.impl.CacheRecordStore
  */
 @SuppressWarnings("checkstyle:methodcount")
-public interface ICacheRecordStore {
+public interface ICacheRecordStore extends SplitBrainAwareDataContainer<Data, Data, CacheRecord> {
 
     /**
      * Gets the value to which the specified key is mapped,

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLegacyMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLegacyMergeOperation.java
@@ -60,7 +60,7 @@ public class CacheLegacyMergeOperation
     public void afterRun() {
         if (backupRecord != null) {
             if (cache.isWanReplicationEnabled()) {
-                final Data valueData = getNodeEngine().toData(backupRecord.getValue());
+                Data valueData = getNodeEngine().toData(backupRecord.getValue());
                 CacheEntryView<Data, Data> entryView = CacheEntryViews.createDefaultEntryView(key, valueData, backupRecord);
                 CacheWanEventPublisher publisher = cacheService.getCacheWanEventPublisher();
                 publisher.publishWanReplicationUpdate(name, entryView);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
-import com.hazelcast.cache.impl.CacheRecordStore;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.event.CacheWanEventPublisher;
@@ -93,7 +92,7 @@ public class CacheMergeOperation extends AbstractNamedOperation implements Backu
     private void merge(SplitBrainMergeEntryView<Data, Data> mergingEntry) {
         Data dataKey = mergingEntry.getKey();
 
-        CacheRecord backupRecord = ((CacheRecordStore) cache).merge(mergingEntry, mergePolicy);
+        CacheRecord backupRecord = cache.merge(mergingEntry, mergePolicy);
         if (backupRecord != null) {
             backupRecords.put(dataKey, backupRecord);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -60,8 +60,7 @@ public class CachePutAllBackupOperation
     }
 
     @Override
-    public void beforeRun()
-            throws Exception {
+    public void beforeRun() throws Exception {
         ICacheService service = getService();
         try {
             cache = service.getOrCreateRecordStore(name, getPartitionId());
@@ -88,10 +87,9 @@ public class CachePutAllBackupOperation
     private void publishWanEvent(Data key, CacheRecord record) {
         if (cache.isWanReplicationEnabled()) {
             ICacheService service = getService();
-            final CacheWanEventPublisher publisher = service.getCacheWanEventPublisher();
-            final CacheEntryView<Data, Data> view = CacheEntryViews.createDefaultEntryView(
-                    key, toData(record.getValue()), record);
-            publisher.publishWanReplicationUpdate(name, view);
+            CacheWanEventPublisher publisher = service.getCacheWanEventPublisher();
+            CacheEntryView<Data, Data> view = CacheEntryViews.createDefaultEntryView(key, toData(record.getValue()), record);
+            publisher.publishWanReplicationUpdateBackup(name, view);
         }
     }
 
@@ -110,15 +108,14 @@ public class CachePutAllBackupOperation
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out)
-            throws IOException {
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeBoolean(cacheRecords != null);
         if (cacheRecords != null) {
             out.writeInt(cacheRecords.size());
             for (Map.Entry<Data, CacheRecord> entry : cacheRecords.entrySet()) {
-                final Data key = entry.getKey();
-                final CacheRecord record = entry.getValue();
+                Data key = entry.getKey();
+                CacheRecord record = entry.getValue();
                 out.writeData(key);
                 out.writeObject(record);
             }
@@ -126,16 +123,15 @@ public class CachePutAllBackupOperation
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in)
-            throws IOException {
+    protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        final boolean recordNotNull = in.readBoolean();
+        boolean recordNotNull = in.readBoolean();
         if (recordNotNull) {
             int size = in.readInt();
             cacheRecords = createHashMap(size);
             for (int i = 0; i < size; i++) {
-                final Data key = in.readData();
-                final CacheRecord record = in.readObject();
+                Data key = in.readData();
+                CacheRecord record = in.readObject();
                 cacheRecords.put(key, record);
             }
         }
@@ -150,5 +146,4 @@ public class CachePutAllBackupOperation
     public int getFactoryId() {
         return CacheDataSerializerHook.F_ID;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 
@@ -65,8 +66,7 @@ public class CachePutBackupOperation
     }
 
     @Override
-    public void runInternal()
-            throws Exception {
+    public void runInternal() {
         ICacheService service = getService();
         ICacheRecordStore cache = service.getOrCreateRecordStore(name, getPartitionId());
         cache.putRecord(key, cacheRecord);
@@ -74,25 +74,24 @@ public class CachePutBackupOperation
     }
 
     @Override
-    public void afterRunInternal() throws Exception {
+    public void afterRunInternal() {
         if (!wanOriginated && cache.isWanReplicationEnabled()) {
+            SerializationService serializationService = getNodeEngine().getSerializationService();
             CacheEntryView<Data, Data> entryView = CacheEntryViews.createDefaultEntryView(key,
-                    getNodeEngine().getSerializationService().toData(cacheRecord.getValue()), cacheRecord);
+                    serializationService.toData(cacheRecord.getValue()), cacheRecord);
             wanEventPublisher.publishWanReplicationUpdateBackup(name, entryView);
         }
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out)
-            throws IOException {
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(cacheRecord);
         out.writeBoolean(wanOriginated);
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in)
-            throws IOException {
+    protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         cacheRecord = in.readObject();
         wanOriginated = in.readBoolean();
@@ -102,5 +101,4 @@ public class CachePutBackupOperation
     public int getId() {
         return CacheDataSerializerHook.PUT_BACKUP;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -33,7 +33,6 @@ import com.hazelcast.map.impl.query.QueryEntryFactory;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.ObjectRecordFactory;
 import com.hazelcast.map.impl.record.RecordFactory;
-import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializableByConvention;
@@ -93,7 +92,7 @@ public class MapContainer {
     protected final ObjectNamespace objectNamespace;
 
     protected WanReplicationPublisher wanReplicationPublisher;
-    protected MapMergePolicy wanMergePolicy;
+    protected Object wanMergePolicy;
 
     protected volatile Evictor evictor;
     protected volatile MapConfig mapConfig;
@@ -192,7 +191,7 @@ public class MapContainer {
         String wanReplicationRefName = wanReplicationRef.getName();
         WanReplicationService wanReplicationService = nodeEngine.getWanReplicationService();
         wanReplicationPublisher = wanReplicationService.getWanReplicationPublisher(wanReplicationRefName);
-        wanMergePolicy = mapServiceContext.getMergePolicyProvider().getLegacyMergePolicy(wanReplicationRef.getMergePolicy());
+        wanMergePolicy = mapServiceContext.getMergePolicyProvider().getMergePolicy(wanReplicationRef.getMergePolicy());
     }
 
     private PartitioningStrategy createPartitioningStrategy() {
@@ -224,12 +223,16 @@ public class MapContainer {
         return wanReplicationPublisher;
     }
 
-    public MapMergePolicy getWanMergePolicy() {
+    public Object getWanMergePolicy() {
         return wanMergePolicy;
     }
 
     public boolean isWanReplicationEnabled() {
         return wanReplicationPublisher != null && wanMergePolicy != null;
+    }
+
+    public boolean isWanRepublishingEnabled() {
+        return isWanReplicationEnabled() && mapConfig.getWanReplicationRef().isRepublishingEnabled();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -239,7 +239,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                 Data value = mapServiceContext.toData(record.getValue());
                 EntryView<Data, Data> entryView = createSimpleEntryView(key, value, record);
 
-                Operation operation = operationProvider.createMergeOperation(name, entryView, mergePolicy, false);
+                Operation operation = operationProvider.createLegacyMergeOperation(name, entryView, mergePolicy, false);
                 try {
                     int partitionId = partitionService.getPartitionId(key);
                     operationService

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -86,8 +86,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
     @Override
     public void publishWanReplicationUpdate(String mapName, EntryView<Data, Data> entryView) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        MapReplicationUpdate replicationEvent
-                = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(), entryView);
+        MapReplicationUpdate replicationEvent = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(), entryView);
         mapContainer.getWanReplicationPublisher().publishReplicationEvent(SERVICE_NAME, replicationEvent);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -35,6 +35,8 @@ import com.hazelcast.spi.SplitBrainMergePolicy;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Collections.singletonList;
+
 /**
  * Creates map operations.
  */
@@ -186,9 +188,15 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createMergeOperation(String name, EntryView<Data, Data> mergingEntry,
-                                             MapMergePolicy policy, boolean disableWanReplicationEvent) {
+    public MapOperation createLegacyMergeOperation(String name, EntryView<Data, Data> mergingEntry,
+                                                   MapMergePolicy policy, boolean disableWanReplicationEvent) {
         return new LegacyMergeOperation(name, mergingEntry, policy, disableWanReplicationEvent);
+    }
+
+    @Override
+    public MapOperation createMergeOperation(String name, SplitBrainMergeEntryView<Data, Data> entryView,
+                                             SplitBrainMergePolicy policy, boolean disableWanReplicationEvent) {
+        return new MergeOperation(name, singletonList(entryView), policy, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -107,7 +107,10 @@ public interface MapOperationProvider {
 
     MapOperation createTxnSetOperation(String name, Data dataKey, Data value, long version, long ttl);
 
-    MapOperation createMergeOperation(String name, EntryView<Data, Data> entryView, MapMergePolicy policy,
+    MapOperation createLegacyMergeOperation(String name, EntryView<Data, Data> entryView, MapMergePolicy policy,
+                                            boolean disableWanReplicationEvent);
+
+    MapOperation createMergeOperation(String name, SplitBrainMergeEntryView<Data, Data> entryView, SplitBrainMergePolicy policy,
                                       boolean disableWanReplicationEvent);
 
     MapOperation createMapFlushOperation(String name);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -174,9 +174,15 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createMergeOperation(String name, EntryView<Data, Data> mergingEntry,
-                                             MapMergePolicy policy, boolean disableWanReplicationEvent) {
-        return getDelegate().createMergeOperation(name, mergingEntry, policy, disableWanReplicationEvent);
+    public MapOperation createLegacyMergeOperation(String name, EntryView<Data, Data> mergingEntry,
+                                                   MapMergePolicy policy, boolean disableWanReplicationEvent) {
+        return getDelegate().createLegacyMergeOperation(name, mergingEntry, policy, disableWanReplicationEvent);
+    }
+
+    @Override
+    public MapOperation createMergeOperation(String name, SplitBrainMergeEntryView<Data, Data> entryView,
+                                             SplitBrainMergePolicy policy, boolean disableWanReplicationEvent) {
+        return getDelegate().createMergeOperation(name, entryView, policy, disableWanReplicationEvent);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
@@ -59,7 +59,7 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
     public Operation createPartitionOperation(int partitionId) {
         for (int i = 0; i < partitions.length; i++) {
             if (partitions[i] == partitionId) {
-                return new MergeOperation(name, mergeEntries[i], policy);
+                return new MergeOperation(name, mergeEntries[i], policy, false);
             }
         }
         throw new IllegalArgumentException("Unknown partitionId " + partitionId + " (" + Arrays.toString(partitions) + ")");

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -69,7 +69,7 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
     @Override
     public void run() {
         hasMapListener = mapEventPublisher.hasEventListener(name);
-        hasWanReplication = hasWanReplication();
+        hasWanReplication = mapContainer.isWanReplicationEnabled();
         hasBackups = hasBackups();
         hasInvalidation = mapContainer.hasInvalidationListener();
 
@@ -83,10 +83,6 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
         for (int i = 0; i < mapEntries.size(); i++) {
             put(mapEntries.getKey(i), mapEntries.getValue(i));
         }
-    }
-
-    private boolean hasWanReplication() {
-        return (mapContainer.getWanReplicationPublisher() != null && mapContainer.getWanMergePolicy() != null);
     }
 
     private boolean hasBackups() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -81,7 +81,7 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
             return;
         }
 
-        if (mapContainer.getWanReplicationPublisher() != null && mapContainer.getWanMergePolicy() != null) {
+        if (mapContainer.isWanReplicationEnabled()) {
             EntryView entryView = EntryViews.createSimpleEntryView(key, value, record);
             mapEventPublisher.publishWanReplicationUpdateBackup(name, entryView);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.core.EntryView;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.query.Query;
+import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.wan.WANReplicationQueueFullException;
 
 import java.util.List;
@@ -163,6 +167,20 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
+    public MapOperation createLegacyMergeOperation(String name, EntryView<Data, Data> mergingEntry, MapMergePolicy policy,
+                                                   boolean disableWanReplicationEvent) {
+        checkWanReplicationQueues(name);
+        return getDelegate().createLegacyMergeOperation(name, mergingEntry, policy, disableWanReplicationEvent);
+    }
+
+    @Override
+    public MapOperation createMergeOperation(String name, SplitBrainMergeEntryView<Data, Data> entryView,
+                                             SplitBrainMergePolicy policy, boolean disableWanReplicationEvent) {
+        checkWanReplicationQueues(name);
+        return getDelegate().createMergeOperation(name, entryView, policy, disableWanReplicationEvent);
+    }
+
+    @Override
     public OperationFactory createPartitionWideEntryOperationFactory(String name, EntryProcessor entryProcessor) {
         checkWanReplicationQueues(name);
         return getDelegate().createPartitionWideEntryOperationFactory(name, entryProcessor);
@@ -173,8 +191,7 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
                                                                                   EntryProcessor entryProcessor,
                                                                                   Predicate predicate) {
         checkWanReplicationQueues(name);
-        return getDelegate()
-                .createPartitionWideEntryWithPredicateOperationFactory(name, entryProcessor, predicate);
+        return getDelegate().createPartitionWideEntryWithPredicateOperationFactory(name, entryProcessor, predicate);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.wan;
 
 import com.hazelcast.core.EntryView;
-import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -30,13 +29,13 @@ import java.io.IOException;
 public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedDataSerializable {
 
     String mapName;
-    MapMergePolicy mergePolicy;
+    Object mergePolicy;
     EntryView<Data, Data> entryView;
 
     public MapReplicationUpdate() {
     }
 
-    public MapReplicationUpdate(String mapName, MapMergePolicy mergePolicy, EntryView<Data, Data> entryView) {
+    public MapReplicationUpdate(String mapName, Object mergePolicy, EntryView<Data, Data> entryView) {
         this.mergePolicy = mergePolicy;
         this.mapName = mapName;
         this.entryView = entryView;
@@ -50,11 +49,11 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
         this.mapName = mapName;
     }
 
-    public MapMergePolicy getMergePolicy() {
+    public Object getMergePolicy() {
         return mergePolicy;
     }
 
-    public void setMergePolicy(MapMergePolicy mergePolicy) {
+    public void setMergePolicy(Object mergePolicy) {
         this.mergePolicy = mergePolicy;
     }
 
@@ -62,7 +61,7 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
         return entryView;
     }
 
-    public void setEntryView(EntryView entryView) {
+    public void setEntryView(EntryView<Data, Data> entryView) {
         this.entryView = entryView;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/MergePolicyProvider.java
@@ -84,19 +84,4 @@ public final class MergePolicyProvider {
             return getOrPutIfAbsent(mergePolicyMap, className, policyConstructorFunction);
         }
     }
-
-    /**
-     * Returns an instance of a merge policy by its classname.
-     * <p>
-     * Tries to resolve the classname as {@link com.hazelcast.map.merge.MapMergePolicy}.
-     * <p>
-     * If no merge policy matches an exception is thrown.
-     *
-     * @param className the classname of the given merge policy
-     * @return an instance of the merge policy class
-     */
-    public MapMergePolicy getLegacyMergePolicy(String className) {
-        checkNotNull(className, "Class name is mandatory!");
-        return getOrPutIfAbsent(mergePolicyMap, className, policyConstructorFunction);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainEntryViews.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.collection.impl.collection.CollectionItem;
 import com.hazelcast.collection.impl.queue.QueueItem;
+import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapMergeContainer;
@@ -31,6 +33,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskDescriptor;
 import com.hazelcast.spi.SplitBrainMergeEntryView;
+import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 
@@ -47,7 +50,30 @@ public final class SplitBrainEntryViews {
     public static <K, V> SplitBrainMergeEntryView<K, V> createSplitBrainMergeEntryView(K key, V value) {
         return new SimpleSplitBrainEntryView<K, V>()
                 .setKey(key)
-                .setValue(value);
+                .setValue(value)
+                .setCreationTime(Clock.currentTimeMillis());
+    }
+
+    public static <K, V> SplitBrainMergeEntryView<K, V> createSplitBrainMergeEntryView(EntryView<K, V> entryView) {
+        return new SimpleSplitBrainEntryView<K, V>()
+                .setKey(entryView.getKey())
+                .setValue(entryView.getValue())
+                .setCreationTime(entryView.getCreationTime())
+                .setLastUpdateTime(entryView.getLastUpdateTime())
+                .setLastAccessTime(entryView.getLastAccessTime())
+                .setHits(entryView.getHits())
+                .setTtl(entryView.getTtl())
+                .setVersion(entryView.getVersion())
+                .setCost(entryView.getCost());
+    }
+
+    public static <K, V> SplitBrainMergeEntryView<K, V> createSplitBrainMergeEntryView(CacheEntryView<K, V> entryView) {
+        return new SimpleSplitBrainEntryView<K, V>()
+                .setKey(entryView.getKey())
+                .setValue(entryView.getValue())
+                .setCreationTime(entryView.getCreationTime())
+                .setLastAccessTime(entryView.getLastAccessTime())
+                .setHits(entryView.getAccessHit());
     }
 
     public static SplitBrainMergeEntryView<Long, Data> createSplitBrainMergeEntryView(CollectionItem item) {

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -81,23 +81,23 @@ public class CacheSimpleConfigTest extends HazelcastTestSupport {
         CacheSimpleEntryListenerConfig blackEntryListenerConfig = new CacheSimpleEntryListenerConfig();
         blackEntryListenerConfig.setCacheEntryListenerFactory("black");
         EqualsVerifier.forClass(CacheSimpleConfig.class)
-                      .allFieldsShouldBeUsedExcept("readOnly")
-                      .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
-                      .withPrefabValues(EvictionConfig.class,
-                              new EvictionConfig(1000, ENTRY_COUNT, EvictionPolicy.LFU),
-                              new EvictionConfig(300, USED_NATIVE_MEMORY_PERCENTAGE, EvictionPolicy.LRU))
-                      .withPrefabValues(WanReplicationRef.class,
-                              new WanReplicationRef("red", null, null,false),
-                              new WanReplicationRef("black", null, null, true))
-                      .withPrefabValues(CacheSimpleConfig.class,
-                              new CacheSimpleConfig().setName("red"),
-                              new CacheSimpleConfig().setName("black"))
-                      .withPrefabValues(CacheSimpleEntryListenerConfig.class,
-                              redEntryListenerConfig,
-                              blackEntryListenerConfig)
-                      .withPrefabValues(CachePartitionLostListenerConfig.class,
-                              new CachePartitionLostListenerConfig("red"),
-                              new CachePartitionLostListenerConfig("black"))
-                      .verify();
+                .allFieldsShouldBeUsedExcept("readOnly")
+                .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+                .withPrefabValues(EvictionConfig.class,
+                        new EvictionConfig(1000, ENTRY_COUNT, EvictionPolicy.LFU),
+                        new EvictionConfig(300, USED_NATIVE_MEMORY_PERCENTAGE, EvictionPolicy.LRU))
+                .withPrefabValues(WanReplicationRef.class,
+                        new WanReplicationRef("red", null, null,false),
+                        new WanReplicationRef("black", null, null, true))
+                .withPrefabValues(CacheSimpleConfig.class,
+                        new CacheSimpleConfig().setName("red"),
+                        new CacheSimpleConfig().setName("black"))
+                .withPrefabValues(CacheSimpleEntryListenerConfig.class,
+                        redEntryListenerConfig,
+                        blackEntryListenerConfig)
+                .withPrefabValues(CachePartitionLostListenerConfig.class,
+                        new CachePartitionLostListenerConfig("red"),
+                        new CachePartitionLostListenerConfig("black"))
+                .verify();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapMergePolicyQuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapMergePolicyQuickTest.java
@@ -53,8 +53,8 @@ public class MapMergePolicyQuickTest extends HazelcastTestSupport {
         Data dataKey = mapServiceContext.toData("key");
 
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(instance, "key"), name);
-        MapMergePolicy mergePolicy = mapServiceContext.getMergePolicyProvider()
-                .getLegacyMergePolicy(LatestUpdateMapMergePolicy.class.getName());
+        MapMergePolicy mergePolicy = (MapMergePolicy) mapServiceContext.getMergePolicyProvider()
+                .getMergePolicy(LatestUpdateMapMergePolicy.class.getName());
         long now = Clock.currentTimeMillis();
         SimpleEntryView<String, String> initialEntry = new SimpleEntryView<String, String>("key", "value1");
         initialEntry.setCreationTime(now);
@@ -82,8 +82,8 @@ public class MapMergePolicyQuickTest extends HazelcastTestSupport {
         Data dataKey = mapServiceContext.toData("key");
 
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(instance, "key"), name);
-        MapMergePolicy mergePolicy = mapServiceContext.getMergePolicyProvider()
-                .getLegacyMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        MapMergePolicy mergePolicy = (MapMergePolicy) mapServiceContext.getMergePolicyProvider()
+                .getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
 
         SimpleEntryView<String, String> initialEntry = new SimpleEntryView<String, String>("key", "value1");
         recordStore.merge(dataKey, initialEntry, mergePolicy);
@@ -104,8 +104,8 @@ public class MapMergePolicyQuickTest extends HazelcastTestSupport {
         Data dataKey = mapServiceContext.toData("key");
 
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(instance, "key"), name);
-        MapMergePolicy mergePolicy = mapServiceContext.getMergePolicyProvider()
-                .getLegacyMergePolicy(PassThroughMergePolicy.class.getName());
+        MapMergePolicy mergePolicy = (MapMergePolicy) mapServiceContext.getMergePolicyProvider()
+                .getMergePolicy(PassThroughMergePolicy.class.getName());
         SimpleEntryView<String, String> initialEntry = new SimpleEntryView<String, String>("key", "value1");
         recordStore.merge(dataKey, initialEntry, mergePolicy);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicySerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicySerializationTest.java
@@ -63,8 +63,8 @@ public class MergePolicySerializationTest extends HazelcastTestSupport {
         Data dataKey = mapServiceContext.toData("key");
 
         RecordStore recordStore = mapServiceContext.getRecordStore(partitionId, name);
-        MapMergePolicy mergePolicy = mapServiceContext.getMergePolicyProvider()
-                .getLegacyMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        MapMergePolicy mergePolicy = (MapMergePolicy) mapServiceContext.getMergePolicyProvider()
+                .getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
         EntryView<String, MyObject> mergingEntryView = new SimpleEntryView<String, MyObject>("key", new MyObject());
         recordStore.merge(dataKey, mergingEntryView, mergePolicy);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/ExpirationTimeSetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/ExpirationTimeSetterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ExpirationTimeSetterTest extends HazelcastTestSupport {
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(ExpirationTimeSetter.class);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MergePolicyProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MergePolicyProviderTest.java
@@ -80,7 +80,7 @@ public class MergePolicyProviderTest extends HazelcastTestSupport {
     }
 
     private void assertMergePolicyCorrectlyInitialised(String mergePolicyName) {
-        MapMergePolicy mergePolicy = mergePolicyProvider.getLegacyMergePolicy(mergePolicyName);
+        Object mergePolicy = mergePolicyProvider.getMergePolicy(mergePolicyName);
 
         assertNotNull(mergePolicy);
         assertEquals(mergePolicyName, mergePolicy.getClass().getName());

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanConfigurationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.WanPublisherConfig;
+import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.config.WanReplicationRef;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.map.merge.PassThroughMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class WanConfigurationTest extends HazelcastTestSupport {
+
+    private boolean isWanReplicationEnabled;
+    private boolean isWanRepublishingEnabled;
+
+    private TestHazelcastInstanceFactory factory;
+    private MapContainer mapContainer;
+
+    @Before
+    public void setUp() {
+        factory = createHazelcastInstanceFactory(1);
+    }
+
+    @Test
+    public void testNoWanReplication() {
+        isWanReplicationEnabled = false;
+        isWanRepublishingEnabled = false;
+        initInstanceAndMapContainer("noWanReplication");
+
+        assertFalse(mapContainer.isWanReplicationEnabled());
+        assertFalse(mapContainer.isWanRepublishingEnabled());
+        assertNull(mapContainer.getWanReplicationPublisher());
+        assertNull(mapContainer.getWanMergePolicy());
+        assertNull(mapContainer.getMapConfig().getWanReplicationRef());
+    }
+
+    @Test
+    public void testWanReplicationAndNoWanRepublishing() {
+        isWanReplicationEnabled = true;
+        isWanRepublishingEnabled = false;
+        initInstanceAndMapContainer("withWanReplicationOnly");
+
+        assertTrue(mapContainer.isWanReplicationEnabled());
+        assertFalse(mapContainer.isWanRepublishingEnabled());
+        assertNotNull(mapContainer.getWanReplicationPublisher());
+        assertNotNull(mapContainer.getWanMergePolicy());
+
+        WanReplicationRef wanReplicationRef = mapContainer.getMapConfig().getWanReplicationRef();
+        assertNotNull(wanReplicationRef);
+        assertEquals(mapContainer.getWanMergePolicy().getClass().getName(), wanReplicationRef.getMergePolicy());
+        assertFalse(wanReplicationRef.isRepublishingEnabled());
+    }
+
+    @Test
+    public void testWanReplicationAndWanRepublishing() {
+        isWanReplicationEnabled = true;
+        isWanRepublishingEnabled = true;
+        initInstanceAndMapContainer("withWanRepublishing");
+
+        assertTrue(mapContainer.isWanReplicationEnabled());
+        assertTrue(mapContainer.isWanRepublishingEnabled());
+        assertNotNull(mapContainer.getWanReplicationPublisher());
+        assertNotNull(mapContainer.getWanMergePolicy());
+
+        WanReplicationRef wanReplicationRef = mapContainer.getMapConfig().getWanReplicationRef();
+        assertNotNull(wanReplicationRef);
+        assertEquals(mapContainer.getWanMergePolicy().getClass().getName(), wanReplicationRef.getMergePolicy());
+        assertTrue(wanReplicationRef.isRepublishingEnabled());
+    }
+
+    @Override
+    protected Config getConfig() {
+        if (!isWanReplicationEnabled) {
+            return super.getConfig();
+        }
+
+        WanPublisherConfig wanPublisherConfig = new WanPublisherConfig()
+                .setClassName(DummyWanReplication.class.getName());
+
+        WanReplicationConfig wanConfig = new WanReplicationConfig()
+                .setName("dummyWan")
+                .addWanPublisherConfig(wanPublisherConfig);
+
+        WanReplicationRef wanRef = new WanReplicationRef()
+                .setName("dummyWan")
+                .setRepublishingEnabled(isWanRepublishingEnabled)
+                .setMergePolicy(PassThroughMergePolicy.class.getName());
+
+        MapConfig mapConfig = new MapConfig("default")
+                .setWanReplicationRef(wanRef);
+
+        return super.getConfig()
+                .addWanReplicationConfig(wanConfig)
+                .addMapConfig(mapConfig);
+    }
+
+    private void initInstanceAndMapContainer(String name) {
+        HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
+        MapProxyImpl mapProxy = (MapProxyImpl) instance.getMap(name);
+        MapService mapService = (MapService) mapProxy.getService();
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        mapContainer = mapServiceContext.getMapContainer(name);
+    }
+}


### PR DESCRIPTION
* fixed WAN replication to send correct operation, depending on configured merge policy
* fixed `SplitBrainEntryViews` to set creationTime for minimal key/value instance
* fixed `ExpirationTimeSetter` for new merged entries with negative statistics values
* fixed `CachePutAllBackupOperation` to send a backup WAN event, not a regular WAN event
* added `WanConfigurationTest` to check `MapContainer` initialization

The purpose of this PR is to implement the new merge policies for the WAN replication (and not just break when they are configured). The old merge policies should still work without any changes on the wire. So a target 3.8 cluster should still work with a source 3.10 cluster, as long as the old merge policies are used.