### PR TITLE
Covariance of projection output in EventJournal

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -533,7 +533,8 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V>
             int maxSize,
             int partitionId,
             Predicate<? super EventJournalCacheEvent<K, V>> predicate,
-            Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+            Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection
+    ) {
         final SerializationService ss = getSerializationService();
         final ClientMessage request = CacheEventJournalReadCodec.encodeRequest(
                 nameWithPrefix, startSequence, minSize, maxSize, ss.toData(predicate), ss.toData(projection));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -182,7 +182,8 @@ import static java.util.Collections.emptyMap;
  * @param <V> value
  */
 @SuppressWarnings("checkstyle:classdataabstractioncoupling")
-public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V>, EventJournalReader<EventJournalMapEvent<K, V>> {
+public class ClientMapProxy<K, V> extends ClientProxy
+        implements IMap<K, V>, EventJournalReader<EventJournalMapEvent<K, V>> {
 
     protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
@@ -1659,7 +1660,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V>, Eve
             int maxSize,
             int partitionId,
             com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
-            Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+            Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection
+    ) {
         final SerializationService ss = getSerializationService();
         final ClientMessage request = MapEventJournalReadCodec.encodeRequest(
                 name, startSequence, minSize, maxSize, ss.toData(predicate), ss.toData(projection));

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -78,7 +78,8 @@ import static com.hazelcast.util.SetUtil.createHashSet;
  * @param <V> the type of value.
  */
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
-public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> implements EventJournalReader<EventJournalCacheEvent<K, V>> {
+public class CacheProxy<K, V> extends AbstractCacheProxy<K, V>
+        implements EventJournalReader<EventJournalCacheEvent<K, V>> {
 
     protected final ILogger logger;
 
@@ -388,7 +389,8 @@ public class CacheProxy<K, V> extends AbstractCacheProxy<K, V> implements EventJ
             int maxSize,
             int partitionId,
             Predicate<? super EventJournalCacheEvent<K, V>> predicate,
-            Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+            Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection
+    ) {
         final CacheEventJournalReadOperation<K, V, T> op = new CacheEventJournalReadOperation<K, V, T>(
                 nameWithPrefix, startSequence, minSize, maxSize, predicate, projection);
         op.setPartitionId(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadOperation.java
@@ -43,16 +43,19 @@ import java.io.IOException;
  *            if the projection is {@code null} or it is the identity projection
  * @since 3.9
  */
-public class CacheEventJournalReadOperation<K, V, T> extends EventJournalReadOperation<T, InternalEventJournalCacheEvent> {
+public class CacheEventJournalReadOperation<K, V, T>
+        extends EventJournalReadOperation<T, InternalEventJournalCacheEvent> {
     protected Predicate<? super EventJournalCacheEvent<K, V>> predicate;
-    protected Projection<? super EventJournalCacheEvent<K, V>, T> projection;
+    protected Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection;
 
     public CacheEventJournalReadOperation() {
     }
 
-    public CacheEventJournalReadOperation(String cacheName, long startSequence, int minSize, int maxSize,
-                                          Predicate<? super EventJournalCacheEvent<K, V>> predicate,
-                                          Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+    public CacheEventJournalReadOperation(
+            String cacheName, long startSequence, int minSize, int maxSize,
+            Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+            Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection
+    ) {
         super(cacheName, startSequence, minSize, maxSize);
         this.predicate = predicate;
         this.projection = projection;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/CacheEventJournalReadResultSetImpl.java
@@ -30,9 +30,11 @@ public class CacheEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetIm
     public CacheEventJournalReadResultSetImpl() {
     }
 
-    CacheEventJournalReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
-                                       final Predicate<? super EventJournalCacheEvent<K, V>> predicate,
-                                       final Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+    CacheEventJournalReadResultSetImpl(
+            int minSize, int maxSize, SerializationService serializationService,
+            final Predicate<? super EventJournalCacheEvent<K, V>> predicate,
+            final Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection
+    ) {
         super(minSize, maxSize, serializationService,
                 predicate == null ? null : new Predicate<InternalEventJournalCacheEvent>() {
                     @Override
@@ -67,9 +69,9 @@ public class CacheEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetIm
     @SerializableByConvention
     private static class ProjectionAdapter<K, V, T> extends Projection<InternalEventJournalCacheEvent, T> {
 
-        private final Projection<? super EventJournalCacheEvent<K, V>, T> projection;
+        private final Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection;
 
-        ProjectionAdapter(Projection<? super EventJournalCacheEvent<K, V>, T> projection) {
+        ProjectionAdapter(Projection<? super EventJournalCacheEvent<K, V>, ? extends T> projection) {
             this.projection = projection;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournalReader.java
@@ -61,10 +61,12 @@ public interface EventJournalReader<E> {
      * @return the future with the filtered and projected journal items
      * @since 3.9
      */
-    <T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(long startSequence,
-                                                                  int minSize,
-                                                                  int maxSize,
-                                                                  int partitionId,
-                                                                  com.hazelcast.util.function.Predicate<? super E> predicate,
-                                                                  Projection<? super E, T> projection);
+    <T> ICompletableFuture<ReadResultSet<T>> readFromEventJournal(
+            long startSequence,
+            int minSize,
+            int maxSize,
+            int partitionId,
+            com.hazelcast.util.function.Predicate<? super E> predicate,
+            Projection<? super E, ? extends T> projection
+    );
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadOperation.java
@@ -46,14 +46,16 @@ import java.io.IOException;
 public class MapEventJournalReadOperation<K, V, T> extends EventJournalReadOperation<T, InternalEventJournalMapEvent> {
 
     protected Predicate<? super EventJournalMapEvent<K, V>> predicate;
-    protected Projection<? super EventJournalMapEvent<K, V>, T> projection;
+    protected Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection;
 
     public MapEventJournalReadOperation() {
     }
 
-    public MapEventJournalReadOperation(String mapName, long startSequence, int minSize, int maxSize,
-                                        Predicate<? super EventJournalMapEvent<K, V>> predicate,
-                                        Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+    public MapEventJournalReadOperation(
+            String mapName, long startSequence, int minSize, int maxSize,
+            Predicate<? super EventJournalMapEvent<K, V>> predicate,
+            Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection
+    ) {
         super(mapName, startSequence, minSize, maxSize);
         this.predicate = predicate;
         this.projection = projection;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalReadResultSetImpl.java
@@ -30,9 +30,11 @@ public class MapEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetImpl
     public MapEventJournalReadResultSetImpl() {
     }
 
-    MapEventJournalReadResultSetImpl(int minSize, int maxSize, SerializationService serializationService,
-                                     final Predicate<? super EventJournalMapEvent<K, V>> predicate,
-                                     final Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+    MapEventJournalReadResultSetImpl(
+            int minSize, int maxSize, SerializationService serializationService,
+            final Predicate<? super EventJournalMapEvent<K, V>> predicate,
+            final Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection
+    ) {
         super(minSize, maxSize, serializationService,
                 predicate == null ? null : new Predicate<InternalEventJournalMapEvent>() {
                     @Override
@@ -67,9 +69,9 @@ public class MapEventJournalReadResultSetImpl<K, V, T> extends ReadResultSetImpl
     @SerializableByConvention
     private static class ProjectionAdapter<K, V, T> extends Projection<InternalEventJournalMapEvent, T> {
 
-        private final Projection<? super EventJournalMapEvent<K, V>, T> projection;
+        private final Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection;
 
-        ProjectionAdapter(Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+        ProjectionAdapter(Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection) {
             this.projection = projection;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -915,7 +915,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
             int maxSize,
             int partitionId,
             com.hazelcast.util.function.Predicate<? super EventJournalMapEvent<K, V>> predicate,
-            Projection<? super EventJournalMapEvent<K, V>, T> projection) {
+            Projection<? super EventJournalMapEvent<K, V>, ? extends T> projection) {
         final ManagedContext context = serializationService.getManagedContext();
         context.initialize(predicate);
         context.initialize(projection);


### PR DESCRIPTION
Usages of `Projection<E, T>` are missing covariance declaration `? extends T`. This is breaking Jet code.