### PR TITLE
Added flake id generator stats

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -417,8 +417,7 @@ public class ClientDynamicClusterConfig extends Config {
                 flakeIdGeneratorConfig.getPrefetchCount(),
                 flakeIdGeneratorConfig.getPrefetchValidityMillis(),
                 flakeIdGeneratorConfig.getIdOffset(),
-                // TODO this should be flakeIdGeneratorConfig.isStatisticsEnabled()
-                true);
+                flakeIdGeneratorConfig.isStatisticsEnabled());
         invoke(request);
         return this;
     }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.10.xsd
@@ -3313,6 +3313,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="parameterized-boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable/disable statistics.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="client-flake-id-generator">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -432,6 +432,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(10L, c.getPrefetchValidityMillis());
         assertEquals(20L, c.getIdOffset());
         assertEquals("flakeIdGenerator*", c.getName());
+        assertFalse(c.isStatisticsEnabled());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -632,7 +632,8 @@
                 <hz:backup-dir>/mnt/hot-backup/</hz:backup-dir>
             </hz:hot-restart-persistence>
 
-            <hz:flake-id-generator name="flakeIdGenerator*" prefetchCount="3" prefetchValidityMillis="10" idOffset="20"/>
+            <hz:flake-id-generator name="flakeIdGenerator*" prefetchCount="3" prefetchValidityMillis="10" idOffset="20" 
+                statistics-enabled="false" />
 
             <hz:crdt-replication max-concurrent-replication-targets="10" replication-period-millis="2000" />
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddFlakeIdGeneratorConfigMessageTask.java
@@ -46,6 +46,7 @@ public class AddFlakeIdGeneratorConfigMessageTask
         config.setPrefetchCount(parameters.prefetchCount);
         config.setPrefetchValidityMillis(parameters.prefetchValidity);
         config.setIdOffset(parameters.idOffset);
+        config.setStatisticsEnabled(parameters.statisticsEnabled);
         return config;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1114,7 +1114,8 @@ public class ConfigXmlGenerator {
             gen.open("flake-id-generator", "name", m.getName())
                     .node("prefetch-count", m.getPrefetchCount())
                     .node("prefetch-validity-millis", m.getPrefetchValidityMillis())
-                    .node("id-offset", m.getIdOffset());
+                    .node("id-offset", m.getIdOffset())
+                    .node("statistics-enabled", m.isStatisticsEnabled());
             gen.close();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -58,6 +58,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
     private int prefetchCount = DEFAULT_PREFETCH_COUNT;
     private long prefetchValidityMillis = DEFAULT_PREFETCH_VALIDITY_MILLIS;
     private long idOffset;
+    private boolean statisticsEnabled = true;
 
     private transient FlakeIdGeneratorConfigReadOnly readOnly;
 
@@ -77,6 +78,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
         this.prefetchCount = other.prefetchCount;
         this.prefetchValidityMillis = other.prefetchValidityMillis;
         this.idOffset = other.idOffset;
+        this.statisticsEnabled = other.statisticsEnabled;
     }
 
     /**
@@ -187,6 +189,26 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
         return this;
     }
 
+    /**
+     * Gets if statistics gathering is enabled or disabled.
+     *
+     * @return {@code true} if statistics gathering is enabled (default), {@code false} otherwise
+     */
+    public boolean isStatisticsEnabled() {
+        return statisticsEnabled;
+    }
+
+    /**
+     * Enables or disables statistics gathering.
+     *
+     * @param statisticsEnabled {@code true} if statistics gathering is enabled, {@code false} otherwise
+     * @return this instance for fluent API
+     */
+    public FlakeIdGeneratorConfig setStatisticsEnabled(boolean statisticsEnabled) {
+        this.statisticsEnabled = statisticsEnabled;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -201,12 +223,13 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
         return prefetchCount == that.prefetchCount
                 && prefetchValidityMillis == that.prefetchValidityMillis
                 && idOffset == that.idOffset
-                && (name != null ? name.equals(that.name) : that.name == null);
+                && (name != null ? name.equals(that.name) : that.name == null)
+                && statisticsEnabled == that.statisticsEnabled;
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(new Object[]{name, prefetchCount, prefetchValidityMillis, idOffset});
+        return Arrays.hashCode(new Object[] { name, prefetchCount, prefetchValidityMillis, idOffset, statisticsEnabled });
     }
 
     @Override
