### PR TITLE
Fix MapListenerTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/core/standalone/LongRunningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/standalone/LongRunningTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.GroupProperty;
 import org.junit.Ignore;
 
 import java.util.List;
@@ -190,7 +191,10 @@ public class LongRunningTest {
             this.valueSize = valueSize;
             this.nodeId = nodeId;
             es = Executors.newFixedThreadPool(threadCount);
-            Config cfg = new XmlConfigBuilder().build();
+            Config cfg = new XmlConfigBuilder().build()
+                    .setProperty(GroupProperty.PHONE_HOME_ENABLED.getName(), "false")
+                    .setProperty(GroupProperty.SOCKET_BIND_ANY.getName(), "false")
+                    .setProperty(GroupProperty.PARTITION_MIGRATION_INTERVAL.getName(), "0");
             hazelcast = Hazelcast.newHazelcastInstance(cfg);
             esStats = Executors.newSingleThreadExecutor();
             createTime = System.currentTimeMillis();
@@ -299,11 +303,5 @@ public class LongRunningTest {
                     + ", gets:" + mapGets.get()
                     + ", remove:" + mapRemoves.get();
         }
-    }
-
-    static {
-        System.setProperty("hazelcast.phone.home.enabled", "false");
-        System.setProperty("hazelcast.socket.bind.any", "false");
-        System.setProperty("hazelcast.partition.migration.interval", "0");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
@@ -28,7 +29,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,6 +41,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.map.impl.event.MapEventPublisherImpl.LISTENER_WITH_PREDICATE_PRODUCES_NATURAL_EVENT_TYPES;
+import static com.hazelcast.spi.properties.GroupProperty.EVENT_THREAD_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -49,12 +54,7 @@ public class MapListenerTest extends HazelcastTestSupport {
 
     private static final int AGE_THRESHOLD = 50;
 
-    static {
-        System.setProperty("hazelcast.map.entry.filtering.natural.event.types", "true");
-    }
-
     @Test
-    @Ignore("fails occasionally with wrong events count")
     public void testListener_eventCountsCorrect() throws Exception {
         // GIVEN
         HazelcastInstance hz = createHazelcastInstance();
@@ -290,4 +290,13 @@ public class MapListenerTest extends HazelcastTestSupport {
         }
     }
 
+    @Override
+    protected Config getConfig() {
+        return super.getConfig()
+                    .setProperty(PARTITION_COUNT.getName(), "10")
+                    .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
+                    .setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
+                    .setProperty(EVENT_THREAD_COUNT.getName(), "1")
+                    .setProperty(LISTENER_WITH_PREDICATE_PRODUCES_NATURAL_EVENT_TYPES.getName(), "true");
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/PluggableMemoryInfoAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/PluggableMemoryInfoAccessorTest.java
@@ -22,17 +22,16 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.config.EvictionPolicy.LFU;
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.FREE_HEAP_PERCENTAGE;
-import static java.lang.System.clearProperty;
-import static java.lang.System.setProperty;
+import static com.hazelcast.test.OverridePropertyRule.set;
 import static org.junit.Assert.assertEquals;
 
 
@@ -42,23 +41,10 @@ public class PluggableMemoryInfoAccessorTest extends HazelcastTestSupport {
 
     private static final String HAZELCAST_MEMORY_INFO_ACCESSOR_IMPL = "hazelcast.memory.info.accessor.impl";
 
-    private String previousValue;
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = set(HAZELCAST_MEMORY_INFO_ACCESSOR_IMPL,
+            ZeroMemoryInfoAccessor.class.getCanonicalName());
 
-    @Before
-    public void setUp() throws Exception {
-        previousValue = System.getProperty(HAZELCAST_MEMORY_INFO_ACCESSOR_IMPL);
-
-        setProperty(HAZELCAST_MEMORY_INFO_ACCESSOR_IMPL, ZeroMemoryInfoAccessor.class.getCanonicalName());
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        if (previousValue != null) {
-            setProperty(HAZELCAST_MEMORY_INFO_ACCESSOR_IMPL, previousValue);
-        } else {
-            clearProperty(HAZELCAST_MEMORY_INFO_ACCESSOR_IMPL);
-        }
-    }
 
     /**
      * Used {@link ZeroMemoryInfoAccessor} to evict every put, map should not contain any entry after this test run.

--- a/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleMapTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.GroupProperty;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -54,11 +55,6 @@ public final class SimpleMapTest {
     private final int putPercentage;
     private final boolean load;
 
-    static {
-        System.setProperty("hazelcast.phone.home.enabled", "false");
-        System.setProperty("java.net.preferIPv4Stack", "true");
-    }
-
     private SimpleMapTest(final int threadCount, final int entryCount, final int valueSize,
                           final int getPercentage, final int putPercentage, final boolean load) {
         this.threadCount = threadCount;
@@ -67,7 +63,9 @@ public final class SimpleMapTest {
         this.getPercentage = getPercentage;
         this.putPercentage = putPercentage;
         this.load = load;
-        Config cfg = new XmlConfigBuilder().build();
+        Config cfg = new XmlConfigBuilder().build()
+                .setProperty(GroupProperty.PHONE_HOME_ENABLED.getName(), "false")
+                .setProperty(GroupProperty.PREFER_IPv4_STACK.getName(), "true");
 
         instance = Hazelcast.newHazelcastInstance(cfg);
         logger = instance.getLoggingService().getLogger("SimpleMapTest");

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
@@ -52,11 +52,6 @@ public class SimpleReplicatedMapTest {
     private final int putPercentage;
     private final boolean load;
 
-    static {
-        System.setProperty("hazelcast.phone.home.enabled", "false");
-        System.setProperty("java.net.preferIPv4Stack", "true");
-    }
-
     private SimpleReplicatedMapTest(final int threadCount, final int entryCount, final int valueSize,
                                     final int getPercentage, final int putPercentage, final boolean load) {
         this.threadCount = threadCount;
@@ -65,9 +60,11 @@ public class SimpleReplicatedMapTest {
         this.getPercentage = getPercentage;
         this.putPercentage = putPercentage;
         this.load = load;
-        Config cfg = new XmlConfigBuilder().build();
-        cfg.setProperty(GroupProperty.HEALTH_MONITORING_LEVEL.getName(), "NOISY");
-        cfg.setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS.getName(), "5");
+        Config cfg = new XmlConfigBuilder().build()
+                                           .setProperty(GroupProperty.HEALTH_MONITORING_LEVEL.getName(), "NOISY")
+                                           .setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS.getName(), "5")
+                                           .setProperty(GroupProperty.PHONE_HOME_ENABLED.getName(), "false")
+                                           .setProperty(GroupProperty.PREFER_IPv4_STACK.getName(), "false");
         instance = Hazelcast.newHazelcastInstance(cfg);
         logger = instance.getLoggingService().getLogger("SimpleReplicatedMapTest");
         random = new Random();


### PR DESCRIPTION
When running locally, seems the test sets the
`hazelcast.map.entry.filtering.natural.event.types` property on some runs
but on others it stays `false`. This causes the test to fail. Changed
setting the property via `System.setProperty` to a config property on the
hazelcast config.

Also changed a couple of other tests to prefer hazelcast config
properties or to use OverridePropertyRule.

Fixes: https://github.com/hazelcast/hazelcast/issues/11285