### PR TITLE
Add support for -beta-x suffix when parsing hazelcast version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -56,8 +56,8 @@ public final class StringUtil {
     /**
      * Pattern used to tokenize version strings.
      */
-    private static final Pattern VERSION_PATTERN
-            = Pattern.compile("^([\\d]+)\\.([\\d]+)(\\.([\\d]+))?(-[\\w]+)?(-SNAPSHOT)?$");
+    public static final Pattern VERSION_PATTERN
+            = Pattern.compile("^(\\d+)\\.(\\d+)(\\.(\\d+))?(-\\w+(?:-\\d+)?)?(-SNAPSHOT)?$");
 
     private static final String GETTER_PREFIX = "get";
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -24,9 +24,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.regex.Pattern;
-
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.util.StringUtil.VERSION_PATTERN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -34,9 +33,6 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class BuildInfoProviderTest extends HazelcastTestSupport {
-
-    // major.minor.patch-RC-SNAPSHOT
-    private static final Pattern VERSION_PATTERN = Pattern.compile("^[\\d]+\\.[\\d]+(\\.[\\d]+)?(\\-[\\w]+)?(\\-SNAPSHOT)?$");
 
     @After
     public void cleanup() {
@@ -46,29 +42,6 @@ public class BuildInfoProviderTest extends HazelcastTestSupport {
     @Test
     public void testConstructor() {
         assertUtilityConstructor(BuildInfoProvider.class);
-    }
-
-    @Test
-    public void testVersionPattern() {
-        assertTrue(VERSION_PATTERN.matcher("3.1").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1-SNAPSHOT").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1-RC").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1-RC1-SNAPSHOT").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1.1").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1.1-RC").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1.1-SNAPSHOT").matches());
-        assertTrue(VERSION_PATTERN.matcher("3.1.1-RC1-SNAPSHOT").matches());
-
-        assertFalse(VERSION_PATTERN.matcher("${project.version}").matches());
-        assertFalse(VERSION_PATTERN.matcher("project.version").matches());
-        assertFalse(VERSION_PATTERN.matcher("3").matches());
-        assertFalse(VERSION_PATTERN.matcher("3.RC").matches());
-        assertFalse(VERSION_PATTERN.matcher("3.SNAPSHOT").matches());
-        assertFalse(VERSION_PATTERN.matcher("3-RC").matches());
-        assertFalse(VERSION_PATTERN.matcher("3-SNAPSHOT").matches());
-        assertFalse(VERSION_PATTERN.matcher("3.").matches());
-        assertFalse(VERSION_PATTERN.matcher("3.1.RC").matches());
-        assertFalse(VERSION_PATTERN.matcher("3.1.SNAPSHOT").matches());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Locale;
 
+import static com.hazelcast.util.StringUtil.VERSION_PATTERN;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -35,6 +36,29 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class StringUtilTest extends HazelcastTestSupport {
+
+    @Test
+    public void testVersionPattern() {
+        assertTrue(VERSION_PATTERN.matcher("3.1").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1-SNAPSHOT").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1-RC").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1-RC1-SNAPSHOT").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1.1").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1.1-RC").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1.1-SNAPSHOT").matches());
+        assertTrue(VERSION_PATTERN.matcher("3.1.1-RC1-SNAPSHOT").matches());
+
+        assertFalse(VERSION_PATTERN.matcher("${project.version}").matches());
+        assertFalse(VERSION_PATTERN.matcher("project.version").matches());
+        assertFalse(VERSION_PATTERN.matcher("3").matches());
+        assertFalse(VERSION_PATTERN.matcher("3.RC").matches());
+        assertFalse(VERSION_PATTERN.matcher("3.SNAPSHOT").matches());
+        assertFalse(VERSION_PATTERN.matcher("3-RC").matches());
+        assertFalse(VERSION_PATTERN.matcher("3-SNAPSHOT").matches());
+        assertFalse(VERSION_PATTERN.matcher("3.").matches());
+        assertFalse(VERSION_PATTERN.matcher("3.1.RC").matches());
+        assertFalse(VERSION_PATTERN.matcher("3.1.SNAPSHOT").matches());
+    }
 
     @Test
     public void getterIntoProperty_whenNull_returnNull() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
@@ -38,6 +38,8 @@ public class MemberVersionTest {
 
     private static final String VERSION_3_8_SNAPSHOT_STRING = "3.8-SNAPSHOT";
     private static final String VERSION_3_8_1_RC1_STRING = "3.8.1-RC1";
+    private static final String VERSION_3_8_1_BETA_1_STRING = "3.8.1-beta-1";
+    private static final String VERSION_3_8_BETA_2_STRING = "3.8-beta-2";
     private static final String VERSION_3_8_2_STRING = "3.8.2";
     private static final String VERSION_3_9_0_STRING = "3.9.0";
     private static final String VERSION_UNKNOWN_STRING = "0.0.0";
@@ -58,6 +60,8 @@ public class MemberVersionTest {
         assertTrue(MemberVersion.UNKNOWN.isUnknown());
         assertFalse(MemberVersion.of(VERSION_3_8_SNAPSHOT_STRING).isUnknown());
         assertFalse(MemberVersion.of(VERSION_3_8_1_RC1_STRING).isUnknown());
+        assertFalse(MemberVersion.of(VERSION_3_8_1_BETA_1_STRING).isUnknown());
+        assertFalse(MemberVersion.of(VERSION_3_8_BETA_2_STRING).isUnknown());
         assertFalse(MemberVersion.of(VERSION_3_8_2_STRING).isUnknown());
     }
 
@@ -70,6 +74,20 @@ public class MemberVersionTest {
     public void testVersionOf_whenVersionStringIsSnapshot() {
         MemberVersion expected = MemberVersion.of(3, 8, 0);
         assertEquals(expected, MemberVersion.of(VERSION_3_8_SNAPSHOT_STRING));
+    }
+
+    @Test
+    public void testVersionOf_whenVersionStringIsBeta() {
+        assertEquals(MemberVersion.of(3, 8, 0), MemberVersion.of(VERSION_3_8_BETA_2_STRING));
+        assertEquals(MemberVersion.of(3, 8, 1), MemberVersion.of(VERSION_3_8_1_BETA_1_STRING));
+    }
+
+    @Test
+    public void test_constituents_whenVersionStringIsBeta() {
+        final MemberVersion expected = MemberVersion.of(VERSION_3_8_BETA_2_STRING);
+        assertEquals(3, expected.getMajor());
+        assertEquals(8, expected.getMinor());
+        assertEquals(0, expected.getPatch());
     }
 
     @Test


### PR DESCRIPTION
Adds support for -beta-x suffix, e.g. 3.10-beta-1.