### PR TITLE
ConsoleApp - String handling improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -41,6 +41,7 @@ import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.util.Clock;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
@@ -68,7 +69,9 @@ import java.util.concurrent.locks.Lock;
 
 import static com.hazelcast.memory.MemoryUnit.BYTES;
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.util.StringUtil.lowerCaseInternal;
+import static com.hazelcast.util.StringUtil.trim;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -180,14 +183,13 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
     /**
      * Handles a command.
      */
-    @SuppressFBWarnings("DM_EXIT")
     @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})
-    protected void handleCommand(String inputCommand) {
+    public void handleCommand(String inputCommand) {
         String command = inputCommand;
         if (command == null) {
             return;
         }
-        command = command.trim();
+        command = trim(command);
         if (command.length() == 0) {
             return;
         }
@@ -207,7 +209,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         String[] argsSplit = command.split(" ");
         String[] args = new String[argsSplit.length];
         for (int i = 0; i < argsSplit.length; i++) {
-            args[i] = argsSplit[i].trim();
+            args[i] = trim(argsSplit[i]);
         }
         if (spaceIndex != -1) {
             first = args[0];
@@ -236,7 +238,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
                     @Override
                     public void run() {
                         String command = threadCommand;
-                        String[] threadArgs = command.replaceAll("\\$t", "" + threadID).trim().split(" ");
+                        String[] threadArgs = trim(command.replaceAll("\\$t", "" + threadID)).split(" ");
                         // TODO &t #4 m.putmany x k
                         if ("m.putmany".equals(threadArgs[0]) || "m.removemany".equals(threadArgs[0])) {
                             if (threadArgs.length < 4) {
@@ -259,13 +261,13 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleColon(command);
         } else if ("silent".equals(first)) {
             silent = Boolean.parseBoolean(args[1]);
-        } else if ("shutdown".equalsIgnoreCase(first)) {
+        } else if (equalsIgnoreCase("shutdown", first)) {
             handleShutdown();
         } else if ("echo".equals(first)) {
             echo = Boolean.parseBoolean(args[1]);
             println("echo: " + echo);
         } else if ("ns".equals(first)) {
-            handleNamespace(command.substring(first.length()).trim());
+            handleNamespace(trim(command.substring(first.length())));
         } else if ("whoami".equals(first)) {
             handleWhoami();
         } else if ("who".equals(first)) {
@@ -312,7 +314,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleSetRemoveMany(args);
         } else if (first.equals("m.replace")) {
             handleMapReplace(args);
-        } else if (first.equalsIgnoreCase("m.putIfAbsent")) {
+        } else if (equalsIgnoreCase(first, "m.putIfAbsent")) {
             handleMapPutIfAbsent(args);
         } else if (first.equals("m.putAsync")) {
             handleMapPutAsync(args);
@@ -322,7 +324,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleMapPut(args);
         } else if (first.equals("m.get")) {
             handleMapGet(args);
-        } else if (first.equalsIgnoreCase("m.getMapEntry")) {
+        } else if (equalsIgnoreCase(first, "m.getMapEntry")) {
             handleMapGetMapEntry(args);
         } else if (first.equals("m.remove")) {
             handleMapRemove(args);
@@ -330,15 +332,15 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleMapDelete(args);
         } else if (first.equals("m.evict")) {
             handleMapEvict(args);
-        } else if (first.equals("m.putmany") || first.equalsIgnoreCase("m.putAll")) {
+        } else if (first.equals("m.putmany") || equalsIgnoreCase(first, "m.putAll")) {
             handleMapPutMany(args);
         } else if (first.equals("m.getmany")) {
             handleMapGetMany(args);
         } else if (first.equals("m.removemany")) {
             handleMapRemoveMany(args);
-        } else if (command.equalsIgnoreCase("m.localKeys")) {
+        } else if (equalsIgnoreCase(command, "m.localKeys")) {
             handleMapLocalKeys();
-        } else if (command.equalsIgnoreCase("m.localSize")) {
+        } else if (equalsIgnoreCase(command, "m.localSize")) {
             handleMapLocalSize();
         } else if (command.equals("m.keys")) {
             handleMapKeys();
@@ -348,7 +350,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleMapEntries();
         } else if (first.equals("m.lock")) {
             handleMapLock(args);
-        } else if (first.equalsIgnoreCase("m.tryLock")) {
+        } else if (equalsIgnoreCase(first, "m.tryLock")) {
             handleMapTryLock(args);
         } else if (first.equals("m.unlock")) {
             handleMapUnlock(args);
@@ -372,7 +374,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             handleMultiMapEntries();
         } else if (first.equals("mm.lock")) {
             handleMultiMapLock(args);
-        } else if (first.equalsIgnoreCase("mm.tryLock")) {
+        } else if (equalsIgnoreCase(first, "mm.tryLock")) {
             handleMultiMapTryLock(args);
         } else if (first.equals("mm.unlock")) {
             handleMultiMapUnlock(args);
@@ -398,25 +400,15 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             execute(args);
         } else if (first.equals("partitions")) {
             handlePartitions(args);
-//      } else if (first.equals("txn")) {
-//          hazelcast.getTransaction().begin();
-//      } else if (first.equals("commit")) {
-//          hazelcast.getTransaction().commit();
-//      } else if (first.equals("rollback")) {
-//          hazelcast.getTransaction().rollback();
-        } else if (first.equalsIgnoreCase("executeOnKey")) {
+        } else if (equalsIgnoreCase(first, "executeOnKey")) {
             executeOnKey(args);
-        } else if (first.equalsIgnoreCase("executeOnMember")) {
+        } else if (equalsIgnoreCase(first, "executeOnMember")) {
             executeOnMember(args);
-        } else if (first.equalsIgnoreCase("executeOnMembers")) {
+        } else if (equalsIgnoreCase(first, "executeOnMembers")) {
             executeOnMembers(args);
-//      } else if (first.equalsIgnoreCase("longOther") || first.equalsIgnoreCase("executeLongOther")) {
-//        executeLongTaskOnOtherMember(args);
-//      } else if (first.equalsIgnoreCase("long") || first.equalsIgnoreCase("executeLong")) {
-//        executeLong(args);
-        } else if (first.equalsIgnoreCase("instances")) {
+        } else if (equalsIgnoreCase(first, "instances")) {
             handleInstances(args);
-        } else if (first.equalsIgnoreCase("quit") || first.equalsIgnoreCase("exit")) {
+        } else if (equalsIgnoreCase(first, "quit") || equalsIgnoreCase(first, "exit")) {
             handleExit();
         } else if (first.startsWith("e") && first.endsWith(".simulateLoad")) {
             handleExecutorSimulate(args);
@@ -954,13 +946,13 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         String lockStr = args[0];
         String key = args[1];
         Lock lock = hazelcast.getLock(key);
-        if (lockStr.equalsIgnoreCase("lock")) {
+        if (equalsIgnoreCase(lockStr, "lock")) {
             lock.lock();
             println("true");
-        } else if (lockStr.equalsIgnoreCase("unlock")) {
+        } else if (equalsIgnoreCase(lockStr, "unlock")) {
             lock.unlock();
             println("true");
-        } else if (lockStr.equalsIgnoreCase("trylock")) {
+        } else if (equalsIgnoreCase(lockStr, "trylock")) {
             String timeout = args.length > 2 ? args[2] : null;
             if (timeout == null) {
                 println(lock.tryLock());

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
@@ -77,11 +77,6 @@ public class ConsoleCommandHandler {
         }
 
         @Override
-        protected void handleCommand(String inputCommand) {
-            super.handleCommand(inputCommand);
-        }
-
-        @Override
         protected void handleAddListener(String[] args) {
             println("Listener commands are not allowed!");
         }

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -353,4 +353,17 @@ public final class StringUtil {
         list.removeAll(Arrays.asList(arr2));
         return list.toArray(new String[list.size()]);
     }
+
+    /**
+     * Returns true if two strings are equals ignoring the letter case in {@link #LOCALE_INTERNAL} locale.
+     *
+     * @param str1 first string to compare
+     * @param str2 second string to compare
+     * @return true if the strings are equals ignoring the case
+     */
+    public static boolean equalsIgnoreCase(String str1, String str2) {
+        return (str1 == null || str2 == null)
+                ? false
+                : (str1 == str2 || lowerCaseInternal(str1).equals(lowerCaseInternal(str2)));
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
@@ -26,7 +26,11 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Locale;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -95,6 +99,25 @@ public class StringUtilTest extends HazelcastTestSupport {
         assertArrayEquals(arr(), StringUtil.subraction(arr(), arr("a", "b")));
         assertArrayEquals(arr("a", "b"), StringUtil.subraction(arr("a", "b"), arr()));
         assertArrayEquals(arr(), StringUtil.subraction(arr("a", "test", "b", "a"), arr("a", "b", "test")));
+    }
+
+    @Test
+    public void testEqualsIgnoreCase() throws Exception {
+        assertFalse(StringUtil.equalsIgnoreCase(null, null));
+        assertFalse(StringUtil.equalsIgnoreCase(null, "a"));
+        assertFalse(StringUtil.equalsIgnoreCase("a", null));
+        assertTrue(StringUtil.equalsIgnoreCase("TEST", "test"));
+        assertTrue(StringUtil.equalsIgnoreCase("test", "TEST"));
+        assertFalse(StringUtil.equalsIgnoreCase("test", "TEST2"));
+
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("tr"));
+        try {
+            assertTrue(StringUtil.equalsIgnoreCase("EXIT", "exit"));
+            assertFalse(StringUtil.equalsIgnoreCase("exıt", "EXIT"));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     private String[] arr(String... strings) {


### PR DESCRIPTION
Small `ConsoleApp` clean-up:
* use internal Locale for case-insensitive String comparisons
* extend trimming to all whitespaces

The `ConsoleApp` would deserve much more care (or rather a replacement). This is a small update after looking into changes introduced in #12283.