### PR TITLE
Filter throwable peeling in MessageTask exception handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.client.impl.client.SecureRequest;
 import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -33,14 +34,20 @@ import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.security.Permission;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hazelcast.util.ExceptionUtil.peel;
 
 /**
  * Base Message task.
  */
 public abstract class AbstractMessageTask<P> implements MessageTask, SecureRequest {
+
+    private static final List<Class<? extends Throwable>> NON_PEELABLE_EXCEPTIONS =
+            Arrays.asList(Error.class, MemberLeftException.class);
 
     protected final ClientMessage clientMessage;
 
@@ -218,7 +225,7 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
 
     protected void sendClientMessage(Throwable throwable) {
         ClientExceptionFactory exceptionFactory = clientEngine.getClientExceptionFactory();
-        ClientMessage exception = exceptionFactory.createExceptionMessage(ExceptionUtil.peel(throwable));
+        ClientMessage exception = exceptionFactory.createExceptionMessage(peelIfNeeded(throwable));
         sendClientMessage(exception);
     }
 
@@ -240,5 +247,19 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
 
     protected final BuildInfo getMemberBuildInfo() {
         return node.getBuildInfo();
+    }
+
+    private Throwable peelIfNeeded(Throwable t) {
+        if (t == null) {
+            return null;
+        }
+
+        for (Class<? extends Throwable> clazz : NON_PEELABLE_EXCEPTIONS) {
+            if (clazz.isAssignableFrom(t.getClass())) {
+                return t;
+            }
+        }
+
+        return peel(t);
     }
 }


### PR DESCRIPTION
Not sure this is the right approach to address the attached issues. 

- `ExceptionUtil.peel()`
appears to be more intrusive than the method name implies, meaning that it wraps exceptions in RuntimeException, even though I was expecting it to just peel the likes of ExecutionException etc. This was **always** the case, so in order to avoid peeling `Error` instances, we need to whitelist them.

- `MemberLeftException`
Started as an IllegalStateException back in the day, and ended up being an ExecutionException. This has been like that for quite a few years. It is a retry-able exception, but it's not a Runtime one. When peeled, with the above API, it gets wrapped in a Runtime holder. 

Ideally, for the latter case, we need to change it to become a `RetryableHazelcastException` instead, which inherits the RuntimeException. However, I am sure this will have other hidden consequences at this stage for 3.10, given the nature of Exceptions in the Java ecosystem.

Applied a filtering approach to handle both cases.
Fixes https://github.com/hazelcast/hazelcast/issues/12419
Fixes https://github.com/hazelcast/hazelcast/issues/12418