### PR TITLE
[WIP]Revising authentication timeout logic to prevent slow shutdown

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -72,6 +72,7 @@ public class ClientInvocation implements Runnable {
     private final long startTimeMillis;
     private final long retryPauseMillis;
     private final String objectName;
+    private long hardTimeoutMillis;
     private volatile ClientConnection sendConnection;
     private boolean bypassHeartbeatCheck;
     private EventHandler handler;
@@ -299,6 +300,14 @@ public class ClientInvocation implements Runnable {
         return sendConnection;
     }
 
+    public long getHardTimeoutMillis() {
+        return hardTimeoutMillis;
+    }
+
+    public void setHardTimeoutMillis(long hardTimeoutMillis) {
+        this.hardTimeoutMillis = hardTimeoutMillis;
+    }
+
     public static boolean isRetrySafeException(Throwable t) {
         return t instanceof IOException
                 || t instanceof HazelcastInstanceNotActiveException
@@ -339,5 +348,9 @@ public class ClientInvocation implements Runnable {
                 + ", objectName = " + objectName
                 + ", target = " + target
                 + ", sendConnection = " + sendConnection + '}';
+    }
+
+    public long startTimeMillis() {
+        return this.startTimeMillis;
     }
 }


### PR DESCRIPTION
For authentication timeout, there was a scheduled task introduced
recently:
Pr
https://github.com/hazelcast/hazelcast/pull/12163
Line
https://github.com/hazelcast/hazelcast/commit/127eb142d1895c5c9e5b29afb268bad7962cd57b#diff-6b832face5ab9f5e23687eaeb478627eR631

Client needs to wait all scheduled tasks to finish before shutdown.
Authentication timeout was scheduled for 5 seconds(default connection timeout)

Hard timeout is introduced in client invocation to solve same
problem. CleanResources task is now responsible to check that timeout.
This new timeout mechanism is only used by authentication for now.