### PR TITLE
Added missing fail() branch to split-brain tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
@@ -47,6 +47,7 @@ import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link com.hazelcast.cache.ICache}.
@@ -132,24 +133,20 @@ public class CacheSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
             afterSplitHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
             afterSplitLatestAccessMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
             afterSplitLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -165,24 +162,20 @@ public class CacheSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
             afterMergeHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
             afterMergeLatestAccessMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
             afterMergeLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/LegacyCacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/LegacyCacheSplitBrainTest.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
@@ -83,18 +84,16 @@ public class LegacyCacheSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == LatestAccessCacheMergePolicy.class) {
             afterSplitLatestAccessCacheMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsCacheMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsCacheMergePolicy.class) {
             afterSplitHigherHitsCacheMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentCacheMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentCacheMergePolicy.class) {
             afterSplitPutIfAbsentCacheMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughCacheMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughCacheMergePolicy.class) {
             afterSplitPassThroughCacheMergePolicy();
-        }
-        if (mergePolicyClass == CustomCacheMergePolicy.class) {
+        } else if (mergePolicyClass == CustomCacheMergePolicy.class) {
             afterSplitCustomCacheMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -105,18 +104,16 @@ public class LegacyCacheSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == LatestAccessCacheMergePolicy.class) {
             afterMergeLatestAccessCacheMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsCacheMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsCacheMergePolicy.class) {
             afterMergeHigherHitsCacheMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentCacheMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentCacheMergePolicy.class) {
             afterMergePutIfAbsentCacheMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughCacheMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughCacheMergePolicy.class) {
             afterMergePassThroughCacheMergePolicy();
-        }
-        if (mergePolicyClass == CustomCacheMergePolicy.class) {
+        } else if (mergePolicyClass == CustomCacheMergePolicy.class) {
             afterMergeCustomCacheMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -44,6 +44,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link IList}.
@@ -136,15 +137,14 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -161,15 +161,14 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -44,6 +44,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link IQueue}.
@@ -137,15 +138,14 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -162,15 +162,14 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
@@ -44,6 +44,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link ISet}.
@@ -136,15 +137,14 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -161,15 +161,14 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongSplitBrainTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link IAtomicLong}.
@@ -109,15 +110,14 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
+        } else if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -133,15 +133,14 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
+        } else if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceSplitBrainTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link IAtomicReference}.
@@ -111,15 +112,14 @@ public class AtomicReferenceSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
+        } else if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -134,15 +134,14 @@ public class AtomicReferenceSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
+        } else if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/LegacyMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/LegacyMapSplitBrainTest.java
@@ -46,6 +46,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link IMap}.
@@ -133,21 +134,18 @@ public class LegacyMapSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == IgnoreMergingEntryMapMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
             afterSplitHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
             afterSplitLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == CustomLegacyMergePolicy.class) {
+        } else if (mergePolicyClass == CustomLegacyMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -163,21 +161,18 @@ public class LegacyMapSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == IgnoreMergingEntryMapMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMapMergePolicy.class) {
             afterMergeHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMapMergePolicy.class) {
             afterMergeLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMapMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == CustomLegacyMergePolicy.class) {
+        } else if (mergePolicyClass == CustomLegacyMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -49,6 +49,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link IMap}.
@@ -141,24 +142,20 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
             afterSplitHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
             afterSplitLatestAccessMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
             afterSplitLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -174,24 +171,20 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
             afterMergeHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
             afterMergeLatestAccessMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
             afterMergeLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link MultiMap}.
@@ -138,24 +139,20 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
             afterSplitHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
             afterSplitLatestAccessMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
             afterSplitLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -171,24 +168,20 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == HigherHitsMergePolicy.class) {
+        } else if (mergePolicyClass == HigherHitsMergePolicy.class) {
             afterMergeHigherHitsMergePolicy();
-        }
-        if (mergePolicyClass == LatestAccessMergePolicy.class) {
+        } else if (mergePolicyClass == LatestAccessMergePolicy.class) {
             afterMergeLatestAccessMergePolicy();
-        }
-        if (mergePolicyClass == LatestUpdateMergePolicy.class) {
+        } else if (mergePolicyClass == LatestUpdateMergePolicy.class) {
             afterMergeLatestUpdateMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferSplitBrainTest.java
@@ -52,6 +52,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests different split-brain scenarios for {@link com.hazelcast.ringbuffer.Ringbuffer}.
@@ -156,15 +157,14 @@ public class RingbufferSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterSplitPassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 
@@ -181,15 +181,14 @@ public class RingbufferSplitBrainTest extends SplitBrainTestSupport {
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterMergeDiscardMergePolicy();
-        }
-        if (mergePolicyClass == PassThroughMergePolicy.class) {
+        } else if (mergePolicyClass == PassThroughMergePolicy.class) {
             afterMergePassThroughMergePolicy();
-        }
-        if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
+        } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        }
-        if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
+        } else {
+            fail();
         }
     }
 


### PR DESCRIPTION
I saw this in Thomas' `CardinalityEstimatorSplitBrainTest` and think it's a good idea for all similar tests.

I've left out the `ReplicatedMapSplitBrainTest`, since it will be refactored in the split-brain implementation PR of the `ReplicatedMap`.