### PR TITLE
Fixed possible overflows in NearCacheRecordStores

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -74,8 +74,8 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
      * we assume 32 bit JVM or compressed-references enabled 64 bit JVM
      * by ignoring compressed-references disable mode on 64 bit JVM.
      */
-    protected static final int REFERENCE_SIZE = MEM_AVAILABLE ? MEM.arrayIndexScale(Object[].class) : (Integer.SIZE / Byte.SIZE);
-    protected static final int MILLI_SECONDS_IN_A_SECOND = 1000;
+    protected static final long REFERENCE_SIZE = MEM_AVAILABLE ? MEM.arrayIndexScale(Object[].class) : (Integer.SIZE / Byte.SIZE);
+    protected static final long MILLI_SECONDS_IN_A_SECOND = 1000;
 
     protected final long timeToLiveMillis;
     protected final long maxIdleMillis;


### PR DESCRIPTION
I don't think the Record heap costs will actually overflow (although people could try to put a 2 GB byte chunk into HZ). But the TTL and idle time are configurable and people do strange things. Anyway the fixes won't harm, so it's easy to remove those possible issues.

Kudos to SonarCube:
![screenshot from 2018-02-07 06-30-18](https://user-images.githubusercontent.com/4196298/35900192-e2433c6e-0bd0-11e8-9244-571a893155fa.png)
![screenshot from 2018-02-07 06-31-51](https://user-images.githubusercontent.com/4196298/35900193-e25cbd38-0bd0-11e8-820b-309df5612a82.png)
![screenshot from 2018-02-07 06-32-17](https://user-images.githubusercontent.com/4196298/35900195-e2769b90-0bd0-11e8-9131-e069f540256f.png)
