### PR TITLE
Fixed split-brain healing of CardinalityEstimator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorProxy.java
@@ -27,7 +27,7 @@ import com.hazelcast.spi.Operation;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-class CardinalityEstimatorProxy
+public class CardinalityEstimatorProxy
         extends AbstractDistributedObject<CardinalityEstimatorService>
         implements CardinalityEstimator {
 
@@ -38,6 +38,10 @@ class CardinalityEstimatorProxy
         super(nodeEngine, service);
         this.name = name;
         this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
+    }
+
+    public int getPartitionId() {
+        return partitionId;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -230,11 +230,6 @@ public class CardinalityEstimatorService
         @Override
         @SuppressWarnings({"checkstyle:methodlength"})
         public void run() {
-            // we cannot merge into a 3.9 cluster, since not all members may understand the CollectionMergeOperation
-            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                return;
-            }
-
             final ILogger logger = nodeEngine.getLogger(CardinalityEstimatorService.class);
             final Semaphore semaphore = new Semaphore(0);
 
@@ -250,6 +245,13 @@ public class CardinalityEstimatorService
                     semaphore.release(1);
                 }
             };
+
+            // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
+            // RU_COMPAT_3_9
+            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
+                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge cardinality estimator instances");
+                return;
+            }
 
             int size = 0;
             int operationCount = 0;

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
@@ -105,6 +105,7 @@ public class HyperLogLogImpl implements HyperLogLog {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(encoder);
+        // RU_COMPAT_3_9
         if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             out.writeInt(m);
         }
