### PR TITLE
Fix failing IScheduledExecutor GetAllScheduledFutures

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -220,11 +220,9 @@ public class DistributedScheduledExecutorService
                 new HashMap<Integer, Map<String, Collection<ScheduledTaskDescriptor>>>();
 
         for (int partition = 0; partition < partitions.length; partition++) {
-            if (nodeEngine.getPartitionService().isPartitionOwner(partition)) {
-                Map<String, Collection<ScheduledTaskDescriptor>> partitionSnapshot = partitions[partition].prepareOwnedSnapshot();
-                if (!partitionSnapshot.isEmpty()) {
-                    state.put(partition, partitionSnapshot);
-                }
+            Map<String, Collection<ScheduledTaskDescriptor>> partitionSnapshot = partitions[partition].prepareOwnedSnapshot();
+            if (!partitionSnapshot.isEmpty()) {
+                state.put(partition, partitionSnapshot);
             }
         }
 
@@ -422,7 +420,7 @@ public class DistributedScheduledExecutorService
                         }
 
                         tasks.clear();
-                        if (mergeEntries.size() > 0) {
+                        if (!mergeEntries.isEmpty()) {
                             sendBatch(partitionId, containerName, mergePolicy, mergeEntries, mergeCallback);
                             operationCount++;
                         }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -228,7 +228,6 @@ public class ScheduledExecutorContainer
                     doSchedule(descriptor);
                 }
 
-                descriptor.setTaskOwner(true);
             } catch (Exception e) {
                 throw rethrow(e);
             }
@@ -397,7 +396,6 @@ public class ScheduledExecutorContainer
                 throw new IllegalArgumentException();
         }
 
-        descriptor.setTaskOwner(true);
         descriptor.setScheduledFuture(future);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
