### PR TITLE
Fixed the timeout calculation in split-brain healing services

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -142,7 +142,7 @@ class CacheSplitBrainHandlerService implements SplitBrainHandlerService {
 
     private class CacheMerger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Semaphore semaphore = new Semaphore(0);
         private final Map<String, Map<Data, CacheRecord>> recordMap;

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -219,7 +219,7 @@ public class CardinalityEstimatorService
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private Map<String, CardinalityEstimatorContainer> snapshot;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -232,7 +232,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Map<Integer, Map<CollectionContainer, List<CollectionItem>>> itemMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -423,7 +423,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Map<Integer, Map<QueueContainer, List<QueueItem>>> itemMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -227,7 +227,7 @@ public class AtomicLongService
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Map<Integer, List<AtomicLongContainer>> containerMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -229,7 +229,7 @@ public class AtomicReferenceService
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Map<Integer, List<AtomicReferenceContainer>> containerMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -127,7 +127,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Semaphore semaphore = new Semaphore(0);
         private final Map<MapContainer, Collection<Record>> recordMap;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -534,7 +534,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Map<MultiMapPartitionContainer, Map<String, MultiMapContainer>> itemMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
@@ -104,7 +104,7 @@ class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerService 
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Semaphore semaphore = new Semaphore(0);
         private final ILogger logger = nodeEngine.getLogger(ReplicatedMapSplitBrainHandlerService.class);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -396,7 +396,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private final Map<Integer, List<RingbufferContainer>> partitionContainerMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -360,7 +360,7 @@ public class DistributedScheduledExecutorService
 
     private class Merger implements Runnable {
 
-        private static final int TIMEOUT_FACTOR = 500;
+        private static final long TIMEOUT_FACTOR = 500;
 
         private Map<Integer, Map<String, Collection<ScheduledTaskDescriptor>>> partitionsSnapshot;
 


### PR DESCRIPTION
There is a possible overflow in the timeout calculation, when there is a huge number of entries in a data structure (I think it's 2^32 / 500 = 8,589,934), the timeout multiplication may overflow.

Kudos to SonarCube:
![screenshot from 2018-02-07 05-49-39](https://user-images.githubusercontent.com/4196298/35899131-071028dc-0bcb-11e8-892f-daf7969c9c8f.png)