### PR TITLE
MembershipFailureTest: Bad test fixed

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -507,8 +507,14 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(1, member3);
 
         assertOpenEventually(mergeLatch);
-        assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
         assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member3));
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
#12373

The member which is not isolated will receive the
new cluster-view only eventually.