### PR TITLE
[BACKPORT] Forbid shutting down member via console on Management Center

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -218,8 +218,12 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             for (int i = 0; i < repeat; i++) {
                 handleCommand(command.substring(first.length()).replaceAll("\\$i", "" + i));
             }
-            long elapsedSeconds = MILLISECONDS.toSeconds(Clock.currentTimeMillis() - started);
-            println("ops/s = " + repeat / elapsedSeconds);
+            long elapsedMilliSeconds = Clock.currentTimeMillis() - started;
+            if (elapsedMilliSeconds > 0) {
+                println(String.format("ops/s = %.2f", (double) repeat * 1000 / elapsedMilliSeconds));
+            } else {
+                println("Bingo, all the operations finished in no time!");
+            }
         } else if (first.startsWith("&") && first.length() > 1) {
             final int fork = Integer.parseInt(first.substring(1));
             final String threadCommand = command.substring(first.length());
@@ -253,8 +257,8 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleColon(command);
         } else if ("silent".equals(first)) {
             silent = Boolean.parseBoolean(args[1]);
-        } else if ("shutdown".equals(first)) {
-            hazelcast.getLifecycleService().shutdown();
+        } else if ("shutdown".equalsIgnoreCase(first)) {
+            handleShutdown();
         } else if ("echo".equals(first)) {
             echo = Boolean.parseBoolean(args[1]);
             println("echo: " + echo);
@@ -409,12 +413,20 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         } else if (first.equalsIgnoreCase("instances")) {
             handleInstances(args);
         } else if (first.equalsIgnoreCase("quit") || first.equalsIgnoreCase("exit")) {
-            System.exit(0);
+            handleExit();
         } else if (first.startsWith("e") && first.endsWith(".simulateLoad")) {
             handleExecutorSimulate(args);
         } else {
             println("type 'help' for help");
         }
+    }
+
+    protected void handleShutdown() {
+        hazelcast.getLifecycleService().shutdown();
+    }
+
+    protected void handleExit() {
+        System.exit(0);
     }
 
     private void handleExecutorSimulate(String[] args) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
@@ -38,19 +38,16 @@ public class ConsoleCommandHandler {
 
 
    /**
-    * Runs a command on the console. Will not run "exit" or "quit".
+    * Runs a command on the console. Will not run "exit", "quit", "shutdown", their upper-case
+    * or mixed case counterparts.
     *
     * @param command The command to run.
     *
     * @return either the command is handled, or a console message is returned if the command is not handled.
     *
-    * @throws java.lang.InterruptedException.
+    * @throws java.lang.InterruptedException
     */
     public String handleCommand(final String command) throws InterruptedException {
-        if ("exit".equals(command) || "quit".equals(command)) {
-            return "'" + command + "' is not allowed!";
-        }
-
         if (lock.tryLock(1, TimeUnit.SECONDS)) {
             try {
                 return doHandleCommand(command);
@@ -103,6 +100,16 @@ public class ConsoleCommandHandler {
         @Override
         public void print(Object obj) {
             buffer.append(String.valueOf(obj));
+        }
+
+        @Override
+        protected void handleExit() {
+            print("'exit' is not allowed!");
+        }
+
+        @Override
+        protected void handleShutdown() {
+            print("'shutdown' is not allowed!");
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ConsoleCommandRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ConsoleCommandRequestTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.management.request.ConsoleCommandRequest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.util.JsonUtil.getObject;
+import static com.hazelcast.util.JsonUtil.getString;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConsoleCommandRequestTest extends HazelcastTestSupport {
+    private ManagementCenterService managementCenterService;
+    private LifecycleService lifecycleService;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance hz = createHazelcastInstance();
+        Node node = getNode(hz);
+        managementCenterService = node.getManagementCenterService();
+        lifecycleService = hz.getLifecycleService();
+    }
+
+    @Test
+    public void testConsoleCommand_exitNotAllowed() throws Exception {
+        String[] forbiddenCommands = new String[]{
+                "exit",
+                "quit",
+                "shutdown",
+                "EXIT",
+                "ExiT",
+                "QUIT",
+                "SHUTDOWN",
+                "#1 shutdown",
+                "#3 exit",
+                "&2 quit",
+                "echo 1;exit; echo 2;",
+        };
+
+        for (String command : forbiddenCommands) {
+            JsonObject requestJson = new JsonObject();
+            requestJson.add("command", command);
+
+            ConsoleCommandRequest consoleCommandRequest = new ConsoleCommandRequest();
+            consoleCommandRequest.fromJson(requestJson);
+
+            JsonObject responseJson = new JsonObject();
+            consoleCommandRequest.writeResponse(managementCenterService, responseJson);
+            assertContains(getString(getObject(responseJson, "result"), "output"), "is not allowed!");
+            assertTrue(lifecycleService.isRunning());
+        }
+    }
+}


### PR DESCRIPTION
Shutting down members individually or the cluster entirely is possible
via Management Center screens. These screens ask for the cluster name
and the password. However, the console tab on Management Center doesn't
ask for any additional credentials for stopping a member, so we don't
allow these operations via console. A bug in our implementation allowed
upper case, mixed case and composite commands to pass through. Executing
 "shutdown" was allowed as well. This commit makes sure that a console
 command coming from Management Center will not be able to shut down
 a member.

(cherry picked from commit 4aab7db)