### PR TITLE
[WIP]Revising authentication timeout logic to prevent slow shutdown

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -86,7 +86,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -112,7 +111,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
 
     private final ILogger logger;
-    private final int connectionTimeout;
+    private final int connectionTimeoutMillis;
 
     private final HazelcastClientInstanceImpl client;
     private final SocketInterceptor socketInterceptor;
@@ -157,7 +156,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
 
         final int connTimeout = networkConfig.getConnectionTimeout();
-        this.connectionTimeout = connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
+        this.connectionTimeoutMillis = connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
 
         this.executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
         this.socketOptions = networkConfig.getSocketOptions();
@@ -557,7 +556,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             socket.setReceiveBufferSize(bufferSize);
             InetSocketAddress inetSocketAddress = address.getInetSocketAddress();
             bindSocketToPort(socket);
-            socketChannel.socket().connect(inetSocketAddress, connectionTimeout);
+            socketChannel.socket().connect(inetSocketAddress, connectionTimeoutMillis);
 
             HazelcastProperties properties = client.getProperties();
             boolean directBuffer = properties.getBoolean(SOCKET_CLIENT_BUFFER_DIRECT);
@@ -627,8 +626,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         final ClientPrincipal principal = getPrincipal();
         ClientMessage clientMessage = encodeAuthenticationRequest(asOwner, client.getSerializationService(), principal);
         ClientInvocation clientInvocation = new ClientInvocation(client, clientMessage, null, connection);
+        clientInvocation.setHardTimeoutMillis(connectionTimeoutMillis);
         ClientInvocationFuture invocationFuture = clientInvocation.invokeUrgent();
-        executionService.schedule(new TimeoutAuthenticationTask(invocationFuture), connectionTimeout, TimeUnit.MILLISECONDS);
         invocationFuture.andThen(new AuthCallback(connection, asOwner, target, future));
     }
 
@@ -720,7 +719,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                 return;
             }
             future.complete(new TimeoutException("Authentication response did not come back in "
-                    + connectionTimeout + " millis"));
+                    + connectionTimeoutMillis + " millis"));
         }
 
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -72,6 +72,7 @@ public class ClientInvocation implements Runnable {
     private final long startTimeMillis;
     private final long retryPauseMillis;
     private final String objectName;
+    private long hardTimeoutMillis;
     private volatile ClientConnection sendConnection;
     private boolean bypassHeartbeatCheck;
     private EventHandler handler;
@@ -287,6 +288,14 @@ public class ClientInvocation implements Runnable {
         return sendConnection;
     }
 
+    public long getHardTimeoutMillis() {
+        return hardTimeoutMillis;
+    }
+
+    public void setHardTimeoutMillis(long hardTimeoutMillis) {
+        this.hardTimeoutMillis = hardTimeoutMillis;
+    }
+
     public static boolean isRetrySafeException(Throwable t) {
         return t instanceof IOException
                 || t instanceof HazelcastInstanceNotActiveException
@@ -327,5 +336,9 @@ public class ClientInvocation implements Runnable {
                 + ", objectName = " + objectName
                 + ", target = " + target
                 + ", sendConnection = " + sendConnection + '}';
+    }
+
+    public long startTimeMillis() {
+        return this.startTimeMillis;
     }
 }


### PR DESCRIPTION
For authentication timeout, there was a scheduled task introduced
recently:
Pr
Line
127eb14#diff-6b832face5ab9f5e23687eaeb478627eR631

Client needs to wait all scheduled tasks to finish before shutdown.
Authentication timeout was scheduled for 5 seconds(default connection timeout)

Hard timeout is introduced in client invocation to solve same
problem. CleanResources task is now responsible to check that timeout.
This new timeout mechanism is only used by authentication for now.