### PR TITLE
Minor NioChannelWriter.poll simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -154,28 +154,21 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
 
     private OutboundFrame poll() {
         for (; ; ) {
-            boolean urgent = true;
             OutboundFrame frame = urgentWriteQueue.poll();
-
             if (frame == null) {
-                urgent = false;
                 frame = writeQueue.poll();
-            }
-
-            if (frame == null) {
-                return null;
+                if (frame == null) {
+                    return null;
+                }
+                normalFramesWritten.inc();
+            } else {
+                priorityFramesWritten.inc();
             }
 
             if (frame.getClass() == TaskFrame.class) {
                 TaskFrame taskFrame = (TaskFrame) frame;
                 taskFrame.task.run();
                 continue;
-            }
-
-            if (urgent) {
-                priorityFramesWritten.inc();
-            } else {
-                normalFramesWritten.inc();
             }
 
             return frame;


### PR DESCRIPTION
Instead of tracking state if a frame was urgent or not and later doing an if/else,
it is immediately taken care of when the item is polled from one of the queues and
the appropriate counters are updated directly.

This means that on the fast path instead of having 4 branches, it has been reduced to 3.