### PR TITLE
Rename read write handler to pipeline

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.internal.networking.nio.NioChannel;
-import com.hazelcast.internal.networking.nio.NioChannelWriter;
+import com.hazelcast.internal.networking.nio.NioOutboundPipeline;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -153,8 +153,8 @@ public class OverloadedConnectionsPlugin extends DiagnosticsPlugin {
     private Queue<OutboundFrame> getOutboundQueue(TcpIpConnection connection, boolean priority) {
         if (connection.getChannel() instanceof NioChannel) {
             NioChannel nioChannel = (NioChannel) connection.getChannel();
-            NioChannelWriter writer = nioChannel.getWriter();
-            return priority ? writer.urgentWriteQueue : writer.writeQueue;
+            NioOutboundPipeline outboundPipeline = nioChannel.getOutboundPipeline();
+            return priority ? outboundPipeline.urgentWriteQueue : outboundPipeline.writeQueue;
         } else {
             return EMPTY_QUEUE;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -29,27 +29,27 @@ import static com.hazelcast.nio.IOUtil.closeResource;
  */
 public class NioChannel extends AbstractChannel {
 
-    private NioChannelReader reader;
-    private NioChannelWriter writer;
+    private NioInboundPipeline inboundPipeline;
+    private NioOutboundPipeline outboundPipeline;
 
     public NioChannel(SocketChannel socketChannel, boolean clientMode) {
         super(socketChannel, clientMode);
     }
 
-    public void setReader(NioChannelReader reader) {
-        this.reader = reader;
+    public void setInboundPipeline(NioInboundPipeline inboundPipeline) {
+        this.inboundPipeline = inboundPipeline;
     }
 
-    public void setWriter(NioChannelWriter writer) {
-        this.writer = writer;
+    public void setOutboundPipeline(NioOutboundPipeline outboundPipeline) {
+        this.outboundPipeline = outboundPipeline;
     }
 
-    public NioChannelReader getReader() {
-        return reader;
+    public NioInboundPipeline getInboundPipeline() {
+        return inboundPipeline;
     }
 
-    public NioChannelWriter getWriter() {
-        return writer;
+    public NioOutboundPipeline getOutboundPipeline() {
+        return outboundPipeline;
     }
 
     @Override
@@ -57,29 +57,29 @@ public class NioChannel extends AbstractChannel {
         if (isClosed()) {
             return false;
         }
-        writer.write(frame);
+        outboundPipeline.write(frame);
         return true;
     }
 
     @Override
     public long lastReadTimeMillis() {
-        return reader.lastReadTimeMillis();
+        return inboundPipeline.lastReadTimeMillis();
     }
 
     @Override
     public long lastWriteTimeMillis() {
-        return writer.lastWriteTimeMillis();
+        return outboundPipeline.lastWriteTimeMillis();
     }
 
     @Override
     public void flush() {
-        writer.flush();
+        outboundPipeline.flush();
     }
 
     @Override
     protected void onClose() {
-        closeResource(reader);
-        closeResource(writer);
+        closeResource(inboundPipeline);
+        closeResource(outboundPipeline);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -38,7 +38,7 @@ import static java.nio.channels.SelectionKey.OP_READ;
  * {@link #handle()} is called to read out the data from the socket into a bytebuffer and hand it over to the
  * {@link ChannelInboundHandler} to get processed.
  */
-public final class NioChannelReader extends AbstractHandler {
+public final class NioInboundPipeline extends NioPipeline {
 
     protected ByteBuffer inputBuffer;
 
@@ -57,7 +57,7 @@ public final class NioChannelReader extends AbstractHandler {
     private volatile long priorityFramesReadLastPublish;
     private volatile long handleCountLastPublish;
 
-    public NioChannelReader(
+    public NioInboundPipeline(
             NioChannel channel,
             NioThread ioThread,
             ILogger logger,
@@ -180,7 +180,7 @@ public final class NioChannelReader extends AbstractHandler {
             @Override
             public void run() {
                 if (ioThread != Thread.currentThread()) {
-                    // the NioChannelReader has migrated to a different IOThread after the close got called.
+                    // the NioInboundPipeline has migrated to a different IOThread after the close got called.
                     // so we need to send the task to the right ioThread. Otherwise multiple ioThreads could be accessing
                     // the same channel.
                     ioThread.addTaskAndWakeup(this);
@@ -198,7 +198,7 @@ public final class NioChannelReader extends AbstractHandler {
 
     @Override
     public String toString() {
-        return channel + ".channelReader";
+        return channel + ".inboundPipeline";
     }
 
     private class StartMigrationTask implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -41,7 +41,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.nio.channels.SelectionKey.OP_WRITE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public final class NioChannelWriter extends AbstractHandler implements Runnable {
+public final class NioOutboundPipeline extends NioPipeline implements Runnable {
 
     private static final long TIMEOUT = 3;
 
@@ -77,11 +77,11 @@ public final class NioChannelWriter extends AbstractHandler implements Runnable 
     private long priorityFramesReadLastPublish;
     private long eventsLastPublish;
 
-    public NioChannelWriter(NioChannel channel,
-                            NioThread ioThread,
-                            ILogger logger,
-                            IOBalancer balancer,
-                            ChannelInitializer initializer) {
+    public NioOutboundPipeline(NioChannel channel,
+                               NioThread ioThread,
+                               ILogger logger,
+                               IOBalancer balancer,
+                               ChannelInitializer initializer) {
         super(channel, ioThread, OP_WRITE, logger, balancer);
         this.initializer = initializer;
     }
@@ -374,14 +374,14 @@ public final class NioChannelWriter extends AbstractHandler implements Runnable 
 
     @Override
     public String toString() {
-        return channel + ".channelWriter";
+        return channel + ".outboundPipeline";
     }
 
     /**
      * The TaskFrame is not really a Frame. It is a way to put a task on one of the frame-queues. Using this approach we
      * can lift on top of the Frame scheduling mechanism and we can prevent having:
-     * - multiple NioThread-tasks for a ChannelWriter on multiple NioThread
-     * - multiple NioThread-tasks for a ChannelWriter on the same NioThread.
+     * - multiple NioThread-tasks for a NioOutboundPipeline on multiple NioThread
+     * - multiple NioThread-tasks for a NioOutboundPipeline on the same NioThread.
      */
     private static final class TaskFrame implements OutboundFrame {
 
@@ -398,8 +398,8 @@ public final class NioChannelWriter extends AbstractHandler implements Runnable 
     }
 
     /**
-     * Triggers the migration when executed by setting the ChannelWriter.newOwner field. When the handle method completes, it
-     * checks if this field if set, if so, the migration starts.
+     * Triggers the migration when executed by setting the NioOutboundPipeline.newOwner field. When the handle method completes,
+     * it checks if this field if set, if so, the migration starts.
      *
      * If the current ioThread is the same as 'theNewOwner' then the call is ignored.
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -30,7 +30,7 @@ import java.nio.channels.SocketChannel;
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
-public abstract class AbstractHandler implements MigratableHandler, Closeable {
+public abstract class NioPipeline implements MigratableHandler, Closeable {
 
     protected static final int LOAD_BALANCING_HANDLE = 0;
     protected static final int LOAD_BALANCING_BYTE = 1;
@@ -59,11 +59,11 @@ public abstract class AbstractHandler implements MigratableHandler, Closeable {
     @Probe
     private final SwCounter migrationCount = newSwCounter();
 
-    AbstractHandler(NioChannel channel,
-                    NioThread ioThread,
-                    int initialOps,
-                    ILogger logger,
-                    IOBalancer ioBalancer) {
+    NioPipeline(NioChannel channel,
+                NioThread ioThread,
+                int initialOps,
+                ILogger logger,
+                IOBalancer ioBalancer) {
         this.channel = channel;
         this.socketChannel = channel.socketChannel();
         this.ioThread = ioThread;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.networking.nio.iobalancer;
 
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.networking.nio.NioInboundPipeline;
 import com.hazelcast.internal.networking.nio.MigratableHandler;
-import com.hazelcast.internal.networking.nio.NioChannelWriter;
-import com.hazelcast.internal.networking.nio.NioChannelReader;
+import com.hazelcast.internal.networking.nio.NioOutboundPipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.internal.util.counters.SwCounter;
@@ -38,8 +38,8 @@ import static com.hazelcast.spi.properties.GroupProperty.IO_THREAD_COUNT;
  * By default Hazelcast uses 3 threads to read data from TCP connections and 3 threads to write data to connections.
  * We have measured significant fluctuations of performance when the threads are not utilized equally.
  *
- * <code>IOBalancer</code> tries to detect such situations and fix them by moving {@link NioChannelReader} and
- * {@link NioChannelWriter} between {@link NioThread} instances.
+ * <code>IOBalancer</code> tries to detect such situations and fix them by moving {@link NioInboundPipeline} and
+ * {@link NioOutboundPipeline} between {@link NioThread} instances.
  *
  * It measures number of events serviced by each handler in a given interval and if imbalance is detected then it
  * schedules handler migration to fix the situation. The exact migration strategy can be customized via

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
+import com.hazelcast.internal.networking.nio.NioPipeline;
 import com.hazelcast.internal.networking.nio.MigratableHandler;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.util.ItemCounter;
@@ -27,7 +28,7 @@ import java.util.Set;
  * Describes a state of NioThread (im-)balance.
  *
  * It's used by {@link MigrationStrategy} to decide whether and what
- * {@link com.hazelcast.internal.networking.nio.AbstractHandler} should be migrated.
+ * {@link NioPipeline} should be migrated.
  */
 class LoadImbalance {
     //number of events recorded by the busiest NioThread

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastTestSupport;
-import org.apache.commons.math3.analysis.function.Abs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +55,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
     private ChannelErrorHandler errorHandler;
     private ILogger logger;
     private MockSelector selector;
-    private AbstractHandler handler;
+    private NioPipeline handler;
     NioThread thread;
 
     @Before
@@ -64,7 +63,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
         logger = Logger.getLogger(NioThread.class);
         errorHandler = mock(ChannelErrorHandler.class);
         selector = new MockSelector();
-        handler = mock(AbstractHandler.class);
+        handler = mock(NioPipeline.class);
     }
 
     @After
@@ -182,7 +181,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
     public void assertStillRunning() {
         // we verify that the thread is still running by scheduling a selection-key event and checking if the
         // handler is being called.
-        final AbstractHandler handler = mock(AbstractHandler.class);
+        final NioPipeline handler = mock(NioPipeline.class);
         SelectionKey selectionKey = mock(SelectionKey.class);
         selectionKey.attach(handler);
         when(selectionKey.isValid()).thenReturn(true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -21,10 +21,10 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.internal.networking.nio.NioInboundPipeline;
 import com.hazelcast.internal.networking.nio.MigratableHandler;
 import com.hazelcast.internal.networking.nio.NioChannel;
-import com.hazelcast.internal.networking.nio.NioChannelReader;
-import com.hazelcast.internal.networking.nio.NioChannelWriter;
+import com.hazelcast.internal.networking.nio.NioOutboundPipeline;
 import com.hazelcast.internal.networking.nio.NioEventLoopGroup;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -102,8 +102,8 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         Map<NioThread, Set<MigratableHandler>> handlersPerSelector = new HashMap<NioThread, Set<MigratableHandler>>();
         for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
             NioChannel channel = (NioChannel) connection.getChannel();
-            add(handlersPerSelector, channel.getReader());
-            add(handlersPerSelector, channel.getWriter());
+            add(handlersPerSelector, channel.getInboundPipeline());
+            add(handlersPerSelector, channel.getOutboundPipeline());
         }
         return handlersPerSelector;
     }
@@ -157,7 +157,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             sb.append(in).append(": ").append(in.getEventCount()).append("\n");
 
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
-                NioChannelReader socketReader = ((NioChannel) connection.getChannel()).getReader();
+                NioInboundPipeline socketReader = ((NioChannel) connection.getChannel()).getInboundPipeline();
                 if (socketReader.getOwner() == in) {
                     sb.append("\t").append(socketReader).append(" eventCount:").append(socketReader.getLoad()).append("\n");
                 }
@@ -168,7 +168,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             sb.append(in).append(": ").append(in.getEventCount()).append("\n");
 
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
-                NioChannelWriter socketWriter = ((NioChannel) connection.getChannel()).getWriter();
+                NioOutboundPipeline socketWriter = ((NioChannel) connection.getChannel()).getOutboundPipeline();
                 if (socketWriter.getOwner() == in) {
                     sb.append("\t").append(socketWriter).append(" eventCount:").append(socketWriter.getLoad()).append("\n");
                 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketDecoderTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.internal.networking.nio.NioChannel;
-import com.hazelcast.internal.networking.nio.NioChannelReader;
+import com.hazelcast.internal.networking.nio.NioInboundPipeline;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.PacketIOHelper;
 import com.hazelcast.spi.impl.PacketHandler;
@@ -45,7 +45,7 @@ public class PacketDecoderTest extends TcpIpConnection_AbstractTest {
     private PacketDecoder readHandler;
     private long oldPriorityPacketsRead;
     private long oldNormalPacketsRead;
-    private NioChannelReader channelReader;
+    private NioInboundPipeline channelReader;
 
     @Before
     public void setup() throws Exception {
@@ -61,7 +61,7 @@ public class PacketDecoderTest extends TcpIpConnection_AbstractTest {
         dispatcher = new MockPacketDispatcher();
         readHandler = new PacketDecoder(connection, dispatcher);
 
-        channelReader = ((NioChannel) connection.getChannel()).getReader();
+        channelReader = ((NioChannel) connection.getChannel()).getInboundPipeline();
         oldNormalPacketsRead = channelReader.getNormalFramesReadCounter().get();
         oldPriorityPacketsRead = channelReader.getPriorityFramesReadCounter().get();
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTransferStressTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.internal.networking.Channel;
+import com.hazelcast.internal.networking.nio.NioInboundPipeline;
 import com.hazelcast.internal.networking.nio.NioChannel;
-import com.hazelcast.internal.networking.nio.NioChannelReader;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestThread;
@@ -138,7 +138,7 @@ public abstract class TcpIpConnection_AbstractTransferStressTest extends TcpIpCo
     private int totalFramesPending(TcpIpConnection connection) {
         Channel channel = connection.getChannel();
         if (channel instanceof NioChannel) {
-            return ((NioChannel) channel).getWriter().totalFramesPending();
+            return ((NioChannel) channel).getOutboundPipeline().totalFramesPending();
         } else {
             throw new RuntimeException();
         }
@@ -147,7 +147,7 @@ public abstract class TcpIpConnection_AbstractTransferStressTest extends TcpIpCo
     private long framesRead(TcpIpConnection connection, boolean priority) {
         Channel channel = connection.getChannel();
         if (channel instanceof NioChannel) {
-            NioChannelReader reader = ((NioChannel) channel).getReader();
+            NioInboundPipeline reader = ((NioChannel) channel).getInboundPipeline();
             return priority ? reader.getPriorityFramesReadCounter().get() : reader.getNormalFramesReadCounter().get();
         } else {
             throw new RuntimeException();


### PR DESCRIPTION
This is preparation of the IO pipeline functionality. The NioReadHandler/NioWriteHander are effectively the pipeline even though they currently only contain a single Handler.

NioReadHandler -> NioInboundPipeline
NioWriteHandler -> NioOutboundPipeline