### PR TITLE
Remove verifying precarious condition in MapLoaderFailoverTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -33,8 +33,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Future;
-
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.LAZY;
 import static com.hazelcast.test.TimeConstants.MINUTE;
 import static org.junit.Assert.assertEquals;
@@ -128,7 +126,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
         IMap<Object, Object> map = nodes[0].getMap(mapName);
 
         // trigger loading and pause half way through
-        Future<Object> asyncVal = map.getAsync(1);
+        map.getAsync(1);
         pausingLoader.awaitPause();
 
         hz3.getLifecycleService().terminate();
@@ -136,7 +134,6 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
 
         pausingLoader.resume();
 
-        assertEquals(1, asyncVal.get());
         assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
         assertTrue(mapLoader.getLoadedValueCount() >= MAP_STORE_ENTRY_COUNT);
         assertEquals(2, mapLoader.getLoadAllKeysInvocations());


### PR DESCRIPTION
The removed verification may fail, because the following sequence of events may happen:

1) asyncGetting a particular key on node X
2) Loading entries from store is triggered by 1)
3) GetOperation retries a couple of times on node X, waits for loading to complete
4) Node X gets terminated
5) GetOperation continues on node Y
6) GetOperation completes on node Y and returns null
7) The requested key gets loaded on node Y

There is a race condition between the migrated GetOperation and the restarted loading process. That means the test's expectation was not in sync with the current implementation (loading asynchronously on the nodes) and may fail occasionally.

Fixes #5257