### PR TITLE
Fixed deserialization of merge operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -35,7 +35,7 @@ import com.hazelcast.spi.impl.AbstractNamedOperation;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -145,8 +145,8 @@ public class CacheMergeOperation extends AbstractNamedOperation implements Backu
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        mergeEntries = new LinkedList<SplitBrainMergeEntryView<Data, Data>>();
         int size = in.readInt();
+        mergeEntries = new ArrayList<SplitBrainMergeEntryView<Data, Data>>(size);
         for (int i = 0; i < size; i++) {
             SplitBrainMergeEntryView<Data, Data> mergeEntry = in.readObject();
             mergeEntries.add(mergeEntry);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
@@ -27,8 +27,8 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOpe
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -83,14 +83,14 @@ public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
         partitions = in.readIntArray();
         //noinspection unchecked
         mergeEntries = new List[partitions.length];
-        for (int i = 0; i < partitions.length; i++) {
-            List<SplitBrainMergeEntryView<Data, Data>> list = new LinkedList<SplitBrainMergeEntryView<Data, Data>>();
+        for (int partitionIndex = 0; partitionIndex < partitions.length; partitionIndex++) {
             int size = in.readInt();
-            for (int j = 0; j < size; j++) {
+            List<SplitBrainMergeEntryView<Data, Data>> list = new ArrayList<SplitBrainMergeEntryView<Data, Data>>(size);
+            for (int i = 0; i < size; i++) {
                 SplitBrainMergeEntryView<Data, Data> mergeEntry = in.readObject();
                 list.add(mergeEntry);
             }
-            mergeEntries[i] = list;
+            mergeEntries[partitionIndex] = list;
         }
         policy = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.spi.SplitBrainMergeEntryView;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +97,7 @@ public class CollectionMergeOperation extends CollectionBackupAwareOperation {
         super.readInternal(in);
         mergePolicy = in.readObject();
         int size = in.readInt();
-        mergingEntries = new LinkedList<SplitBrainMergeEntryView<Long, Data>>();
+        mergingEntries = new ArrayList<SplitBrainMergeEntryView<Long, Data>>(size);
         for (int i = 0; i < size; i++) {
             SplitBrainMergeEntryView<Long, Data> mergingEntry = in.readObject();
             mergingEntries.add(mergingEntry);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -103,7 +103,7 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
         super.readInternal(in);
         mergePolicy = in.readObject();
         int size = in.readInt();
-        mergingEntries = new LinkedList<SplitBrainMergeEntryView<Long, Data>>();
+        mergingEntries = new ArrayList<SplitBrainMergeEntryView<Long, Data>>(size);
         for (int i = 0; i < size; i++) {
             SplitBrainMergeEntryView<Long, Data> mergingEntry = in.readObject();
             mergingEntries.add(mergingEntry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
@@ -27,8 +27,8 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOpe
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -82,15 +82,16 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
         partitions = in.readIntArray();
+        //noinspection unchecked
         mergeEntries = new List[partitions.length];
-        for (int i = 0; i < partitions.length; i++) {
-            List<SplitBrainMergeEntryView<Data, Data>> list = new LinkedList<SplitBrainMergeEntryView<Data, Data>>();
+        for (int partitionIndex = 0; partitionIndex < partitions.length; partitionIndex++) {
             int size = in.readInt();
-            for (int j = 0; j < size; j++) {
+            List<SplitBrainMergeEntryView<Data, Data>> list = new ArrayList<SplitBrainMergeEntryView<Data, Data>>(size);
+            for (int i = 0; i < size; i++) {
                 SplitBrainMergeEntryView<Data, Data> mergeEntry = in.readObject();
                 list.add(mergeEntry);
             }
-            mergeEntries[i] = list;
+            mergeEntries[partitionIndex] = list;
         }
         policy = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.spi.SplitBrainMergeEntryView;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -86,8 +86,8 @@ public class MergeOperation extends AbstractNamedSerializableOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         name = in.readUTF();
-        mergeEntries = new LinkedList<SplitBrainMergeEntryView<Object, Object>>();
         int size = in.readInt();
+        mergeEntries = new ArrayList<SplitBrainMergeEntryView<Object, Object>>(size);
         for (int i = 0; i < size; i++) {
             SplitBrainMergeEntryView<Object, Object> mergeEntry = in.readObject();
             mergeEntries.add(mergeEntry);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperationFactory.java
@@ -25,8 +25,8 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOpe
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -81,14 +81,14 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
         partitions = in.readIntArray();
         //noinspection unchecked
         mergeEntries = new List[partitions.length];
-        for (int i = 0; i < partitions.length; i++) {
-            List<SplitBrainMergeEntryView<Object, Object>> list = new LinkedList<SplitBrainMergeEntryView<Object, Object>>();
+        for (int partitionIndex = 0; partitionIndex < partitions.length; partitionIndex++) {
             int size = in.readInt();
-            for (int j = 0; j < size; j++) {
+            List<SplitBrainMergeEntryView<Object, Object>> list = new ArrayList<SplitBrainMergeEntryView<Object, Object>>(size);
+            for (int i = 0; i < size; i++) {
                 SplitBrainMergeEntryView<Object, Object> mergeEntry = in.readObject();
                 list.add(mergeEntry);
             }
-            mergeEntries[i] = list;
+            mergeEntries[partitionIndex] = list;
         }
         policy = in.readObject();
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
@@ -38,7 +38,7 @@ import com.hazelcast.spi.SplitBrainMergeEntryView;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -181,7 +181,7 @@ public class MergeOperation extends Operation implements IdentifiedDataSerializa
         namespace = in.readObject();
         mergePolicy = in.readObject();
         int size = in.readInt();
-        mergingEntries = new LinkedList<SplitBrainMergeEntryView<Long, Object>>();
+        mergingEntries = new ArrayList<SplitBrainMergeEntryView<Long, Object>>(size);
         for (int i = 0; i < size; i++) {
             SplitBrainMergeEntryView<Long, Object> mergingEntry = in.readObject();
             mergingEntries.add(mergingEntry);


### PR DESCRIPTION
Used `ArrayList` instead of `LinkedList` since size is always known.