### PR TITLE
Fixed WAN replication in CachePutAllBackupOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -90,7 +90,7 @@ public class CachePutAllBackupOperation
             final CacheWanEventPublisher publisher = service.getCacheWanEventPublisher();
             final CacheEntryView<Data, Data> view = CacheEntryViews.createDefaultEntryView(
                     key, toData(record.getValue()), record);
-            publisher.publishWanReplicationUpdate(name, view);
+            publisher.publishWanReplicationUpdateBackup(name, view);
         }
     }
 


### PR DESCRIPTION
I found this bug in a 3.19 PR: https://github.com/hazelcast/hazelcast/pull/12241#discussion_r165555080

We cannot easily backport the 3.10 test, since it's a split-brain related test and it relies on the new merge policies, which are not available in Hazelcast 3.9. We need to write an independent WAN backup test to verify this properly.