### PR TITLE
[DONT MERGE] Dont wait for scheduled tasks to end when closing down client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -305,7 +305,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         for (Connection connection : activeConnections.values()) {
             connection.close("Hazelcast client is shutting down", null);
         }
-        ClientExecutionServiceImpl.shutdownExecutor("cluster", clusterConnectionExecutor, logger);
+        ClientExecutionServiceImpl.shutdownExecutor("cluster", clusterConnectionExecutor, logger, true);
         stopEventLoopGroup();
         connectionListeners.clear();
         heartbeat.shutdown();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/AbstractClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/AbstractClientListenerService.java
@@ -100,7 +100,7 @@ public abstract class AbstractClientListenerService implements ClientListenerSer
 
     public void shutdown() {
         eventExecutor.shutdown();
-        ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger);
+        ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger, true);
     }
 
     public void start() {


### PR DESCRIPTION
User related runnables are printed as warning if they are cancelled.
Internal runnables are printed as finest if they are cancelled.

Main purpose is to avoid unncessary waiting and speed up the shutdown
client.