### PR TITLE
[BACKPORT] Text connection send buffer not correctly sized

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
@@ -154,7 +154,7 @@ public class MemberChannelInitializer implements ChannelInitializer {
         TextChannelOutboundHandler outboundHandler = new TextChannelOutboundHandler(connection);
         channel.attributeMap().put(TEXT_OUTBOUND_HANDLER, outboundHandler);
 
-        ByteBuffer inputBuffer = newInputBuffer(channel, ioService.getSocketReceiveBufferSize());
+        ByteBuffer inputBuffer = newInputBuffer(channel, ioService.getSocketClientReceiveBufferSize());
         inputBuffer.put(stringToBytes(protocol));
 
         ChannelInboundHandler inboundHandler = new TextChannelInboundHandler(connection, outboundHandler);


### PR DESCRIPTION
It was sized based on the server setting, not on the client setting.

Backport of https://github.com/hazelcast/hazelcast/pull/12326