### PR TITLE
Bad test fixed: Invocation_OnBackupLeftTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
@@ -38,9 +38,10 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.spi.impl.operationservice.impl.InvocationConstant.VOID;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 import static java.util.Collections.newSetFromMap;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -117,7 +118,7 @@ public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertNotNull(f.invocation.pendingResponse);
+                assertNotEquals(VOID, f.invocation.pendingResponse);
             }
         });
     }


### PR DESCRIPTION
Fixes #12308

The logic in
```java
    private void waitForPrimaryResponse(final InvocationFuture f) {
        assertTrueEventually(new AssertTask() {
            @Override
            public void run() {
                assertNotNull(f.invocation.pendingResponse);
            }
        });
    }
```

was flawed. It's supposed to wait for an invocation to receive
a response from a primary, but `null` is actually a valid response
-> `assertNotNull()` does not make sense.

Initial state of the `pendingResponse` field is
`InvocationConstant.VOID`. This is what the `waitForPrimaryResponse()`
has to be checking for.

The test was passing most of the time because the
`waitForPrimaryResponse()` is normally invoked before the
`PrimaryOperation` is executed -> `waitForPrimaryResponse()` returns
successfully as the pending response inside `Invocation` is *still*
in its initial state - `VOID` (=non-null)

However when the `PrimaryOperation` was executed BEFORE the
`waitForPrimaryResponse()` checked the `pendingResponse` field then the
field was set to `null` - that's what the `PrimaryOperation` returns
as a response. In this case the test failed as the field stayed `null`
forever.