### PR TITLE
Cleanup of DefaultPortableReader and DefaultPortableWriter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import static com.hazelcast.internal.serialization.impl.PortableUtils.getPortableArrayCellPosition;
 
 /**
- * Can't be accessed concurrently
+ * Can't be accessed concurrently.
  */
 public class DefaultPortableReader extends ValueReader implements PortableReader {
 
@@ -109,7 +109,7 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
         return in;
     }
 
-    final void end() throws IOException {
+    final void end() {
         in.position(finalPosition);
     }
 
@@ -697,7 +697,7 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
                 in.position(position.getStreamPosition());
                 return (T) serializer.readAndInitialize(in, position.getFactoryId(), position.getClassId());
             default:
-                throw new IllegalArgumentException("Unsupported type " + position.getType());
+                throw new IllegalArgumentException("Unsupported type: " + position.getType());
         }
     }
 
@@ -767,7 +767,7 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
     private void validateNotMultiPosition(PortablePosition position) {
         if (position.isMultiPosition()) {
             throw new IllegalArgumentException("The method expected a single result but multiple results have been returned."
-                    + "Did you use the [any] quantifier? If so, use the readArray method family.");
+                    + " Did you use the [any] quantifier? If so, use the readArray method family.");
         }
     }
 
@@ -777,9 +777,9 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
             returnedType = returnedType != null ? returnedType.getSingleType() : null;
         }
         if (expectedType != returnedType) {
-            throw new IllegalArgumentException("Wrong type read! Actual:" + returnedType.name() + " Expected: "
-                    + expectedType.name() + ". Did you you a correct read method? E.g. readInt() for int.");
+            String name = returnedType != null ? returnedType.name() : null;
+            throw new IllegalArgumentException("Wrong type read! Actual: " + name + " Expected: " + expectedType.name()
+                    + ". Did you use a correct read method? E.g. readInt() for int.");
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableWriter.java
@@ -40,10 +40,10 @@ public class DefaultPortableWriter implements PortableWriter {
     private final int begin;
     private final int offset;
     private final Set<String> writtenFields;
+
     private boolean raw;
 
-    public DefaultPortableWriter(PortableSerializer serializer, BufferObjectDataOutput out, ClassDefinition cd)
-            throws IOException {
+    DefaultPortableWriter(PortableSerializer serializer, BufferObjectDataOutput out, ClassDefinition cd) throws IOException {
         this.serializer = serializer;
         this.out = out;
         this.cd = cd;
@@ -161,8 +161,7 @@ public class DefaultPortableWriter implements PortableWriter {
     }
 
     @Override
-    public void writeBooleanArray(String fieldName, boolean[] booleans)
-            throws IOException {
+    public void writeBooleanArray(String fieldName, boolean[] booleans) throws IOException {
         setPosition(fieldName, FieldType.BOOLEAN_ARRAY);
         out.writeBooleanArray(booleans);
     }
@@ -204,8 +203,7 @@ public class DefaultPortableWriter implements PortableWriter {
     }
 
     @Override
-    public void writeUTFArray(String fieldName, String[] values)
-            throws IOException {
+    public void writeUTFArray(String fieldName, String[] values) throws IOException {
         setPosition(fieldName, FieldType.UTF_ARRAY);
         out.writeUTFArray(values);
     }
@@ -222,7 +220,7 @@ public class DefaultPortableWriter implements PortableWriter {
         if (len > 0) {
             final int offset = out.position();
             out.writeZeroBytes(len * 4);
-            for (int i = 0; i < portables.length; i++) {
+            for (int i = 0; i < len; i++) {
                 Portable portable = portables[i];
                 checkPortableAttributes(fd, portable);
                 int position = out.position();


### PR DESCRIPTION
* fixed a NPE confusion for static code analyzer with `portables.length` in `DefaultPortableWriter`
* fixed a possible NPE in logging of `validateType()` in `DefaultPortableReader`
* fixed some typos

I was triggered by SonarCube to look into this. The code is in `DefaultPortableWriter` correct, but hard to read. In `DefaultPortableWriter` there is a real NPE hidden. Also the typos are worth fixing the classes :)
![screenshot from 2018-02-07 06-54-49](https://user-images.githubusercontent.com/4196298/35900787-0362ce02-0bd4-11e8-845c-5e9a1bccb7fb.png)