@@ -83,6 +83,7 @@ public class ScheduledExecutorPartition
 
     public Map<String, Collection<ScheduledTaskDescriptor>> prepareOwnedSnapshot() {
         Map<String, Collection<ScheduledTaskDescriptor>> snapshot = new HashMap<String, Collection<ScheduledTaskDescriptor>>();
+        boolean owner = nodeEngine.getPartitionService().isPartitionOwner(partitionId);
 
         if (logger.isFinestEnabled()) {
             logger.finest("[Partition: " + partitionId + "] Prepare snapshot of partition owned tasks.");
@@ -91,7 +92,7 @@ public class ScheduledExecutorPartition
         for (ScheduledExecutorContainer container : getContainers()) {
             try {
                 SplitBrainMergePolicy mergePolicy = getMergePolicy(container.getName());
-                if (!(mergePolicy instanceof DiscardMergePolicy)) {
+                if (owner && !(mergePolicy instanceof DiscardMergePolicy)) {
                     snapshot.put(container.getName(), container.prepareForReplication(true).values());
                 }
             } finally {
@@ -134,7 +135,7 @@ public class ScheduledExecutorPartition
 
     void promoteSuspended() {
         if (logger.isFinestEnabled()) {
-            logger.finest("[Partition: " + partitionId + "] " + "Promote stashes");
+            logger.finest("[Partition: " + partitionId + "] " + "Promote suspended");
         }
 
         for (ScheduledExecutorContainer container : containers.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -19,7 +19,6 @@ package com.hazelcast.scheduledexecutor.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.scheduledexecutor.impl.operations.GetAllScheduledOnMemberOperation;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,15 +38,7 @@ public class ScheduledTaskDescriptor
 
     private TaskDefinition definition;
 
-    private ScheduledFuture<?> future;
-
-    /**
-     * Only accessed through a member lock or partition threads Used to identify which replica of the task is the owner, to only
-     * return that instance when {@link GetAllScheduledOnMemberOperation} operation is triggered. This flag is set to true only on
-     * initial scheduling of a task, and on after a promotion (stashed or migration), in the latter case the other replicas get
-     * disposed.
-     */
-    private transient boolean isTaskOwner;
+    private transient ScheduledFuture<?> future;
 
     /**
      * SPMC (see. Member owned tasks)
@@ -84,14 +75,6 @@ public class ScheduledTaskDescriptor
 
     public TaskDefinition getDefinition() {
         return definition;
-    }
-
-    public boolean isTaskOwner() {
-        return isTaskOwner;
-    }
-
-    void setTaskOwner(boolean taskOwner) {
-        this.isTaskOwner = taskOwner;
     }
 
     ScheduledTaskStatisticsImpl getStatsSnapshot() {
@@ -149,7 +132,6 @@ public class ScheduledTaskDescriptor
      */
     void suspend() {
         // Result is not set, allowing task to get re-scheduled, if/when needed.
-        this.isTaskOwner = false;
 
         if (future != null) {
             this.future.cancel(true);
@@ -240,7 +222,6 @@ public class ScheduledTaskDescriptor
         return "ScheduledTaskDescriptor{"
                 + "definition=" + definition
                 + ", future=" + future
-                + ", isTaskOwner=" + isTaskOwner
                 + ", stats=" + stats
                 + ", resultRef=" + resultRef.get()
                 + ", state=" + state

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractGetAllScheduledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractGetAllScheduledOperation.java
@@ -45,14 +45,7 @@ public abstract class AbstractGetAllScheduledOperation
 
         Collection<ScheduledTaskDescriptor> tasks = container.getTasks();
         for (ScheduledTaskDescriptor task : tasks) {
-            if (isRunningOnTaskOwner()) {
-                handlers.add(container.offprintHandler(task.getDefinition().getName()));
-            }
+            handlers.add(container.offprintHandler(task.getDefinition().getName()));
         }
     }
-
-    protected boolean isRunningOnTaskOwner() {
-        return getNodeEngine().getPartitionService().isPartitionOwner(getPartitionId());
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractGetAllScheduledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/AbstractGetAllScheduledOperation.java
@@ -45,10 +45,14 @@ public abstract class AbstractGetAllScheduledOperation
 
         Collection<ScheduledTaskDescriptor> tasks = container.getTasks();
         for (ScheduledTaskDescriptor task : tasks) {
-            if (task.isTaskOwner()) {
+            if (isRunningOnTaskOwner()) {
                 handlers.add(container.offprintHandler(task.getDefinition().getName()));
             }
         }
+    }
+
+    protected boolean isRunningOnTaskOwner() {
+        return getNodeEngine().getPartitionService().isPartitionOwner(getPartitionId());
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnMemberOperation.java
@@ -50,6 +50,11 @@ public class GetAllScheduledOnMemberOperation
     }
 
     @Override
+    protected boolean isRunningOnTaskOwner() {
+        return true;
+    }
+
+    @Override
     public List<ScheduledTaskHandler> getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOnMemberOperation.java
@@ -50,11 +50,6 @@ public class GetAllScheduledOnMemberOperation
     }
 
     @Override
-    protected boolean isRunningOnTaskOwner() {
-        return true;
-    }
-
-    @Override
     public List<ScheduledTaskHandler> getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.spi.annotation.Beta;
 
 /**
- * Marker interface for operations that changes map state/data.
+ * Marker interface for operations that change state/data.
  * Used for quorum to reject operations if quorum size not satisfied
  *
  * Operations implementing {@link com.hazelcast.spi.BackupOperation} should not be marked with this interface.

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorSplitBrainTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -59,7 +58,6 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-@Ignore(value = "https://github.com/hazelcast/hazelcast/issues/12255")
 public class ScheduledExecutorSplitBrainTest extends SplitBrainTestSupport {
 
     private final String name = randomString();
@@ -225,4 +223,5 @@ public class ScheduledExecutorSplitBrainTest extends SplitBrainTestSupport {
             assertEquals(30, future.get(), 0);
         }
     }
+
 }


### PR DESCRIPTION
- There appears to be a race-condition between `GetAllScheduledFutures` & `MigrationOperation`.
IScheduledExecutor has an internal notion of whats called a task owner, which pretty much reads `isRunningOnPartitionOwner`. This flag is toggled, at the time of migration preparation, and it gets back to true, on the new owner, upon commit of the migration. However, in between the two events, the flag is false on both sides, and since it is consulted from the `GetAllScheduledFutures` to know whether to include the task or if its a backup, it could produce wrong results. 

   Removed the concept of the task ownership, and we now rely solely on the `isPartitionOwner(id)` check. This means, that during the `GetAllScheduledFutures` we will return correct results, with a small side-effect, of the task being suspended during that call (due to the initiated migration). However, this shouldn't cause any problems, since the call is only reading Future handlers.
 Fixes https://github.com/hazelcast/hazelcast/issues/12255

- By removing **all** tasks (including backup ones) regardless of the partition ownership check we were doing before, it fixes partially (the scheduled exec side only) https://github.com/hazelcast/hazelcast/issues/12278

- Last, it should also fix https://github.com/hazelcast/hazelcast/issues/11126, https://github.com/hazelcast/hazelcast/issues/10462, https://github.com/hazelcast/hazelcast/issues/10363, https://github.com/hazelcast/hazelcast/issues/10462