### PR TITLE
Cleanup of OperationServiceImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.internal.util.concurrent.MPSCQueue;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.LiveOperations;
@@ -76,7 +75,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 @SuppressWarnings("checkstyle:methodcount")
 public final class OperationExecutorImpl implements OperationExecutor, MetricsProvider {
-    public static final HazelcastProperty IDLE_STRATEGY
+
+    private static final HazelcastProperty IDLE_STRATEGY
             = new HazelcastProperty("hazelcast.operation.partitionthread.idlestrategy", "block");
 
     private static final int TERMINATION_TIMEOUT_SECONDS = 3;
@@ -98,15 +98,11 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     private final OperationRunner adHocOperationRunner;
     private final int priorityThreadCount;
 
-    public OperationExecutorImpl(HazelcastProperties properties,
-                                 LoggingService loggerService,
-                                 Address thisAddress,
-                                 OperationRunnerFactory runnerFactory,
-                                 NodeExtension nodeExtension,
-                                 String hzName,
+    public OperationExecutorImpl(HazelcastProperties properties, Address thisAddress, ILogger logger,
+                                 OperationRunnerFactory runnerFactory, NodeExtension nodeExtension, String hzName,
                                  ClassLoader configClassLoader) {
         this.thisAddress = thisAddress;
-        this.logger = loggerService.getLogger(OperationExecutorImpl.class);
+        this.logger = logger;
 
         this.adHocOperationRunner = runnerFactory.createAdHocRunner();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -18,7 +18,6 @@ package com.hazelcast.spi.impl.operationexecutor.slowoperationdetector;
 
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -72,13 +71,10 @@ public final class SlowOperationDetector {
     private boolean isFirstLog = true;
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public SlowOperationDetector(LoggingService loggingServices,
-                                 OperationRunner[] genericOperationRunners,
-                                 OperationRunner[] partitionOperationRunners,
-                                 HazelcastProperties hazelcastProperties,
+    public SlowOperationDetector(ILogger logger, OperationRunner[] genericOperationRunners,
+                                 OperationRunner[] partitionOperationRunners, HazelcastProperties hazelcastProperties,
                                  String hzName) {
-
-        this.logger = loggingServices.getLogger(SlowOperationDetector.class);
+        this.logger = logger;
 
         this.slowOperationThresholdNanos = hazelcastProperties.getNanos(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS);
         this.logPurgeIntervalNanos = hazelcastProperties.getNanos(SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -46,11 +46,11 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 /**
  * The {@link AsyncInboundResponseHandler} is a PacketHandler that asynchronously process operation-response packets. The
  * actual processing is done by the {@link InboundResponseHandler}.
- *
+ * <p>
  * So when a response is received from a remote system, it is put in the responseQueue of the ResponseThread.
  * Then the ResponseThread takes it from this responseQueue and calls the {@link PacketHandler} for the
  * actual processing.
- *
+ * <p>
  * The reason that the IO thread doesn't immediately deals with the response is that deserializing the
  * {@link com.hazelcast.spi.impl.operationservice.impl.responses.Response} and let the invocation-future
  * deal with the response can be rather expensive.
@@ -68,9 +68,7 @@ public class AsyncInboundResponseHandler implements PacketHandler, MetricsProvid
     final ResponseThread responseThread;
     private final ILogger logger;
 
-    AsyncInboundResponseHandler(ClassLoader classLoader, String hzName,
-                                ILogger logger,
-                                PacketHandler responsePacketHandler,
+    AsyncInboundResponseHandler(ClassLoader classLoader, String hzName, ILogger logger, PacketHandler responsePacketHandler,
                                 HazelcastProperties properties) {
         this.logger = logger;
         this.responseThread = new ResponseThread(classLoader, hzName, responsePacketHandler, properties);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
@@ -27,7 +27,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 
@@ -53,7 +53,7 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
     private final ILogger logger;
     private final InternalSerializationService serializationService;
     private final InvocationRegistry invocationRegistry;
-    private final NodeEngineImpl nodeEngine;
+    private final NodeEngine nodeEngine;
     @Probe(name = "responses[normal]", level = MANDATORY)
     private final SwCounter responsesNormal = newSwCounter();
     @Probe(name = "responses[timeout]", level = MANDATORY)
@@ -69,7 +69,7 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
     InboundResponseHandler(ILogger logger,
                            InternalSerializationService serializationService,
                            InvocationRegistry invocationRegistry,
-                           NodeEngineImpl nodeEngine) {
+                           NodeEngine nodeEngine) {
         this.logger = logger;
         this.useBigEndian = serializationService.getByteOrder() == ByteOrder.BIG_ENDIAN;
         this.serializationService = serializationService;
@@ -83,7 +83,7 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
     }
 
     @Override
-    public void handle(Packet packet) throws Exception {
+    public void handle(Packet packet) {
         byte[] bytes = packet.toByteArray();
         int typeId = Bits.readInt(bytes, OFFSET_TYPE_ID, useBigEndian);
         long callId = Bits.readLong(bytes, OFFSET_CALL_ID, useBigEndian);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -92,8 +92,8 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
 
     protected OperationExecutorImpl initExecutor() {
         props = new HazelcastProperties(config);
-        executor = new OperationExecutorImpl(
-                props, loggingService, thisAddress, handlerFactory, nodeExtension, "hzName", Thread.currentThread().getContextClassLoader());
+        executor = new OperationExecutorImpl(props, thisAddress, loggingService.getLogger(OperationExecutorImpl.class),
+                handlerFactory, nodeExtension, "hzName", Thread.currentThread().getContextClassLoader());
         executor.start();
         return executor;
     }
@@ -101,7 +101,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
     public static <E> void assertEqualsEventually(final PartitionSpecificCallable task, final E expected) {
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertTrue(task + " has not given a response", task.completed());
                 assertEquals(expected, task.getResult());
             }
@@ -114,7 +114,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         List<Response> responses = synchronizedList(new LinkedList<Response>());
 
         @Override
-        public void handle(Packet packet) throws Exception {
+        public void handle(Packet packet) {
             packets.add(packet);
             Response response = serializationService.toObject(packet);
             responses.add(response);


### PR DESCRIPTION
* removed some dependencies on `NodeEngineImpl`, `NodeEngine` and `LoggingService` on constructed classes
* aligned order of fields and constructor in some classes

In general I just had a look how the majority of instances in the `OperationService` is constructed and went by that style. So the loggers are created there instead of passing the `NodeEngine` or `LoggingService` down to the other constructors. This already helped to reduce some dependencies without any big trouble.