### PR TITLE
Fixed rounding issue in TypeConverters

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -25,6 +25,7 @@ import java.sql.Timestamp;
 import java.util.Date;
 
 public final class TypeConverters {
+
     public static final TypeConverter BIG_INTEGER_CONVERTER = new BigIntegerConverter();
     public static final TypeConverter BIG_DECIMAL_CONVERTER = new BigDecimalConverter();
     public static final TypeConverter DOUBLE_CONVERTER = new DoubleConverter();
@@ -195,7 +196,7 @@ public final class TypeConverters {
             }
             if (isFloatingPointDataType(value)) {
                 Number number = (Number) value;
-                return new BigDecimal(number.doubleValue());
+                return BigDecimal.valueOf(number.doubleValue());
             }
             if (value instanceof Boolean) {
                 return ((Boolean) value) ? BigDecimal.ONE : BigDecimal.ZERO;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -55,7 +56,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedStringValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedStringValue_thenConvertToBigInteger() {
         String stringValue = "3141593";
         Comparable expectedBigIntValue = new BigInteger(stringValue);
 
@@ -68,7 +69,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedDoubleValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedDoubleValue_thenConvertToBigInteger() {
         Double doubleValue = 3.141593;
         Comparable expectedBigIntValue = BigInteger.valueOf(doubleValue.longValue());
 
@@ -81,7 +82,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedFloatValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedFloatValue_thenConvertToBigInteger() {
         Float doubleValue = 3.141593F;
         Comparable expectedBigIntValue = BigInteger.valueOf(3);
 
@@ -94,9 +95,9 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedLongValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedLongValue_thenConvertToBigInteger() {
         Long longValue = 3141593L;
-        Comparable expectedBigIntValue = BigInteger.valueOf(longValue.longValue());
+        Comparable expectedBigIntValue = BigInteger.valueOf(longValue);
 
         Comparable comparable = TypeConverters.BIG_INTEGER_CONVERTER.convert(longValue);
 
@@ -107,7 +108,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedIntegerValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedIntegerValue_thenConvertToBigInteger() {
         Integer integerValue = 3141593;
         Comparable expectedBigIntValue = BigInteger.valueOf(integerValue.longValue());
 
@@ -120,7 +121,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedBigDecimalValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedBigDecimalValue_thenConvertToBigInteger() {
         BigDecimal value = BigDecimal.valueOf(4.9999);
         Comparable expectedBigIntValue = BigInteger.valueOf(value.longValue());
 
@@ -133,7 +134,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedHugeBigDecimalValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedHugeBigDecimalValue_thenConvertToBigInteger() {
         BigDecimal value = BigDecimal.ONE.add(
                 BigDecimal.valueOf(Long.MAX_VALUE));
         Comparable expectedBigIntValue = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
@@ -147,7 +148,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedBigIntegerValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedBigIntegerValue_thenConvertToBigInteger() {
         BigInteger value = BigInteger.ONE;
         Comparable expectedBigIntValue = BigInteger.valueOf(value.longValue());
 
@@ -160,9 +161,11 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedBooleanValue_thenConvertToBigInteger() throws Exception {
+    @SuppressWarnings("ConstantConditions")
+    public void testBigIntegerConvert_whenPassedBooleanValue_thenConvertToBigInteger() {
+        // Boolean TRUE means non-zero value, i.e. 1, FALSE means 0
         Boolean value = Boolean.TRUE;
-        Comparable trueAsNumber = BigInteger.ONE; // Boolean TRUE means non-zero value, i.e. 1, FALSE means 0
+        Comparable trueAsNumber = BigInteger.ONE;
 
         Comparable comparable = TypeConverters.BIG_INTEGER_CONVERTER.convert(value);
 
@@ -173,7 +176,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigIntegerConvert_whenPassedNullValue_thenConvertToBigInteger() throws Exception {
+    public void testBigIntegerConvert_whenPassedNullValue_thenConvertToBigInteger() {
         Comparable value = "NotANumber";
         thrown.expect(NumberFormatException.class);
         thrown.expectMessage(startsWith("For input string: "));
@@ -182,7 +185,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedStringValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedStringValue_thenConvertToBigDecimal() {
         String stringValue = "3141593";
         Comparable expectedDecimal = new BigDecimal(stringValue);
 
@@ -194,36 +197,46 @@ public class TypeConverterTest {
         ));
     }
 
+    /**
+     * Checks that the {@link TypeConverters#BIG_DECIMAL_CONVERTER} doesn't return a rounded {@link BigDecimal}.
+     */
     @Test
-    public void testBigDecimalConvert_whenPassedDoubleValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedDoubleValue_thenConvertToBigDecimal() {
         Double doubleValue = 3.141593;
-        Comparable expectedDecimal = new BigDecimal(doubleValue);
+        Comparable expectedDecimal = BigDecimal.valueOf(doubleValue);
+        Comparable unexpectedDecimal = new BigDecimal(doubleValue);
 
         Comparable comparable = TypeConverters.BIG_DECIMAL_CONVERTER.convert(doubleValue);
 
         assertThat(comparable, allOf(
                 is(instanceOf(BigDecimal.class)),
-                is(equalTo(expectedDecimal))
+                is(equalTo(expectedDecimal)),
+                not(equalTo(unexpectedDecimal))
         ));
     }
 
+    /**
+     * Checks that the {@link TypeConverters#BIG_DECIMAL_CONVERTER} doesn't return a rounded {@link BigDecimal}.
+     */
     @Test
-    public void testBigDecimalConvert_whenPassedFloatValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedFloatValue_thenConvertToBigDecimal() {
         Float floatValue = 3.141593F;
-        Comparable expectedDecimal = new BigDecimal(floatValue);
+        Comparable expectedDecimal = BigDecimal.valueOf(floatValue);
+        Comparable unexpectedDecimal = new BigDecimal(floatValue);
 
         Comparable comparable = TypeConverters.BIG_DECIMAL_CONVERTER.convert(floatValue);
 
         assertThat(comparable, allOf(
                 is(instanceOf(BigDecimal.class)),
-                is(equalTo(expectedDecimal))
+                is(equalTo(expectedDecimal)),
+                not(equalTo(unexpectedDecimal))
         ));
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedLongValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedLongValue_thenConvertToBigDecimal() {
         Long longValue = 3141593L;
-        Comparable expectedDecimal = BigDecimal.valueOf(longValue.longValue());
+        Comparable expectedDecimal = BigDecimal.valueOf(longValue);
 
         Comparable comparable = TypeConverters.BIG_DECIMAL_CONVERTER.convert(longValue);
 
@@ -234,7 +247,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedIntegerValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedIntegerValue_thenConvertToBigDecimal() {
         Integer integerValue = 3141593;
         Comparable expectedDecimal = new BigDecimal(integerValue.toString());
 
@@ -247,9 +260,8 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedHugeBigIntegerValue_thenConvertToBigDecimal() throws Exception {
-        BigInteger value = BigInteger.ONE.add(
-                BigInteger.valueOf(Long.MAX_VALUE));
+    public void testBigDecimalConvert_whenPassedHugeBigIntegerValue_thenConvertToBigDecimal() {
+        BigInteger value = BigInteger.ONE.add(BigInteger.valueOf(Long.MAX_VALUE));
         Comparable expectedDecimal = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
 
         Comparable comparable = TypeConverters.BIG_DECIMAL_CONVERTER.convert(value);
@@ -261,7 +273,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedBigIntegerValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedBigIntegerValue_thenConvertToBigDecimal() {
         BigInteger value = BigInteger.ONE;
         Comparable expectedDecimal = BigDecimal.valueOf(value.longValue());
 
@@ -274,9 +286,11 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedBooleanValue_thenConvertToBigDecimal() throws Exception {
+    @SuppressWarnings("ConstantConditions")
+    public void testBigDecimalConvert_whenPassedBooleanValue_thenConvertToBigDecimal() {
+        // Boolean TRUE means non-zero value, i.e. 1, FALSE means 0
         Boolean value = Boolean.TRUE;
-        Comparable trueAsDecimal = BigDecimal.ONE; // Boolean TRUE means non-zero value, i.e. 1, FALSE means 0
+        Comparable trueAsDecimal = BigDecimal.ONE;
 
         Comparable comparable = TypeConverters.BIG_DECIMAL_CONVERTER.convert(value);
 
@@ -287,7 +301,7 @@ public class TypeConverterTest {
     }
 
     @Test
-    public void testBigDecimalConvert_whenPassedNullValue_thenConvertToBigDecimal() throws Exception {
+    public void testBigDecimalConvert_whenPassedNullValue_thenConvertToBigDecimal() {
         Comparable value = "NotANumber";
         thrown.expect(NumberFormatException.class);
 
@@ -296,10 +310,10 @@ public class TypeConverterTest {
 
     @Test
     public void testCharConvert_whenPassedNumeric_thenConvertToChar() {
-        final Comparable value = 1;
-        final Comparable expectedCharacter = (char) 1;
+        Comparable value = 1;
+        Comparable expectedCharacter = (char) 1;
 
-        final Comparable actualCharacter = TypeConverters.CHAR_CONVERTER.convert(value);
+        Comparable actualCharacter = TypeConverters.CHAR_CONVERTER.convert(value);
 
         assertThat(actualCharacter, allOf(
                 is(instanceOf(Character.class)),
@@ -309,10 +323,10 @@ public class TypeConverterTest {
 
     @Test
     public void testCharConvert_whenPassedString_thenConvertToChar() {
-        final Comparable value = "foo";
-        final Comparable expectedCharacter = 'f';
+        Comparable value = "foo";
+        Comparable expectedCharacter = 'f';
 
-        final Comparable actualCharacter = TypeConverters.CHAR_CONVERTER.convert(value);
+        Comparable actualCharacter = TypeConverters.CHAR_CONVERTER.convert(value);
 
         assertThat(actualCharacter, allOf(
                 is(instanceOf(Character.class)),
@@ -322,10 +336,9 @@ public class TypeConverterTest {
 
     @Test
     public void testCharConvert_whenPassedEmptyString_thenConvertToChar() {
-        final Comparable value = "";
+        Comparable value = "";
         thrown.expect(IllegalArgumentException.class);
 
         TypeConverters.CHAR_CONVERTER.convert(value);
     }
-
 }


### PR DESCRIPTION
Because of floating point imprecision, you're unlikely to get the value
you expect from the `BigDecimal(double)` constructor.

From the JavaDocs:

> The results of this constructor can be somewhat unpredictable.
> One might assume that writing new BigDecimal(0.1) in Java creates a
> BigDecimal which is exactly equal to 0.1 (an unscaled value of 1,
> with a scale of 1), but it is actually equal to
> 0.1000000000000000055511151231257827021181583404541015625.

> This is because 0.1 cannot be represented exactly as a double (or, for
> that matter, as a binary fraction of any finite length). Thus, the
> value that is being passed in to the constructor is not exactly equal
> to 0.1, appearances notwithstanding.

Instead, you should use `BigDecimal.valueOf`, which uses a string under
the covers to eliminate floating point rounding errors, or the
constructor that takes a String argument.

We can see this in the tests, when we just fix one side. Then the given
floating value `3.141593` is changed to `3.1415929999999998578630311385...`
The test only passes, since it does the same (wrong) conversion.

Once again kudos to SonarCube (also for the nice explanation):
![screenshot from 2018-02-07 07-24-28](https://user-images.githubusercontent.com/4196298/35901719-54e67310-0bd8-11e8-8b65-164c23b0de2c.png)
