### PR TITLE
Relaxing owner connection check for client invocations

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -58,7 +58,7 @@ public interface ClientConnectionManager extends ConnectionListenable {
      * @return associated connection if available, returns null and triggers new connection creation otherwise
      * @throws IOException if connection is not able to triggered
      */
-    Connection getOrTriggerConnect(Address address) throws IOException;
+    Connection getOrTriggerConnect(Address address, boolean acquiresResource) throws IOException;
 
     void addConnectionHeartbeatListener(ConnectionHeartbeatListener connectionHeartbeatListener);
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.connection.nio;
 import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.ClientExtension;
 import com.hazelcast.client.ClientTypes;
+import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.SocketOptions;
 import com.hazelcast.client.connection.AddressProvider;
@@ -91,6 +92,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.config.SocketOptions.DEFAULT_BUFFER_SIZE_BYTE;
 import static com.hazelcast.client.config.SocketOptions.KILO_BYTE;
+import static com.hazelcast.client.spi.properties.ClientProperty.ALLOW_INVOCATIONS_WHEN_DISCONNECTED;
 import static com.hazelcast.client.spi.properties.ClientProperty.IO_BALANCER_INTERVAL_SECONDS;
 import static com.hazelcast.client.spi.properties.ClientProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.client.spi.properties.ClientProperty.IO_OUTPUT_THREAD_COUNT;
@@ -129,7 +131,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     private final ConcurrentMap<Address, AuthenticationFuture> connectionsInProgress =
             new ConcurrentHashMap<Address, AuthenticationFuture>();
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
-
+    private final boolean allowInvokeWhenDisconnected;
     private final Credentials credentials;
     private final NioEventLoopGroup eventLoopGroup;
 
@@ -151,7 +153,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     @SuppressWarnings("checkstyle:executablestatementcount")
     public ClientConnectionManagerImpl(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
                                        Collection<AddressProvider> addressProviders) {
-
+        allowInvokeWhenDisconnected = client.getProperties().getBoolean(ALLOW_INVOCATIONS_WHEN_DISCONNECTED);
         this.client = client;
         this.addressTranslator = addressTranslator;
 
@@ -344,8 +346,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     }
 
     @Override
-    public Connection getOrTriggerConnect(Address target) throws IOException {
-        Connection connection = getConnection(target, false);
+    public Connection getOrTriggerConnect(Address target, boolean acquiresResources) throws IOException {
+        Connection connection = getConnection(target, false, acquiresResources);
         if (connection != null) {
             return connection;
         }
@@ -353,13 +355,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         return null;
     }
 
-    private Connection getConnection(Address target, boolean asOwner) throws IOException {
-        if (!asOwner) {
-            connectionStrategy.beforeGetConnection(target);
-        }
-        if (!asOwner && getOwnerConnection() == null) {
-            throw new IOException("Owner connection is not available!");
-        }
+    private Connection getConnection(Address target, boolean asOwner, boolean acquiresResources) throws IOException {
+        checkAllowed(target, asOwner, acquiresResources);
         if (target == null) {
             throw new IllegalStateException("Address can not be null");
         }
@@ -377,6 +374,29 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         return null;
     }
 
+    private void checkAllowed(Address target, boolean asOwner, boolean acquiresResources) throws IOException {
+        if (asOwner) {
+            //opening an owner connection is always allowed
+            return;
+        }
+        try {
+            connectionStrategy.beforeGetConnection(target);
+        } catch (HazelcastClientOfflineException e) {
+            if (allowInvokeWhenDisconnected && !acquiresResources) {
+                //invocations that does not acquire resources are allowed to invoke when disconnected
+                return;
+            }
+            throw e;
+        }
+        if (getOwnerConnection() == null) {
+            if (allowInvokeWhenDisconnected && !acquiresResources) {
+                //invocations that does not acquire resources are allowed to invoke when disconnected
+                return;
+            }
+            throw new IOException("Owner connection is not available!");
+        }
+    }
+
     @Override
     public Address getOwnerConnectionAddress() {
         return ownerConnectionAddress;
@@ -390,7 +410,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     private Connection getOrConnect(Address address, boolean asOwner) {
         try {
             while (true) {
-                ClientConnection connection = (ClientConnection) getConnection(address, asOwner);
+                ClientConnection connection = (ClientConnection) getConnection(address, asOwner, true);
                 if (connection != null) {
                     return connection;
                 }
@@ -441,8 +461,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             logger.info("Trying to connect to " + address + " as owner member");
             connection = getOrConnect(address, true);
             client.onClusterConnect(connection);
-            setOwnerConnectionAddress(connection.getEndPoint());
-            logger.info("Setting " + connection + " as owner with principal " + principal);
             fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
             connectionStrategy.onConnectToCluster();
         } catch (Exception e) {
@@ -964,6 +982,11 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                         connection.setIsAuthenticatedAsOwner();
                         ClientPrincipal principal = new ClientPrincipal(result.uuid, result.ownerUuid);
                         setPrincipal(principal);
+                        //setting owner connection is moved to here(before onAuthenticated/before connected event)
+                        //so that invocations that requires owner connection on this connection go through
+                        setOwnerConnectionAddress(connection.getEndPoint());
+                        logger.info("Setting " + connection + " as owner with principal " + principal);
+
                     }
                     onAuthenticated(target, connection);
                     future.onSuccess(connection);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionProxy.java
@@ -70,6 +70,9 @@ final class TransactionProxy {
 
     void begin() {
         try {
+            if (client.getConnectionManager().getOwnerConnection() == null) {
+                throw new TransactionException("Owner connection needs to be present to begin a transaction");
+            }
             if (state == ACTIVE) {
                 throw new IllegalStateException("Transaction is already active");
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -27,6 +27,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import com.hazelcast.transaction.impl.xa.XAResourceImpl;
@@ -92,6 +93,9 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     }
 
     private TransactionContext createTransactionContext(Xid xid) {
+        if (getContext().getConnectionManager().getOwnerConnection() == null) {
+            throw new TransactionException("Owner connection needs to be present to begin a transaction");
+        }
         ClientTransactionManagerService transactionManager = getContext().getTransactionManager();
         TransactionContext context = transactionManager.newXATransactionContext(xid, timeoutInSeconds.get());
         getTransaction(context).begin();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionProxy.java
@@ -72,6 +72,9 @@ public class XATransactionProxy {
 
     void begin() {
         try {
+            if (client.getConnectionManager().getOwnerConnection() == null) {
+                throw new TransactionException("Owner connection needs to be present to begin a transaction");
+            }
             startTime = Clock.currentTimeMillis();
             ClientMessage request = XATransactionCreateCodec.encodeRequest(xid, timeout);
             ClientMessage response = ClientTransactionUtil.invoke(request, txnId, client, connection);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionProxy.java
@@ -72,9 +72,6 @@ public class XATransactionProxy {
 
     void begin() {
         try {
-            if (client.getConnectionManager().getOwnerConnection() == null) {
-                throw new TransactionException("Owner connection needs to be present to begin a transaction");
-            }
             startTime = Clock.currentTimeMillis();
             ClientMessage request = XATransactionCreateCodec.encodeRequest(xid, timeout);
             ClientMessage response = ClientTransactionUtil.invoke(request, txnId, client, connection);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/SmartClientInvocationService.java
@@ -45,7 +45,7 @@ public class SmartClientInvocationService extends AbstractClientInvocationServic
             throw new TargetNotMemberException("Partition owner '" + owner + "' is not a member.");
         }
         invocation.getClientMessage().setPartitionId(partitionId);
-        Connection connection = getOrTriggerConnect(owner);
+        Connection connection = getOrTriggerConnect(owner, invocation.getClientMessage().acquiresResource());
         send(invocation, (ClientConnection) connection);
     }
 
@@ -55,7 +55,7 @@ public class SmartClientInvocationService extends AbstractClientInvocationServic
         if (randomAddress == null) {
             throw new IOException("No address found to invoke");
         }
-        Connection connection = getOrTriggerConnect(randomAddress);
+        Connection connection = getOrTriggerConnect(randomAddress, invocation.getClientMessage().acquiresResource());
         send(invocation, (ClientConnection) connection);
     }
 
@@ -65,12 +65,12 @@ public class SmartClientInvocationService extends AbstractClientInvocationServic
         if (!isMember(target)) {
             throw new TargetNotMemberException("Target '" + target + "' is not a member.");
         }
-        Connection connection = getOrTriggerConnect(target);
+        Connection connection = getOrTriggerConnect(target, invocation.getClientMessage().acquiresResource());
         invokeOnConnection(invocation, (ClientConnection) connection);
     }
 
-    private Connection getOrTriggerConnect(Address target) throws IOException {
-        Connection connection = connectionManager.getOrTriggerConnect(target);
+    private Connection getOrTriggerConnect(Address target, boolean acquiresResource) throws IOException {
+        Connection connection = connectionManager.getOrTriggerConnect(target, acquiresResource);
         if (connection == null) {
             throw new IOException("No available connection to address " + target);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
@@ -205,7 +205,7 @@ public class SmartClientListenerService extends AbstractClientListenerService
                 Collection<Member> memberList = clientClusterService.getMemberList();
                 for (Member member : memberList) {
                     try {
-                        clientConnectionManager.getOrTriggerConnect(member.getAddress());
+                        clientConnectionManager.getOrTriggerConnect(member.getAddress(), false);
                     } catch (IOException e) {
                         return;
                     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -27,6 +27,14 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public final class ClientProperty {
 
     /**
+     * Client disallows doing invocations on client disconnected state. When this property is set to true, even client
+     * is not connected to all cluster, it allows invocations that can go thorough available ones.
+     */
+    public static final HazelcastProperty ALLOW_INVOCATIONS_WHEN_DISCONNECTED
+            = new HazelcastProperty("hazelcast.client.allow.invocations.when.disconnected", false);
+
+
+    /**
      * Client shuffles the given member list to prevent all clients to connect to the same node when
      * this property is set to true. When it is set to false, the client tries to connect to the nodes
      * in the given order.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -225,13 +225,13 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         clientConfig.getConnectionStrategyConfig().setReconnectMode(reconnectMode);
         clientConfig.setProperty(ClientProperty.ALLOW_INVOCATIONS_WHEN_DISCONNECTED.getName(), "true");
         final AtomicBoolean waitFlag = new AtomicBoolean();
-        final CountDownLatch testFinishedSuccessfully = new CountDownLatch(1);
+        final CountDownLatch testFinished = new CountDownLatch(1);
         final AddressProvider addressProvider = new AddressProvider() {
             @Override
             public Collection<Address> loadAddresses() {
                 if (waitFlag.get()) {
                     try {
-                        testFinishedSuccessfully.await();
+                        testFinished.await();
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
@@ -270,7 +270,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         clientMap.put(keyOwnedBy2, 1);
         assertEquals(1, clientMap.get(keyOwnedBy2));
 
-        testFinishedSuccessfully.countDown();
+        testFinished.countDown();
 
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -114,7 +114,7 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
 
     @Test
     public void testTranslatorIsNotUsedOnTriggerConnect() throws Exception {
-        Connection connection = clientConnectionManager.getOrTriggerConnect(privateAddress);
+        Connection connection = clientConnectionManager.getOrTriggerConnect(privateAddress, false);
         assertNotNull(connection);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.txn;
+
+import com.atomikos.icatch.jta.UserTransactionManager;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.HazelcastClientFactory;
+import com.hazelcast.client.HazelcastClientManager;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.impl.ClientConnectionManagerFactory;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.client.util.AddressHelper;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.HazelcastXAResource;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.transaction.Transaction;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientTxnOwnerDisconnectedTest {
+
+    @After
+    public void after() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Before
+    public void before() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTransactionBeginShouldFail_onDisconnectedState() {
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        final AtomicBoolean waitFlag = new AtomicBoolean();
+        final CountDownLatch testFinished = new CountDownLatch(1);
+        final AddressProvider addressProvider = new AddressProvider() {
+            @Override
+            public Collection<Address> loadAddresses() {
+                if (waitFlag.get()) {
+                    try {
+                        testFinished.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+                return AddressHelper.getSocketAddresses("127.0.0.1");
+            }
+        };
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
+        final HazelcastInstance client = HazelcastClientManager.newHazelcastClient(clientConfig, new HazelcastClientFactory() {
+            @Override
+            public HazelcastClientInstanceImpl createHazelcastInstanceClient(ClientConfig config, ClientConnectionManagerFactory factory) {
+                return new HazelcastClientInstanceImpl(config, factory, addressProvider);
+            }
+
+            @Override
+            public HazelcastClientProxy createProxy(HazelcastClientInstanceImpl client) {
+                return new HazelcastClientProxy(client);
+            }
+        });
+
+
+        Hazelcast.newHazelcastInstance();
+        final TransactionContext context = client.newTransactionContext();
+
+        //we are closing owner connection and making sure owner connection is not established ever again
+        waitFlag.set(true);
+        instance1.shutdown();
+
+        try {
+            context.beginTransaction();
+        } finally {
+            testFinished.countDown();
+        }
+
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testNewTransactionContextShouldFail_onDisconnectedState() {
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        final AtomicBoolean waitFlag = new AtomicBoolean();
+        final CountDownLatch testFinished = new CountDownLatch(1);
+        final AddressProvider addressProvider = new AddressProvider() {
+            @Override
+            public Collection<Address> loadAddresses() {
+                if (waitFlag.get()) {
+                    try {
+                        testFinished.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+                return AddressHelper.getSocketAddresses("127.0.0.1");
+            }
+        };
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
+        final HazelcastInstance client = HazelcastClientManager.newHazelcastClient(clientConfig, new HazelcastClientFactory() {
+            @Override
+            public HazelcastClientInstanceImpl createHazelcastInstanceClient(ClientConfig config, ClientConnectionManagerFactory factory) {
+                return new HazelcastClientInstanceImpl(config, factory, addressProvider);
+            }
+
+            @Override
+            public HazelcastClientProxy createProxy(HazelcastClientInstanceImpl client) {
+                return new HazelcastClientProxy(client);
+            }
+        });
+
+
+        Hazelcast.newHazelcastInstance();
+
+        //we are closing owner connection and making sure owner connection is not established ever again
+        waitFlag.set(true);
+        instance1.shutdown();
+
+        try {
+            client.newTransactionContext();
+        } finally {
+            testFinished.countDown();
+        }
+
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testXAShouldFail_onDisconnectedState() throws Throwable {
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        final AtomicBoolean waitFlag = new AtomicBoolean();
+        final CountDownLatch testFinished = new CountDownLatch(1);
+        final AddressProvider addressProvider = new AddressProvider() {
+            @Override
+            public Collection<Address> loadAddresses() {
+                if (waitFlag.get()) {
+                    try {
+                        testFinished.await();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+                return AddressHelper.getSocketAddresses("127.0.0.1");
+            }
+        };
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
+        clientConfig.setProperty(ClientProperty.ALLOW_INVOCATIONS_WHEN_DISCONNECTED.getName(), "true");
+        final HazelcastInstance client = HazelcastClientManager.newHazelcastClient(clientConfig, new HazelcastClientFactory() {
+            @Override
+            public HazelcastClientInstanceImpl createHazelcastInstanceClient(ClientConfig config, ClientConnectionManagerFactory factory) {
+                return new HazelcastClientInstanceImpl(config, factory, addressProvider);
+            }
+
+            @Override
+            public HazelcastClientProxy createProxy(HazelcastClientInstanceImpl client) {
+                return new HazelcastClientProxy(client);
+            }
+        });
+
+        Hazelcast.newHazelcastInstance();
+
+
+        HazelcastXAResource xaResource = client.getXAResource();
+        UserTransactionManager tm = new UserTransactionManager();
+        cleanAtomikosLogs();
+        tm.setTransactionTimeout(3);
+        tm.begin();
+        Transaction transaction = tm.getTransaction();
+
+        //we are closing owner connection and making sure owner connection is not established ever again
+        waitFlag.set(true);
+        instance1.shutdown();
+
+        try {
+            transaction.enlistResource(xaResource);
+        } finally {
+            transaction.rollback();
+            tm.close();
+            cleanAtomikosLogs();
+            testFinished.countDown();
+        }
+
+
+    }
+
+    public void cleanAtomikosLogs() {
+        try {
+            File currentDir = new File(".");
+            final File[] tmLogs = currentDir.listFiles(new FilenameFilter() {
+                public boolean accept(File dir, String name) {
+                    if (name.endsWith(".epoch") || name.startsWith("tmlog")) {
+                        return true;
+                    }
+                    return false;
+                }
+            });
+            for (File tmLog : tmLogs) {
+                tmLog.delete();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -107,6 +107,7 @@ public class ClientMessage
 
     private transient int writeOffset;
     private transient boolean isRetryable;
+    private transient boolean acquiresResource;
     private transient String operationName;
 
     protected ClientMessage() {
@@ -369,6 +370,14 @@ public class ClientMessage
 
     public boolean isRetryable() {
         return isRetryable;
+    }
+
+    public boolean acquiresResource() {
+        return acquiresResource;
+    }
+
+    public void setAcquiresResource(boolean acquiresResource) {
+        this.acquiresResource = acquiresResource;
     }
 
     public void setRetryable(boolean isRetryable) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.XATransactionCollectTransactionsCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
 import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -62,6 +63,12 @@ public class XACollectTransactionsMessageTask
     protected Object reduce(Map<Member, Object> map) throws Throwable {
         List<Data> list = new ArrayList<Data>();
         for (Object o : map.values()) {
+            if (o instanceof Throwable) {
+                if (o instanceof MemberLeftException) {
+                    continue;
+                }
+                throw (Throwable) o;
+            }
             SerializableList xidSet = (SerializableList) o;
             list.addAll(xidSet.getCollection());
         }


### PR DESCRIPTION
Owner connection check is only needed for the invocations that
will acquire resources like map.lock/trylock lock.lock/trylock
and most of the semaphore operations. Other invocations does not
need owner connection to be available. This improvement is made
to isolate owner connection failure from invocations on other
connections.