### PR TITLE
Fix invalid stats on IScheduledExecutor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -350,7 +350,9 @@ public class ScheduledExecutorContainer {
         }
 
         Operation op = new SyncStateOperation(getName(), taskName, stateSnapshot, statsSnapshot, result);
-        createInvocationBuilder(op).invoke().join();
+        createInvocationBuilder(op)
+                .invoke()
+                .join();
     }
 
     protected InvocationBuilder createInvocationBuilder(Operation op) {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/TaskRunner.java
@@ -116,7 +116,7 @@ class TaskRunner<V>
                 ((StatefulTask) original).save(state);
             }
 
-            container.publishTaskState(taskName, state, statistics, resolution);
+            container.publishTaskState(taskName, state, statistics.snapshot(), resolution);
         } catch (Exception ex) {
             container.log(WARNING, taskName, "Unexpected exception during afterRun occurred", ex);
         } finally {


### PR DESCRIPTION
- Wrong reference sharing upon task completion, with side-effect of negative result on `getLastDuration()`
- LastDuration was computed on transient fields, so it was only available on local invocations. This is now
changed to be available on Versions >= 3.10

Fixes https://github.com/hazelcast/hazelcast/issues/11929