@@ -113,14 +114,14 @@ public class HyperLogLogImpl implements HyperLogLog {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         encoder = in.readObject();
+        // RU_COMPAT_3_9
         if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             m = in.readInt();
         }
     }
 
     private void convertToDenseIfNeeded() {
-        boolean shouldConvertToDense = SPARSE.equals(encoder.getEncodingType())
-                && encoder.getMemoryFootprint() >= m;
+        boolean shouldConvertToDense = SPARSE.equals(encoder.getEncodingType()) && encoder.getMemoryFootprint() >= m;
         if (shouldConvertToDense) {
             encoder = ((SparseHyperLogLogEncoder) encoder).asDense();
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -49,13 +49,14 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, V
     /**
      * The default merge policy used for cardinality estimators
      */
-    public static final MergePolicyConfig DEFAULT_MERGE_POLICY_CONFIG =
-            new MergePolicyConfig(HyperLogLogMergePolicy.class.getSimpleName(), MergePolicyConfig.DEFAULT_BATCH_SIZE);
+    public static final MergePolicyConfig DEFAULT_MERGE_POLICY_CONFIG
+            = new MergePolicyConfig(HyperLogLogMergePolicy.class.getSimpleName(), MergePolicyConfig.DEFAULT_BATCH_SIZE);
 
     private static final String[] ALLOWED_POLICIES = {
-            "com.hazelcast.spi.merge.HyperLogLogMergePolicy", "HyperLogLogMergePolicy",
-            "com.hazelcast.spi.merge.PutIfAbsentMergePolicy", "PutIfAbsentMergePolicy",
             "com.hazelcast.spi.merge.DiscardMergePolicy", "DiscardMergePolicy",
+            "com.hazelcast.spi.merge.HyperLogLogMergePolicy", "HyperLogLogMergePolicy",
+            "com.hazelcast.spi.merge.PassThroughMergePolicy", "PassThroughMergePolicy",
+            "com.hazelcast.spi.merge.PutIfAbsentMergePolicy", "PutIfAbsentMergePolicy",
     };
 
     private String name = "default";
@@ -225,7 +226,7 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, V
     @Override
     public String toString() {
         return "CardinalityEstimatorConfig{" + "name='" + name + '\'' + ", backupCount=" + backupCount + ", asyncBackupCount="
-                + asyncBackupCount + ", readOnly=" + readOnly + ", quorumName=" + quorumName +  ", mergePolicyConfig="
+                + asyncBackupCount + ", readOnly=" + readOnly + ", quorumName=" + quorumName + ", mergePolicyConfig="
                 + mergePolicyConfig + '}';
     }
 
@@ -251,6 +252,7 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, V
         out.writeUTF(name);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
+        // RU_COMPAT_3_9
         if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             out.writeUTF(quorumName);
             out.writeObject(mergePolicyConfig);
@@ -262,6 +264,7 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, V
         name = in.readUTF();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
+        // RU_COMPAT_3_9
         if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             quorumName = in.readUTF();
             mergePolicyConfig = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
@@ -20,18 +20,17 @@ import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.spi.SplitBrainMergeEntryView;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import static com.hazelcast.spi.merge.SplitBrainMergePolicyDataSerializerHook.HLL;
+import static com.hazelcast.spi.merge.SplitBrainMergePolicyDataSerializerHook.HYPER_LOG_LOG;
 
 /**
  * Only available for HyperLogLog backed {@link com.hazelcast.cardinality.CardinalityEstimator}.
- *
- * <p>Uses the default merge algorithm from HyperLogLog research, keeping the max register value of the two given
- * instances. The result should be the union to the two HyperLogLog estimations.
+ * <p>
+ * Uses the default merge algorithm from HyperLogLog research, keeping the max register value of the two given instances.
+ * The result should be the union to the two HyperLogLog estimations.
  *
  * @since 3.10
  */
-public class HyperLogLogMergePolicy
-        extends AbstractMergePolicy {
+public class HyperLogLogMergePolicy extends AbstractMergePolicy {
 
     public HyperLogLogMergePolicy() {
     }
@@ -40,6 +39,9 @@ public class HyperLogLogMergePolicy
     public <K, V> V merge(SplitBrainMergeEntryView<K, V> mergingEntry, SplitBrainMergeEntryView<K, V> existingEntry) {
         if (!(mergingEntry.getValue() instanceof HyperLogLog)) {
             throw new IllegalArgumentException("Unsupported merging entries");
+        }
+        if (existingEntry == null) {
+            return mergingEntry.getValue();
         }
 
         ((HyperLogLog) mergingEntry.getValue()).merge((HyperLogLog) existingEntry.getValue());
@@ -52,6 +54,6 @@ public class HyperLogLogMergePolicy
 
     @Override
     public int getId() {
-        return HLL;
+        return HYPER_LOG_LOG;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyDataSerializerHook.java
@@ -43,13 +43,13 @@ public final class SplitBrainMergePolicyDataSerializerHook implements DataSerial
     public static final int ENTRY_VIEW = 0;
     public static final int DISCARD = 1;
     public static final int HIGHER_HITS = 2;
-    public static final int LATEST_ACCESS = 3;
-    public static final int LATEST_UPDATE = 4;
-    public static final int PASS_THROUGH = 5;
-    public static final int PUT_IF_ABSENT = 6;
-    public static final int HLL = 7;
+    public static final int HYPER_LOG_LOG = 3;
+    public static final int LATEST_ACCESS = 4;
+    public static final int LATEST_UPDATE = 5;
+    public static final int PASS_THROUGH = 6;
+    public static final int PUT_IF_ABSENT = 7;
 
-    private static final int LEN = HLL + 1;
+    private static final int LEN = PUT_IF_ABSENT + 1;
 
     @Override
     public int getFactoryId() {
@@ -76,6 +76,12 @@ public final class SplitBrainMergePolicyDataSerializerHook implements DataSerial
                 return new HigherHitsMergePolicy();
             }
         };
+        constructors[HYPER_LOG_LOG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new HyperLogLogMergePolicy();
+            }
+        };
         constructors[LATEST_ACCESS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new LatestAccessMergePolicy();
@@ -94,12 +100,6 @@ public final class SplitBrainMergePolicyDataSerializerHook implements DataSerial
         constructors[PUT_IF_ABSENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new PutIfAbsentMergePolicy();
-            }
-        };
-        constructors[HLL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new HyperLogLogMergePolicy();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
@@ -44,11 +44,11 @@ public final class SplitBrainMergePolicyProvider {
         OUT_OF_THE_BOX_MERGE_POLICIES = new HashMap<String, SplitBrainMergePolicy>();
         addPolicy(DiscardMergePolicy.class, new DiscardMergePolicy());
         addPolicy(HigherHitsMergePolicy.class, new HigherHitsMergePolicy());
+        addPolicy(HyperLogLogMergePolicy.class, new HyperLogLogMergePolicy());
         addPolicy(LatestAccessMergePolicy.class, new LatestAccessMergePolicy());
         addPolicy(LatestUpdateMergePolicy.class, new LatestUpdateMergePolicy());
         addPolicy(PassThroughMergePolicy.class, new PassThroughMergePolicy());
         addPolicy(PutIfAbsentMergePolicy.class, new PutIfAbsentMergePolicy());
-        addPolicy(HyperLogLogMergePolicy.class, new HyperLogLogMergePolicy());
     }
 
     private final NodeEngine nodeEngine;

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -2068,6 +2068,7 @@
                             The out-of-the-box policies are:
                             <br/>DiscardMergePolicy: the estimator from the smaller cluster will be discarded.
                             <br/>HyperLogLogMergePolicy: the estimator will merge with the existing one, using the algorithmic merge for HyperLogLog.
+                            <br/>PassThroughMergePolicy: the estimator from the smaller cluster wins.
                             <br/>PutIfAbsentMergePolicy: the estimator from the smaller cluster wins if it doesn't exist in the cluster.
                             <br/>The default policy is: HyperLogLogMergePolicy
                         </p>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -303,14 +303,14 @@
 
     <cardinality-estimator name="default">
         <backup-count>1</backup-count>
-        <merge-policy batch-size="100">HyperLogLogMergePolicy</merge-policy>
         <async-backup-count>0</async-backup-count>
+        <merge-policy batch-size="100">HyperLogLogMergePolicy</merge-policy>
     </cardinality-estimator>
 
     <scheduled-executor-service name="default">
-        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
         <capacity>100</capacity>
         <durability>1</durability>
         <pool-size>16</pool-size>
+        <merge-policy batch-size="100">PutIfAbsentMergePolicy</merge-policy>
     </scheduled-executor-service>
 </hazelcast>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -624,7 +624,7 @@ https://hazelcast.org/documentation/.
        Adds the Split Brain Protection for this data-structure which you configure using the <quorum> element. You should set the <quorum-ref>'s value
        as the <quorum>'s name.
     * <merge-policy>:
-        The default policy is `com.hazelcast.cardinality.impl.hyperloglog.HyperLogLogMergePolicy` with a batch size of 100.
+        The default policy is `com.hazelcast.spi.merge.HyperLogLogMergePolicy` with a batch size of 100.
         This is the policy used when merging estimators from sub-clusters (after split-brain recovery).
     -->
     <cardinality-estimator name="default">

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorSplitBrainTest.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.cardinality;
 
-import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
+import com.hazelcast.cardinality.impl.CardinalityEstimatorProxy;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
@@ -30,38 +32,49 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
+import static com.hazelcast.cardinality.CardinalityEstimatorTestUtil.getBackupEstimate;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
-
-    private final String name = randomName();
 
     private final int INITIAL_COUNT = 100000;
     private final int EXTRA_COUNT = 10000;
     private final int TOTAL_COUNT = INITIAL_COUNT + (brains().length * EXTRA_COUNT);
 
+    private String estimatorNameA = randomMapName("estimatorA-");
+    private String estimatorNameB = randomMapName("estimatorB-");
+    private CardinalityEstimator estimatorA1;
+    private CardinalityEstimator estimatorA2;
+    private CardinalityEstimator estimatorB1;
+    private CardinalityEstimator estimatorB2;
+    private long expectedEstimateA;
+    private long expectedEstimateB;
+    private long backupEstimateA;
+    private long backupEstimateB;
     private MergeLifecycleListener mergeLifecycleListener;
-    private long estimate;
 
-    @Parameterized.Parameters(name = "mergePolicy:{0}")
+    @Parameters(name = "mergePolicy:{0}")
     public static Collection<Object> parameters() {
         return asList(new Object[]{
                 DiscardMergePolicy.class,
-                PutIfAbsentMergePolicy.class,
                 HyperLogLogMergePolicy.class,
-
+                PassThroughMergePolicy.class,
+                PutIfAbsentMergePolicy.class,
         });
     }
 
-    @Parameterized.Parameter
+    @Parameter
     public Class<? extends SplitBrainMergePolicy> mergePolicyClass;
 
     @Override
@@ -71,7 +84,11 @@ public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
                 .setBatchSize(10);
 
         Config config = super.config();
-        config.getCardinalityEstimatorConfig(name)
+        config.getCardinalityEstimatorConfig(estimatorNameA)
+              .setBackupCount(1)
+              .setAsyncBackupCount(0)
+              .setMergePolicyConfig(mergePolicyConfig);
+        config.getCardinalityEstimatorConfig(estimatorNameB)
               .setBackupCount(1)
               .setAsyncBackupCount(0)
               .setMergePolicyConfig(mergePolicyConfig);
@@ -80,13 +97,12 @@ public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
 
     @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
-        CardinalityEstimator estimator = instances[0].getCardinalityEstimator(name);
-
+        CardinalityEstimator estimator = instances[0].getCardinalityEstimator(estimatorNameA);
         for (int i = 0; i < INITIAL_COUNT; i++) {
             estimator.add(String.valueOf(i));
         }
 
-        estimate = estimator.estimate();
+        expectedEstimateA = estimator.estimate();
         waitAllForSafeState(instances);
     }
 
@@ -97,12 +113,23 @@ public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
             instance.getLifecycleService().addLifecycleListener(mergeLifecycleListener);
         }
 
+        estimatorA1 = firstBrain[0].getCardinalityEstimator(estimatorNameA);
+        estimatorA2 = secondBrain[0].getCardinalityEstimator(estimatorNameA);
+
+        estimatorB2 = secondBrain[0].getCardinalityEstimator(estimatorNameB);
+        for (int i = 0; i < INITIAL_COUNT; i++) {
+            estimatorB2.add(String.valueOf(i));
+        }
+        expectedEstimateB = estimatorB2.estimate();
+
         if (mergePolicyClass == DiscardMergePolicy.class) {
-            onAfterSplitDiscardPolicy(firstBrain, secondBrain);
+            onAfterSplitDiscardMergePolicy();
         } else if (mergePolicyClass == HyperLogLogMergePolicy.class) {
-            onAfterSplitHLLMergePolicy(firstBrain, secondBrain);
+            onAfterSplitHyperLogLogMergePolicy();
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
+            onAfterSplitPassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
-            onAfterSplitPutAbsentPolicy(firstBrain, secondBrain);
+            onAfterSplitPutIfAbsentMergePolicy();
         } else {
             fail();
         }
@@ -113,69 +140,109 @@ public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
         // wait until merge completes
         mergeLifecycleListener.await();
 
+        estimatorB1 = instances[0].getCardinalityEstimator(estimatorNameB);
+
+        int partitionId = ((CardinalityEstimatorProxy) estimatorA1).getPartitionId();
+        backupEstimateA = getBackupEstimate(getFirstBackupInstance(instances, partitionId), estimatorNameA);
+        partitionId = ((CardinalityEstimatorProxy) estimatorB1).getPartitionId();
+        backupEstimateB = getBackupEstimate(getFirstBackupInstance(instances, partitionId), estimatorNameB);
+
         if (mergePolicyClass == DiscardMergePolicy.class) {
-            onAfterMergeDiscardMergePolicy(instances);
+            onAfterMergeDiscardMergePolicy();
         } else if (mergePolicyClass == HyperLogLogMergePolicy.class) {
-            onAfterMergeHLLMergePolicy(instances);
+            onAfterMergeHyperLogLogMergePolicy(instances);
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
+            onAfterMergePassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
-            onAfterMergePutAbsentMergePolicy(instances);
+            onAfterMergePutIfAbsentMergePolicy();
         } else {
             fail();
         }
-
     }
 
-    private void onAfterSplitDiscardPolicy(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
-        CardinalityEstimator estimator = secondBrain[0].getCardinalityEstimator(name);
+    private void onAfterSplitDiscardMergePolicy() {
+        // we should not have these items in the merged estimator, since they are in the smaller cluster only
         for (int i = INITIAL_COUNT; i < TOTAL_COUNT; i++) {
-            estimator.add(String.valueOf(i));
+            estimatorA2.add(String.valueOf(i));
+            estimatorB2.add(String.valueOf(i));
         }
     }
 
-    private void onAfterMergeDiscardMergePolicy(HazelcastInstance[] instances) {
-        CardinalityEstimator estimator = instances[0].getCardinalityEstimator(name);
-        assertEquals(estimate, estimator.estimate());
+    private void onAfterMergeDiscardMergePolicy() {
+        assertEquals(expectedEstimateA, estimatorA1.estimate());
+        assertEquals(expectedEstimateA, estimatorA2.estimate());
+        assertEquals(expectedEstimateA, backupEstimateA);
+
+        assertEquals(0, estimatorB1.estimate());
+        assertEquals(0, estimatorB2.estimate());
+        assertEquals(0, backupEstimateB);
     }
 
-    private void onAfterSplitPutAbsentPolicy(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
-        CardinalityEstimator estimator = secondBrain[0].getCardinalityEstimator("Absent");
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            estimator.add(String.valueOf(i));
-        }
-
-        estimate = estimator.estimate();
-    }
-
-    private void onAfterMergePutAbsentMergePolicy(HazelcastInstance[] instances) {
-        CardinalityEstimator estimator = instances[0].getCardinalityEstimator(name);
-        CardinalityEstimator absent = instances[0].getCardinalityEstimator(name);
-
-        assertEquals(estimate, estimator.estimate());
-        assertEquals(estimate, absent.estimate());
-    }
-
-    private void onAfterSplitHLLMergePolicy(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+    private void onAfterSplitHyperLogLogMergePolicy() {
         int firstBrainBump = INITIAL_COUNT + EXTRA_COUNT;
 
-        CardinalityEstimator estimator1 = firstBrain[0].getCardinalityEstimator(name);
         for (int i = INITIAL_COUNT; i < firstBrainBump; i++) {
-            estimator1.add(String.valueOf(i));
+            estimatorA1.add(String.valueOf(i));
         }
-
-        CardinalityEstimator estimator2 = secondBrain[0].getCardinalityEstimator(name);
         for (int i = INITIAL_COUNT; i < TOTAL_COUNT; i++) {
-            estimator2.add(String.valueOf(i));
+            estimatorA2.add(String.valueOf(i));
+            estimatorB2.add(String.valueOf(i));
         }
     }
 
-    private void onAfterMergeHLLMergePolicy(HazelcastInstance[] instances) {
-        CardinalityEstimator estimator = instances[0].getCardinalityEstimator(name);
-        CardinalityEstimator expected = instances[0].getCardinalityEstimator("Expected");
+    private void onAfterMergeHyperLogLogMergePolicy(HazelcastInstance[] instances) {
+        CardinalityEstimator expectedEstimator = instances[0].getCardinalityEstimator("expectedEstimator");
         for (int i = 0; i < TOTAL_COUNT; i++) {
-            expected.add(String.valueOf(i));
+            expectedEstimator.add(String.valueOf(i));
         }
+        long expectedValue = expectedEstimator.estimate();
 
-        assertEquals(expected.estimate(), estimator.estimate());
+        assertEquals(expectedValue, estimatorA1.estimate());
+        assertEquals(expectedValue, estimatorA2.estimate());
+        assertEquals(expectedValue, backupEstimateA);
+
+        assertEquals(expectedValue, estimatorB2.estimate());
+        assertEquals(expectedValue, backupEstimateB);
     }
 
+    private void onAfterSplitPassThroughMergePolicy() {
+        // we should not lose the additional values from estimatorA2 and estimatorB2
+        for (int i = INITIAL_COUNT; i < TOTAL_COUNT; i++) {
+            estimatorA2.add(String.valueOf(i));
+            estimatorB2.add(String.valueOf(i));
+        }
+
+        expectedEstimateA = estimatorA2.estimate();
+        expectedEstimateB = estimatorB2.estimate();
+    }
+
+    private void onAfterMergePassThroughMergePolicy() {
+        assertEquals(expectedEstimateA, estimatorA1.estimate());
+        assertEquals(expectedEstimateA, estimatorA2.estimate());
+        assertEquals(expectedEstimateA, backupEstimateA);
+
+        assertEquals(expectedEstimateB, estimatorB1.estimate());
+        assertEquals(expectedEstimateB, estimatorB2.estimate());
+        assertEquals(expectedEstimateB, backupEstimateB);
+    }
+
+    private void onAfterSplitPutIfAbsentMergePolicy() {
+        // we should not lose the additional values from estimatorB2, but from estimatorA2
+        for (int i = INITIAL_COUNT; i < TOTAL_COUNT; i++) {
+            estimatorA2.add(String.valueOf(i));
+            estimatorB2.add(String.valueOf(i));
+        }
+
+        expectedEstimateB = estimatorB2.estimate();
+    }
+
+    private void onAfterMergePutIfAbsentMergePolicy() {
+        assertEquals(expectedEstimateA, estimatorA1.estimate());
+        assertEquals(expectedEstimateA, estimatorA2.estimate());
+        assertEquals(expectedEstimateA, backupEstimateA);
+
+        assertEquals(expectedEstimateB, estimatorB1.estimate());
+        assertEquals(expectedEstimateB, estimatorB2.estimate());
+        assertEquals(expectedEstimateB, backupEstimateB);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorTestUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cardinality;
+
+import com.hazelcast.cardinality.impl.CardinalityEstimatorContainer;
+import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+
+final class CardinalityEstimatorTestUtil {
+
+    private CardinalityEstimatorTestUtil() {
+    }
+
+    static long getBackupEstimate(HazelcastInstance backupInstance, String estimatorName) {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(backupInstance);
+        CardinalityEstimatorService service = nodeEngine.getService(CardinalityEstimatorService.SERVICE_NAME);
+        CardinalityEstimatorContainer container = service.getCardinalityEstimatorContainer(estimatorName);
+        return container.estimate();
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -247,6 +247,7 @@
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>
         <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
+        <merge-policy batch-size="50">HyperLogLogMergePolicy</merge-policy>
     </cardinality-estimator>
 
     <queue name="default">


### PR DESCRIPTION
* fixed possible NPE in `HyperLogLogMergePolicy`
* fixed path to `HyperLogLogMergePolicy` in `hazelcast-full-example.xml`
* added missing `<merge-policy>` to `hazelcast-fullconfig.xml`
* added missing test cases to `CardinalityEstimatorSplitBrainTest`
* added backup testing to `CardinalityEstimatorSplitBrainTest`
* added `CardinalityEstimatorTestUtil` to retrieve backup estimate
* added `PassThroughMergePolicy` to the allowed merge policies
* added missing `// RU_COMPAT_3_9` comments

I've aligned the style of `CardinalityEstimatorSplitBrainTest` a bit with the other tests. This made it easier to add the missing test cases. The `A` estimators are existing in both clusters (even before the split-brain happens), the `B` estimators are only created in the smaller sub-cluster and after the split-brain has been healed. This is how it's done in all other split-brain tests.

The fixed NPE is:
```java
java.lang.NullPointerException
	at com.hazelcast.spi.merge.HyperLogLogMergePolicy.merge(HyperLogLogMergePolicy.java:47) ~[classes/:?]
	at com.hazelcast.cardinality.impl.CardinalityEstimatorContainer.merge(CardinalityEstimatorContainer.java:83) ~[classes/:?]
	at com.hazelcast.cardinality.impl.operations.MergeOperation.run(MergeOperation.java:56) ~[classes/:?]
```
This happens when a `CardinalityEstimator` is created in the smaller cluster only and then merged with the `HyperLogLogMergePolicy`. There is no existing entry in this case.

I've added a test case which fails in this case:
```
java.lang.AssertionError: 
Expected :115273
Actual   :0

	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at com.hazelcast.cardinality.CardinalityEstimatorSplitBrainTest.onAfterMergeHLLMergePolicy(CardinalityEstimatorSplitBrainTest.java:193)
	at com.hazelcast.cardinality.CardinalityEstimatorSplitBrainTest.onAfterSplitBrainHealed(CardinalityEstimatorSplitBrainTest.java:145)
```
That's the line: `assertEquals(expectedValue, estimatorB2.estimate());`