### PR TITLE
Renamed EventCountBasicMigrationStrategy to LoadMigrationStrategy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -41,7 +41,7 @@ import static com.hazelcast.spi.properties.GroupProperty.IO_THREAD_COUNT;
  * <code>IOBalancer</code> tries to detect such situations and fix them by moving {@link NioChannelReader} and
  * {@link NioChannelWriter} between {@link NioThread} instances.
  *
- * It measures number of events serviced by each handler in a given interval and if imbalance is detected then it
+ * It measures amount of load serviced by each handler in a given interval and if imbalance is detected then it
  * schedules handler migration to fix the situation. The exact migration strategy can be customized via
  * {@link com.hazelcast.internal.networking.nio.iobalancer.MigrationStrategy}.
  *
@@ -149,13 +149,13 @@ public class IOBalancer {
             tryMigrate(loadImbalance);
         } else {
             if (logger.isFinestEnabled()) {
-                long min = loadImbalance.minimumEvents;
-                long max = loadImbalance.maximumEvents;
+                long min = loadImbalance.minimumLoad;
+                long max = loadImbalance.maximumLoad;
                 if (max == Long.MIN_VALUE) {
                     logger.finest("There is at most 1 handler associated with each thread. "
                             + "There is nothing to balance");
                 } else {
-                    logger.finest("No imbalance has been detected. Max. events: " + max + " Min events: " + min + ".");
+                    logger.finest("No imbalance has been detected. Max. load: " + max + " Min load: " + min + ".");
                 }
             }
         }