@@ -216,6 +239,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
                 + ", prefetchCount=" + prefetchCount
                 + ", prefetchValidityMillis=" + prefetchValidityMillis
                 + ", idOffset=" + idOffset
+                + ", statisticsEnabled=" + statisticsEnabled
                 + '}';
     }
 
@@ -235,6 +259,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
         out.writeInt(prefetchCount);
         out.writeLong(prefetchValidityMillis);
         out.writeLong(idOffset);
+        out.writeBoolean(statisticsEnabled);
     }
 
     @Override
@@ -243,5 +268,6 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
         prefetchCount = in.readInt();
         prefetchValidityMillis = in.readLong();
         idOffset = in.readLong();
+        statisticsEnabled = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.monitor.LocalFlakeIdGeneratorStats;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -190,18 +191,18 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Gets if statistics gathering is enabled or disabled.
-     *
-     * @return {@code true} if statistics gathering is enabled (default), {@code false} otherwise
+     * @see #setStatisticsEnabled(boolean)
      */
     public boolean isStatisticsEnabled() {
         return statisticsEnabled;
     }
 
     /**
-     * Enables or disables statistics gathering.
+     * Enables or disables statistics gathering of
+     * {@link LocalFlakeIdGeneratorStats}.
      *
-     * @param statisticsEnabled {@code true} if statistics gathering is enabled, {@code false} otherwise
+     * @param statisticsEnabled {@code true} if statistics gathering is enabled
+     *        (which is also the default), {@code false} otherwise
      * @return this instance for fluent API
      */
     public FlakeIdGeneratorConfig setStatisticsEnabled(boolean statisticsEnabled) {

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfigReadOnly.java
@@ -47,6 +47,11 @@ public class FlakeIdGeneratorConfigReadOnly extends FlakeIdGeneratorConfig {
         throw throwReadOnly();
     }
 
+    @Override
+    public FlakeIdGeneratorConfig setStatisticsEnabled(boolean statisticsEnabled) {
+        throw throwReadOnly();
+    }
+
     private UnsupportedOperationException throwReadOnly() {
         throw new UnsupportedOperationException("This config is read-only");
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -784,6 +784,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 generatorConfig.setPrefetchValidityMillis(Long.parseLong(value));
             } else if ("id-offset".equalsIgnoreCase(nodeName)) {
                 generatorConfig.setIdOffset(Long.parseLong(value));
+            } else if ("statistics-enabled".equals(nodeName)) {
+                generatorConfig.setStatisticsEnabled(getBooleanValue(value));
             }
         }
         config.addFlakeIdGeneratorConfig(generatorConfig);

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -113,6 +113,7 @@ public class FlakeIdGeneratorProxy
 
     @Override
     public long newId() {
+        getService().incrementNewId(name);
         // The cluster version is checked when ClusterService.getMemberListJoinVersion() is called. This always happens
         // before first ID is generated.
         return batcher.newId();

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -193,7 +193,7 @@ public class FlakeIdGeneratorProxy
         long waitTime = Math.max(0, ((base + batchSize - now) >> BITS_SEQUENCE) - ALLOWED_FUTURE_MILLIS);
         base = base << BITS_NODE_ID | nodeId;
 
-        getService().incrementNewId(name);
+        getService().incrementStatsForNewId(name);
         return new IdBatchAndWaitTime(new IdBatch(base, INCREMENT, batchSize), waitTime);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -193,6 +193,8 @@ public class FlakeIdGeneratorProxy
 
         long waitTime = Math.max(0, ((base + batchSize - now) >> BITS_SEQUENCE) - ALLOWED_FUTURE_MILLIS);
         base = base << BITS_NODE_ID | nodeId;
+
+        getService().incrementNewId(name, batchSize);
         return new IdBatchAndWaitTime(new IdBatch(base, INCREMENT, batchSize), waitTime);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -113,7 +113,6 @@ public class FlakeIdGeneratorProxy
 
     @Override
     public long newId() {
-        getService().incrementNewId(name);
         // The cluster version is checked when ClusterService.getMemberListJoinVersion() is called. This always happens
         // before first ID is generated.
         return batcher.newId();
@@ -194,7 +193,7 @@ public class FlakeIdGeneratorProxy
         long waitTime = Math.max(0, ((base + batchSize - now) >> BITS_SEQUENCE) - ALLOWED_FUTURE_MILLIS);
         base = base << BITS_NODE_ID | nodeId;
 
-        getService().incrementNewId(name, batchSize);
+        getService().incrementNewId(name);
         return new IdBatchAndWaitTime(new IdBatch(base, INCREMENT, batchSize), waitTime);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.monitor.LocalFlakeIdGeneratorStats;
 import com.hazelcast.monitor.impl.LocalFlakeIdGeneratorStatsImpl;
 import com.hazelcast.spi.ManagedService;
@@ -81,7 +82,13 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService,
         return new HashMap<String, LocalFlakeIdGeneratorStats>(statsMap);
     }
 
-    public void incrementNewId(String name) {
+    /**
+     * Increments the usage count of the {@link FlakeIdGenerator} with the given
+     * name.
+     *
+     * @param name name of the generator, not null
+     */
+    public void incrementStatsForNewId(String name) {
         getLocalFlakeIdStats(name).incrementUsage();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -85,10 +85,6 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService,
         getLocalFlakeIdStats(name).incrementUsage();
     }
 
-    public void incrementNewId(String name, int size) {
-        getLocalFlakeIdStats(name).incrementUsage(size);
-    }
-
     private LocalFlakeIdGeneratorStatsImpl getLocalFlakeIdStats(String name) {
         return getOrPutIfAbsent(statsMap, name, localFlakeIdStatsConstructorFunction);
     }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -16,18 +16,36 @@
 
 package com.hazelcast.flakeidgen.impl;
 
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.monitor.LocalFlakeIdGeneratorStats;
+import com.hazelcast.monitor.impl.LocalFlakeIdGeneratorStatsImpl;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.util.ConstructorFunction;
 
-import java.util.Properties;
-
-public class FlakeIdGeneratorService implements ManagedService, RemoteService {
+public class FlakeIdGeneratorService implements ManagedService, RemoteService,
+        StatisticsAwareService<LocalFlakeIdGeneratorStats> {
 
     public static final String SERVICE_NAME = "hz:impl:flakeIdGeneratorService";
 
     private NodeEngine nodeEngine;
+    private final ConcurrentHashMap<String, LocalFlakeIdGeneratorStatsImpl> statsMap
+        = new ConcurrentHashMap<String, LocalFlakeIdGeneratorStatsImpl>();
+    private final ConstructorFunction<String, LocalFlakeIdGeneratorStatsImpl> localFlakeIdStatsConstructorFunction
+        = new ConstructorFunction<String, LocalFlakeIdGeneratorStatsImpl>() {
+        public LocalFlakeIdGeneratorStatsImpl createNew(String key) {
+            return new LocalFlakeIdGeneratorStatsImpl();
+        }
+    };
 
     public FlakeIdGeneratorService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -40,6 +58,7 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService {
 
     @Override
     public void reset() {
+        statsMap.clear();
     }
 
     @Override
@@ -54,5 +73,19 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService {
 
     @Override
     public void destroyDistributedObject(String name) {
+        statsMap.remove(name);
+    }
+
+    @Override
+    public Map<String, LocalFlakeIdGeneratorStats> getStats() {
+        return new HashMap<String, LocalFlakeIdGeneratorStats>(statsMap);
+    }
+
+    public void incrementNewId(String name) {
+        getLocalFlakeIdStats(name).incrementUsage();
+    }
+
+    private LocalFlakeIdGeneratorStatsImpl getLocalFlakeIdStats(String name) {
+        return getOrPutIfAbsent(statsMap, name, localFlakeIdStatsConstructorFunction);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -85,6 +85,10 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService,
         getLocalFlakeIdStats(name).incrementUsage();
     }
 
+    public void incrementNewId(String name, int size) {
+        getLocalFlakeIdStats(name).incrementUsage(size);
+    }
+
     private LocalFlakeIdGeneratorStatsImpl getLocalFlakeIdStats(String name) {
         return getOrPutIfAbsent(statsMap, name, localFlakeIdStatsConstructorFunction);
     }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalFlakeIdGeneratorStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalFlakeIdGeneratorStats.java
@@ -24,7 +24,7 @@ public interface LocalFlakeIdGeneratorStats extends LocalInstanceStats {
 
     /**
      * @return the total number of times the ID generator has been used to generate
-     *         a new ID since its {@link #getCreationTime()}.
+     *         a new ID batch since its {@link #getCreationTime()}.
      */
     long getUsageCount();
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalFlakeIdGeneratorStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalFlakeIdGeneratorStats.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.monitor;
+
+/**
+ * Local flake id statistics interface to be used
+ * by {@link com.hazelcast.monitor.MemberState} implementations.
+ */
+public interface LocalFlakeIdGeneratorStats extends LocalInstanceStats {
+
+    /**
+     * @return the total number of times the ID generator has been used to generate
+     *         a new ID since its {@link #getCreationTime()}.
+     */
+    long getUsageCount();
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/MemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/MemberState.java
@@ -50,6 +50,8 @@ public interface MemberState extends JsonSerializable {
 
     LocalWanStats getLocalWanStats(String schemeName);
 
+    LocalFlakeIdGeneratorStats getLocalFlakeIdGeneratorStats(String flakeIdName);
+
     Collection<ClientEndPointDTO> getClients();
 
     MXBeansDTO getMXBeans();

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
@@ -54,10 +54,6 @@ public class LocalFlakeIdGeneratorStatsImpl implements LocalFlakeIdGeneratorStat
         USAGE_COUNT.incrementAndGet(this);
     }
 
-    public void incrementUsage(int size) {
-        USAGE_COUNT.addAndGet(this, size);
-    }
-
     @Override
     public JsonObject toJson() {
         JsonObject root = new JsonObject();

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
@@ -54,6 +54,10 @@ public class LocalFlakeIdGeneratorStatsImpl implements LocalFlakeIdGeneratorStat
         USAGE_COUNT.incrementAndGet(this);
     }
 
+    public void incrementUsage(int size) {
+        USAGE_COUNT.addAndGet(this, size);
+    }
+
     @Override
     public JsonObject toJson() {
         JsonObject root = new JsonObject();

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalFlakeIdGeneratorStatsImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.monitor.impl;
+
+import static com.hazelcast.util.JsonUtil.getLong;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.monitor.LocalFlakeIdGeneratorStats;
+import com.hazelcast.util.Clock;
+
+public class LocalFlakeIdGeneratorStatsImpl implements LocalFlakeIdGeneratorStats {
+
+    private static final AtomicLongFieldUpdater<LocalFlakeIdGeneratorStatsImpl> USAGE_COUNT =
+            newUpdater(LocalFlakeIdGeneratorStatsImpl.class, "usageCount");
+
+    @Probe
+    private volatile long creationTime;
+    @Probe
+    private volatile long usageCount;
+
+    public LocalFlakeIdGeneratorStatsImpl() {
+        creationTime = Clock.currentTimeMillis();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public long getUsageCount() {
+        return usageCount;
+    }
+
+    public void incrementUsage() {
+        USAGE_COUNT.incrementAndGet(this);
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        root.add("creationTime", creationTime);
+        root.add("usageCount", usageCount);
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        creationTime = getLong(json, "creationTime", -1L);
+        usageCount = getLong(json, "usageCount", -1L);
+    }
+
+    @Override
+    public String toString() {
+        return "LocalFlakeIdStatsImpl{" + "creationTime=" + creationTime + ", usageCount=" + usageCount + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -52,7 +52,7 @@ import static com.hazelcast.util.JsonUtil.getArray;
 import static com.hazelcast.util.JsonUtil.getObject;
 import static com.hazelcast.util.JsonUtil.getString;
 
-@SuppressWarnings("checkstyle:classdataabstractioncoupling")
+@SuppressWarnings({"checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public class MemberStateImpl implements MemberState {
 
     private String address;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -27,6 +27,7 @@ import com.hazelcast.internal.management.dto.MXBeansDTO;
 import com.hazelcast.monitor.HotRestartState;
 import com.hazelcast.monitor.LocalCacheStats;
 import com.hazelcast.monitor.LocalExecutorStats;
+import com.hazelcast.monitor.LocalFlakeIdGeneratorStats;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.LocalMemoryStats;
 import com.hazelcast.monitor.LocalMultiMapStats;
@@ -66,6 +67,7 @@ public class MemberStateImpl implements MemberState {
     private Map<String, LocalReplicatedMapStats> replicatedMapStats = new HashMap<String, LocalReplicatedMapStats>();
     private Map<String, LocalCacheStats> cacheStats = new HashMap<String, LocalCacheStats>();
     private Map<String, LocalWanStats> wanStats = new HashMap<String, LocalWanStats>();
+    private Map<String, LocalFlakeIdGeneratorStats> flakeIdGeneratorStats = new HashMap<String, LocalFlakeIdGeneratorStats>();
     private Collection<ClientEndPointDTO> clients = new HashSet<ClientEndPointDTO>();
     private Map<String, String> clientStats = new HashMap<String, String>();
     private MXBeansDTO beans = new MXBeansDTO();
@@ -140,6 +142,11 @@ public class MemberStateImpl implements MemberState {
     }
 
     @Override
+    public LocalFlakeIdGeneratorStats getLocalFlakeIdGeneratorStats(String flakeIdName) {
+        return flakeIdGeneratorStats.get(flakeIdName);
+    }
+
+    @Override
     public String getAddress() {
         return address;
     }
@@ -186,6 +193,10 @@ public class MemberStateImpl implements MemberState {
 
     public void putLocalWanStats(String name, LocalWanStats localWanStats) {
         wanStats.put(name, localWanStats);
+    }
+
+    public void putLocalFlakeIdStats(String name, LocalFlakeIdGeneratorStats localFlakeIdStats) {
+        flakeIdGeneratorStats.put(name, localFlakeIdStats);
     }
 
     public Collection<ClientEndPointDTO> getClients() {
@@ -286,6 +297,7 @@ public class MemberStateImpl implements MemberState {
         serializeMap(root, "executorStats", executorStats);
         serializeMap(root, "cacheStats", cacheStats);
         serializeMap(root, "wanStats", wanStats);
+        serializeMap(root, "flakeIdStats", flakeIdGeneratorStats);
 
         final JsonObject runtimePropsObject = new JsonObject();
         for (Map.Entry<String, Long> entry : runtimeProps.entrySet()) {
@@ -379,6 +391,11 @@ public class MemberStateImpl implements MemberState {
             stats.fromJson(next.getValue().asObject());
             wanStats.put(next.getName(), stats);
         }
+        for (JsonObject.Member next : getObject(json, "flakeIdStats", new JsonObject())) {
+            LocalFlakeIdGeneratorStats stats = new LocalFlakeIdGeneratorStatsImpl();
+            stats.fromJson(next.getValue().asObject());
+            flakeIdGeneratorStats.put(next.getName(), stats);
+        }
         for (JsonObject.Member next : getObject(json, "runtimeProps")) {
             runtimeProps.put(next.getName(), next.getValue().asLong());
         }
@@ -452,6 +469,7 @@ public class MemberStateImpl implements MemberState {
                 + ", hotRestartState=" + hotRestartState
                 + ", clusterHotRestartStatus=" + clusterHotRestartStatus
                 + ", wanSyncState=" + wanSyncState
+                + ", flakeIdStats=" + flakeIdGeneratorStats
                 + ", clientStats=" + clientStats
                 + '}';
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -3774,6 +3774,13 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the Flake ID Generator, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -289,6 +289,7 @@
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
         <id-offset>0</id-offset>
+        <statistics-enabled>true</statistics-enabled>
     </flake-id-generator>
 
     <atomic-long name="default">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1655,11 +1655,14 @@ https://hazelcast.org/documentation/.
 
             Negative values are allowed to increase the lifespan of the generator, however keep in
             mind that the generated IDs might also be negative.
+        * <statistics-enabled>:
+            When you enable it, you can retrieve the Flake ID generators statistics. Its default value is true.
     -->
     <flake-id-generator name="default">
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
         <id-offset>0</id-offset>
+        <statistics-enabled>true</statistics-enabled>
     </flake-id-generator>
 
     <!--

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -617,7 +617,8 @@ class ConfigCompatibilityChecker {
             return nullSafeEqual(c1.getName(), c2.getName())
                     && c1.getPrefetchCount() == c2.getPrefetchCount()
                     && c1.getPrefetchValidityMillis() == c2.getPrefetchValidityMillis()
-                    && c1.getIdOffset() == c2.getIdOffset();
+                    && c1.getIdOffset() == c2.getIdOffset()
+                    && c1.isStatisticsEnabled() == c2.isStatisticsEnabled();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -383,7 +383,8 @@ public class ConfigXmlGeneratorTest {
         FlakeIdGeneratorConfig figConfig = new FlakeIdGeneratorConfig("flake-id-gen1")
                 .setPrefetchCount(3)
                 .setPrefetchValidityMillis(10L)
-                .setIdOffset(20L);
+                .setIdOffset(20L)
+                .setStatisticsEnabled(false);
 
         Config config = new Config()
                 .addFlakeIdGeneratorConfig(figConfig);

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1164,6 +1164,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "  <prefetch-count>3</prefetch-count>"
                 + "  <prefetch-validity-millis>10</prefetch-validity-millis>"
                 + "  <id-offset>20</id-offset>"
+                + "  <statistics-enabled>false</statistics-enabled>"
                 + "</flake-id-generator>"
                 + HAZELCAST_END_TAG;
         Config config = buildConfig(xml);
@@ -1172,6 +1173,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(3, fConfig.getPrefetchCount());
         assertEquals(10L, fConfig.getPrefetchValidityMillis());
         assertEquals(20L, fConfig.getIdOffset());
+        assertFalse(fConfig.isStatisticsEnabled());
     }
 
     @Test(expected = InvalidConfigurationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxyTest.java
@@ -74,13 +74,14 @@ public class FlakeIdGeneratorProxyTest {
         ILogger logger = mock(ILogger.class);
         clusterService = mock(ClusterService.class);
         NodeEngine nodeEngine = mock(NodeEngine.class);
+        FlakeIdGeneratorService service = mock(FlakeIdGeneratorService.class);
         when(nodeEngine.getLogger(FlakeIdGeneratorProxy.class)).thenReturn(logger);
         when(nodeEngine.isRunning()).thenReturn(true);
         when(nodeEngine.getConfig()).thenReturn(new Config().addFlakeIdGeneratorConfig(
                 new FlakeIdGeneratorConfig("foo").setIdOffset(idOffset)
         ));
         when(nodeEngine.getClusterService()).thenReturn(clusterService);
-        gen = new FlakeIdGeneratorProxy("foo", nodeEngine, null);
+        gen = new FlakeIdGeneratorProxy("foo", nodeEngine, service);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -550,7 +550,8 @@ public class DynamicConfigTest extends HazelcastTestSupport {
         FlakeIdGeneratorConfig config = new FlakeIdGeneratorConfig(randomName())
                 .setPrefetchCount(123)
                 .setPrefetchValidityMillis(456)
-                .setIdOffset(789);
+                .setIdOffset(789)
+                .setStatisticsEnabled(false);
         driver.getConfig().addFlakeIdGeneratorConfig(config);
         assertConfigurationsEqualsOnAllMembers(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -107,6 +107,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         memberState.putLocalExecutorStats("executorStats", new LocalExecutorStatsImpl());
         memberState.putLocalReplicatedMapStats("replicatedMapStats", replicatedMapStats);
         memberState.putLocalCacheStats("cacheStats", new LocalCacheStatsImpl(cacheStatistics));
+        memberState.putLocalFlakeIdStats("flakeIdStats", new LocalFlakeIdGeneratorStatsImpl());
         memberState.setRuntimeProps(runtimeProps);
         memberState.setLocalMemoryStats(new LocalMemoryStatsImpl());
         memberState.setOperationStats(new LocalOperationStatsImpl());
@@ -130,6 +131,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         assertNotNull(deserialized.getLocalReplicatedMapStats("replicatedMapStats").toString());
         assertEquals(1, deserialized.getLocalReplicatedMapStats("replicatedMapStats").getPutOperationCount());
         assertNotNull(deserialized.getLocalCacheStats("cacheStats").toString());
+        assertNotNull(deserialized.getLocalFlakeIdGeneratorStats("flakeIdStats").toString());
         assertEquals(5, deserialized.getLocalCacheStats("cacheStats").getCacheHits());
         assertNotNull(deserialized.getRuntimeProps());
         assertEquals(Long.valueOf(598123L), deserialized.getRuntimeProps().get("prop1"));

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -608,6 +608,7 @@
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
         <id-offset>0</id-offset>
+        <statistics-enabled>false</statistics-enabled>
     </flake-id-generator>
 
     <listeners>


### PR DESCRIPTION
Added statistics for the new flake ID generators.

The statistics itself only counts number of usages of each generator (how often a new ID is requested/generated).

I chose `f:` as prefix for the instance names when they are used as _long instance names_.

I tried to follow the patterns already present as far as I could identify them.
I had to suppress a checkstyle rule for `MemberStateImpl` as the problem is caused by a bad pattern I cannot change in this addition. 

Reviewers should especially think about changes required/expected elsewhere that I did not make (missed).