### PR TITLE
Map&Cache SplitBrainHandlerService unifications

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1673,4 +1673,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     public ObjectNamespace getObjectNamespace() {
         return objectNamespace;
     }
+
+    @Override
+    public int getPartitionId() {
+        return partitionId;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.cache.CacheEntryView;
+import com.hazelcast.cache.CacheMergePolicy;
+import com.hazelcast.cache.impl.merge.entry.DefaultCacheEntryView;
+import com.hazelcast.cache.impl.operation.CacheLegacyMergeOperation;
+import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.impl.AbstractMergeRunnable;
+import com.hazelcast.spi.merge.MergingEntryHolder;
+import com.hazelcast.util.function.BiConsumer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
+import static com.hazelcast.config.MergePolicyConfig.DEFAULT_BATCH_SIZE;
+import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
+
+class CacheMergeRunnable extends AbstractMergeRunnable<ICacheRecordStore, MergingEntryHolder<Data, Data>> {
+
+    private final CacheService cacheService;
+    private final CacheSplitBrainHandlerService cacheSplitBrainHandlerService;
+
+    CacheMergeRunnable(Map<String, Collection<ICacheRecordStore>> collectedStores,
+                       Map<String, Collection<ICacheRecordStore>> collectedStoresWithLegacyPolicies,
+                       Collection<ICacheRecordStore> backupStores,
+                       CacheSplitBrainHandlerService cacheSplitBrainHandlerService,
+                       NodeEngine nodeEngine) {
+        super(CacheService.SERVICE_NAME, collectedStores, collectedStoresWithLegacyPolicies, backupStores, nodeEngine);
+
+        this.cacheService = nodeEngine.getService(SERVICE_NAME);
+        this.cacheSplitBrainHandlerService = cacheSplitBrainHandlerService;
+    }
+
+    @Override
+    protected void consumeStore(ICacheRecordStore store, BiConsumer<Integer, MergingEntryHolder<Data, Data>> consumer) {
+        int partitionId = store.getPartitionId();
+
+        for (Map.Entry<Data, CacheRecord> entry : store.getReadOnlyRecords().entrySet()) {
+            Data key = entry.getKey();
+            CacheRecord record = entry.getValue();
+            Data dataValue = toData(record.getValue());
+
+            consumer.accept(partitionId, createMergeHolder(key, dataValue, record));
+        }
+    }
+
+    @Override
+    protected void consumeStoreLegacy(ICacheRecordStore recordStore, BiConsumer<Integer, Operation> consumer) {
+        int partitionId = recordStore.getPartitionId();
+        String name = recordStore.getName();
+        CacheMergePolicy mergePolicy = ((CacheMergePolicy) getMergePolicy(name));
+
+        for (Map.Entry<Data, CacheRecord> entry : recordStore.getReadOnlyRecords().entrySet()) {
+            Data key = entry.getKey();
+            CacheRecord record = entry.getValue();
+            CacheEntryView<Data, Data> entryView = new DefaultCacheEntryView(
+                    key,
+                    toData(record.getValue()),
+                    record.getCreationTime(),
+                    record.getExpirationTime(),
+                    record.getLastAccessTime(),
+                    record.getAccessHit());
+
+            consumer.accept(partitionId, new CacheLegacyMergeOperation(name, key, entryView, mergePolicy));
+        }
+    }
+
+    @Override
+    protected InMemoryFormat getInMemoryFormat(String dataStructureName) {
+        return cacheSplitBrainHandlerService.getConfigs().get(dataStructureName).getInMemoryFormat();
+    }
+
+    @Override
+    protected int getBatchSize(String dataStructureName) {
+        // Batch size cannot be get from MergePolicyConfig. Because
+        // there is no MergePolicyConfig in CacheConfig. Adding it breaks
+        // backward compatibility
+        return DEFAULT_BATCH_SIZE;
+    }
+
+    @Override
+    protected Object getMergePolicy(String dataStructureName) {
+        return cacheSplitBrainHandlerService.getMergePolicy(dataStructureName);
+    }
+
+    @Override
+    protected void destroyStores(Collection<ICacheRecordStore> stores) {
+        cacheSplitBrainHandlerService.destroyStores(stores);
+    }
+
+    @Override
+    protected OperationFactory createMergeOperationFactory(String dataStructureName,
+                                                           SplitBrainMergePolicy mergePolicy,
+                                                           int[] partitions,
+                                                           List<MergingEntryHolder<Data, Data>>[] entries) {
+        CacheConfig cacheConfig = cacheService.getCacheConfig(dataStructureName);
+        CacheOperationProvider operationProvider
+                = cacheService.getCacheOperationProvider(dataStructureName, cacheConfig.getInMemoryFormat());
+        return operationProvider.createMergeOperationFactory(dataStructureName, partitions, entries, mergePolicy);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -16,347 +16,81 @@
 
 package com.hazelcast.cache.impl;
 
-import com.hazelcast.cache.CacheEntryView;
-import com.hazelcast.cache.CacheMergePolicy;
-import com.hazelcast.cache.impl.merge.entry.DefaultCacheEntryView;
 import com.hazelcast.cache.impl.merge.policy.CacheMergePolicyProvider;
-import com.hazelcast.cache.impl.operation.CacheLegacyMergeOperation;
-import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.Address;
-import com.hazelcast.nio.Disposable;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationFactory;
-import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.SplitBrainHandlerService;
-import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.MergingEntryHolder;
-import com.hazelcast.spi.partition.IPartitionService;
-import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.MutableLong;
+import com.hazelcast.spi.impl.AbstractSplitBrainHandlerService;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.impl.AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE;
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
-import static com.hazelcast.config.MergePolicyConfig.DEFAULT_BATCH_SIZE;
-import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.util.Collections.singletonList;
 
 /**
  * Handles split-brain functionality for cache.
  */
-class CacheSplitBrainHandlerService implements SplitBrainHandlerService {
+class CacheSplitBrainHandlerService extends AbstractSplitBrainHandlerService<ICacheRecordStore> {
 
-    protected static final long TIMEOUT_FACTOR = 500;
+    private final CacheService cacheService;
+    private final CachePartitionSegment[] segments;
+    private final Map<String, CacheConfig> configs;
+    private final CacheMergePolicyProvider mergePolicyProvider;
 
-    protected final int partitionCount;
-    protected final ILogger logger;
-    protected final NodeEngine nodeEngine;
-    protected final CacheService cacheService;
-    protected final Map<String, CacheConfig> configs;
-    protected final CachePartitionSegment[] segments;
-    protected final OperationService operationService;
-    protected final IPartitionService partitionService;
-    protected final SerializationService serializationService;
-    protected final CacheMergePolicyProvider mergePolicyProvider;
-
-    CacheSplitBrainHandlerService(NodeEngine nodeEngine, Map<String, CacheConfig> configs, CachePartitionSegment[] segments) {
-        this.nodeEngine = nodeEngine;
+    CacheSplitBrainHandlerService(NodeEngine nodeEngine,
+                                  Map<String, CacheConfig> configs,
+                                  CachePartitionSegment[] segments) {
+        super(nodeEngine);
         this.configs = configs;
         this.segments = segments;
         this.mergePolicyProvider = new CacheMergePolicyProvider(nodeEngine);
-        this.partitionService = nodeEngine.getPartitionService();
-        this.partitionCount = partitionService.getPartitionCount();
         this.cacheService = nodeEngine.getService(SERVICE_NAME);
-        this.serializationService = nodeEngine.getSerializationService();
-        this.operationService = nodeEngine.getOperationService();
-        this.logger = nodeEngine.getLogger(getClass());
     }
 
     @Override
-    public Runnable prepareMergeRunnable() {
-        Map<String, Map<Data, CacheRecord>> recordMap = createHashMap(configs.size());
-
-        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-            // add your owned entries so they will be merged
-            if (partitionService.isPartitionOwner(partitionId)) {
-                CachePartitionSegment segment = segments[partitionId];
-                List<Iterator<ICacheRecordStore>> iterators = iteratorsOf(segment);
-                for (Iterator<ICacheRecordStore> iterator : iterators) {
-                    while (iterator.hasNext()) {
-                        ICacheRecordStore cacheRecordStore = iterator.next();
-                        String cacheName = cacheRecordStore.getName();
-                        if (cacheRecordStore.getConfig().getInMemoryFormat() == NATIVE
-                                && nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                            logger.warning("Split-brain recovery can not be applied NATIVE in-memory-formatted cache ["
-                                    + cacheName + ']');
-                            continue;
-                        }
-
-                        Map<Data, CacheRecord> records = recordMap.get(cacheName);
-                        if (records == null) {
-                            records = createHashMap(cacheRecordStore.size());
-                            recordMap.put(cacheName, records);
-                        }
-                        for (Map.Entry<Data, CacheRecord> cacheRecordEntry : cacheRecordStore.getReadOnlyRecords().entrySet()) {
-                            Data key = cacheRecordEntry.getKey();
-                            CacheRecord cacheRecord = cacheRecordEntry.getValue();
-                            records.put(key, cacheRecord);
-                        }
-                    }
-                }
-            }
-        }
-
-        invalidateNearCaches(recordMap);
-
-        return new CacheMerger(recordMap);
+    protected Runnable newMergeRunnable(Map<String, Collection<ICacheRecordStore>> collectedStores,
+                                        Map<String, Collection<ICacheRecordStore>> collectedStoresWithLegacyPolicies,
+                                        Collection<ICacheRecordStore> backupStores,
+                                        NodeEngine nodeEngine) {
+        return new CacheMergeRunnable(collectedStores, collectedStoresWithLegacyPolicies,
+                backupStores, this, nodeEngine);
     }
 
-    // overridden on ee
-    protected List<Iterator<ICacheRecordStore>> iteratorsOf(CachePartitionSegment segment) {
-        return singletonList(segment.recordStoreIterator());
+    @Override
+    public String getDataStructureName(ICacheRecordStore recordStore) {
+        return recordStore.getName();
     }
 
-    // overridden on ee
-    protected void destroySegment(CachePartitionSegment segment) {
-        // don't use iteratorsOf here
-        Collection<ICacheRecordStore> recordStores = segment.recordStores.values();
-
-        Iterator<ICacheRecordStore> iterator = recordStores.iterator();
-        while (iterator.hasNext()) {
-            try {
-                ICacheRecordStore recordStore = iterator.next();
-                recordStore.destroy();
-            } finally {
-                iterator.remove();
-            }
-        }
-    }
-
-    /**
-     * Sends cache invalidation event regardless if any actually cleared or not
-     * (no need to know how many actually cleared)
-     */
-    private void invalidateNearCaches(Map<String, Map<Data, CacheRecord>> recordMap) {
-        for (String cacheName : recordMap.keySet()) {
-            cacheService.sendInvalidationEvent(cacheName, null, SOURCE_NOT_AVAILABLE);
-        }
-    }
-
-    private Object getCacheMergePolicy(String cacheName) {
-        CacheConfig cacheConfig = configs.get(cacheName);
+    @Override
+    protected Object getMergePolicy(String dataStructureName) {
+        CacheConfig cacheConfig = configs.get(dataStructureName);
         String mergePolicyName = cacheConfig.getMergePolicy();
         return mergePolicyProvider.getMergePolicy(mergePolicyName);
     }
 
-    // TODO traverse over recordstores not copy to heap eagerly
-    private class CacheMerger implements Runnable, Disposable {
-
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ILogger logger = nodeEngine.getLogger(CacheService.class);
-
-        private final Map<String, Map<Data, CacheRecord>> recordMap;
-
-        CacheMerger(Map<String, Map<Data, CacheRecord>> recordMap) {
-            this.recordMap = recordMap;
+    @Override
+    protected void onPrepareMergeRunnableEnd(Collection<String> dataStructureNames) {
+        for (String cacheName : dataStructureNames) {
+            cacheService.sendInvalidationEvent(cacheName, null, SOURCE_NOT_AVAILABLE);
         }
+    }
 
-        @Override
-        public void run() {
-            int recordCount = 0;
-            for (Map.Entry<String, Map<Data, CacheRecord>> recordMapEntry : recordMap.entrySet()) {
-                String cacheName = recordMapEntry.getKey();
-                Map<Data, CacheRecord> records = recordMapEntry.getValue();
-                Object mergePolicy = getCacheMergePolicy(cacheName);
-                if (mergePolicy instanceof SplitBrainMergePolicy) {
-                    // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperationFactory
-                    // RU_COMPAT_3_9
-                    if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                        logger.info("Cannot merge cache '" + cacheName
-                                + "' with merge policy '" + mergePolicy.getClass().getName()
-                                + "' until cluster is running version " + Versions.V3_10);
-                        continue;
-                    }
-                    recordCount += handleMerge(cacheName, records, (SplitBrainMergePolicy) mergePolicy, DEFAULT_BATCH_SIZE);
-                } else {
-                    recordCount += handleMerge(cacheName, records, (CacheMergePolicy) mergePolicy);
-                }
-            }
-            recordMap.clear();
+    @Override
+    protected Collection<Iterator<ICacheRecordStore>> iteratorsOf(int partitionId) {
+        return singletonList(segments[partitionId].recordStoreIterator());
+    }
 
-            try {
-                if (!semaphore.tryAcquire(recordCount, recordCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for caches didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of caches...");
-                Thread.currentThread().interrupt();
-            }
-        }
+    @Override
+    protected void destroyStore(ICacheRecordStore store) {
+        assert store.getConfig().getInMemoryFormat() != NATIVE;
 
-        private int handleMerge(String name, Map<Data, CacheRecord> recordMap, SplitBrainMergePolicy mergePolicy, int batchSize) {
-            Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
+        store.destroy();
+    }
 
-            // create a mapping between partition IDs and
-            // a) an entry counter per member (a batch operation is sent out once this counter matches the batch size)
-            // b) the member address (so we can retrieve the target address from the current partition ID)
-            MutableLong[] counterPerMember = new MutableLong[partitionCount];
-            Address[] addresses = new Address[partitionCount];
-            for (Map.Entry<Address, List<Integer>> addressListEntry : memberPartitionsMap.entrySet()) {
-                MutableLong counter = new MutableLong();
-                Address address = addressListEntry.getKey();
-                for (int partitionId : addressListEntry.getValue()) {
-                    counterPerMember[partitionId] = counter;
-                    addresses[partitionId] = address;
-                }
-            }
-
-            // sort the entries per partition and send out batch operations (multiple partitions per member)
-            //noinspection unchecked
-            List<MergingEntryHolder<Data, Data>>[] entriesPerPartition = new List[partitionCount];
-            int recordCount = 0;
-            for (Map.Entry<Data, CacheRecord> entry : recordMap.entrySet()) {
-                recordCount++;
-                Data key = entry.getKey();
-                CacheRecord record = entry.getValue();
-                int partitionId = partitionService.getPartitionId(key);
-                List<MergingEntryHolder<Data, Data>> entries = entriesPerPartition[partitionId];
-                if (entries == null) {
-                    entries = new LinkedList<MergingEntryHolder<Data, Data>>();
-                    entriesPerPartition[partitionId] = entries;
-                }
-
-                Data dataValue = serializationService.toData(record.getValue());
-                MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(key, dataValue, record);
-                entries.add(mergingEntry);
-
-                long currentSize = ++counterPerMember[partitionId].value;
-                if (currentSize % batchSize == 0) {
-                    List<Integer> partitions = memberPartitionsMap.get(addresses[partitionId]);
-                    sendBatch(name, partitions, entriesPerPartition, mergePolicy);
-                }
-            }
-            // invoke operations for remaining entriesPerPartition
-            for (Map.Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
-                sendBatch(name, entry.getValue(), entriesPerPartition, mergePolicy);
-            }
-            return recordCount;
-        }
-
-        private int handleMerge(String cacheName, Map<Data, CacheRecord> recordMap, CacheMergePolicy mergePolicy) {
-            ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object response) {
-                    semaphore.release(1);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    logger.warning("Error while running cache merge operation: " + t.getMessage());
-                    semaphore.release(1);
-                }
-            };
-
-            int recordCount = 0;
-            for (Map.Entry<Data, CacheRecord> entry : recordMap.entrySet()) {
-                recordCount++;
-                Data key = entry.getKey();
-                CacheRecord record = entry.getValue();
-                CacheEntryView<Data, Data> entryView = new DefaultCacheEntryView(
-                        key,
-                        serializationService.toData(record.getValue()),
-                        record.getCreationTime(),
-                        record.getExpirationTime(),
-                        record.getLastAccessTime(),
-                        record.getAccessHit());
-
-                Operation operation = new CacheLegacyMergeOperation(cacheName, key, entryView, mergePolicy);
-                try {
-                    int partitionId = partitionService.getPartitionId(key);
-                    operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                            .andThen(mergeCallback);
-                } catch (Throwable t) {
-                    throw rethrow(t);
-                }
-            }
-            return recordCount;
-        }
-
-        private void sendBatch(String name, List<Integer> memberPartitions,
-                               List<MergingEntryHolder<Data, Data>>[] entriesPerPartition,
-                               SplitBrainMergePolicy mergePolicy) {
-            int size = memberPartitions.size();
-            int[] partitions = new int[size];
-            int index = 0;
-            for (Integer partitionId : memberPartitions) {
-                if (entriesPerPartition[partitionId] != null) {
-                    partitions[index++] = partitionId;
-                }
-            }
-            if (index == 0) {
-                return;
-            }
-            // trim partition array to real size
-            if (index < size) {
-                partitions = Arrays.copyOf(partitions, index);
-                size = index;
-            }
-
-            //noinspection unchecked
-            List<MergingEntryHolder<Data, Data>>[] entries = new List[size];
-            index = 0;
-            int totalSize = 0;
-            for (int partitionId : partitions) {
-                int batchSize = entriesPerPartition[partitionId].size();
-                entries[index++] = entriesPerPartition[partitionId];
-                totalSize += batchSize;
-                entriesPerPartition[partitionId] = null;
-            }
-            if (totalSize == 0) {
-                return;
-            }
-
-            invokeMergeOperationFactory(name, mergePolicy, partitions, entries, totalSize);
-        }
-
-        private void invokeMergeOperationFactory(String name, SplitBrainMergePolicy mergePolicy, int[] partitions,
-                                                 List<MergingEntryHolder<Data, Data>>[] entries, int totalSize) {
-            try {
-                CacheConfig cacheConfig = cacheService.getCacheConfig(name);
-                CacheOperationProvider operationProvider = cacheService.getCacheOperationProvider(name,
-                        cacheConfig.getInMemoryFormat());
-                OperationFactory factory = operationProvider.createMergeOperationFactory(name, partitions, entries, mergePolicy);
-                operationService.invokeOnPartitions(SERVICE_NAME, factory, partitions);
-            } catch (Throwable t) {
-                logger.warning("Error while running cache merge operation: " + t.getMessage());
-                throw rethrow(t);
-            } finally {
-                semaphore.release(totalSize);
-            }
-        }
-
-        @Override
-        public void dispose() {
-            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-                destroySegment(segments[partitionId]);
-            }
-        }
+    public Map<String, CacheConfig> getConfigs() {
+        return configs;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -505,4 +505,10 @@ public interface ICacheRecordStore {
      * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
      */
     CacheRecord merge(MergingEntryHolder<Data, Data> mergingEntry, SplitBrainMergePolicy mergePolicy);
+
+
+    /**
+     * @return partition ID of this store
+     */
+    int getPartitionId();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.impl.AbstractMergeRunnable;
+import com.hazelcast.spi.merge.MergingEntryHolder;
+import com.hazelcast.util.Clock;
+import com.hazelcast.util.function.BiConsumer;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
+import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
+
+class MapMergeRunnable extends AbstractMergeRunnable<RecordStore, MergingEntryHolder<Data, Data>> {
+
+    private final MapServiceContext mapServiceContext;
+    private final MapSplitBrainHandlerService mapSplitBrainHandlerService;
+
+    MapMergeRunnable(Map<String, Collection<RecordStore>> collectedStores,
+                     Map<String, Collection<RecordStore>> collectedStoresWithLegacyPolicies,
+                     Collection<RecordStore> backupStores, MapServiceContext mapServiceContext,
+                     MapSplitBrainHandlerService mapSplitBrainHandlerService) {
+        super(MapService.SERVICE_NAME, collectedStores, collectedStoresWithLegacyPolicies,
+                backupStores, mapServiceContext.getNodeEngine());
+
+        this.mapServiceContext = mapServiceContext;
+        this.mapSplitBrainHandlerService = mapSplitBrainHandlerService;
+    }
+
+    @Override
+    protected void consumeStore(RecordStore store, BiConsumer<Integer, MergingEntryHolder<Data, Data>> consumer) {
+        long now = Clock.currentTimeMillis();
+        int partitionId = store.getPartitionId();
+
+        Iterator<Record> iterator = store.iterator(now, false);
+        while (iterator.hasNext()) {
+            Record record = iterator.next();
+
+            Data dataValue = toData(record.getValue());
+            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(record, dataValue);
+            consumer.accept(partitionId, mergingEntry);
+        }
+    }
+
+    @Override
+    protected void consumeStoreLegacy(RecordStore store, BiConsumer<Integer, Operation> consumer) {
+        long now = Clock.currentTimeMillis();
+        int partitionId = store.getPartitionId();
+        String name = store.getName();
+        MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(name);
+        MapMergePolicy mergePolicy = ((MapMergePolicy) getMergePolicy(name));
+
+        Iterator<Record> iterator = store.iterator(now, false);
+        while (iterator.hasNext()) {
+            Record record = iterator.next();
+            Data key = record.getKey();
+            Data value = toData(record.getValue());
+            EntryView<Data, Data> entryView = createSimpleEntryView(key, value, record);
+
+            Operation operation = operationProvider.createLegacyMergeOperation(name, entryView, mergePolicy, false);
+
+            consumer.accept(partitionId, operation);
+        }
+    }
+
+    @Override
+    protected int getBatchSize(String dataStructureName) {
+        MapConfig mapConfig = mapSplitBrainHandlerService.getMapConfig(dataStructureName);
+        MergePolicyConfig mergePolicyConfig = mapConfig.getMergePolicyConfig();
+        return mergePolicyConfig.getBatchSize();
+    }
+
+    @Override
+    protected InMemoryFormat getInMemoryFormat(String dataStructureName) {
+        MapConfig mapConfig = mapSplitBrainHandlerService.getMapConfig(dataStructureName);
+        return mapConfig.getInMemoryFormat();
+    }
+
+    @Override
+    protected Object getMergePolicy(String dataStructureName) {
+        return mapSplitBrainHandlerService.getMergePolicy(dataStructureName);
+    }
+
+    @Override
+    protected void destroyStores(Collection<RecordStore> stores) {
+        mapSplitBrainHandlerService.destroyStores(stores);
+    }
+
+    @Override
+    protected OperationFactory createMergeOperationFactory(String dataStructureName,
+                                                           SplitBrainMergePolicy mergePolicy,
+                                                           int[] partitions,
+                                                           List<MergingEntryHolder<Data, Data>>[] entries) {
+        MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(dataStructureName);
+        return operationProvider.createMergeOperationFactory(dataStructureName, partitions, entries, mergePolicy);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.event.MapEventPublisher;
@@ -64,6 +65,7 @@ import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataType;
 import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
@@ -132,7 +134,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final AtomicInteger writeBehindQueueItemCounter = new AtomicInteger(0);
 
     protected final NodeEngine nodeEngine;
-    protected final SerializationService serializationService;
+    protected final InternalSerializationService serializationService;
     protected final ConstructorFunction<String, MapContainer> mapConstructor;
     protected final PartitionContainer[] partitionContainers;
     protected final ExpirationManager expirationManager;
@@ -155,7 +157,7 @@ class MapServiceContextImpl implements MapServiceContext {
 
     MapServiceContextImpl(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        this.serializationService = nodeEngine.getSerializationService();
+        this.serializationService = ((InternalSerializationService) nodeEngine.getSerializationService());
         this.mapConstructor = createMapConstructor();
         this.queryCacheContext = new NodeQueryCacheContext(this);
         this.partitionContainers = createPartitionContainers();
@@ -522,7 +524,7 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public Data toData(Object object) {
-        return serializationService.toData(object);
+        return serializationService.toData(object, DataType.HEAP);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -16,335 +16,76 @@
 
 package com.hazelcast.map.impl;
 
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MergePolicyConfig;
-import com.hazelcast.core.EntryView;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.map.impl.operation.MapOperationProvider;
-import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
-import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.map.merge.MergePolicyProvider;
-import com.hazelcast.nio.Address;
-import com.hazelcast.nio.Disposable;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationFactory;
-import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.SplitBrainHandlerService;
-import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.DiscardMergePolicy;
-import com.hazelcast.spi.merge.MergingEntryHolder;
-import com.hazelcast.spi.partition.IPartitionService;
-import com.hazelcast.util.Clock;
-import com.hazelcast.util.MutableLong;
+import com.hazelcast.spi.impl.AbstractSplitBrainHandlerService;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
-import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.MapUtil.createHashMap;
+import static java.util.Collections.singletonList;
 
-class MapSplitBrainHandlerService implements SplitBrainHandlerService {
+class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<RecordStore> {
 
-    protected static final long TIMEOUT_FACTOR = 500;
-
-    protected final int partitionCount;
-    protected final ILogger logger;
-    protected final NodeEngine nodeEngine;
-    protected final OperationService operationService;
-    protected final IPartitionService partitionService;
-    protected final MapServiceContext mapServiceContext;
-    protected final MergePolicyProvider mergePolicyProvider;
+    private final MapServiceContext mapServiceContext;
+    private final MergePolicyProvider mergePolicyProvider;
 
     MapSplitBrainHandlerService(MapServiceContext mapServiceContext) {
+        super(mapServiceContext.getNodeEngine());
         this.mapServiceContext = mapServiceContext;
-        this.nodeEngine = mapServiceContext.getNodeEngine();
-        this.logger = nodeEngine.getLogger(getClass());
-        this.partitionService = nodeEngine.getPartitionService();
-        this.partitionCount = partitionService.getPartitionCount();
         this.mergePolicyProvider = mapServiceContext.getMergePolicyProvider();
-        this.operationService = nodeEngine.getOperationService();
     }
 
     @Override
-    public Runnable prepareMergeRunnable() {
-        long now = Clock.currentTimeMillis();
-
-        Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
-        Map<MapContainer, Collection<Record>> recordMap = createHashMap(mapContainers.size());
-
-        for (MapContainer mapContainer : mapContainers.values()) {
-            MapConfig mapConfig = mapContainer.getMapConfig();
-            InMemoryFormat inMemoryFormat = mapConfig.getInMemoryFormat();
-            if (inMemoryFormat == NATIVE
-                    && nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                logger.warning("Split-brain recovery can not be applied NATIVE in-memory-formatted map ["
-                        + mapContainer.name + ']');
-
-                continue;
-            }
-
-            Object mergePolicy = getMergePolicy(mapConfig.getMergePolicyConfig());
-            boolean mergePartitionData = !(mergePolicy instanceof IgnoreMergingEntryMapMergePolicy)
-                    && !(mergePolicy instanceof DiscardMergePolicy);
-
-            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-                RecordStore<Record> recordStore = getOrNullRecordStore(mapContainer.name, inMemoryFormat, partitionId);
-                if (recordStore == null) {
-                    continue;
-                }
-                // add your owned entries to the map so they will be merged
-                if (mergePartitionData && partitionService.isPartitionOwner(partitionId)) {
-                    Collection<Record> records = recordMap.get(mapContainer);
-                    if (records == null) {
-                        records = new LinkedList<Record>();
-                        recordMap.put(mapContainer, records);
-                    }
-                    Iterator<Record> iterator = recordStore.iterator(now, false);
-                    while (iterator.hasNext()) {
-                        records.add(iterator.next());
-                    }
-                }
-            }
-        }
-
-        return new Merger(recordMap);
+    protected Runnable newMergeRunnable(Map<String, Collection<RecordStore>> collectedStores,
+                                        Map<String, Collection<RecordStore>> collectedStoresWithLegacyPolicies,
+                                        Collection<RecordStore> backupStores,
+                                        NodeEngine nodeEngine) {
+        return new MapMergeRunnable(collectedStores, collectedStoresWithLegacyPolicies,
+                backupStores, mapServiceContext, this);
     }
 
-    // overridden on ee
-    protected void destroyRecordStores(Collection<RecordStore> recordStores) {
-        Iterator<RecordStore> iterator = recordStores.iterator();
-        while (iterator.hasNext()) {
-            RecordStore recordStore = iterator.next();
-            try {
-                recordStore.getMapContainer().getIndexes(recordStore.getPartitionId()).clearIndexes();
-                recordStore.destroy();
-            } finally {
-                iterator.remove();
-            }
-        }
+    @Override
+    protected String getDataStructureName(RecordStore recordStore) {
+        return recordStore.getName();
     }
 
-    // overridden on ee
-    protected RecordStore<Record> getOrNullRecordStore(String mapName, InMemoryFormat inMemoryFormat, int partitionId) {
+    @Override
+    protected Object getMergePolicy(String dataStructureName) {
+        MapConfig mapConfig = getMapConfig(dataStructureName);
+        MergePolicyConfig mergePolicyConfig = mapConfig.getMergePolicyConfig();
+        return mergePolicyProvider.getMergePolicy(mergePolicyConfig.getPolicy());
+    }
+
+    @Override
+    protected boolean isDiscardPolicy(Object mergePolicy) {
+        return mergePolicy instanceof IgnoreMergingEntryMapMergePolicy
+                || super.isDiscardPolicy(mergePolicy);
+    }
+
+    @Override
+    protected Collection<Iterator<RecordStore>> iteratorsOf(int partitionId) {
         PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
-        //noinspection unchecked
-        RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
-        if (recordStore == null) {
-            return null;
-        }
-
-        return (RecordStore<Record>) recordStore;
+        Collection<RecordStore> recordStores = partitionContainer.getAllRecordStores();
+        return singletonList(recordStores.iterator());
     }
 
-    private Object getMergePolicy(MergePolicyConfig config) {
-        return mergePolicyProvider.getMergePolicy(config.getPolicy());
+    @Override
+    protected void destroyStore(RecordStore store) {
+        assert store.getMapContainer().getMapConfig().getInMemoryFormat() != NATIVE;
+
+        store.getMapContainer().getIndexes(store.getPartitionId()).clearIndexes();
+        store.destroy();
     }
 
-    // TODO traverse over recordstores not copy to heap eagerly
-    private class Merger implements Runnable, Disposable {
-
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ILogger logger = nodeEngine.getLogger(MapSplitBrainHandlerService.class);
-
-        private final Map<MapContainer, Collection<Record>> recordMap;
-
-        Merger(Map<MapContainer, Collection<Record>> recordMap) {
-            this.recordMap = recordMap;
-        }
-
-        @Override
-        public void run() {
-            int recordCount = 0;
-            for (Map.Entry<MapContainer, Collection<Record>> recordMapEntry : recordMap.entrySet()) {
-                MapContainer mapContainer = recordMapEntry.getKey();
-                Collection<Record> recordList = recordMapEntry.getValue();
-
-                String mapName = mapContainer.getName();
-                MergePolicyConfig mergePolicyConfig = mapContainer.getMapConfig().getMergePolicyConfig();
-                Object mergePolicy = getMergePolicy(mergePolicyConfig);
-                if (mergePolicy instanceof SplitBrainMergePolicy) {
-                    // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperationFactory
-                    // RU_COMPAT_3_9
-                    if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                        logger.info("Cannot merge map '" + mapName + "' with merge policy '" + mergePolicyConfig.getPolicy()
-                                + "' until cluster is running version " + Versions.V3_10);
-                        continue;
-                    }
-                    int batchSize = mergePolicyConfig.getBatchSize();
-                    recordCount += handleMerge(mapName, recordList, (SplitBrainMergePolicy) mergePolicy, batchSize);
-                } else {
-                    recordCount += handleMerge(mapName, recordList, (MapMergePolicy) mergePolicy);
-                }
-            }
-            recordMap.clear();
-
-            try {
-                if (!semaphore.tryAcquire(recordCount, recordCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for maps didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of maps...");
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        private int handleMerge(String name, Collection<Record> recordList, SplitBrainMergePolicy mergePolicy, int batchSize) {
-            Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
-
-            // create a mapping between partition IDs and
-            // a) an entry counter per member (a batch operation is sent out once this counter matches the batch size)
-            // b) the member address (so we can retrieve the target address from the current partition ID)
-            MutableLong[] counterPerMember = new MutableLong[partitionCount];
-            Address[] addresses = new Address[partitionCount];
-            for (Map.Entry<Address, List<Integer>> addressListEntry : memberPartitionsMap.entrySet()) {
-                MutableLong counter = new MutableLong();
-                Address address = addressListEntry.getKey();
-                for (int partitionId : addressListEntry.getValue()) {
-                    counterPerMember[partitionId] = counter;
-                    addresses[partitionId] = address;
-                }
-            }
-
-            // sort the entries per partition and send out batch operations (multiple partitions per member)
-            //noinspection unchecked
-            List<MergingEntryHolder<Data, Data>>[] entriesPerPartition = new List[partitionCount];
-            int recordCount = 0;
-            for (Record record : recordList) {
-                recordCount++;
-                int partitionId = partitionService.getPartitionId(record.getKey());
-                List<MergingEntryHolder<Data, Data>> entries = entriesPerPartition[partitionId];
-                if (entries == null) {
-                    entries = new LinkedList<MergingEntryHolder<Data, Data>>();
-                    entriesPerPartition[partitionId] = entries;
-                }
-
-                Data dataValue = mapServiceContext.toData(record.getValue());
-                MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(record, dataValue);
-                entries.add(mergingEntry);
-
-                long currentSize = ++counterPerMember[partitionId].value;
-                if (currentSize % batchSize == 0) {
-                    List<Integer> partitions = memberPartitionsMap.get(addresses[partitionId]);
-                    sendBatch(name, partitions, entriesPerPartition, mergePolicy);
-                }
-            }
-            // invoke operations for remaining entriesPerPartition
-            for (Map.Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
-                sendBatch(name, entry.getValue(), entriesPerPartition, mergePolicy);
-            }
-            return recordCount;
-        }
-
-        private int handleMerge(String name, Collection<Record> recordList, MapMergePolicy mergePolicy) {
-            ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object response) {
-                    semaphore.release(1);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    logger.warning("Error while running map merge operation: " + t.getMessage());
-                    semaphore.release(1);
-                }
-            };
-            MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(name);
-
-            int recordCount = 0;
-            for (Record record : recordList) {
-                recordCount++;
-                Data key = record.getKey();
-                Data value = mapServiceContext.toData(record.getValue());
-                EntryView<Data, Data> entryView = createSimpleEntryView(key, value, record);
-
-                Operation operation = operationProvider.createLegacyMergeOperation(name, entryView, mergePolicy, false);
-                try {
-                    int partitionId = partitionService.getPartitionId(key);
-                    operationService
-                            .invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                            .andThen(mergeCallback);
-                } catch (Throwable t) {
-                    throw rethrow(t);
-                }
-            }
-            return recordCount;
-        }
-
-        private void sendBatch(String name, List<Integer> memberPartitions,
-                               List<MergingEntryHolder<Data, Data>>[] entriesPerPartition,
-                               SplitBrainMergePolicy mergePolicy) {
-            int size = memberPartitions.size();
-            int[] partitions = new int[size];
-            int index = 0;
-            for (Integer partitionId : memberPartitions) {
-                if (entriesPerPartition[partitionId] != null) {
-                    partitions[index++] = partitionId;
-                }
-            }
-            if (index == 0) {
-                return;
-            }
-            // trim partition array to real size
-            if (index < size) {
-                partitions = Arrays.copyOf(partitions, index);
-                size = index;
-            }
-
-            //noinspection unchecked
-            List<MergingEntryHolder<Data, Data>>[] entries = new List[size];
-            index = 0;
-            int totalSize = 0;
-            for (int partitionId : partitions) {
-                int batchSize = entriesPerPartition[partitionId].size();
-                entries[index++] = entriesPerPartition[partitionId];
-                totalSize += batchSize;
-                entriesPerPartition[partitionId] = null;
-            }
-            if (totalSize == 0) {
-                return;
-            }
-
-            invokeMergeOperationFactory(name, mergePolicy, partitions, entries, totalSize);
-        }
-
-        private void invokeMergeOperationFactory(String name, SplitBrainMergePolicy mergePolicy, int[] partitions,
-                                                 List<MergingEntryHolder<Data, Data>>[] entries, int totalSize) {
-            try {
-                MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(name);
-                OperationFactory factory = operationProvider.createMergeOperationFactory(name, partitions, entries, mergePolicy);
-                operationService.invokeOnPartitions(SERVICE_NAME, factory, partitions);
-            } catch (Throwable t) {
-                logger.warning("Error while running map merge operation: " + t.getMessage());
-                throw rethrow(t);
-            } finally {
-                semaphore.release(totalSize);
-            }
-        }
-
-        @Override
-        public void dispose() {
-            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-                PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
-                Collection<RecordStore> recordStores = partitionContainer.getAllRecordStores();
-                destroyRecordStores(recordStores);
-            }
-        }
+    public MapConfig getMapConfig(String dataStructureName) {
+        MapContainer mapContainer = mapServiceContext.getMapContainer(dataStructureName);
+        return mapContainer.getMapConfig();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractMergeRunnable.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Disposable;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.partition.IPartitionService;
+import com.hazelcast.util.MutableLong;
+import com.hazelcast.util.function.BiConsumer;
+import com.hazelcast.version.Version;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Used by both {@link com.hazelcast.cache.ICache} and {@link com.hazelcast.core.IMap}
+ * to provide a shared merge runnable for {@link SplitBrainHandlerService#prepareMergeRunnable()}
+ *
+ * @param <Store> type of the store in a partition
+ */
+public abstract class AbstractMergeRunnable<Store, MergingItem> implements Runnable, Disposable {
+
+    private static final long TIMEOUT_FACTOR = 500;
+
+    private final ILogger logger;
+    private final String serviceName;
+    private final ClusterService clusterService;
+    private final InternalSerializationService ss;
+    private final OperationService operationService;
+    private final IPartitionService partitionService;
+    private final Collection<Store> backupStores;
+    private final Map<String, Collection<Store>> collectedStores;
+    private final Map<String, Collection<Store>> collectedStoresWithLegacyPolicies;
+    private final Semaphore semaphore = new Semaphore(0);
+
+    protected AbstractMergeRunnable(String serviceName, Map<String, Collection<Store>> collectedStores,
+                                    Map<String, Collection<Store>> collectedStoresWithLegacyPolicies,
+                                    Collection<Store> backupStores, NodeEngine nodeEngine) {
+
+        this.serviceName = serviceName;
+        this.logger = nodeEngine.getLogger(getClass());
+        this.partitionService = nodeEngine.getPartitionService();
+        this.clusterService = nodeEngine.getClusterService();
+        this.operationService = nodeEngine.getOperationService();
+        this.ss = (InternalSerializationService) nodeEngine.getSerializationService();
+        this.backupStores = backupStores;
+        this.collectedStores = collectedStores;
+        this.collectedStoresWithLegacyPolicies = collectedStoresWithLegacyPolicies;
+    }
+
+    @Override
+    public final void run() {
+        int mergedCount = 0;
+
+        mergedCount += mergeWithSplitBrainMergePolicy();
+        mergedCount += mergeWithLegacyMergePolicy();
+
+        waitMergeEnd(mergedCount);
+    }
+
+    private int mergeWithSplitBrainMergePolicy() {
+        int mergedCount = 0;
+        for (Map.Entry<String, Collection<Store>> entry : collectedStores.entrySet()) {
+            String dataStructureName = entry.getKey();
+            Collection<Store> recordStores = entry.getValue();
+
+            SplitBrainMergePolicy mergePolicy = ((SplitBrainMergePolicy) getMergePolicy(dataStructureName));
+            if (!isClusterVersion310OrLater(dataStructureName, mergePolicy)) {
+                continue;
+            }
+
+            int batchSize = getBatchSize(dataStructureName);
+            MergingItemBiConsumer consumer = new MergingItemBiConsumer(dataStructureName, mergePolicy, batchSize);
+
+            for (Store recordStore : recordStores) {
+                consumeStore(recordStore, consumer);
+            }
+
+            consumer.consumeRemaining();
+
+            mergedCount += consumer.mergedCount;
+        }
+        return mergedCount;
+    }
+
+    private boolean isClusterVersion310OrLater(String dataStructureName, SplitBrainMergePolicy policy) {
+        Version v310 = V3_10;
+        Version currentVersion = clusterService.getClusterVersion();
+
+        if (currentVersion.isGreaterOrEqual(v310)) {
+            return true;
+        }
+        // RU_COMPAT_3_9
+        String msg = "Cannot merge '%s' with merge policy '%s'."
+                + " Cluster version should be %s or later but found %s";
+        logger.info(format(msg, dataStructureName, policy, v310, currentVersion));
+
+        return false;
+    }
+
+    private int mergeWithLegacyMergePolicy() {
+        LegacyOperationBiConsumer consumer = new LegacyOperationBiConsumer();
+
+        for (Map.Entry<String, Collection<Store>> entry : collectedStoresWithLegacyPolicies.entrySet()) {
+            String dataStructureName = entry.getKey();
+            Collection<Store> recordStores = entry.getValue();
+
+            if (!canLegacyMergeInMemoryFormat(dataStructureName)) {
+                continue;
+            }
+
+            for (Store recordStore : recordStores) {
+                consumeStoreLegacy(recordStore, consumer);
+            }
+        }
+
+        return consumer.mergedCount;
+    }
+
+    private boolean canLegacyMergeInMemoryFormat(String dataStructureName) {
+        InMemoryFormat inMemoryFormat = getInMemoryFormat(dataStructureName);
+
+        if (inMemoryFormat != NATIVE) {
+            return true;
+        }
+
+        String msg = "Split brain recovery is not supported for '%s'."
+                + " Because its using legacy merge policy `%s` to merge `%s` data."
+                + " To fix this, use a type of `%s` with a cluster version `%s` or later";
+
+        Object mergePolicy = getMergePolicy(dataStructureName);
+        logger.warning(format(msg, dataStructureName, mergePolicy.getClass().getName(),
+                NATIVE, SplitBrainMergePolicy.class.getName(), V3_10));
+
+        return false;
+    }
+
+    private void waitMergeEnd(int mergedCount) {
+        try {
+            if (!semaphore.tryAcquire(mergedCount, mergedCount * TIMEOUT_FACTOR, MILLISECONDS)) {
+                logger.warning("Split-brain healing didn't finish within the timeout...");
+            }
+        } catch (InterruptedException e) {
+            logger.finest("Interrupted while waiting for split-brain healing...");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Consumer to use when a {@link SplitBrainMergePolicy} type is used
+     */
+    private class MergingItemBiConsumer implements BiConsumer<Integer, MergingItem> {
+
+        private final int batchSize;
+        private final int partitionCount;
+        private final String dataStructureName;
+        private final Address[] addresses;
+        private final MutableLong[] counterPerMember;
+        private final SplitBrainMergePolicy mergePolicy;
+        private final List<MergingItem>[] mergingItemsPerPartition;
+        private final Map<Address, List<Integer>> memberPartitionsMap;
+
+        private int mergedCount;
+
+        MergingItemBiConsumer(String dataStructureName,
+                              SplitBrainMergePolicy mergePolicy, int batchSize) {
+            this.dataStructureName = dataStructureName;
+            this.batchSize = batchSize;
+            this.mergePolicy = mergePolicy;
+            this.memberPartitionsMap = partitionService.getMemberPartitionsMap();
+            this.partitionCount = partitionService.getPartitionCount();
+            this.addresses = new Address[partitionCount];
+            this.counterPerMember = new MutableLong[partitionCount];
+            this.mergingItemsPerPartition = (List<MergingItem>[]) new List[partitionCount];
+
+            init();
+        }
+
+        private void init() {
+            // create a mapping between partition IDs and
+            // a) an entry counter per member (a batch operation is sent out
+            //    once this counter matches the batch size)
+            // b) the member address (so we can retrieve the target address
+            //    from the current partition ID)
+            for (Map.Entry<Address, List<Integer>> addressListEntry : memberPartitionsMap.entrySet()) {
+                MutableLong counter = new MutableLong();
+                Address address = addressListEntry.getKey();
+                for (int partitionId : addressListEntry.getValue()) {
+                    counterPerMember[partitionId] = counter;
+                    addresses[partitionId] = address;
+                }
+            }
+        }
+
+        @Override
+        public void accept(Integer partitionId, MergingItem mergingItem) {
+            List<MergingItem> entries = mergingItemsPerPartition[partitionId];
+            if (entries == null) {
+                entries = new LinkedList<MergingItem>();
+                mergingItemsPerPartition[partitionId] = entries;
+            }
+
+            entries.add(mergingItem);
+            mergedCount++;
+
+            long currentSize = ++counterPerMember[partitionId].value;
+            if (currentSize % batchSize == 0) {
+                List<Integer> partitions = memberPartitionsMap.get(addresses[partitionId]);
+                sendBatch(dataStructureName, partitions, mergingItemsPerPartition, mergePolicy);
+            }
+        }
+
+        private void consumeRemaining() {
+            for (Map.Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
+                sendBatch(dataStructureName, entry.getValue(), mergingItemsPerPartition, mergePolicy);
+            }
+        }
+    }
+
+    /**
+     * Consumer to use with legacy merge operations
+     */
+    private class LegacyOperationBiConsumer implements BiConsumer<Integer, Operation> {
+
+        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                semaphore.release(1);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                logger.warning("Error while running merge operation: " + t.getMessage());
+                semaphore.release(1);
+            }
+        };
+
+        private int mergedCount;
+
+        @Override
+        public void accept(Integer partitionId, Operation operation) {
+            try {
+                operationService.invokeOnPartition(serviceName, operation, partitionId)
+                        .andThen(mergeCallback);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+
+            mergedCount++;
+        }
+
+    }
+
+    private void sendBatch(String dataStructureName, List<Integer> memberPartitions,
+                           List<MergingItem>[] entriesPerPartition,
+                           SplitBrainMergePolicy mergePolicy) {
+        int size = memberPartitions.size();
+        int[] partitions = new int[size];
+        int index = 0;
+        for (Integer partitionId : memberPartitions) {
+            if (entriesPerPartition[partitionId] != null) {
+                partitions[index++] = partitionId;
+            }
+        }
+        if (index == 0) {
+            return;
+        }
+        // trim partition array to real size
+        if (index < size) {
+            partitions = Arrays.copyOf(partitions, index);
+            size = index;
+        }
+
+        //noinspection unchecked
+        List<MergingItem>[] entries = new List[size];
+        index = 0;
+        int totalSize = 0;
+        for (int partitionId : partitions) {
+            int batchSize = entriesPerPartition[partitionId].size();
+            entries[index++] = entriesPerPartition[partitionId];
+            totalSize += batchSize;
+            entriesPerPartition[partitionId] = null;
+        }
+        if (totalSize == 0) {
+            return;
+        }
+
+        sendMergingData(dataStructureName, mergePolicy, partitions, entries, totalSize);
+    }
+
+    private void sendMergingData(String dataStructureName, SplitBrainMergePolicy mergePolicy,
+                                 int[] partitions, List<MergingItem>[] entries, int totalSize) {
+        try {
+            OperationFactory factory
+                    = createMergeOperationFactory(dataStructureName, mergePolicy, partitions, entries);
+            operationService.invokeOnPartitions(serviceName, factory, partitions);
+        } catch (Throwable t) {
+            logger.warning("Error while running merge operation: " + t.getMessage());
+            throw rethrow(t);
+        } finally {
+            semaphore.release(totalSize);
+        }
+    }
+
+    @Override
+    public final void dispose() {
+        for (Collection<Store> stores : collectedStores.values()) {
+            destroyStores(stores);
+        }
+
+        for (Collection<Store> stores : collectedStoresWithLegacyPolicies.values()) {
+            destroyStores(stores);
+        }
+
+        destroyStores(backupStores);
+    }
+
+    protected Data toData(Object object) {
+        return ss.toData(object);
+    }
+
+    /**
+     * Destroy a collection of stores
+     */
+    protected abstract void destroyStores(Collection<Store> stores);
+
+    /**
+     * Use to merge with policies which are a type of {@link SplitBrainMergePolicy}
+     */
+    protected abstract void consumeStore(Store recordStore, BiConsumer<Integer, MergingItem> consumer);
+
+    /**
+     * Use to merge with legacy merge policies
+     */
+    protected abstract void consumeStoreLegacy(Store recordStore, BiConsumer<Integer, Operation> consumer);
+
+    /**
+     * This batch size can only be used when merge policy is
+     * a type of {@link SplitBrainMergePolicy}, legacy merge policies
+     * don't support batch data sending.
+     *
+     * @return batch size from {@link com.hazelcast.config.MergePolicyConfig}
+     */
+    protected abstract int getBatchSize(String dataStructureName);
+
+    /**
+     * @return a type of {@link SplitBrainMergePolicy} or a legacy merge policy
+     */
+    protected abstract Object getMergePolicy(String dataStructureName);
+
+    /**
+     * @return in memory format of data structure
+     */
+    protected abstract InMemoryFormat getInMemoryFormat(String dataStructureName);
+
+    /**
+     * Returned {@link OperationFactory} is used for
+     * {@link SplitBrainMergePolicy} types, legacy ones don't use this method.
+     *
+     * @return a new operation factory
+     */
+    protected abstract OperationFactory createMergeOperationFactory(String dataStructureName,
+                                                                    SplitBrainMergePolicy mergePolicy,
+                                                                    int[] partitions,
+                                                                    List<MergingItem>[] entries);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractSplitBrainHandlerService.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.partition.IPartitionService;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains common functionality to implement a {@link SplitBrainHandlerService}
+ *
+ * @param <Store> store of a partition
+ */
+public abstract class AbstractSplitBrainHandlerService<Store> implements SplitBrainHandlerService {
+
+    private final int partitionCount;
+    private final NodeEngine nodeEngine;
+    private final IPartitionService partitionService;
+
+    protected AbstractSplitBrainHandlerService(NodeEngine nodeEngine) {
+        this.nodeEngine = nodeEngine;
+        this.partitionService = nodeEngine.getPartitionService();
+        this.partitionCount = partitionService.getPartitionCount();
+    }
+
+    @Override
+    public final Runnable prepareMergeRunnable() {
+        onPrepareMergeRunnableStart();
+
+        Map<String, Collection<Store>> collectedStores = new HashMap<String, Collection<Store>>();
+        Map<String, Collection<Store>> collectedStoresWithLegacyPolicies = new HashMap<String, Collection<Store>>();
+        List<Store> backupStores = new LinkedList<Store>();
+
+        LinkedList<String> mergingDataStructureNames = new LinkedList<String>();
+
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+            boolean partitionOwner = partitionService.isPartitionOwner(partitionId);
+            Collection<Iterator<Store>> iterators = iteratorsOf(partitionId);
+            for (Iterator<Store> iterator : iterators) {
+                while (iterator.hasNext()) {
+                    Store store = iterator.next();
+
+                    if (partitionOwner) {
+                        String dataStructureName = getDataStructureName(store);
+                        Object mergePolicy = getMergePolicy(dataStructureName);
+
+                        if (!isDiscardPolicy(mergePolicy)) {
+
+                            if (mergePolicy instanceof SplitBrainMergePolicy) {
+                                copyToCollectedStores(store, collectedStores);
+                            } else {
+                                copyToCollectedStores(store, collectedStoresWithLegacyPolicies);
+                            }
+
+                            mergingDataStructureNames.add(dataStructureName);
+                        }
+                    } else {
+                        backupStores.add(store);
+                    }
+
+                    iterator.remove();
+                }
+            }
+        }
+
+        onPrepareMergeRunnableEnd(mergingDataStructureNames);
+
+        return newMergeRunnable(collectedStores, collectedStoresWithLegacyPolicies, backupStores, nodeEngine);
+    }
+
+    protected void onPrepareMergeRunnableStart() {
+        // NOP intentionally, implementations can override this method
+    }
+
+    protected void onPrepareMergeRunnableEnd(Collection<String> dataStructureNames) {
+        // NOP intentionally, implementations can override this method
+    }
+
+    protected boolean isDiscardPolicy(Object mergePolicy) {
+        return mergePolicy instanceof DiscardMergePolicy;
+    }
+
+    // overridden on ee
+    public void destroyStores(Collection<Store> recordStores) {
+        Iterator<Store> iterator = recordStores.iterator();
+        while (iterator.hasNext()) {
+            try {
+                destroyStore(iterator.next());
+            } finally {
+                iterator.remove();
+            }
+        }
+    }
+
+    private void copyToCollectedStores(Store store, Map<String, Collection<Store>> collectedStores) {
+        String dataStructureName = getDataStructureName(store);
+
+        Collection<Store> stores = collectedStores.get(dataStructureName);
+        if (stores == null) {
+            stores = new LinkedList<Store>();
+            collectedStores.put(dataStructureName, stores);
+        }
+
+        stores.add(store);
+    }
+
+    /**
+     * Destroys provided store
+     */
+    protected abstract void destroyStore(Store store);
+
+    /**
+     * @return name of the data structure
+     */
+    protected abstract String getDataStructureName(Store store);
+
+    /**
+     * @return merge policy for the data structure
+     */
+    protected abstract Object getMergePolicy(String dataStructureName);
+
+    /**
+     * @return collection of iterators to scan data in the partition
+     */
+    protected abstract Collection<Iterator<Store>> iteratorsOf(int partitionId);
+
+    /**
+     * @return new merge runnable
+     */
+    protected abstract Runnable newMergeRunnable(Map<String, Collection<Store>> collectedStores,
+                                                 Map<String, Collection<Store>> collectedStoresWithLegacyPolicies,
+                                                 Collection<Store> backupStores,
+                                                 NodeEngine nodeEngine);
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -21,8 +21,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.test.backup.BackupAccessor;
-import com.hazelcast.test.backup.TestBackupUtils;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
 import com.hazelcast.spi.merge.HigherHitsMergePolicy;
@@ -34,6 +32,8 @@ import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.backup.BackupAccessor;
+import com.hazelcast.test.backup.TestBackupUtils;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -70,6 +70,8 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("WeakerAccess")
 public class MapSplitBrainTest extends SplitBrainTestSupport {
 
+    private static final int[] BRAINS = new int[]{3, 3};
+
     @Parameters(name = "format:{0}, mergePolicy:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
@@ -101,6 +103,11 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
     private BackupAccessor<Object, Object> backupMapA;
     private BackupAccessor<Object, Object> backupMapB;
     private MergeLifecycleListener mergeLifecycleListener;
+
+    @Override
+    protected int[] brains() {
+        return BRAINS;
+    }
 
     @Override
     protected Config config() {


### PR DESCRIPTION
- Unify icache and imap merging related codes under `AbstractMergeRunnable` and `AbstractSplitBrainHandlerService`
- Remove record stores from partition containers and destroy them during dispose
- Iterate over record stores to get records instead of eager copying them to heap
- Cleanup CacheSplitBrainHandlerService

ee part: https://github.com/hazelcast/hazelcast-enterprise/pull/1926