### PR TITLE
 Ensure CacheConfig is created on cluster when getting Cache proxy 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
 import com.hazelcast.cache.impl.journal.CacheEventJournal;
 import com.hazelcast.cache.impl.journal.RingbufferCacheEventJournalImpl;
+import com.hazelcast.cache.impl.operation.CacheCreateConfigOperation;
 import com.hazelcast.cache.impl.operation.OnJoinCacheOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -33,8 +34,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PreJoinAwareService;
@@ -209,6 +212,8 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
                 validateCacheConfig(cacheConfig);
                 putCacheConfigIfAbsent(cacheConfig);
+                // ensure cache config becomes available on all members before the proxy is returned to the caller
+                createCacheConfigOnAllMembers(cacheConfig);
 
                 return new CacheProxy(cacheConfig, nodeEngine, this);
             }
@@ -706,5 +711,14 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     @Override
     public CacheEventJournal getEventJournal() {
         return eventJournal;
+    }
+
+    // creates the given CacheConfig on all members of the cluster synchronously
+    private <K, V> void createCacheConfigOnAllMembers(CacheConfig<K, V> cacheConfig) {
+        OperationService operationService = nodeEngine.getOperationService();
+        CacheCreateConfigOperation op = new CacheCreateConfigOperation(cacheConfig);
+        InternalCompletableFuture future =
+                operationService.invokeOnTarget(CacheService.SERVICE_NAME, op, nodeEngine.getThisAddress());
+        future.join();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
@@ -392,6 +392,23 @@ public class CacheThroughHazelcastInstanceTest extends HazelcastTestSupport {
         hzCacheManager.getCache("any-cache");
     }
 
+    @Test
+    public void cacheConfigIsAvailableOnAllMembers_afterGetCacheCompletes() {
+        Config config = createConfig();
+        config.addCacheConfig(createCacheSimpleConfig(CACHE_NAME));
+
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory();
+
+        HazelcastInstance instance1 = instanceFactory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = instanceFactory.newHazelcastInstance(config);
+
+        ICacheService cacheServiceOnInstance2 = getNodeEngineImpl(instance2).getService(ICacheService.SERVICE_NAME);
+        retrieveCache(instance1, true);
+        assertNotNull("Cache config was not available on other instance after cache proxy was created",
+                cacheServiceOnInstance2.getCacheConfig(
+                HazelcastCacheManager.CACHE_MANAGER_PREFIX + CACHE_NAME));
+    }
+
     private static ICache<Integer, Integer> retrieveCache(HazelcastInstance instance, boolean getCache) {
         return retrieveCache(instance, CACHE_NAME, getCache);
     }


### PR DESCRIPTION
When getting Cache proxy via `HazelcastInstance.getCacheManager.getCache`
the `CacheConfig` must be created on other cluster members before the
method returns to the caller (as is the case when getting or creating a `Cache`
via `CacheManager` interface). Otherwise, it is possible Cache operations
may fail with `CacheNotExistsException` until the proxy creation event
is processed on all members.

Also includes a small compatibility code cleanup as a separate commit.

Fixes #12177 