### PR TITLE
Fix event journal replication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -164,7 +164,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
                 if (onShutdown) {
                     partitionSegment.shutdown();
                 } else {
-                    partitionSegment.clear();
+                    partitionSegment.reset();
                     partitionSegment.init();
                 }
             }
@@ -269,7 +269,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     }
 
     private void clearPartitionReplica(int partitionId) {
-        segments[partitionId].clear();
+        segments[partitionId].reset();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -120,10 +120,10 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
         }
     }
 
-    public void clear() {
+    public void reset() {
         synchronized (mutex) {
             for (ICacheRecordStore store : recordStores.values()) {
-                store.clear();
+                store.reset();
             }
         }
     }
@@ -142,7 +142,7 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
             for (ICacheRecordStore store : recordStores.values()) {
                 CacheConfig cacheConfig = store.getConfig();
                 if (backupCount > cacheConfig.getTotalBackupCount()) {
-                    store.clear();
+                    store.reset();
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -312,6 +312,12 @@ public interface ICacheRecordStore {
     void clear();
 
     /**
+     * Resets the record store to it's initial state.
+     * Used in replication operations.
+     */
+    void reset();
+
+    /**
      * records of keys will be deleted one by one and will publish a REMOVE event
      * for each key.
      *
@@ -384,11 +390,11 @@ public interface ICacheRecordStore {
      * Associates the specified record with the specified key.
      * This is simply a put operation on the internal map data
      * without any CacheLoad. It also <b>DOES</b> trigger eviction!
-     *
-     * @param key    the key to the entry.
+     *  @param key    the key to the entry.
      * @param record the value to be associated with the specified key.
+     * @param updateJournal when true an event is appended to related event-journal
      */
-    void putRecord(Data key, CacheRecord record);
+    void putRecord(Data key, CacheRecord record, boolean updateJournal);
 
     /**
      * Removes the record for a key.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/journal/RingbufferCacheEventJournalImpl.java
@@ -184,11 +184,12 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
     }
 
     @Override
-    public RingbufferConfig toRingbufferConfig(EventJournalConfig config) {
+    public RingbufferConfig toRingbufferConfig(EventJournalConfig config, ObjectNamespace namespace) {
+        CacheConfig cacheConfig = getCacheService().getCacheConfig(namespace.getObjectName());
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         return new RingbufferConfig()
-                .setAsyncBackupCount(0)
-                .setBackupCount(0)
+                .setAsyncBackupCount(cacheConfig.getAsyncBackupCount())
+                .setBackupCount(cacheConfig.getBackupCount())
                 .setInMemoryFormat(InMemoryFormat.OBJECT)
                 .setCapacity(config.getCapacity() / partitionCount)
                 .setTimeToLiveSeconds(config.getTimeToLiveSeconds());
@@ -275,7 +276,7 @@ public class RingbufferCacheEventJournalImpl implements CacheEventJournal {
 
     private RingbufferContainer<InternalEventJournalCacheEvent, Object> getOrCreateRingbufferContainer(
             ObjectNamespace namespace, int partitionId, EventJournalConfig config) {
-        RingbufferConfig ringbufferConfig = toRingbufferConfig(config);
+        RingbufferConfig ringbufferConfig = toRingbufferConfig(config, namespace);
         return getRingbufferService().getOrCreateContainer(partitionId, namespace, ringbufferConfig);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -77,7 +77,7 @@ public class CachePutAllBackupOperation
         if (cacheRecords != null) {
             for (Map.Entry<Data, CacheRecord> entry : cacheRecords.entrySet()) {
                 CacheRecord record = entry.getValue();
-                cache.putRecord(entry.getKey(), record);
+                cache.putRecord(entry.getKey(), record, true);
 
                 publishWanEvent(entry.getKey(), record);
             }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -69,7 +69,7 @@ public class CachePutBackupOperation
     public void runInternal() {
         ICacheService service = getService();
         ICacheRecordStore cache = service.getOrCreateRecordStore(name, getPartitionId());
-        cache.putRecord(key, cacheRecord);
+        cache.putRecord(key, cacheRecord, true);
         response = Boolean.TRUE;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -104,7 +104,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
         ICacheService service = getService();
         for (Map.Entry<String, Map<Data, CacheRecord>> entry : data.entrySet()) {
             ICacheRecordStore cache = service.getOrCreateRecordStore(entry.getKey(), getPartitionId());
-            cache.clear();
+            cache.reset();
             Map<Data, CacheRecord> map = entry.getValue();
 
             Iterator<Map.Entry<Data, CacheRecord>> iterator = map.entrySet().iterator();
@@ -113,7 +113,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
                 Data key = next.getKey();
                 CacheRecord record = next.getValue();
                 iterator.remove();
-                cache.putRecord(key, record);
+                cache.putRecord(key, record, false);
             }
         }
         data.clear();

--- a/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/journal/EventJournal.java
@@ -174,7 +174,8 @@ public interface EventJournal<E> {
      * event journal events for a single partition.
      *
      * @param config the event journal config
+     * @param namespace the object namespace
      * @return the ringbuffer config for a single partition of the event journal
      */
-    RingbufferConfig toRingbufferConfig(EventJournalConfig config);
+    RingbufferConfig toRingbufferConfig(EventJournalConfig config, ObjectNamespace namespace);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -209,7 +209,7 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     private MapEventJournal createEventJournal() {
-        return new RingbufferMapEventJournalImpl(getNodeEngine());
+        return new RingbufferMapEventJournalImpl(getNodeEngine(), this);
     }
 
     private LocalMapStatsProvider createLocalMapStatsProvider() {
@@ -310,7 +310,6 @@ class MapServiceContextImpl implements MapServiceContext {
                 final MapContainer mapContainer = recordStore.getMapContainer();
                 if (backupCount > mapContainer.getTotalBackupCount()) {
                     recordStore.clearPartition(false);
-                    eventJournal.destroy(mapContainer.getObjectNamespace(), partitionId);
                     iter.remove();
                 }
             }
@@ -323,7 +322,6 @@ class MapServiceContextImpl implements MapServiceContext {
         if (container != null) {
             for (RecordStore mapPartition : container.getMaps().values()) {
                 mapPartition.clearPartition(false);
-                eventJournal.destroy(mapPartition.getMapContainer().getObjectNamespace(), partitionId);
             }
             container.getMaps().clear();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -158,8 +158,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void putRecord(Data key, Record record) {
         markRecordStoreExpirable(record.getTtl());
         storage.put(key, record);
-        eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
-                key, record.getValue());
         updateStatsOnPut(record.getHits());
     }
 
@@ -443,7 +441,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     public void reset() {
         mapDataStore.reset();
         storage.clear(false);
-        eventJournal.destroy(mapContainer.getObjectNamespace(), partitionId);
         stats.reset();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -289,6 +289,9 @@ public interface RecordStore<R extends Record> {
 
     /**
      * Resets the record store to it's initial state.
+     * Used in replication operations.
+     *
+     * @see #putRecord(Data, Record)
      */
     void reset();
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
@@ -133,12 +133,12 @@ public class MergeOperation extends Operation implements IdentifiedDataSerializa
             MapService mapService = getNodeEngine().getService(MapService.SERVICE_NAME);
             MapEventJournal journal = mapService.getMapServiceContext().getEventJournal();
             EventJournalConfig journalConfig = journal.getEventJournalConfig(ns);
-            return journal.toRingbufferConfig(journalConfig);
+            return journal.toRingbufferConfig(journalConfig, namespace);
         } else if (CacheService.SERVICE_NAME.equals(serviceName)) {
             CacheService cacheService = getNodeEngine().getService(CacheService.SERVICE_NAME);
             CacheEventJournal journal = cacheService.getEventJournal();
             EventJournalConfig journalConfig = journal.getEventJournalConfig(ns);
-            return journal.toRingbufferConfig(journalConfig);
+            return journal.toRingbufferConfig(journalConfig, namespace);
         } else {
             throw new IllegalArgumentException("Unsupported ringbuffer service name: " + serviceName);
         }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReplicationOperation.java
@@ -89,12 +89,12 @@ public class ReplicationOperation extends Operation implements IdentifiedDataSer
             final MapService mapService = getNodeEngine().getService(MapService.SERVICE_NAME);
             final MapEventJournal journal = mapService.getMapServiceContext().getEventJournal();
             final EventJournalConfig journalConfig = journal.getEventJournalConfig(ns);
-            return journal.toRingbufferConfig(journalConfig);
+            return journal.toRingbufferConfig(journalConfig, ns);
         } else if (CacheService.SERVICE_NAME.equals(serviceName)) {
             final CacheService cacheService = getNodeEngine().getService(CacheService.SERVICE_NAME);
             final CacheEventJournal journal = cacheService.getEventJournal();
             final EventJournalConfig journalConfig = journal.getEventJournalConfig(ns);
-            return journal.toRingbufferConfig(journalConfig);
+            return journal.toRingbufferConfig(journalConfig, ns);
         } else {
             throw new IllegalArgumentException("Unsupported ringbuffer service name " + serviceName);
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/AdvancedCacheJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/AdvancedCacheJournalTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.journal;
+
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AdvancedCacheJournalTest extends HazelcastTestSupport {
+
+    private static final int PARTITION_COUNT = 100;
+
+    private HazelcastInstance[] instances;
+
+    @Before
+    public void init() {
+        instances = createHazelcastInstanceFactory().newInstances(getConfig(), 4);
+        warmUpPartitions(instances);
+    }
+
+    @Override
+    protected Config getConfig() {
+        EventJournalConfig eventJournalConfig = new EventJournalConfig()
+                .setEnabled(true)
+                .setCacheName("default");
+
+        CacheSimpleConfig cacheConfig = new CacheSimpleConfig().setName("*");
+        cacheConfig.getEvictionConfig().setSize(Integer.MAX_VALUE);
+
+        return super.getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT))
+                .addEventJournalConfig(eventJournalConfig)
+                .addCacheConfig(cacheConfig);
+    }
+
+    @Test
+    public void testBackupSafety() throws Exception {
+        String name = randomMapName();
+        Cache<Object, Object> cache = getCache(instances[0], name);
+        int keyCount = 1000;
+        int updateCount = 3;
+
+        for (int n = 0; n < updateCount; n++) {
+            for (int i = 0; i < keyCount; i++) {
+                cache.put(i, randomString());
+            }
+        }
+
+        LinkedList<HazelcastInstance> instanceList = new LinkedList<HazelcastInstance>(Arrays.asList(instances));
+        waitAllForSafeState(instanceList);
+
+        int expectedSize = keyCount * updateCount;
+        while (instanceList.size() > 1) {
+            HazelcastInstance instance = instanceList.removeFirst();
+            instance.getLifecycleService().terminate();
+            waitAllForSafeState(instanceList);
+
+            cache = getCache(instanceList.getFirst(), name);
+            int journalSize = getJournalSize(cache);
+            assertEquals(expectedSize, journalSize);
+        }
+    }
+
+    private Cache<Object, Object> getCache(HazelcastInstance instance, String name) {
+        CacheManager cacheManager =
+                HazelcastServerCachingProvider.createCachingProvider(instance).getCacheManager();
+        return cacheManager.getCache(name);
+    }
+
+    private static <K, V> int getJournalSize(Cache<K, V> cache) throws ExecutionException, InterruptedException {
+        int total = 0;
+        for (int i = 0; i < PARTITION_COUNT; i++) {
+            ICompletableFuture<ReadResultSet<Object>> future =
+                    ((CacheProxy<K, V>) cache).readFromEventJournal(0, 0, 10000, i, null, null);
+            ReadResultSet<Object> resultSet = future.get();
+            int readCount = resultSet.readCount();
+            total += readCount;
+        }
+        return total;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/AdvancedMapJournalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/AdvancedMapJournalTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.journal;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.ringbuffer.ReadResultSet;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AdvancedMapJournalTest extends HazelcastTestSupport {
+
+    private static final int PARTITION_COUNT = 100;
+
+    private HazelcastInstance[] instances;
+
+    @Before
+    public void init() {
+        instances = createHazelcastInstanceFactory().newInstances(getConfig(), 4);
+        warmUpPartitions(instances);
+    }
+
+    @Override
+    protected Config getConfig() {
+        EventJournalConfig eventJournalConfig = new EventJournalConfig()
+                .setEnabled(true)
+                .setMapName("default");
+        return super.getConfig()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT))
+                .addEventJournalConfig(eventJournalConfig);
+    }
+
+    @Test
+    public void testBackupSafety() throws Exception {
+        String name = randomMapName();
+        IMap<Integer, Object> m = instances[0].getMap(name);
+        int keyCount = 1000;
+        int updateCount = 3;
+
+        for (int n = 0; n < updateCount; n++) {
+            for (int i = 0; i < keyCount; i++) {
+                m.set(i, randomString());
+            }
+        }
+
+        LinkedList<HazelcastInstance> instanceList = new LinkedList<HazelcastInstance>(Arrays.asList(instances));
+        waitAllForSafeState(instanceList);
+
+        int expectedSize = keyCount * updateCount;
+        while (instanceList.size() > 1) {
+            HazelcastInstance instance = instanceList.removeFirst();
+            instance.getLifecycleService().terminate();
+            waitAllForSafeState(instanceList);
+
+            m = instanceList.getFirst().getMap(name);
+            int journalSize = getJournalSize(m);
+            assertEquals(expectedSize, journalSize);
+        }
+    }
+
+    private static <K, V> int getJournalSize(IMap<K, V> map) throws ExecutionException, InterruptedException {
+        int total = 0;
+        for (int i = 0; i < PARTITION_COUNT; i++) {
+            ICompletableFuture<ReadResultSet<Object>> future =
+                    ((MapProxyImpl<K, V>) map).readFromEventJournal(0, 0, 10000, i, null, null);
+            ReadResultSet<Object> resultSet = future.get();
+            int readCount = resultSet.readCount();
+            total += readCount;
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
Anti-entropy and backup replication isn't working for ringbuffers backing event journal.
Reason is, these ringbuffers are created with 0 backups. That means, when a member leaves un-gracefully,
missing backup replicas for these journals are not created by either migration system or anti-entropy.

Additionally, when a map/cache partition is replicated, they destroy the specific ringbuffers
and each record creates a new event in journal.
That's causes missing ringbuffers to be created using the latest map/cache records and previous write/update events to be lost.

Map and cache should only write event-journal while adding/updating events due to map/cache writes
and additionally while clearing and destroying data structures. RingbufferService should handle migration/replication
of ringbuffers backing event-journals on its own.

Fixes https://github.com/hazelcast/hazelcast/issues/12300

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/1927