### PR TITLE
[#3066] Re-enabling RepartitioningStreeTest.callWithBackups

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/RepartitioningStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/RepartitioningStressTest.java
@@ -96,7 +96,6 @@ public class RepartitioningStressTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore(value = "https://github.com/hazelcast/hazelcast/issues/3683")
     public void callWithBackups() throws Exception {
         int itemCount = 10000;
         ConcurrentMap<Integer, Integer> map = hz.getMap("map");


### PR DESCRIPTION
According to @mdogan 's comment (https://github.com/hazelcast/hazelcast/issues/3066#issuecomment-364371013), there were a lot of improvements in this area and the issue might be actually fixed. Let's enable the test and see.