### PR TITLE
[DON'T MERGE] Log progress when loading from the map store

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -97,6 +97,7 @@ public class MapContainer {
     protected volatile Evictor evictor;
     protected volatile MapConfig mapConfig;
     protected final EventJournalConfig eventJournalConfig;
+    protected final MapLoadProgressTracker loadProgressTracker;
 
 
     /**
@@ -127,6 +128,8 @@ public class MapContainer {
         }
         this.mapStoreContext = createMapStoreContext(this);
         this.mapStoreContext.start();
+        this.loadProgressTracker = new MapLoadProgressTracker(name);
+
         initEvictor();
     }
 
@@ -304,6 +307,10 @@ public class MapContainer {
 
     public Evictor getEvictor() {
         return evictor;
+    }
+
+    public MapLoadProgressTracker getLoadProgressTracker() {
+        return loadProgressTracker;
     }
 
     // only used for testing purposes

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapLoadProgressTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapLoadProgressTracker.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Class tracking the progress of map record loading. It logs the
+ * progress in every 10 seconds if there is loading activity, which
+ * triggers logging.
+ * <p>
+ * The tracking is done in separate instances for each map, which are
+ * shared between partitions on the same node. The instances are created
+ * on the first access of the map, and are destroyed with destroying the
+ * map they belong to.
+ * <p>
+ * <b>Notes:</b>
+ * <ul>
+ * <li>Only batch loading is tracked by this class, loading individual
+ * keys are not.
+ * <li>This class logs the number of records loaded in the last 10
+ * seconds but does not log when the load starts or completes. This is
+ * because the current map loader implementation does not provide
+ * callbacks for these events.
+ * <li>Due to the lack of the callbacks mentioned previously, the
+ * counter that tracks loading gets never reset. This is the
+ * reason for logging only the difference of the current and last logged
+ * value of the counter. Otherwise consecutive loads (such as multiple
+ * {@link IMap#loadAll(boolean)} invocations) would report incorrect
+ * values.
+ * </ul>
+ *
+ * @see MapContainer#MapContainer
+ */
+public class MapLoadProgressTracker {
+    private static final long TEN_SECS = SECONDS.toMillis(10);
+    private static final int INITIAL_REPORT_TIMESTAMP = -1;
+
+    private final String mapName;
+    private final ILogger logger;
+
+    private final AtomicLong recordsLoaded = new AtomicLong(0);
+    private final AtomicReference<LoadSnapshot> lastReportedSnapshotRef;
+
+    MapLoadProgressTracker(String mapName) {
+        this(mapName, Logger.getLogger(MapLoadProgressTracker.class));
+    }
+
+    MapLoadProgressTracker(String mapName, LoggingService loggingService) {
+        this(mapName, loggingService.getLogger(MapLoadProgressTracker.class));
+    }
+
+    private MapLoadProgressTracker(String mapName, ILogger logger) {
+        this.mapName = mapName;
+        this.lastReportedSnapshotRef = new AtomicReference<LoadSnapshot>(new LoadSnapshot(0, INITIAL_REPORT_TIMESTAMP));
+        this.logger = logger;
+    }
+
+    public void onBatchLoaded(int records) {
+        recordsLoaded.addAndGet(records);
+
+        LoadSnapshot lastReportedSnapshot = lastReportedSnapshotRef.get();
+        long now = System.currentTimeMillis();
+        long lastReportTimestamp = lastReportedSnapshot.timestamp;
+        long lastReportRecordsLoaded = lastReportedSnapshot.recordsLoaded;
+
+        long recordsLoadedSinceLastReport = recordsLoaded.get() - lastReportRecordsLoaded;
+        long elapsedMillisSinceLastReport = now - lastReportTimestamp;
+
+        if (lastReportTimestamp == INITIAL_REPORT_TIMESTAMP) {
+            LoadSnapshot newSnapshot = new LoadSnapshot(0, now);
+            lastReportedSnapshotRef.compareAndSet(lastReportedSnapshot, newSnapshot);
+        } else if (elapsedMillisSinceLastReport >= TEN_SECS && recordsLoadedSinceLastReport > 0) {
+            LoadSnapshot newSnapshot = new LoadSnapshot(recordsLoaded.get(), now);
+            if (lastReportedSnapshotRef.compareAndSet(lastReportedSnapshot, newSnapshot)) {
+                logger.info("Loaded " + recordsLoadedSinceLastReport + " records for the map " + mapName + " in the last "
+                        + MILLISECONDS.toSeconds(elapsedMillisSinceLastReport) + " seconds");
+            }
+        }
+    }
+
+    private static final class LoadSnapshot {
+        private final long recordsLoaded;
+        private final long timestamp;
+
+        private LoadSnapshot(long recordsLoaded, long timestamp) {
+            this.recordsLoaded = recordsLoaded;
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.recordstore;
 
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
@@ -72,13 +73,15 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
      * {@link ExecutionService#MAP_LOADER_EXECUTOR} executor.
      */
     @Override
-    public Future<?> loadValues(List<Data> keys, boolean replaceExistingValues) {
+    public ICompletableFuture loadValues(List<Data> keys, boolean replaceExistingValues) {
         Callable task = new GivenKeysLoaderTask(keys, replaceExistingValues);
         return executeTask(MAP_LOADER_EXECUTOR, task);
     }
 
-    private Future<?> executeTask(String executorName, Callable task) {
-        return getExecutionService().submit(executorName, task);
+    private ICompletableFuture executeTask(String executorName, Callable task) {
+        ExecutionService executionService = getExecutionService();
+        Future taskFuture = executionService.submit(executorName, task);
+        return executionService.asCompletableFuture(taskFuture);
     }
 
     private ExecutionService getExecutionService() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreLoader.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.map.impl.recordstore;
 
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
-import java.util.concurrent.Future;
 
 /**
  * Loader contract for a {@link RecordStore}.
@@ -32,7 +32,7 @@ interface RecordStoreLoader {
      */
     RecordStoreLoader EMPTY_LOADER = new RecordStoreLoader() {
         @Override
-        public Future loadValues(List<Data> keys, boolean replaceExistingValues) {
+        public ICompletableFuture loadValues(List<Data> keys, boolean replaceExistingValues) {
             return null;
         }
     };
@@ -49,5 +49,5 @@ interface RecordStoreLoader {
      *                              be replaced with the loaded values
      * @return future representing the pending completion for the value loading task
      */
-    Future<?> loadValues(List<Data> keys, boolean replaceExistingValues);
+    ICompletableFuture<?> loadValues(List<Data> keys, boolean replaceExistingValues);
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapLoadProgressTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapLoadProgressTrackerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({SlowTest.class, NightlyTest.class})
+public class MapLoadProgressTrackerTest {
+
+    private static final String TEST_MAP_NAME = "testMap";
+
+    @Mock
+    private LoggingService loggingService;
+    @Mock
+    private ILogger logger;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        given(loggingService.getLogger(MapLoadProgressTracker.class)).willReturn(logger);
+    }
+
+    @Test
+    public void logCountOfLoadedRecordsSinceLastReport() throws Exception {
+        MapLoadProgressTracker tracker = new MapLoadProgressTracker(TEST_MAP_NAME, loggingService);
+
+        tracker.onBatchLoaded(100);
+        SECONDS.sleep(10);
+        tracker.onBatchLoaded(121);
+
+        tracker.onBatchLoaded(101);
+        SECONDS.sleep(10);
+        tracker.onBatchLoaded(199);
+
+        ArgumentCaptor<String> logCaptor = forClass(String.class);
+
+        verify(logger, times(2)).info(logCaptor.capture());
+        verifyNoMoreInteractions(logger);
+
+        List<String> allCapturedLogLine = logCaptor.getAllValues();
+        String firstLoggedLine = allCapturedLogLine.get(0);
+        String secondLoggedLine = allCapturedLogLine.get(1);
+
+        assertTrue(firstLoggedLine.contains(TEST_MAP_NAME));
+        assertTrue(firstLoggedLine.contains(Integer.toString(221)));
+        assertTrue(secondLoggedLine.contains(TEST_MAP_NAME));
+        assertTrue(secondLoggedLine.contains(Integer.toString(300)));
+    }
+
+    @Test
+    public void testFirstBatchLoadsDoNotReport() {
+        MapLoadProgressTracker tracker = new MapLoadProgressTracker(TEST_MAP_NAME, loggingService);
+        tracker.onBatchLoaded(100);
+        tracker.onBatchLoaded(100);
+
+        verify(logger, never()).info(anyString());
+    }
+}


### PR DESCRIPTION
Enhance logging when loading a map from a map store.
In every 10 seconds (not configurable) the number of loaded records since the last report is logged to show progress if loading takes long.

Implements #11674