### PR TITLE
[BACKPORT] Fixed ommited timeToLiveSeconds value

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -76,6 +76,7 @@ public class AddMapConfigMessageTask
         if (parameters.mapStoreConfig != null) {
             config.setMapStoreConfig(parameters.mapStoreConfig.asMapStoreConfig(serializationService));
         }
+        config.setTimeToLiveSeconds(parameters.timeToLiveSeconds);
         config.setMaxIdleSeconds(parameters.maxIdleSeconds);
         config.setMaxSizeConfig(new MaxSizeConfig(parameters.maxSizeConfigSize,
                 MaxSizeConfig.MaxSizePolicy.valueOf(parameters.maxSizeConfigMaxSizePolicy)));

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -773,6 +773,7 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         config.setInMemoryFormat(InMemoryFormat.OBJECT);
         config.setMergePolicy("com.hazelcast.SomeMergePolicy");
         config.setMaxSizeConfig(new MaxSizeConfig(4096, MaxSizeConfig.MaxSizePolicy.PER_NODE));
+        config.setTimeToLiveSeconds(220);
         config.setMaxIdleSeconds(110);
         config.setQuorumName(randomString());
         config.addMapAttributeConfig(new MapAttributeConfig("attributeName", "com.attribute.extractor"));


### PR DESCRIPTION
backport of #12273 
It's not possible to cherry-pick from master because setTimeToLiveSeconds call for MapConfig is used in chain.