### PR TITLE
Added merge policies to ConfigValidator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.internal.config.ConfigValidator;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.EmptyStatement;
@@ -26,6 +25,7 @@ import com.hazelcast.util.ExceptionUtil;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -239,6 +239,7 @@ public final class CacheProxyUtil {
     }
 
     public static <K, V> void validateCacheConfig(CacheConfig<K, V> cacheConfig) {
-        ConfigValidator.checkCacheConfig(cacheConfig.getInMemoryFormat(), cacheConfig.getEvictionConfig());
+        checkCacheConfig(cacheConfig.getInMemoryFormat(), cacheConfig.getEvictionConfig(), cacheConfig.isStatisticsEnabled(),
+                cacheConfig.getMergePolicy());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkCollectionConfig;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.util.Collections.singleton;
@@ -71,6 +72,8 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
     public void initialize() {
         final NodeEngine nodeEngine = getNodeEngine();
         CollectionConfig config = getConfig(nodeEngine);
+        checkCollectionConfig(config);
+
         final List<ItemListenerConfig> itemListenerConfigs = config.getItemListenerConfigs();
         for (ItemListenerConfig itemListenerConfig : itemListenerConfigs) {
             ItemListener listener = itemListenerConfig.getImplementation();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.queue;
 
+import com.hazelcast.config.QueueConfig;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.monitor.LocalQueueStats;
 import com.hazelcast.nio.serialization.Data;
@@ -39,8 +40,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, InitializingObject {
 
-    public QueueProxyImpl(String name, QueueService queueService, NodeEngine nodeEngine) {
-        super(name, queueService, nodeEngine);
+    public QueueProxyImpl(String name, QueueService queueService, NodeEngine nodeEngine, QueueConfig config) {
+        super(name, queueService, nodeEngine, config);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
@@ -57,11 +57,11 @@ abstract class QueueProxySupport extends AbstractDistributedObject<QueueService>
     final int partitionId;
     final QueueConfig config;
 
-    QueueProxySupport(final String name, final QueueService queueService, NodeEngine nodeEngine) {
+    QueueProxySupport(final String name, final QueueService queueService, NodeEngine nodeEngine, QueueConfig config) {
         super(nodeEngine, queueService);
         this.name = name;
         this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
-        this.config = nodeEngine.getConfig().findQueueConfig(name);
+        this.config = config;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkQueueConfig;
 import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -264,7 +265,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     @Override
     public QueueProxyImpl createDistributedObject(String objectId) {
-        return new QueueProxyImpl(objectId, this, nodeEngine);
+        QueueConfig queueConfig = nodeEngine.getConfig().findQueueConfig(objectId);
+        checkQueueConfig(queueConfig);
+
+        return new QueueProxyImpl(objectId, this, nodeEngine, queueConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkBasicConfig;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
@@ -116,6 +117,9 @@ public class AtomicLongService
 
     @Override
     public AtomicLongProxy createDistributedObject(String name) {
+        AtomicLongConfig atomicLongConfig = nodeEngine.getConfig().findAtomicLongConfig(name);
+        checkBasicConfig(atomicLongConfig);
+
         return new AtomicLongProxy(name, nodeEngine, this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkBasicConfig;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -117,6 +118,9 @@ public class AtomicReferenceService
 
     @Override
     public AtomicReferenceProxy createDistributedObject(String name) {
+        AtomicReferenceConfig atomicReferenceConfig = nodeEngine.getConfig().findAtomicReferenceConfig(name);
+        checkBasicConfig(atomicReferenceConfig);
+
         return new AtomicReferenceProxy(name, nodeEngine, this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -49,9 +49,9 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
     protected final String name;
     protected final LockProxySupport lockSupport;
 
-    protected MultiMapProxySupport(MultiMapService service, NodeEngine nodeEngine, String name) {
+    protected MultiMapProxySupport(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
         super(nodeEngine, service);
-        this.config = nodeEngine.getConfig().findMultiMapConfig(name);
+        this.config = config;
         this.name = name;
 
         lockSupport = new LockProxySupport(new DistributedObjectNamespace(MultiMapService.SERVICE_NAME, name),

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.internal.config.ConfigValidator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.monitor.LocalMultiMapStats;
@@ -192,7 +193,10 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
     @Override
     public DistributedObject createDistributedObject(String name) {
-        return new ObjectMultiMapProxy(this, nodeEngine, name);
+        MultiMapConfig multiMapConfig = nodeEngine.getConfig().findMultiMapConfig(name);
+        ConfigValidator.checkMultiMapConfig(multiMapConfig);
+
+        return new ObjectMultiMapProxy(multiMapConfig, this, nodeEngine, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/ObjectMultiMapProxy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl;
 
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
@@ -65,8 +66,8 @@ public class ObjectMultiMapProxy<K, V>
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
 
-    public ObjectMultiMapProxy(MultiMapService service, NodeEngine nodeEngine, String name) {
-        super(service, nodeEngine, name);
+    public ObjectMultiMapProxy(MultiMapConfig config, MultiMapService service, NodeEngine nodeEngine, String name) {
+        super(config, service, nodeEngine, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -90,7 +90,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
 
     private int retryCount;
 
-    ReplicatedMapProxy(NodeEngine nodeEngine, String name, ReplicatedMapService service) {
+    ReplicatedMapProxy(NodeEngine nodeEngine, String name, ReplicatedMapService service, ReplicatedMapConfig config) {
         super(nodeEngine, service);
         this.name = name;
         this.nodeEngine = nodeEngine;
@@ -98,7 +98,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
         this.eventPublishingService = service.getEventPublishingService();
         this.serializationService = nodeEngine.getSerializationService();
         this.partitionService = (InternalPartitionServiceImpl) nodeEngine.getPartitionService();
-        this.config = service.getReplicatedMapConfig(name);
+        this.config = config;
     }
 
     @Override
@@ -147,7 +147,6 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
     @Override
     protected boolean preDestroy() {
         if (super.preDestroy()) {
-            ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
             eventPublishingService.fireMapClearedEvent(size(), name);
             return true;
         }
@@ -342,7 +341,6 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
             for (Object deletedEntryPerPartition : results.values()) {
                 deletedEntrySize += (Integer) deletedEntryPerPartition;
             }
-            ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
             eventPublishingService.fireMapClearedEvent(deletedEntrySize, name);
         } catch (Throwable t) {
             throw rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkRingbufferConfig;
 import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
 import static com.hazelcast.spi.partition.MigrationEndpoint.DESTINATION;
 import static com.hazelcast.spi.partition.MigrationEndpoint.SOURCE;
@@ -141,7 +142,9 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
 
     @Override
     public DistributedObject createDistributedObject(String objectName) {
-        final RingbufferConfig ringbufferConfig = getRingbufferConfig(objectName);
+        RingbufferConfig ringbufferConfig = getRingbufferConfig(objectName);
+        checkRingbufferConfig(ringbufferConfig);
+
         return new RingbufferProxy(nodeEngine, this, objectName, ringbufferConfig);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -59,6 +59,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkScheduledExecutorConfig;
 import static com.hazelcast.spi.merge.SplitBrainEntryViews.createSplitBrainMergeEntryView;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 import static com.hazelcast.util.ExceptionUtil.peel;
@@ -184,6 +185,9 @@ public class DistributedScheduledExecutorService
 
     @Override
     public DistributedObject createDistributedObject(String name) {
+        ScheduledExecutorConfig executorConfig = nodeEngine.getConfig().findScheduledExecutorConfig(name);
+        checkScheduledExecutorConfig(executorConfig);
+
         return new ScheduledExecutorServiceProxy(name, nodeEngine, this);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/AbstractConfigValidatorMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/AbstractConfigValidatorMergePolicyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
+import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
+import com.hazelcast.spi.merge.LatestAccessMergePolicy;
+import com.hazelcast.spi.merge.LatestUpdateMergePolicy;
+import com.hazelcast.spi.merge.PassThroughMergePolicy;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+
+/**
+ * Provides a test setup with merge policies, which need statistics implemented and enabled as well as specialized merge policies.
+ */
+public abstract class AbstractConfigValidatorMergePolicyTest extends HazelcastTestSupport {
+
+    @Parameters(name = "mergePolicy:{2} (stats:{0} (HLL:{1}) (simpleName:{3})")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {false, false, DiscardMergePolicy.class, true},
+                {false, false, DiscardMergePolicy.class, false},
+                {false, false, PassThroughMergePolicy.class, true},
+                {false, false, PassThroughMergePolicy.class, false},
+                {false, false, PutIfAbsentMergePolicy.class, true},
+                {false, false, PutIfAbsentMergePolicy.class, false},
+
+                {false, true, HyperLogLogMergePolicy.class, true},
+                {false, true, HyperLogLogMergePolicy.class, false},
+
+                {true, false, HigherHitsMergePolicy.class, true},
+                {true, false, HigherHitsMergePolicy.class, false},
+                {true, false, LatestAccessMergePolicy.class, true},
+                {true, false, LatestAccessMergePolicy.class, false},
+                {true, false, LatestUpdateMergePolicy.class, true},
+                {true, false, LatestUpdateMergePolicy.class, false},
+        });
+    }
+
+    @Parameter
+    public boolean requiresStatistics;
+
+    @Parameter(1)
+    public boolean requiresCardinalityEstimator;
+
+    @Parameter(2)
+    public Class<? extends SplitBrainMergePolicy> mergePolicyClass;
+
+    @Parameter(3)
+    public boolean useSimpleName;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    MergePolicyConfig mergePolicyConfig;
+
+    @Before
+    public final void prepareConfig() {
+        mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(useSimpleName ? mergePolicyClass.getSimpleName() : mergePolicyClass.getName());
+    }
+
+    void expectedExceptions() {
+        if (requiresCardinalityEstimator) {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage(containsString("CardinalityEstimator"));
+        }
+    }
+
+    void expectExceptionsWithoutStatistics() {
+        if (requiresStatistics) {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage(containsString(mergePolicyConfig.getPolicy()));
+        } else if (requiresCardinalityEstimator) {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage(containsString("CardinalityEstimator"));
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyAtomicLongTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyAtomicLongTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkBasicConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyAtomicLongTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private AtomicLongConfig atomicLongConfig = new AtomicLongConfig("ConfigValidationMergePolicyAtomicLongTest");
+
+    @Test
+    public void testConfig() {
+        atomicLongConfig
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkBasicConfig(atomicLongConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyAtomicReferenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyAtomicReferenceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.AtomicReferenceConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkBasicConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyAtomicReferenceTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private AtomicReferenceConfig atomicReferenceConfig
+            = new AtomicReferenceConfig("ConfigValidationMergePolicyAtomicReferenceTest");
+
+    @Test
+    public void testConfig() {
+        atomicReferenceConfig
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkBasicConfig(atomicReferenceConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyCacheTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyCacheTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private CacheSimpleConfig cacheConfig = new CacheSimpleConfig()
+            .setName("ConfigValidationMergePolicyCacheTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        cacheConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicy(mergePolicyConfig.getPolicy());
+
+        expectedExceptions();
+        checkCacheConfig(cacheConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        cacheConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicy(mergePolicyConfig.getPolicy());
+
+        expectExceptionsWithoutStatistics();
+        checkCacheConfig(cacheConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyIntegrationTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.AtomicReferenceConfig;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ListConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.config.QueueConfig;
+import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.config.ScheduledExecutorConfig;
+import com.hazelcast.config.SetConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.merge.HigherHitsMergePolicy;
+import com.hazelcast.spi.merge.HyperLogLogMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+/**
+ * Tests the integration of the {@link ConfigValidator} into the proxy creation of split-brain capable data structures.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyIntegrationTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private MergePolicyConfig hyperLogLogMergePolicy;
+    private MergePolicyConfig statisticsMergePolicy;
+
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void setUp() {
+        hyperLogLogMergePolicy = new MergePolicyConfig()
+                .setPolicy(HyperLogLogMergePolicy.class.getSimpleName());
+        statisticsMergePolicy = new MergePolicyConfig()
+                .setPolicy(HigherHitsMergePolicy.class.getName());
+
+        factory = createHazelcastInstanceFactory();
+    }
+
+    @Test
+    public void testCache_withHyperLogLogMergePolicy() {
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig();
+        cacheSimpleConfig.setName("cardinalityEstimator");
+        cacheSimpleConfig.setMergePolicy(hyperLogLogMergePolicy.getPolicy());
+
+        Config config = new Config()
+                .addCacheConfig(cacheSimpleConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getCacheManager().getCache("cardinalityEstimator");
+    }
+
+    @Test
+    public void testCache_withStatisticsMergePolicy() {
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig();
+        cacheSimpleConfig.setName("statistics");
+        cacheSimpleConfig.setStatisticsEnabled(false);
+        cacheSimpleConfig.setMergePolicy(statisticsMergePolicy.getPolicy());
+
+        Config config = new Config()
+                .addCacheConfig(cacheSimpleConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getCacheManager().getCache("statistics");
+    }
+
+    @Test
+    public void testMap_withHyperLogLogMergePolicy() {
+        MapConfig mapConfig = new MapConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addMapConfig(mapConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getMap("cardinalityEstimator");
+    }
+
+    @Test
+    public void testMap_withStatisticsMergePolicy() {
+        MapConfig mapConfig = new MapConfig("statistics")
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addMapConfig(mapConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getMap("statistics");
+    }
+
+    @Test
+    public void testReplicatedMap_withHyperLogLogMergePolicy() {
+        ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addReplicatedMapConfig(replicatedMapConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getReplicatedMap("cardinalityEstimator");
+    }
+
+    @Test
+    public void testReplicatedMap_withStatisticsMergePolicy() {
+        ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig("statistics")
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addReplicatedMapConfig(replicatedMapConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getReplicatedMap("statistics");
+    }
+
+    @Test
+    public void testMultiMap_withHyperLogLogMergePolicy() {
+        MultiMapConfig multiMapConfig = new MultiMapConfig("cardinalityEstimator")
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addMultiMapConfig(multiMapConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getMultiMap("cardinalityEstimator");
+    }
+
+    @Test
+    public void testMultiMap_withStatisticsMergePolicy() {
+        MultiMapConfig multiMapConfig = new MultiMapConfig("statistics")
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addMultiMapConfig(multiMapConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getMultiMap("statistics");
+    }
+
+    @Test
+    public void testQueue_withHyperLogLogMergePolicy() {
+        QueueConfig queueConfig = new QueueConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addQueueConfig(queueConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getQueue("cardinalityEstimator");
+    }
+
+    @Test
+    public void testQueue_withStatisticsMergePolicy() {
+        // queue statistics are not suitable for merge policies
+        QueueConfig queueConfig = new QueueConfig("statistics")
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addQueueConfig(queueConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getQueue("statistics");
+    }
+
+    @Test
+    public void testList_withHyperLogLogMergePolicy() {
+        ListConfig listConfig = new ListConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addListConfig(listConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getList("cardinalityEstimator");
+    }
+
+    @Test
+    public void testList_withStatisticsMergePolicy() {
+        // list statistics are not suitable for merge policies
+        ListConfig listConfig = new ListConfig("statistics")
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addListConfig(listConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getList("statistics");
+    }
+
+    @Test
+    public void testSet_withHyperLogLogMergePolicy() {
+        SetConfig setConfig = new SetConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addSetConfig(setConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getSet("cardinalityEstimator");
+    }
+
+    @Test
+    public void testSet_withStatisticsMergePolicy() {
+        // set statistics are not suitable for merge policies
+        SetConfig setConfig = new SetConfig("statistics")
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addSetConfig(setConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getSet("statistics");
+    }
+
+    @Test
+    public void testRingbuffer_withHyperLogLogMergePolicy() {
+        RingbufferConfig ringbufferConfig = new RingbufferConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addRingBufferConfig(ringbufferConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getRingbuffer("cardinalityEstimator");
+    }
+
+    @Test
+    public void testRingbuffer_withStatisticsMergePolicy() {
+        RingbufferConfig ringbufferConfig = new RingbufferConfig("statistics")
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addRingBufferConfig(ringbufferConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getRingbuffer("statistics");
+    }
+
+    @Test
+    public void testAtomicLong_withHyperLogLogMergePolicy() {
+        AtomicLongConfig atomicLongConfig = new AtomicLongConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addAtomicLongConfig(atomicLongConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getAtomicLong("cardinalityEstimator");
+    }
+
+    @Test
+    public void testAtomicLong_withStatisticsMergePolicy() {
+        AtomicLongConfig atomicLongConfig = new AtomicLongConfig("statistics")
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addAtomicLongConfig(atomicLongConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getAtomicLong("statistics");
+    }
+
+    @Test
+    public void testAtomicReference_withHyperLogLogMergePolicy() {
+        AtomicReferenceConfig atomicReferenceConfig = new AtomicReferenceConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addAtomicReferenceConfig(atomicReferenceConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getAtomicReference("cardinalityEstimator");
+    }
+
+    @Test
+    public void testAtomicReference_withStatisticsMergePolicy() {
+        AtomicReferenceConfig atomicReferenceConfig = new AtomicReferenceConfig("statistics")
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addAtomicReferenceConfig(atomicReferenceConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getAtomicReference("statistics");
+    }
+
+    @Test
+    public void testScheduledExecutor_withHyperLogLogMergePolicy() {
+        ScheduledExecutorConfig scheduledExecutorConfig = new ScheduledExecutorConfig("cardinalityEstimator")
+                .setMergePolicyConfig(hyperLogLogMergePolicy);
+
+        Config config = new Config()
+                .addScheduledExecutorConfig(scheduledExecutorConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectCardinalityEstimatorException();
+        hz.getScheduledExecutorService("cardinalityEstimator");
+    }
+
+    @Test
+    public void testScheduledExecutor_withStatisticsMergePolicy() {
+        ScheduledExecutorConfig scheduledExecutorConfig = new ScheduledExecutorConfig("statistics")
+                .setMergePolicyConfig(statisticsMergePolicy);
+
+        Config config = new Config()
+                .addScheduledExecutorConfig(scheduledExecutorConfig);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        expectStatisticsException();
+        hz.getScheduledExecutorService("statistics");
+    }
+
+    private void expectCardinalityEstimatorException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString("CardinalityEstimator"));
+    }
+
+    private void expectStatisticsException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(containsString(statisticsMergePolicy.getPolicy()));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyListTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ListConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkCollectionConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyListTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private ListConfig listConfig = new ListConfig("ConfigValidationMergePolicyListTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        listConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkCollectionConfig(listConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        listConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkCollectionConfig(listConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyMapTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkMapConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyMapTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private MapConfig mapConfig = new MapConfig("ConfigValidationMergePolicyMapTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        mapConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectedExceptions();
+        checkMapConfig(mapConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        mapConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkMapConfig(mapConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyMultiMapTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkMultiMapConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyMultiMapTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private MultiMapConfig multiMapConfig = new MultiMapConfig("ConfigValidationMergePolicyMultiMapTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        multiMapConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectedExceptions();
+        checkMultiMapConfig(multiMapConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        multiMapConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkMultiMapConfig(multiMapConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyQueueTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.QueueConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkQueueConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyQueueTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private QueueConfig queueConfig = new QueueConfig("ConfigValidationMergePolicyQueueTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        queueConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkQueueConfig(queueConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        queueConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkQueueConfig(queueConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyReplicatedMapTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkReplicatedMapConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyReplicatedMapTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig("ConfigValidationMergePolicyReplicatedMapTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        replicatedMapConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectedExceptions();
+        checkReplicatedMapConfig(replicatedMapConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        replicatedMapConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkReplicatedMapConfig(replicatedMapConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyRingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyRingbufferTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkRingbufferConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyRingbufferTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private RingbufferConfig ringbufferConfig = new RingbufferConfig("ConfigValidationMergePolicyRingbufferTest");
+
+    @Test
+    public void testConfig() {
+        ringbufferConfig
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkRingbufferConfig(ringbufferConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyScheduledExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicyScheduledExecutorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.ScheduledExecutorConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkScheduledExecutorConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicyScheduledExecutorTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private ScheduledExecutorConfig scheduledExecutorConfig
+            = new ScheduledExecutorConfig("ConfigValidationMergePolicyScheduledExecutorTest");
+
+    @Test
+    public void testConfig() {
+        scheduledExecutorConfig
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkScheduledExecutorConfig(scheduledExecutorConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidationMergePolicySetTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.SetConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkCollectionConfig;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidationMergePolicySetTest extends AbstractConfigValidatorMergePolicyTest {
+
+    private SetConfig setConfig = new SetConfig("ConfigValidationMergePolicySetTest");
+
+    @Test
+    public void testConfig_withEnabledStatisticsEnabled() {
+        setConfig
+                .setStatisticsEnabled(true)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkCollectionConfig(setConfig);
+    }
+
+    @Test
+    public void testConfig_withDisabledStatistics() {
+        setConfig
+                .setStatisticsEnabled(false)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        expectExceptionsWithoutStatistics();
+        checkCollectionConfig(setConfig);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -263,22 +263,28 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void checkCacheConfig_whenNATIVEAndEntryCountMaxSizePolicy() {
-        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig();
-        cacheSimpleConfig.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
-        cacheSimpleConfig.setInMemoryFormat(NATIVE);
+        EvictionConfig evictionConfig = new EvictionConfig()
+                .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
+                .setInMemoryFormat(NATIVE)
+                .setEvictionConfig(evictionConfig);
+
         checkCacheConfig(cacheSimpleConfig);
     }
 
     @Test
     public void checkCacheConfig_whenOBJECTAndEntryCountMaxSizePolicy() {
-        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig();
-        cacheSimpleConfig.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
-        cacheSimpleConfig.setInMemoryFormat(OBJECT);
+        EvictionConfig evictionConfig = new EvictionConfig()
+                .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
+                .setInMemoryFormat(OBJECT)
+                .setEvictionConfig(evictionConfig);
+
         checkCacheConfig(cacheSimpleConfig);
     }
 
     @Test
-    public void test_checkNearCacheConfig_withPreLoaderConfig_onClients() {
+    public void checkNearCacheConfig_withPreLoaderConfig_onClients() {
         NearCacheConfig nearCacheConfig = getNearCacheConfig(BINARY)
                 .setCacheLocalEntries(false);
         nearCacheConfig.getPreloaderConfig()
@@ -290,7 +296,7 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void test_checkNearCacheConfig_withPreloader_onMembers() {
+    public void checkNearCacheConfig_withPreloaderConfig_onMembers() {
         NearCacheConfig nearCacheConfig = getNearCacheConfig(BINARY);
         nearCacheConfig.getPreloaderConfig()
                 .setEnabled(true)
@@ -301,17 +307,17 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void not_supports_near_cache_localUpdatePolicy_CACHE_ON_UPDATE() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig();
-        nearCacheConfig.setLocalUpdatePolicy(CACHE_ON_UPDATE);
+    public void checkNearCacheConfig_withLocalUpdatePolicy_CACHE_ON_UPDATE() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setLocalUpdatePolicy(CACHE_ON_UPDATE);
 
         checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
     }
 
     @Test
-    public void supports_near_cache_localUpdatePolicy_INVALIDATE() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig();
-        nearCacheConfig.setLocalUpdatePolicy(INVALIDATE);
+    public void checkNearCacheConfig_withLocalUpdatePolicy_INVALIDATE() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setLocalUpdatePolicy(INVALIDATE);
 
         checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
     }
@@ -338,8 +344,9 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
 
     @Test
     public void should_not_throw_exception_with_native_memory_config_when_native_memory_used_on_ee() {
-        NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig();
-        nativeMemoryConfig.setEnabled(true);
+        NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig()
+                .setEnabled(true);
+
         checkNearCacheNativeMemoryConfig(InMemoryFormat.NATIVE, nativeMemoryConfig, true);
     }
 


### PR DESCRIPTION
This provides the fail-fast behavior for unsupported merge policy configurations.

On data structures which provide statistics, we check if they are enabled, when a merge policy is configured, which needs them. We also check for `HyperLogLogMergePolicy`, which is not allowed to be used for other data structures than `CardinalityEstimator`.

The `CardinalityEstiamatorConfig` has a built-in check for merge policies, so it's not handled via the `ConfigValidator`.