### PR TITLE
Fix indexed query consistency during migration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -72,6 +72,17 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
 
     @Override
     public void beforeMigration(PartitionMigrationEvent event) {
+        if (isLocalPromotion(event)) {
+            // It's a local partition promotion. We need to populate non-global indexes here since
+            // there is no map replication performed in this case. Global indexes are populated
+            // during promotion finalization phase.
+
+            // 1. Defensively clear possible stale leftovers from the previous failed promotion attempt.
+            clearNonGlobalIndexes(event);
+
+            // 2. Populate non-global partitioned indexes.
+            populateIndexes(event, TargetIndexes.NON_GLOBAL);
+        }
     }
 
     @Override
@@ -86,8 +97,7 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
     }
 
     @Override
-    public Operation prepareReplicationOperation(PartitionReplicationEvent event,
-                                                 Collection<ServiceNamespace> namespaces) {
+    public Operation prepareReplicationOperation(PartitionReplicationEvent event, Collection<ServiceNamespace> namespaces) {
 
         assert assertAllKnownNamespaces(namespaces);
 
@@ -109,7 +119,11 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
 
     @Override
     public void commitMigration(PartitionMigrationEvent event) {
-        migrateIndex(event);
+        if (event.getMigrationEndpoint() == DESTINATION) {
+            populateIndexes(event, TargetIndexes.GLOBAL);
+        } else {
+            depopulateIndexes(event);
+        }
 
         if (SOURCE == event.getMigrationEndpoint()) {
             clearMapsHavingLesserBackupCountThan(event.getPartitionId(), event.getNewReplicaIndex());
@@ -148,6 +162,21 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
         mapServiceContext.reloadOwnedPartitions();
     }
 
+    private void clearNonGlobalIndexes(PartitionMigrationEvent event) {
+        final PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
+        for (RecordStore recordStore : container.getMaps().values()) {
+            final MapContainer mapContainer = mapServiceContext.getMapContainer(recordStore.getName());
+
+            final Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
+            if (!indexes.hasIndex() || indexes.isGlobal()) {
+                // no indexes to work with
+                continue;
+            }
+
+            indexes.clearContents();
+        }
+    }
+
     private void clearMapsHavingLesserBackupCountThan(int partitionId, int thresholdReplicaIndex) {
         if (thresholdReplicaIndex < 0) {
             mapServiceContext.clearPartitionData(partitionId);
@@ -160,7 +189,15 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
         return mapServiceContext.getMapNearCacheManager().getInvalidator().getMetaDataGenerator();
     }
 
-    private void migrateIndex(PartitionMigrationEvent event) {
+    private void populateIndexes(PartitionMigrationEvent event, TargetIndexes targetIndexes) {
+        assert event.getMigrationEndpoint() == DESTINATION;
+        assert targetIndexes != null;
+
+        if (event.getNewReplicaIndex() != 0) {
+            // backup partitions have no indexes to populate
+            return;
+        }
+
         final long now = getNow();
 
         final PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
@@ -169,26 +206,70 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
 
             final Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
             if (!indexes.hasIndex()) {
+                // no indexes to work with
+                continue;
+            }
+
+            if (indexes.isGlobal() && targetIndexes == TargetIndexes.NON_GLOBAL) {
+                continue;
+            }
+            if (!indexes.isGlobal() && targetIndexes == TargetIndexes.GLOBAL) {
                 continue;
             }
 
             final Iterator<Record> iterator = recordStore.iterator(now, false);
             while (iterator.hasNext()) {
-                Record record = iterator.next();
-                Data key = record.getKey();
-                if (event.getMigrationEndpoint() == SOURCE) {
-                    assert event.getNewReplicaIndex() != 0 : "Invalid migration event: " + event;
-                    Object value = Records.getValueOrCachedValue(record, serializationService);
-                    indexes.removeEntryIndex(key, value);
-                } else if (event.getNewReplicaIndex() == 0) {
-                    Object value = Records.getValueOrCachedValue(record, serializationService);
-                    if (value != null) {
-                        QueryableEntry queryEntry = mapContainer.newQueryEntry(record.getKey(), value);
-                        indexes.saveEntryIndex(queryEntry, null);
-                    }
+                final Record record = iterator.next();
+                final Data key = record.getKey();
+
+                final Object value = Records.getValueOrCachedValue(record, serializationService);
+                if (value != null) {
+                    QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
+                    indexes.saveEntryIndex(queryEntry, null);
                 }
             }
         }
+    }
+
+    private void depopulateIndexes(PartitionMigrationEvent event) {
+        assert event.getMigrationEndpoint() == SOURCE;
+        assert event.getNewReplicaIndex() != 0 : "Invalid migration event: " + event;
+
+        if (event.getCurrentReplicaIndex() != 0) {
+            // backup partitions have no indexes to depopulate
+            return;
+        }
+
+        final long now = getNow();
+
+        final PartitionContainer container = mapServiceContext.getPartitionContainer(event.getPartitionId());
+        for (RecordStore recordStore : container.getMaps().values()) {
+            final MapContainer mapContainer = mapServiceContext.getMapContainer(recordStore.getName());
+
+            final Indexes indexes = mapContainer.getIndexes(event.getPartitionId());
+            if (!indexes.hasIndex()) {
+                // no indexes to work with
+                continue;
+            }
+
+            final Iterator<Record> iterator = recordStore.iterator(now, false);
+            while (iterator.hasNext()) {
+                final Record record = iterator.next();
+                final Data key = record.getKey();
+
+                final Object value = Records.getValueOrCachedValue(record, serializationService);
+                indexes.removeEntryIndex(key, value);
+            }
+        }
+    }
+
+    private enum TargetIndexes {
+        GLOBAL, NON_GLOBAL
+    }
+
+    private static boolean isLocalPromotion(PartitionMigrationEvent event) {
+        return event.getMigrationEndpoint() == DESTINATION && event.getCurrentReplicaIndex() > 0
+                && event.getNewReplicaIndex() == 0;
     }
 
     protected long getNow() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -88,6 +88,15 @@ public class Indexes {
         hasIndex = false;
     }
 
+    /**
+     * Clears contents of indexes managed by this instance.
+     */
+    public void clearContents() {
+        for (Index index : getIndexes()) {
+            index.clear();
+        }
+    }
+
     public void removeEntryIndex(Data key, Object value) throws QueryException {
         Index[] indexes = getIndexes();
         for (Index index : indexes) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/batching/PartitionAwareCallableBatchingRunnable.java
@@ -108,7 +108,7 @@ public class PartitionAwareCallableBatchingRunnable implements Runnable {
                 break;
             }
             PartitionAwareCallable task = factory.create();
-            if (partition.isLocal() && !partition.isMigrating()) {
+            if (partition.isLocal()) {
                 try {
                     results.add(task.call(currentPartitionId));
                 } catch (Exception ex) {


### PR DESCRIPTION
There is a short window during partition migration when partition
table is already updated on the destination member, but indexes are
not populated yet. To avoid consulting empty indexes while executing
queries the check for migration status of partitions is performed and
migrating partitions are skipped.

During the last step of query processing skipped partitions are asked
again for the results, see `AbstractMapQueryMessageTask#invokeOnMissingPartitions`.
Usually this works well, but there is a chance that some of the
partitions are still migrating and their indexes are still empty.

This change brings following:

1. Moves per-partition index population from migration
finalization/commit phase to map replication phase. This guaranties
per-partition non-global indexes availability during all phases of
migration done after replication phase.

2. Adds per-partition non-global index population while performing
before migration operations for promoted partitions.

3. Keeps global index population on finalization/commit phase as it
was before. Partitions with global indexes are handled in a special
way and they are resistant to "empty index" problem. See
`QueryRunner#runUsingGlobalIndexSafely` and `CountingMigrationAwareService`.

4. Removes the check for migrating flag during processing of queries
covered by per-partition indexes, since the indexes are guaranteed to
be available for owned partitions.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1851
See also: https://github.com/hazelcast/hazelcast/issues/8385