### PR TITLE
Move ClientJoinOperation to PreJoin

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -137,7 +137,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         assertOpenEventually(shutdownLatch);
     }
 
-    @Test(expected = HazelcastClientNotActiveException.class, timeout = 30000)
+    @Test(expected = HazelcastClientNotActiveException.class)
     public void testRequestShouldFailOnShutdown() {
         final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
@@ -165,7 +165,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         test.get("key");
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void testShutdownClient_whenThereIsNoCluster() {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getConnectionStrategyConfig().setAsyncStart(true);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDataSerializerHook.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.impl.operations.ClientDisconnectionOperation;
 import com.hazelcast.client.impl.operations.ClientReAuthOperation;
 import com.hazelcast.client.impl.operations.GetConnectedClientsOperation;
 import com.hazelcast.client.impl.operations.OperationFactoryWrapper;
-import com.hazelcast.client.impl.operations.PostJoinClientOperation;
+import com.hazelcast.client.impl.operations.OnJoinClientOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
@@ -36,7 +36,7 @@ public class ClientDataSerializerHook implements DataSerializerHook {
     public static final int CLIENT_DISCONNECT = 0;
     public static final int RE_AUTH = 1;
     public static final int GET_CONNECTED_CLIENTS = 2;
-    public static final int POST_JOIN = 3;
+    public static final int ON_JOIN = 3;
     public static final int OP_FACTORY_WRAPPER = 4;
 
     @Override
@@ -56,8 +56,8 @@ public class ClientDataSerializerHook implements DataSerializerHook {
                         return new ClientReAuthOperation();
                     case GET_CONNECTED_CLIENTS:
                         return new GetConnectedClientsOperation();
-                    case POST_JOIN:
-                        return new PostJoinClientOperation();
+                    case ON_JOIN:
+                        return new OnJoinClientOperation();
                     case OP_FACTORY_WRAPPER:
                         return new OperationFactoryWrapper();
                     default:

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -66,6 +66,7 @@ import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -86,12 +87,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.ExecutionService.CLIENT_MANAGEMENT_EXECUTOR;
 import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
@@ -119,6 +121,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
     private final Node node;
     private final NodeEngineImpl nodeEngine;
     private final Executor executor;
+    private final ExecutorService clientManagementExecutor;
     private final Executor queryExecutor;
 
     private final SerializationService serializationService;
@@ -145,6 +148,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
         this.endpointManager = new ClientEndpointManagerImpl(nodeEngine);
         this.executor = newClientExecutor();
         this.queryExecutor = newClientQueryExecutor();
+        this.clientManagementExecutor = newClientsManagementExecutor();
         this.messageTaskFactory = new CompositeMessageTaskFactory(nodeEngine);
         this.clientExceptionFactory = initClientExceptionFactory();
         this.endpointRemoveDelaySeconds = node.getProperties().getInteger(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS);
@@ -154,6 +158,16 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
     private ClientExceptionFactory initClientExceptionFactory() {
         boolean jcacheAvailable = JCacheDetector.isJCacheAvailable(nodeEngine.getConfigClassLoader());
         return new ClientExceptionFactory(jcacheAvailable);
+    }
+
+    private ExecutorService newClientsManagementExecutor() {
+        //CLIENT_MANAGEMENT_EXECUTOR is a single threaded executor to ensure that disconnect/auth are executed in correct order.
+        InternalExecutionService executionService = nodeEngine.getExecutionService();
+        return executionService.register(CLIENT_MANAGEMENT_EXECUTOR, 1, Integer.MAX_VALUE, ExecutorType.CACHED);
+    }
+
+    public ExecutorService getClientManagementExecutor() {
+        return clientManagementExecutor;
     }
 
     private Executor newClientExecutor() {
@@ -493,25 +507,12 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
                 // "a disconnected client is reconnected back to same node"
                 return;
             }
-            ClientDisconnectionOperation op = createClientDisconnectionOperation(clientUuid, memberUuid);
-            operationService.run(op);
 
             for (Member member : memberList) {
-                if (!member.localMember()) {
-                    op = createClientDisconnectionOperation(clientUuid, memberUuid);
-                    operationService.send(op, member.getAddress());
-                }
+                ClientDisconnectionOperation op = new ClientDisconnectionOperation(clientUuid, memberUuid);
+                operationService.createInvocationBuilder(SERVICE_NAME, op, member.getAddress()).invoke();
             }
         }
-    }
-
-    private ClientDisconnectionOperation createClientDisconnectionOperation(String clientUuid, String memberUuid) {
-        ClientDisconnectionOperation op = new ClientDisconnectionOperation(clientUuid, memberUuid);
-        op.setNodeEngine(nodeEngine)
-                .setServiceName(SERVICE_NAME)
-                .setService(this)
-                .setOperationResponseHandler(createEmptyResponseHandler());
-        return op;
     }
 
     private class DestroyEndpointTask implements Runnable {
@@ -523,12 +524,14 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
 
         @Override
         public void run() {
+            InternalOperationService service = nodeEngine.getOperationService();
+            Address thisAddr = getLocalMember().getAddress();
             for (Map.Entry<String, String> entry : ownershipMappings.entrySet()) {
                 String clientUuid = entry.getKey();
                 String memberUuid = entry.getValue();
                 if (deadMemberUuid.equals(memberUuid)) {
-                    ClientDisconnectionOperation op = createClientDisconnectionOperation(clientUuid, deadMemberUuid);
-                    nodeEngine.getOperationService().run(op);
+                    ClientDisconnectionOperation op = new ClientDisconnectionOperation(clientUuid, memberUuid);
+                    service.createInvocationBuilder(ClientEngineImpl.SERVICE_NAME, op, thisAddr).invoke();
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/OnJoinClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/OnJoinClientOperation.java
@@ -18,25 +18,22 @@ package com.hazelcast.client.impl.operations;
 
 import com.hazelcast.client.impl.ClientDataSerializerHook;
 import com.hazelcast.client.impl.ClientEngineImpl;
-import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
 
-public class PostJoinClientOperation extends AbstractClientOperation {
+public class OnJoinClientOperation extends AbstractClientOperation {
 
     private Map<String, String> mappings;
 
-    public PostJoinClientOperation() {
+    public OnJoinClientOperation() {
     }
 
-    public PostJoinClientOperation(Map<String, String> mappings) {
+    public OnJoinClientOperation(Map<String, String> mappings) {
         this.mappings = mappings;
     }
 
@@ -45,19 +42,9 @@ public class PostJoinClientOperation extends AbstractClientOperation {
         if (mappings == null) {
             return;
         }
-
         ClientEngineImpl engine = getService();
-        Set<Member> members = getNodeEngine().getClusterService().getMembers();
-        HashSet<String> uuids = new HashSet<String>();
-        for (Member member : members) {
-            uuids.add(member.getUuid());
-        }
-
         for (Map.Entry<String, String> entry : mappings.entrySet()) {
-            String ownerMemberUuid = entry.getValue();
-            if (uuids.contains(ownerMemberUuid)) {
-                engine.addOwnershipMapping(entry.getKey(), ownerMemberUuid);
-            }
+            engine.addOwnershipMapping(entry.getKey(), entry.getValue());
         }
     }
 
@@ -100,6 +87,6 @@ public class PostJoinClientOperation extends AbstractClientOperation {
 
     @Override
     public int getId() {
-        return ClientDataSerializerHook.POST_JOIN;
+        return ClientDataSerializerHook.ON_JOIN;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractStableClusterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractStableClusterMessageTask.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.function.Supplier;
+
+import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
+
+public abstract class AbstractStableClusterMessageTask<P> extends AbstractMessageTask<P> implements ExecutionCallback {
+
+    private static final int RETRY_COUNT = 100;
+
+    protected AbstractStableClusterMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected void processMessage() throws Throwable {
+        ICompletableFuture<Object> future = invokeOnStableClusterSerial(nodeEngine, createOperationSupplier(), RETRY_COUNT);
+        future.andThen(this);
+    }
+
+    abstract Supplier<Operation> createOperationSupplier();
+
+    protected abstract Object resolve(Object response);
+
+    @Override
+    public final void onResponse(Object response) {
+        sendResponse(resolve(response));
+    }
+
+    @Override
+    public final void onFailure(Throwable t) {
+        handleProcessingFailure(t);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -25,7 +25,6 @@ import com.hazelcast.client.impl.protocol.AuthenticationStatus;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Member;
-import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -41,24 +40,18 @@ import com.hazelcast.util.function.Supplier;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.security.Permission;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-
-import static java.util.Collections.synchronizedList;
 
 /**
  * Base authentication task
  */
-public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTargetMessageTask<P> {
-
+public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClusterMessageTask<P> {
 
     protected transient ClientPrincipal principal;
     protected transient Credentials credentials;
     protected transient byte clientSerializationVersion;
     protected transient String clientVersion;
-    private final List<Member> cleanedUpMembers = synchronizedList(new ArrayList<Member>());
 
     public AuthenticationBaseMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -70,28 +63,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
     }
 
     @Override
-    protected Object reduce(Map<Member, Object> map) throws Throwable {
-        for (Map.Entry<Member, Object> entry : map.entrySet()) {
-            Member member = entry.getKey();
-            Object response = entry.getValue();
-            if (response instanceof Throwable) {
-                if (response instanceof MemberLeftException) {
-                    cleanedUpMembers.add(member);
-                    continue;
-                }
-                throw (Throwable) response;
-            }
-            boolean isClientDisconnectOperationRun = (Boolean) response;
-            if (isClientDisconnectOperationRun) {
-                cleanedUpMembers.add(member);
-            }
-        }
+    protected Object resolve(Object response) {
         return prepareAuthenticatedClientMessage();
-    }
-
-    @Override
-    public Collection<Member> getTargets() {
-        return clientEngine.getClusterService().getMembers();
     }
 
     @Override
@@ -227,7 +200,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
         final Address thisAddress = clientEngine.getThisAddress();
         byte status = AuthenticationStatus.AUTHENTICATED.getId();
         return encodeAuth(status, thisAddress, principal.getUuid(), principal.getOwnerUuid(),
-                serializationService.getVersion(), cleanedUpMembers);
+                serializationService.getVersion(), Collections.<Member>emptyList());
     }
 
     private void setConnectionType() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -58,6 +58,11 @@ public interface ExecutionService {
     String CLIENT_QUERY_EXECUTOR = "hz:client-query";
 
     /**
+     * Name of the client management executor.
+     */
+    String CLIENT_MANAGEMENT_EXECUTOR = "hz:client-management";
+
+    /**
      * Name of the query executor.
      */
     String QUERY_EXECUTOR = "hz:query";

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumOperationTest.java
@@ -64,7 +64,7 @@ public class QuorumOperationTest {
     private static final Collection<String> INTERNAL_CLASS_NAMES = asList(
             "merge", "backup",
             "replication", "migration",
-            "postjoin", "rollback",
+            "postjoin", "rollback", "onjoin",
             "detachmember", "putresult"
     );
 


### PR DESCRIPTION
Client ownership info is carried via OnJoinClientOperation.
It was used to work after join which was creating a potential race.
In rare cases, it was possible that a recently joined member is
not aware of the client, if a client is also joined recently.

ClientReAuthOperation is the operation distributes the client
ownership info when a client joined the cluster.

As a fix, the related operation is running before join.
And, ClientReAuthOperation is invoked via `invokeOnStableCluster`

To avoid race, make sure clientReauthOp and CLientDisconnectionOp runs on same  thread