### PR TITLE
Fix ClientService reporting dead clients

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -167,6 +167,30 @@ public class ClientServiceTest extends HazelcastTestSupport {
         assertEquals(0, instance2.getClientService().getConnectedClients().size());
     }
 
+    @Test
+    public void testGetConnectedClients_whenOwnerAndClientDiesTogether() throws Exception {
+        HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+
+        final String instance1Key = generateKeyOwnedBy(instance1);
+        final String instance2Key = generateKeyOwnedBy(instance2);
+
+        final IMap<Object, Object> map = client.getMap("map");
+        map.put(instance1Key, 0);
+        map.put(instance2Key, 0);
+
+        instance1.shutdown();
+        client.shutdown();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, instance2.getClientService().getConnectedClients().size());
+            }
+        });
+
+    }
 
     @Test
     public void testConnectedClients() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -302,7 +302,9 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     public Collection<Client> getClients() {
         final HashSet<Client> clients = new HashSet<Client>();
         for (ClientEndpoint endpoint : endpointManager.getEndpoints()) {
-            clients.add((Client) endpoint);
+            if (endpoint.isAlive()) {
+                clients.add((Client) endpoint);
+            }
         }
         return clients;
     }
@@ -618,10 +620,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     @Override
     public Map<ClientType, Integer> getConnectedClientStats() {
 
-        int numberOfCppClients    = 0;
+        int numberOfCppClients = 0;
         int numberOfDotNetClients = 0;
-        int numberOfJavaClients   = 0;
-        int numberOfOtherClients  = 0;
+        int numberOfJavaClients = 0;
+        int numberOfOtherClients = 0;
 
         Operation clientInfoOperation = new GetConnectedClientsOperation();
         OperationService operationService = node.nodeEngine.getOperationService();

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -459,7 +459,7 @@ public final class TestNodeRegistry {
 
         @Override
         public boolean isAlive() {
-            return true;
+            return live;
         }
 
         @Override


### PR DESCRIPTION
Fix is only for wrong report. Actual resource cleanups
(lock/semaphore etc) is not fixed in this commit.