### PR TITLE
ExecutorQuorumWriteTest: Tests more resilient against JVM hiccups

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -60,5 +61,17 @@ public class ClientExecutorQuorumWriteTest extends ExecutorQuorumWriteTest {
     @Override
     protected IExecutorService exec(int index, QuorumType quorumType, String postfix) {
         return clients.client(index).getExecutorService(EXEC_NAME + quorumType.name() + postfix);
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void invokeAll_timeout_quorum_short_timeout() throws Exception {
+        super.invokeAll_timeout_quorum_short_timeout();
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
+    public void invokeAll_timeout_noQuorum() throws Exception {
+        super.invokeAll_timeout_noQuorum();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
@@ -71,6 +71,12 @@ public class ClientExecutorQuorumWriteTest extends ExecutorQuorumWriteTest {
 
     @Override
     @Test(expected = UnsupportedOperationException.class)
+    public void invokeAll_timeout_quorum_long_timeout() throws Exception {
+        super.invokeAll_timeout_quorum_long_timeout();
+    }
+
+    @Override
+    @Test(expected = UnsupportedOperationException.class)
     public void invokeAll_timeout_noQuorum() throws Exception {
         super.invokeAll_timeout_noQuorum();
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/executor/ExecutorQuorumWriteTest.java
@@ -457,7 +457,17 @@ public class ExecutorQuorumWriteTest extends AbstractQuorumTest {
     @Test
     public void invokeAll_timeout_quorum_short_timeout() throws Exception {
         List<Future<?>> futures = exec(0).invokeAll(Arrays.<Callable<Object>>asList(callable(), callable()), 10l, TimeUnit.SECONDS);
+
+        // 10s is relatively short timeout -> there is some chance the task will be cancelled before it
+        // had a chance to be executed. especially in slow environments -> we have to tolerate the CancellationException
+        // see the test bellow for a scenario where the timeout is sufficiently long
         assertAllowedException(futures, CancellationException.class);
+    }
+
+    @Test
+    public void invokeAll_timeout_quorum_long_timeout() throws Exception {
+        // 30s is a long enough timeout - the task should never be cancelled -> any exception means a test failure
+        wait(exec(0).invokeAll(Arrays.<Callable<Object>>asList(callable(), callable()), 30l, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
Fixes #12311

It has multiple parts:
1. `invokeAll_timeout_quorum_short_timeout()`
 - 10 seconds was too low timeout. When a task is cancelled
   before it's executed then it throws `CancellationException`. This
   was the reason for the test failure in #12311. The test now
   tolerates this exception.
 - The `UnsupportedOperationException` is now allowed only in the
   subclass with a client test. Client ExecutorService does
   not implement all versions of invokeAll() method.
   Having this in the basic test class was unnecessary broad and
   it could hide another problem.

2. `invokeAll_timeout_noQuorum()`
 - Move `UnsupportedOperationException` to the client test subclass.
   Again - no reason to have this in the basic test class.