### PR TITLE
Improved logging of split-brain healing failures

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -221,31 +221,29 @@ public class CardinalityEstimatorService
 
         private static final int TIMEOUT_FACTOR = 500;
 
-        private Map<String, CardinalityEstimatorContainer> snapshot;
+        private final ILogger logger = nodeEngine.getLogger(CardinalityEstimatorService.class);
+        private final Semaphore semaphore = new Semaphore(0);
+        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                semaphore.release(1);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                logger.warning("Error while running cardinality estimator merge operation: " + t.getMessage());
+                semaphore.release(1);
+            }
+        };
+
+        private final Map<String, CardinalityEstimatorContainer> snapshot;
 
         Merger(Map<String, CardinalityEstimatorContainer> snapshot) {
             this.snapshot = snapshot;
         }
 
         @Override
-        @SuppressWarnings({"checkstyle:methodlength"})
         public void run() {
-            final ILogger logger = nodeEngine.getLogger(CardinalityEstimatorService.class);
-            final Semaphore semaphore = new Semaphore(0);
-
-            ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object response) {
-                    semaphore.release(1);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    logger.warning("Error while running merge operation: " + t.getMessage());
-                    semaphore.release(1);
-                }
-            };
-
             // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
             // RU_COMPAT_3_9
             if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
@@ -257,12 +255,11 @@ public class CardinalityEstimatorService
             int operationCount = 0;
 
             try {
-                // TODO: Batching support (tkountis)
+                // TODO: batching support (tkountis)
                 for (Map.Entry<String, CardinalityEstimatorContainer> entry : snapshot.entrySet()) {
                     String containerName = entry.getKey();
                     CardinalityEstimatorContainer container = entry.getValue();
                     int partitionId = getPartitionId(containerName);
-
                     operationCount++;
 
                     SplitBrainMergePolicy mergePolicy = getMergePolicy(containerName);
@@ -278,15 +275,18 @@ public class CardinalityEstimatorService
                 }
 
                 snapshot.clear();
-            } catch (Exception ex) {
-                logger.warning("CardinalityEstimatorService merging didn't complete successfully.", ex);
-                throw rethrow(ex);
+            } catch (Exception e) {
+                logger.warning("Split-brain healing of cardinality estimators didn't complete successfully...", e);
+                throw rethrow(e);
             }
 
             try {
-                semaphore.tryAcquire(operationCount, size * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS);
+                if (!semaphore.tryAcquire(operationCount, size * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
+                    logger.warning("Split-brain healing for cardinality estimators didn't finish within the timeout...");
+                }
             } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for merge operation...");
+                logger.finest("Interrupted while waiting for split-brain healing of cardinality estimators...");
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -234,6 +234,21 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
         private static final int TIMEOUT_FACTOR = 500;
 
+        private final ILogger logger = nodeEngine.getLogger(CollectionService.class);
+        private final Semaphore semaphore = new Semaphore(0);
+        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                semaphore.release(1);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                logger.warning("Error while running collection merge operation: " + t.getMessage());
+                semaphore.release(1);
+            }
+        };
+
         private final Map<Integer, Map<CollectionContainer, List<CollectionItem>>> itemMap;
 
         Merger(Map<Integer, Map<CollectionContainer, List<CollectionItem>>> itemMap) {
@@ -242,22 +257,6 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
         @Override
         public void run() {
-            final ILogger logger = nodeEngine.getLogger(CollectionService.class);
-            final Semaphore semaphore = new Semaphore(0);
-
-            ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object response) {
-                    semaphore.release(1);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    logger.warning("Error while running merge operation: " + t.getMessage());
-                    semaphore.release(1);
-                }
-            };
-
             // we cannot merge into a 3.9 cluster, since not all members may understand the CollectionMergeOperation
             // RU_COMPAT_3_9
             if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
@@ -301,9 +300,12 @@ public abstract class CollectionService implements ManagedService, RemoteService
             itemMap.clear();
 
             try {
-                semaphore.tryAcquire(operationCount, itemCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS);
+                if (!semaphore.tryAcquire(operationCount, itemCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
+                    logger.warning("Split-brain healing for collections didn't finish within the timeout...");
+                }
             } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for merge operation...");
+                logger.finest("Interrupted while waiting for split-brain healing of collections...");
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -231,6 +231,21 @@ public class AtomicReferenceService
 
         private static final int TIMEOUT_FACTOR = 500;
 
+        private final ILogger logger = nodeEngine.getLogger(AtomicReferenceService.class);
+        private final Semaphore semaphore = new Semaphore(0);
+        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                semaphore.release(1);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                logger.warning("Error while running AtomicReference merge operation: " + t.getMessage());
+                semaphore.release(1);
+            }
+        };
+
         private final Map<Integer, List<AtomicReferenceContainer>> containerMap;
 
         Merger(Map<Integer, List<AtomicReferenceContainer>> containerMap) {
@@ -239,22 +254,6 @@ public class AtomicReferenceService
 
         @Override
         public void run() {
-            final ILogger logger = nodeEngine.getLogger(AtomicReferenceService.class);
-            final Semaphore semaphore = new Semaphore(0);
-
-            ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object response) {
-                    semaphore.release(1);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    logger.warning("Error while running merge operation: " + t.getMessage());
-                    semaphore.release(1);
-                }
-            };
-
             // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
             // RU_COMPAT_3_9
             if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
@@ -286,9 +285,12 @@ public class AtomicReferenceService
             containerMap.clear();
 
             try {
-                semaphore.tryAcquire(valueCount, valueCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS);
+                if (!semaphore.tryAcquire(valueCount, valueCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
+                    logger.warning("Split-brain healing for AtomicReference instances didn't finish within the timeout...");
+                }
             } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for merge operation...");
+                logger.finest("Interrupted while waiting for split-brain healing of AtomicReference instances...");
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
This should help to identify better where a split-brain healing failed. It also corrects the `InterruptedException` handling.

Kudos to SonarCube:
![screenshot from 2018-02-07 06-14-24](https://user-images.githubusercontent.com/4196298/35899731-51ac0b9c-0bce-11e8-99ca-5954d356e847.png)
![screenshot from 2018-02-07 06-14-49](https://user-images.githubusercontent.com/4196298/35899732-537e29e6-0bce-11e8-8a7b-6b29389c356a.png)