### PR TITLE
Remove outdated warnings regarding TTL from IMap's javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -150,11 +150,6 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * No atomicity guarantees are given. It could be that in case of failure
      * some of the key/value-pairs get written, while others are not.
-     * <p>
-     * <b>Warning:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
-     * expire when the initial TTL has elapsed.
      *
      * <p><b>Interactions with the map store</b>
      * <p>
@@ -251,11 +246,6 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
-     * <p>
-     * <b>Warning 3:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
-     * expire when the initial TTL has elapsed.
      * <p>
      * <p><b>Note:</b>
      * Use {@link #set(Object, Object)} if you don't need the return value, it's slightly more efficient.
@@ -612,16 +602,11 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * }</pre>
      * ExecutionException is never thrown.
      * <p>
-     * <b>Warning 1:</b>
+     * <b>Warning:</b>
      * <p>
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
-     * <p>
-     * <b>Warning 2:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
-     * expire when the initial TTL has elapsed.
      * <p>
      * <p><b>Note:</b>
      * Use {@link #setAsync(Object, Object)} if you don't need the return value, it's slightly more efficient.
@@ -774,16 +759,11 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * }</pre>
      * ExecutionException is never thrown.
      * <p>
-     * <b>Warning 1:</b>
+     * <b>Warning:</b>
      * <p>
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
-     * <p>
-     * <b>Warning 2:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
-     * expire when the initial TTL has elapsed.
      *
      * <p><b>Interactions with the map store</b>
      * <p>
@@ -953,16 +933,11 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * the caller thread could not acquire the lock for the key within the
      * timeout duration, thus the put operation is not successful.
      * <p>
-     * <b>Warning 1:</b>
+     * <b>Warning:</b>
      * <p>
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
-     * <p>
-     * <b>Warning 2:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
-     * expire when the initial TTL has elapsed.
      *
      * <p><b>Interactions with the map store</b>
      * <p>
@@ -1195,10 +1170,6 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * This method returns a clone of the previous value, not the original (identically equal) value
      * previously put into the map.
-     * <p>
-     * <b>Warning 3:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the same TTL will be again set on the new value.
      *
      * <p><b>Interactions with the map store</b>
      * <p>
@@ -1231,11 +1202,6 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * This method uses {@code hashCode} and {@code equals} of the binary form of
      * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
      * defined in the {@code key}'s class.
-     * <p>
-     * <b>Warning 3:</b>
-     * <p>
-     * If you have previously set a TTL for the key, the TTL remains unchanged and the entry will
-     * expire when the initial TTL has elapsed.
      *
      * <p><b>Interactions with the map store</b>
      * <p>

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -38,6 +38,7 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.util.Clock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,9 +46,12 @@ import org.junit.runner.RunWith;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -104,6 +108,71 @@ public class EvictionTest extends HazelcastTestSupport {
         map.put(1, "value2", 300, TimeUnit.SECONDS);
         sleepSeconds(2);
 
+        assertTrue(map.containsKey(1));
+    }
+
+    @Test
+    public void testTTL_prolongationAfterNonTTLUpdate_Quick() {
+        final IMap<Integer, String> map = createSimpleMap();
+
+        map.put(1, "value0", 3, TimeUnit.SECONDS);
+        // 1 second safety margin before eviction
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        // this should prolong the life of the entry for another 3 seconds
+        map.put(1, "value1");
+        // 4 seconds of wait time in total, 1 second safety margin after a potential eviction
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+    }
+
+    @Test
+    @Category(SlowTest.class)
+    public void testTTL_prolongationAfterNonTTLUpdate_Slow() throws ExecutionException, InterruptedException {
+        final IMap<Integer, String> map = createSimpleMap();
+
+        map.put(1, "value0", 3, TimeUnit.SECONDS);
+        // 1 second safety margin before eviction
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        // this should prolong the life of the entry for another 3 seconds
+        map.put(1, "value1");
+        // 4 seconds of wait time in total, 1 second safety margin after a potential eviction
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        map.set(1, "value2");
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        final HashMap<Integer, String> items = new HashMap<Integer, String>();
+        items.put(1, "value3");
+        items.put(2, "value1");
+        items.put(3, "value1");
+        map.putAll(items);
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        map.putAsync(1, "value4").get();
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        map.setAsync(1, "value5").get();
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        assertTrue(map.tryPut(1, "value6", 333, TimeUnit.MILLISECONDS));
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        map.replace(1, "value7");
+        sleepSeconds(2);
+        assertTrue(map.containsKey(1));
+
+        map.replace(1, "value7", "value8");
+        sleepSeconds(2);
         assertTrue(map.containsKey(1));
     }
 


### PR DESCRIPTION
There were outdated warnings in `IMap` javadoc regarding expiration and TTL behavior on mutating methods don't accepting TTL as a parameter.

1. Added the tests to verify the current behavior and to make sure we won't silently break it in the future one more time.

2. Removed the warnings themselves.

Fixes: #12144