@@ -168,7 +168,7 @@ public class IOBalancer {
             return new MonkeyMigrationStrategy();
         } else {
             logger.finest("Using normal IO Balancer Strategy.");
-            return new EventCountBasicMigrationStrategy();
+            return new LoadMigrationStrategy();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
@@ -31,10 +31,10 @@ import java.util.Set;
  * {@link SelectionHandler} should be migrated.
  */
 class LoadImbalance {
-    //number of events recorded by the busiest NioThread
-    long maximumEvents;
-    //number of events recorded by the least busy NioThread
-    long minimumEvents;
+    //load recorded by the busiest NioThread
+    long maximumLoad;
+    //load recorded by the least busy NioThread
+    long minimumLoad;
     //busiest NioThread
     NioThread sourceSelector;
     //least busy NioThread
@@ -59,7 +59,7 @@ class LoadImbalance {
 
     /**
      * @param handler
-     * @return number of events recorded by the handler
+     * @return load recorded by the handler
      */
     long getLoad(MigratableHandler handler) {
         return handlerLoadCounter.get(handler);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerMemoryLeakTest.java
@@ -119,10 +119,10 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
                 LoadTracker outLoadTracker = ioBalancer.getOutLoadTracker();
                 int inHandlerSize = inLoadTracker.getHandlers().size();
                 int outHandlerSize = outLoadTracker.getHandlers().size();
-                int inHandlerEventsCount = inLoadTracker.getHandlerEventsCounter().keySet().size();
-                int outHandlerEventsCount = outLoadTracker.getHandlerEventsCounter().keySet().size();
-                int inLastEventsCount = inLoadTracker.getLastEventCounter().keySet().size();
-                int outLastEventsCount = outLoadTracker.getLastEventCounter().keySet().size();
+                int inHandlerEventsCount = inLoadTracker.getHandlerLoad().keySet().size();
+                int outHandlerEventsCount = outLoadTracker.getHandlerLoad().keySet().size();
+                int inLastEventsCount = inLoadTracker.getLastLoad().keySet().size();
+                int outLastEventsCount = outLoadTracker.getLastLoad().keySet().size();
                 assertEquals(0, inHandlerSize);
                 assertEquals(0, outHandlerSize);
                 assertEquals(0, inHandlerEventsCount);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategyTest.java
@@ -41,25 +41,25 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
+public class LoadMigrationStrategyTest extends HazelcastTestSupport {
 
     private Map<NioThread, Set<MigratableHandler>> selectorToHandlers;
     private ItemCounter<MigratableHandler> handlerEventsCounter;
     private LoadImbalance imbalance;
 
-    private EventCountBasicMigrationStrategy strategy;
+    private LoadMigrationStrategy strategy;
 
     @Before
     public void setUp() {
         selectorToHandlers = new HashMap<NioThread, Set<MigratableHandler>>();
         handlerEventsCounter = new ItemCounter<MigratableHandler>();
         imbalance = new LoadImbalance(selectorToHandlers, handlerEventsCounter);
-        strategy = new EventCountBasicMigrationStrategy();
+        strategy = new LoadMigrationStrategy();
     }
 
     @Test
     public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMinimum() throws Exception {
-        imbalance.minimumEvents = Long.MIN_VALUE;
+        imbalance.minimumLoad = Long.MIN_VALUE;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
         assertFalse(imbalanceDetected);
@@ -67,7 +67,7 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
 
     @Test
     public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMaximum() throws Exception {
-        imbalance.maximumEvents = Long.MAX_VALUE;
+        imbalance.maximumLoad = Long.MAX_VALUE;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
         assertFalse(imbalanceDetected);
@@ -75,8 +75,8 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
 
     @Test
     public void testImbalanceDetected_shouldReturnFalseWhenBalanced() throws Exception {
-        imbalance.maximumEvents = 1000;
-        imbalance.minimumEvents = (long) (1000 * 0.8);
+        imbalance.maximumLoad = 1000;
+        imbalance.minimumLoad = (long) (1000 * 0.8);
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
         assertFalse(imbalanceDetected);
@@ -84,8 +84,8 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
 
     @Test
     public void testImbalanceDetected_shouldReturnTrueWhenNotBalanced() throws Exception {
-        imbalance.maximumEvents = 1000;
-        imbalance.minimumEvents = (long) (1000 * 0.8) - 1;
+        imbalance.maximumLoad = 1000;
+        imbalance.minimumLoad = (long) (1000 * 0.8) - 1;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
         assertTrue(imbalanceDetected);
@@ -98,12 +98,12 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
         imbalance.sourceSelector = sourceSelector;
         imbalance.destinationSelector = destinationSelector;
 
-        imbalance.minimumEvents = 100;
+        imbalance.minimumLoad = 100;
         MigratableHandler handler1 = mock(MigratableHandler.class);
         handlerEventsCounter.set(handler1, 100L);
         selectorToHandlers.put(destinationSelector, singleton(handler1));
 
-        imbalance.maximumEvents = 300;
+        imbalance.maximumLoad = 300;
         MigratableHandler handler2 = mock(MigratableHandler.class);
         MigratableHandler handler3 = mock(MigratableHandler.class);
         handlerEventsCounter.set(handler2, 200L);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
@@ -79,12 +79,12 @@ public class LoadTrackerTest {
         loadTracker.addHandler(selector2Handler3);
 
         LoadImbalance loadImbalance = loadTracker.updateImbalance();
-        assertEquals(0, loadImbalance.minimumEvents);
-        assertEquals(0, loadImbalance.maximumEvents);
+        assertEquals(0, loadImbalance.minimumLoad);
+        assertEquals(0, loadImbalance.maximumLoad);
 
         loadTracker.updateImbalance();
-        assertEquals(100, loadImbalance.minimumEvents);
-        assertEquals(300, loadImbalance.maximumEvents);
+        assertEquals(100, loadImbalance.minimumLoad);
+        assertEquals(300, loadImbalance.maximumLoad);
         assertEquals(selector1, loadImbalance.destinationSelector);
         assertEquals(selector2, loadImbalance.sourceSelector);
     }
@@ -110,8 +110,8 @@ public class LoadTrackerTest {
 
         LoadImbalance loadImbalance = loadTracker.updateImbalance();
 
-        assertEquals(400, loadImbalance.minimumEvents);
-        assertEquals(400, loadImbalance.maximumEvents);
+        assertEquals(400, loadImbalance.minimumLoad);
+        assertEquals(400, loadImbalance.maximumLoad);
         assertEquals(selector2, loadImbalance.destinationSelector);
         assertEquals(selector2, loadImbalance.sourceSelector);
     }


### PR DESCRIPTION
The MigritableHandler returns 'load' and not event count. And in the
MigratableHandler there is a switch what load actually means.

So the EventCountBasicMigrationStrategy is not tied to 'eventCount' any longer; it just works based on 'load'. 