### PR TITLE
Improve logging factories creation and sharing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
@@ -19,9 +19,35 @@ package com.hazelcast.logging;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.util.StringUtil;
 
+/**
+ * Provides static utilities to access the global shared logging machinery.
+ * <p>
+ * Note: if possible, avoid logging in the global shared context exposed by the utilities of this class,
+ * use {@link LoggingService} instead.
+ */
 public final class Logger {
 
+    /**
+     * The goal of this field is to share the common global factory instance to allow access to it from the static context and
+     * from the {@link LoggingService} context.
+     * <ul>
+     * <li>If the class of the factory is configured using {@code hazelcast.logging.class} in {@link System#getProperties}, all
+     * {@link com.hazelcast.core.HazelcastInstance HazelcastInstance}s will share this single instance.
+     * <li>If the type of the factory is configured using {@code hazelcast.logging.type} in {@link System#getProperties} and
+     * {@link #getLogger(String) getLogger} is invoked before the first call to {@link #newLoggerFactory}, all
+     * {@link com.hazelcast.core.HazelcastInstance HazelcastInstance}s that have the same logging type configured will share
+     * this single instance.
+     * <li>If the first invocation of {@link #newLoggerFactory} is done before a call to {@link #getLogger(String) getLogger},
+     * this field will store a factory constructed during this first invocation of {@link #newLoggerFactory}, which is typically
+     * done during the construction of the first {@link com.hazelcast.core.HazelcastInstance HazelcastInstance}. In this case,
+     * this factory instance will be shared with all {@link com.hazelcast.core.HazelcastInstance HazelcastInstance}s having the
+     * same logging type configured, all other {@link com.hazelcast.core.HazelcastInstance HazelcastInstance}s will receive their
+     * own logging factories.
+     * </ul>
+     */
     private static volatile LoggerFactory loggerFactory;
+
+    private static String loggerFactoryClassOrType;
 
     private static final Object FACTORY_LOCK = new Object();
 
@@ -29,97 +55,187 @@ public final class Logger {
     }
 
     /**
-     * @param clazz class to take the logger name from
-     * @return the logger
-     * Use LoggingService instead if possible. Do not log in static context if possible.
+     * Obtains a {@link ILogger logger} for the given {@code clazz}.
+     *
+     * @param clazz the class to obtain the logger for.
+     * @return the obtained logger.
      */
     public static ILogger getLogger(Class clazz) {
         return getLogger(clazz.getName());
     }
 
     /**
-     * @param name name of the logger
-     * @return the logger
-     * Use LoggingService instead if possible. Do not log in static context if possible.
+     * Obtains a {@link ILogger logger} of the given {@code name}.
+     *
+     * @param name the name of the logger to obtain.
+     * @return the obtained logger.
      */
     public static ILogger getLogger(String name) {
-        LoggerFactory loggerFactoryToUse = loggerFactory;
-        // fast-track when factory is initialized
-        if (loggerFactoryToUse != null) {
-            return loggerFactoryToUse.getLogger(name);
+        // try the fast path first
+        LoggerFactory existingFactory = loggerFactory;
+        if (existingFactory != null) {
+            return existingFactory.getLogger(name);
         }
 
         synchronized (FACTORY_LOCK) {
-            if (loggerFactory == null) {
-                // init static logger with user-specified custom logger class
-                String loggerClass = System.getProperty("hazelcast.logging.class");
-                if (!StringUtil.isNullOrEmpty(loggerClass)) {
-                    // ok, there is a custom logging factory class -> let's use it now and store it for next time
-                    loggerFactoryToUse = loadLoggerFactory(loggerClass);
-                    loggerFactory = loggerFactoryToUse;
-                } else {
-                    String loggerType = System.getProperty("hazelcast.logging.type");
-                    loggerFactoryToUse = newLoggerFactory(loggerType);
-                    // store the factory only when the type was set explicitly. we do not want to store default type.
-                    if (!StringUtil.isNullOrEmpty(loggerType)) {
-                        loggerFactory = loggerFactoryToUse;
-                    }
+            existingFactory = loggerFactory;
+            if (existingFactory != null) {
+                return existingFactory.getLogger(name);
+            }
+
+            LoggerFactory createdFactory = null;
+
+            final String loggingClass = System.getProperty("hazelcast.logging.class");
+            if (!StringUtil.isNullOrEmpty(loggingClass)) {
+                createdFactory = tryToCreateLoggerFactory(loggingClass);
+            }
+
+            if (createdFactory != null) {
+                // hazelcast.logging.class property overrides everything, so it's safe to store the factory for reuse
+                loggerFactory = createdFactory;
+                loggerFactoryClassOrType = loggingClass;
+            } else {
+                final String loggingType = System.getProperty("hazelcast.logging.type");
+                createdFactory = createLoggerFactory(loggingType);
+
+                if (!StringUtil.isNullOrEmpty(loggingType)) {
+                    // hazelcast.logging.type property is the recommended way of configuring the logging, in most setups
+                    // the configured value should match with the value passed to newLoggerFactory(), so we store the created
+                    // factory for reuse
+                    loggerFactory = createdFactory;
+                    loggerFactoryClassOrType = loggingType;
                 }
             }
+
+            return createdFactory.getLogger(name);
         }
-        // loggerFactory was initialized by other thread before we acquired the lock -> loggerFactoryToUse was left to null
-        if (loggerFactoryToUse == null) {
-            loggerFactoryToUse = loggerFactory;
-        }
-        return loggerFactoryToUse.getLogger(name);
     }
 
+    /**
+     * @return the no operation logger, which ignores all logging requests.
+     */
     public static ILogger noLogger() {
         return new NoLogFactory.NoLogger();
     }
 
-    @SuppressWarnings("checkstyle:npathcomplexity")
-    public static LoggerFactory newLoggerFactory(String loggerType) {
-        LoggerFactory loggerFactory = null;
-        String loggerClass = System.getProperty("hazelcast.logging.class");
-        if (loggerClass != null) {
-            loggerFactory = loadLoggerFactory(loggerClass);
-        }
+    /**
+     * Creates a {@link LoggerFactory logger factory} instance of the given preferred type.
+     * <p>
+     * The type of the created logger factory doesn't necessarily match the given preferred type. For example, if
+     * {@code hazelcast.logging.class} system property is set, the configured logger factory class will be used
+     * despite the given preferred type. Also, if factory instance construction is failed for some reason,
+     * {@link StandardLoggerFactory} instance will be returned instead.
+     *
+     * @param preferredType the preferred type of the logger factory to create.
+     * @return the created logger factory.
+     */
+    public static LoggerFactory newLoggerFactory(String preferredType) {
+        // creation of a new logger factory is not a performance critical operation, so we can afford doing it under the lock
+        // and perform many non-cached accesses to volatile loggerFactory field to simplify the code
 
-        if (loggerFactory == null) {
-            if (loggerType != null) {
-                if ("log4j".equals(loggerType)) {
-                    loggerFactory = loadLoggerFactory("com.hazelcast.logging.Log4jFactory");
-                } else if ("log4j2".equals(loggerType)) {
-                    loggerFactory = loadLoggerFactory("com.hazelcast.logging.Log4j2Factory");
-                } else if ("slf4j".equals(loggerType)) {
-                    loggerFactory = loadLoggerFactory("com.hazelcast.logging.Slf4jFactory");
-                } else if ("jdk".equals(loggerType)) {
-                    loggerFactory = new StandardLoggerFactory();
-                } else if ("none".equals(loggerType)) {
-                    loggerFactory = new NoLogFactory();
-                }
+        synchronized (FACTORY_LOCK) {
+            LoggerFactory obtainedFactory;
+
+            obtainedFactory = tryToObtainFactoryByConfiguredClass();
+            if (obtainedFactory != null) {
+                return obtainedFactory;
             }
-        }
 
-        if (loggerFactory == null) {
-            loggerFactory = new StandardLoggerFactory();
-        }
-
-        // init static field as early as possible
-        if (Logger.loggerFactory == null) {
-            //noinspection SynchronizationOnStaticField
-            synchronized (FACTORY_LOCK) {
-                if (Logger.loggerFactory == null) {
-                    Logger.loggerFactory = loggerFactory;
-                }
+            obtainedFactory = tryToObtainFactoryByPreferredType(preferredType);
+            if (obtainedFactory != null) {
+                return obtainedFactory;
             }
-        }
 
-        return loggerFactory;
+            assert StringUtil.isNullOrEmpty(preferredType);
+            obtainedFactory = obtainFactoryByRecoveringFromNullOrEmptyPreferredType();
+
+            return obtainedFactory;
+        }
     }
 
-    private static LoggerFactory loadLoggerFactory(String className) {
+    private static LoggerFactory tryToObtainFactoryByConfiguredClass() {
+        final String loggingClass = System.getProperty("hazelcast.logging.class");
+
+        if (!StringUtil.isNullOrEmpty(loggingClass)) {
+            if (sharedFactoryIsCompatibleWith(loggingClass)) {
+                return loggerFactory;
+            }
+
+            final LoggerFactory createdFactory = tryToCreateLoggerFactory(loggingClass);
+            if (createdFactory != null) {
+                if (loggerFactory == null) {
+                    loggerFactory = createdFactory;
+                    loggerFactoryClassOrType = loggingClass;
+                }
+                return createdFactory;
+            }
+        }
+
+        return null;
+    }
+
+    private static LoggerFactory tryToObtainFactoryByPreferredType(String preferredType) {
+        if (!StringUtil.isNullOrEmpty(preferredType)) {
+            if (sharedFactoryIsCompatibleWith(preferredType)) {
+                return loggerFactory;
+            }
+
+            final LoggerFactory createdFactory = createLoggerFactory(preferredType);
+            if (loggerFactory == null) {
+                loggerFactory = createdFactory;
+                loggerFactoryClassOrType = preferredType;
+            }
+            return createdFactory;
+        }
+
+        return null;
+    }
+
+    private static LoggerFactory obtainFactoryByRecoveringFromNullOrEmptyPreferredType() {
+        if (loggerFactory != null) {
+            return loggerFactory;
+        }
+
+        final String loggingType = System.getProperty("hazelcast.logging.type");
+        if (!StringUtil.isNullOrEmpty(loggingType)) {
+            final LoggerFactory createdFactory = createLoggerFactory(loggingType);
+            loggerFactory = createdFactory;
+            loggerFactoryClassOrType = loggingType;
+            return createdFactory;
+        }
+
+        final LoggerFactory createdFactory = new StandardLoggerFactory();
+        loggerFactory = createdFactory;
+        loggerFactoryClassOrType = "jdk";
+        return createdFactory;
+    }
+
+    private static boolean sharedFactoryIsCompatibleWith(String requiredClassOrType) {
+        return loggerFactory != null && !StringUtil.isNullOrEmpty(loggerFactoryClassOrType) && loggerFactoryClassOrType
+                .equals(requiredClassOrType);
+    }
+
+    private static LoggerFactory createLoggerFactory(String preferredType) {
+        final LoggerFactory createdFactory;
+
+        if ("log4j".equals(preferredType)) {
+            createdFactory = tryToCreateLoggerFactory("com.hazelcast.logging.Log4jFactory");
+        } else if ("log4j2".equals(preferredType)) {
+            createdFactory = tryToCreateLoggerFactory("com.hazelcast.logging.Log4j2Factory");
+        } else if ("slf4j".equals(preferredType)) {
+            createdFactory = tryToCreateLoggerFactory("com.hazelcast.logging.Slf4jFactory");
+        } else if ("jdk".equals(preferredType)) {
+            createdFactory = new StandardLoggerFactory();
+        } else if ("none".equals(preferredType)) {
+            createdFactory = new NoLogFactory();
+        } else {
+            createdFactory = new StandardLoggerFactory();
+        }
+
+        return createdFactory;
+    }
+
+    private static LoggerFactory tryToCreateLoggerFactory(String className) {
         try {
             return ClassLoaderUtil.newInstance(null, className);
         } catch (Exception e) {
@@ -128,4 +244,5 @@ public final class Logger {
             return null;
         }
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/logging/CustomLoggerFactorySingularityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/CustomLoggerFactorySingularityTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.logging;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class CustomLoggerFactorySingularityTest extends HazelcastTestSupport {
+
+    private static final int TEST_DURATION_SECONDS = 5;
+    private static final int THREAD_COUNT = 4;
+
+    private static final String LOGGING_CLASS_PROP_NAME = "hazelcast.logging.class";
+
+    private static final Field LOGGER_FACTORY_FIELD = getField("loggerFactory");
+    private static final Field FACTORY_LOCK_FIELD = getField("FACTORY_LOCK");
+
+    private String originalLoggingClass;
+    private LoggerFactory originLoggerFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        originalLoggingClass = System.getProperty(LOGGING_CLASS_PROP_NAME);
+        originLoggerFactory = (LoggerFactory) LOGGER_FACTORY_FIELD.get(null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        restoreProperty(LOGGING_CLASS_PROP_NAME, originalLoggingClass);
+        LOGGER_FACTORY_FIELD.set(null, originLoggerFactory);
+    }
+
+    @Test
+    public void testCustomLoggerFactorySingularity() throws Exception {
+        System.setProperty(LOGGING_CLASS_PROP_NAME, CustomLoggerFactory.class.getName());
+
+        long deadLine = System.currentTimeMillis() + SECONDS.toMillis(TEST_DURATION_SECONDS);
+        TestThread[] threads = startThreads(deadLine);
+
+        while (System.currentTimeMillis() < deadLine) {
+            if (CustomLoggerFactory.singularityCheckFailed) {
+                fail("singularity check failed");
+            }
+
+            // begin the new round of a factory creation
+            synchronized (FACTORY_LOCK_FIELD.get(null)) {
+                CustomLoggerFactory.INSTANCE_COUNT.set(0);
+                LOGGER_FACTORY_FIELD.set(null, null);
+            }
+        }
+
+        assertThreadsEventuallyFinishesWithoutException(threads);
+    }
+
+    private static Field getField(String name) {
+        Field field;
+        try {
+            field = Logger.class.getDeclaredField(name);
+        } catch (NoSuchFieldException e) {
+            throw new AssertionError(name + " field not found");
+        }
+        field.setAccessible(true);
+        return field;
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    private static TestThread[] startThreads(long deadLine) {
+        TestThread[] threads = new TestThread[THREAD_COUNT];
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            threads[i] = new TestThread(deadLine);
+        }
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            threads[i].start();
+        }
+        return threads;
+    }
+
+    private static void assertThreadsEventuallyFinishesWithoutException(TestThread[] threads) throws Exception {
+        for (TestThread thread : threads) {
+            thread.join();
+            Exception exception = thread.e;
+            if (exception != null) {
+                throw exception;
+            }
+        }
+    }
+
+    private static class CustomLoggerFactory implements LoggerFactory {
+
+        public static final AtomicLong INSTANCE_COUNT = new AtomicLong();
+
+        public static volatile boolean singularityCheckFailed = false;
+
+        public CustomLoggerFactory() {
+            final long count = INSTANCE_COUNT.incrementAndGet();
+
+            // XXX: All exceptions during factory construction are inhibited in Logger.tryCreateLoggerFactory(), so we use a flag
+            // here to pass the status to the main thread instead of an assertion.
+            if (count != 1) {
+                singularityCheckFailed = true;
+            }
+        }
+
+        @Override
+        public ILogger getLogger(String name) {
+            return mock(ILogger.class, withSettings().stubOnly());
+        }
+    }
+
+    private static class TestThread extends Thread {
+
+        private final long deadLine;
+        private Exception e;
+
+        TestThread(long deadLine) {
+            this.deadLine = deadLine;
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (System.currentTimeMillis() < deadLine) {
+                    Logger.getLogger(randomName());
+                    assertInstanceOf(CustomLoggerFactory.class, Logger.newLoggerFactory("irrelevant"));
+                }
+            } catch (Exception e) {
+                this.e = e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change brings following:

1. Eliminates the chance of creating `hazelcast.logging.class` factory
twice by doing the creation under the lock.

2. Improves the sharing of the static logger factory instance with
`LoggingService`s. If the type of the the static logger factory matches
with the type requested during the logging service construction, the
service will receive the shared logger factory instance.

3. Fixes the issue with the shared factory get set while invoking
`getLogger` when there is no `hazelcast.logging.type` setting provided.

4. Adds test cases to verify the expected behavior.

Fixes: https://github.com/hazelcast/hazelcast/issues/5641