### PR TITLE
Rename Maven property hazelcast.test.additionalJvmArguments to extraVmArgs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 
         <h2.version>1.3.160</h2.version>
         <atomikos.version>3.9.3</atomikos.version>
-        <hazelcast.test.additionalJvmArguments></hazelcast.test.additionalJvmArguments>
+        <extraVmArgs></extraVmArgs>
     </properties>
     <licenses>
         <license>
@@ -251,7 +251,7 @@
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.test.use.network=false
-                        ${hazelcast.test.additionalJvmArguments}
+                        ${extraVmArgs}
                     </argLine>
                     <includes>
                         <include>**/**.java</include>
@@ -289,7 +289,7 @@
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=true
-                        ${hazelcast.test.additionalJvmArguments}
+                        ${extraVmArgs}
                     </argLine>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <useSystemClassLoader>true</useSystemClassLoader>
@@ -342,7 +342,7 @@
                                         -Dhazelcast.test.use.network=false
                                         -Dhazelcast.test.multiple.jvm=true
                                         -Dlog4j.configurationFile=log4j2-info.xml
-                                        ${hazelcast.test.additionalJvmArguments}
+                                        ${extraVmArgs}
                                     </argLine>
                                     <includes>
                                         <include>**/**.java</include>
@@ -381,7 +381,7 @@
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
                                         -Dlog4j.configurationFile=log4j2-info.xml
-                                        ${hazelcast.test.additionalJvmArguments}
+                                        ${extraVmArgs}
                                     </argLine>
                                     <includes>
                                         <include>**/**.java</include>
@@ -428,7 +428,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/**.java</include>
@@ -465,7 +465,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
                             <useSystemClassLoader>true</useSystemClassLoader>
@@ -527,7 +527,7 @@
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/YourTestFileHear.java</include>
@@ -564,7 +564,7 @@
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
                     -Dlog4j.skipJansi=true
-                    ${hazelcast.test.additionalJvmArguments}
+                    ${extraVmArgs}
                 </argLine>
             </properties>
             <build>
@@ -638,7 +638,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <groups>
                                 com.hazelcast.test.annotation.QuickTest,
@@ -745,7 +745,7 @@
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
 
                             <includes>
@@ -778,7 +778,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/AtomicLongTest*.java</include>
@@ -1009,7 +1009,7 @@
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/**.java</include>
@@ -1044,7 +1044,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
                             <useSystemClassLoader>true</useSystemClassLoader>
@@ -1085,7 +1085,7 @@
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
                                 -Dlog4j.skipJansi=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/**.java</include>
@@ -1121,7 +1121,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
                             <useSystemClassLoader>true</useSystemClassLoader>
@@ -1163,7 +1163,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/**.java</include>
@@ -1216,7 +1216,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                                 -Dhazelcast.test.sample.serialized.objects=${target.dir}/serialized-objects-${project.version}-
-                                ${hazelcast.test.additionalJvmArguments}
+                                ${extraVmArgs}
                             </argLine>
                             <includes>
                                 <include>**/**.java</include>


### PR DESCRIPTION
This aligns PR aligns the naming with the enterprise edition.

Thanks @Donnerbart  for catching this. (https://github.com/hazelcast/hazelcast/pull/12400#issuecomment-367325458)