### PR TITLE
Renamed MigritableHandler to MigritablePipeline.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratablePipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratablePipeline.java
@@ -17,38 +17,38 @@
 package com.hazelcast.internal.networking.nio;
 
 /**
- * A nio event handler that supports migration between {@link NioThread} instances.
+ * A NioPipeline that supports migration between {@link NioThread} instances.
  * This API is called by the {@link com.hazelcast.internal.networking.nio.iobalancer.IOBalancer}.
  */
-public interface MigratableHandler {
+public interface MigratablePipeline {
 
     /**
-     * Requests the MigratableHandler to move to the new NioThread. This call will not wait for the
+     * Requests the MigratablePipeline to move to the new NioThread. This call will not wait for the
      * migration to complete.
      *
      * This method can be called by any thread, and will probably be called by the
      * {@link com.hazelcast.internal.networking.nio.iobalancer.IOBalancer}.
      *
-     * Call is ignored when handler is moving to the same NioThread.
+     * Call is ignored when pipeline is moving to the same NioThread.
      *
-     * @param newOwner the NioThread that is going to own this MigratableHandler
+     * @param newOwner the NioThread that is going to own this MigratablePipeline
      */
     void requestMigration(NioThread newOwner);
 
     /**
-     * Get NioThread currently owning this handler. Handler owner is a thread running this handler.
+     * Get NioThread currently owning this pipeline. Pipeline owner is a thread running this pipeline.
      * {@link com.hazelcast.internal.networking.nio.iobalancer.IOBalancer IOBalancer} can decide to migrate
-     * a handler to another owner.
+     * a pipeline to another owner.
      *
      * @return current owner
      */
     NioThread getOwner();
 
     /**
-     * Get 'load' recorded by the current handler. It can be used to calculate whether
-     * this handler should be migrated to a different {@link NioThread}
+     * Get 'load' recorded by the current pipeline. It can be used to calculate whether
+     * this pipeline should be migrated to a different {@link NioThread}
      *
-     * @return total load recorded by this handler
+     * @return total load recorded by this pipeline
      */
     long getLoad();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -35,7 +35,7 @@ import static java.nio.channels.SelectionKey.OP_READ;
 
 /**
  * When the {@link NioThread} receives a read event from the {@link java.nio.channels.Selector}, then the
- * {@link #handle()} is called to read out the data from the socket into a bytebuffer and hand it over to the
+ * {@link #process()} is called to read out the data from the socket into a bytebuffer and hand it over to the
  * {@link ChannelInboundHandler} to get processed.
  */
 public final class NioInboundPipeline extends NioPipeline {
@@ -71,7 +71,7 @@ public final class NioInboundPipeline extends NioPipeline {
     public long getLoad() {
         switch (LOAD_TYPE) {
             case LOAD_BALANCING_HANDLE:
-                return handleCount.get();
+                return processCount.get();
             case LOAD_BALANCING_BYTE:
                 return bytesRead.get();
             case LOAD_BALANCING_FRAME:
@@ -99,14 +99,14 @@ public final class NioInboundPipeline extends NioPipeline {
     }
 
     /**
-     * Migrates this handler to a new NioThread.
+     * Migrates this Pipeline to a new NioThread.
      * The migration logic is rather simple:
      * <p><ul>
      * <li>Submit a de-registration task to a current NioThread</li>
      * <li>The de-registration task submits a registration task to the new NioThread</li>
      * </ul></p>
      *
-     * @param newOwner target NioThread this handler migrates to
+     * @param newOwner target NioThread this pipeline migrates to
      */
     @Override
     public void requestMigration(NioThread newOwner) {
@@ -114,8 +114,8 @@ public final class NioInboundPipeline extends NioPipeline {
     }
 
     @Override
-    public void handle() throws Exception {
-        handleCount.inc();
+    public void process() throws Exception {
+        processCount.inc();
         // we are going to set the timestamp even if the channel is going to fail reading. In that case
         // the connection is going to be closed anyway.
         lastReadTime = currentTimeMillis();
@@ -166,12 +166,12 @@ public final class NioInboundPipeline extends NioPipeline {
         ioThread.bytesTransceived += bytesRead.get() - bytesReadLastPublish;
         ioThread.framesTransceived += normalFramesRead.get() - normalFramesReadLastPublish;
         ioThread.priorityFramesTransceived += priorityFramesRead.get() - priorityFramesReadLastPublish;
-        ioThread.handleCount += handleCount.get() - handleCountLastPublish;
+        ioThread.handleCount += processCount.get() - handleCountLastPublish;
 
         bytesReadLastPublish = bytesRead.get();
         normalFramesReadLastPublish = normalFramesRead.get();
         priorityFramesReadLastPublish = priorityFramesRead.get();
-        handleCountLastPublish = handleCount.get();
+        handleCountLastPublish = processCount.get();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -90,7 +90,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
     public long getLoad() {
         switch (LOAD_TYPE) {
             case LOAD_BALANCING_HANDLE:
-                return handleCount.get();
+                return processCount.get();
             case LOAD_BALANCING_BYTE:
                 return bytesWritten.get() + priorityFramesWritten.get();
             case LOAD_BALANCING_FRAME:
@@ -250,8 +250,8 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void handle() throws Exception {
-        handleCount.inc();
+    public void process() throws Exception {
+        processCount.inc();
         lastWriteTime = currentTimeMillis();
 
         if (outboundHandler == null && !init()) {
@@ -280,7 +280,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
     private boolean init() throws IOException {
         InitResult<ChannelOutboundHandler> init = initializer.initOutbound(channel);
         if (init == null) {
-            // we can't initialize the outbound-handler yet since insufficient data is available.
+            // we can't initialize the outbound-pipeline yet since insufficient data is available.
             unschedule();
             return false;
         }
@@ -344,7 +344,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
     @Override
     public void run() {
         try {
-            handle();
+            process();
         } catch (Throwable t) {
             onFailure(t);
         }
@@ -423,12 +423,12 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
         ioThread.bytesTransceived += bytesWritten.get() - bytesReadLastPublish;
         ioThread.framesTransceived += normalFramesWritten.get() - normalFramesReadLastPublish;
         ioThread.priorityFramesTransceived += priorityFramesWritten.get() - priorityFramesReadLastPublish;
-        ioThread.handleCount += handleCount.get() - eventsLastPublish;
+        ioThread.handleCount += processCount.get() - eventsLastPublish;
 
         bytesReadLastPublish = bytesWritten.get();
         normalFramesReadLastPublish = normalFramesWritten.get();
         priorityFramesReadLastPublish = priorityFramesWritten.get();
-        eventsLastPublish = handleCount.get();
+        eventsLastPublish = processCount.get();
     }
 
     private class CloseTask implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -30,7 +30,7 @@ import java.nio.channels.SocketChannel;
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
-public abstract class NioPipeline implements MigratableHandler, Closeable {
+public abstract class NioPipeline implements MigratablePipeline, Closeable {
 
     protected static final int LOAD_BALANCING_HANDLE = 0;
     protected static final int LOAD_BALANCING_BYTE = 1;
@@ -40,7 +40,7 @@ public abstract class NioPipeline implements MigratableHandler, Closeable {
     protected static final int LOAD_TYPE = Integer.getInteger("hazelcast.io.load", LOAD_BALANCING_BYTE);
 
     @Probe
-    protected final SwCounter handleCount = newSwCounter();
+    protected final SwCounter processCount = newSwCounter();
     @Probe
     protected final SwCounter completedMigrations = newSwCounter();
     protected final ILogger logger;
@@ -51,7 +51,7 @@ public abstract class NioPipeline implements MigratableHandler, Closeable {
     private final int initialOps;
     private final IOBalancer ioBalancer;
 
-    // shows the ID of the ioThread that is currently owning the handler
+    // shows the ID of the ioThread that is currently owning the pipeline
     @Probe
     private volatile int ioThreadId;
 
@@ -142,17 +142,17 @@ public abstract class NioPipeline implements MigratableHandler, Closeable {
      *
      * @throws Exception
      */
-    public abstract void handle() throws Exception;
+    public abstract void process() throws Exception;
 
     /**
-     * Is called when the {@link #handle()} throws an exception.
+     * Is called when the {@link #process()} throws an exception.
      *
-     * The idiom to use a handler is:
+     * The idiom to use a pipeline is:
      * <code>
      *     try{
-     *         handler.handle();
+     *         pipeline.handle();
      *     } catch(Throwable t) {
-     *         handler.onFailure(t);
+     *         pipeline.onFailure(t);
      *     }
      * </code>
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -355,8 +355,8 @@ public class NioThread extends Thread implements OperationHostileThread {
     }
 
     private NioThread getTargetIOThread(Runnable task) {
-        if (task instanceof MigratableHandler) {
-            return ((MigratableHandler) task).getOwner();
+        if (task instanceof MigratablePipeline) {
+            return ((MigratablePipeline) task).getOwner();
         } else {
             return this;
         }
@@ -384,7 +384,7 @@ public class NioThread extends Thread implements OperationHostileThread {
             // we don't need to check for sk.isReadable/sk.isWritable since the pipeline has only registered
             // for events it can handle.
             eventCount.inc();
-            pipeline.handle();
+            pipeline.process();
         } catch (Throwable t) {
             pipeline.onFailure(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategy.java
@@ -16,17 +16,17 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 
 import java.util.Set;
 
 /**
- * Default {@link MigrationStrategy} for {@link MigratableHandler} instances.
+ * Default {@link MigrationStrategy} for {@link MigratablePipeline} instances.
  *
  * It attempts to trigger a migration if a ratio between least busy and most busy selectors
  * exceeds {@link #MIN_MAX_RATIO_MIGRATION_THRESHOLD}.
  *
- * Once a migration is triggered it tries to find the busiest handler registered in
+ * Once a migration is triggered it tries to find the busiest pipeline registered in
  * {@link LoadImbalance#sourceSelector} which wouldn't cause
  * overload of the {@link LoadImbalance#destinationSelector} after a migration.
  *
@@ -44,7 +44,7 @@ class EventCountBasicMigrationStrategy implements MigrationStrategy {
     private static final double MIN_MAX_RATIO_MIGRATION_THRESHOLD = 0.8;
 
     /**
-     * You can use this property to tune a selection process for handler migration. The higher number is the more
+     * You can use this property to tune a selection process for pipeline migration. The higher number is the more
      * aggressive migration process is.
      */
     private static final double MAXIMUM_NO_OF_EVENTS_AFTER_MIGRATION_COEFFICIENT = 0.9;
@@ -68,24 +68,24 @@ class EventCountBasicMigrationStrategy implements MigrationStrategy {
     }
 
     /**
-     * Attempt to find a handler to migrate to a new NioThread.
+     * Attempt to find a pipeline to migrate to a new NioThread.
      *
      * @param imbalance describing a snapshot of NioThread load
-     * @return the handler to migrate to a new NioThread or null if no handler needs to be migrated.
+     * @return the pipeline to migrate to a new NioThread or null if no pipeline needs to be migrated.
      */
     @Override
-    public MigratableHandler findHandlerToMigrate(LoadImbalance imbalance) {
-        Set<? extends MigratableHandler> candidates = imbalance.getHandlersOwnerBy(imbalance.sourceSelector);
+    public MigratablePipeline findPipelineToMigrate(LoadImbalance imbalance) {
+        Set<? extends MigratablePipeline> candidates = imbalance.getPipelinesOwnerBy(imbalance.sourceSelector);
         long migrationThreshold = (long) ((imbalance.maximumEvents - imbalance.minimumEvents)
                 * MAXIMUM_NO_OF_EVENTS_AFTER_MIGRATION_COEFFICIENT);
-        MigratableHandler candidate = null;
+        MigratablePipeline candidate = null;
         long eventCountInSelectedHandler = 0;
-        for (MigratableHandler handler : candidates) {
-            long eventCount = imbalance.getLoad(handler);
+        for (MigratablePipeline migratablePipeline : candidates) {
+            long eventCount = imbalance.getLoad(migratablePipeline);
             if (eventCount > eventCountInSelectedHandler) {
                 if (eventCount < migrationThreshold) {
                     eventCountInSelectedHandler = eventCount;
-                    candidate = handler;
+                    candidate = migratablePipeline;
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.networking.nio.iobalancer;
 
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioInboundPipeline;
-import com.hazelcast.internal.networking.nio.MigratableHandler;
 import com.hazelcast.internal.networking.nio.NioOutboundPipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.internal.util.counters.MwCounter;
@@ -41,8 +41,8 @@ import static com.hazelcast.spi.properties.GroupProperty.IO_THREAD_COUNT;
  * <code>IOBalancer</code> tries to detect such situations and fix them by moving {@link NioInboundPipeline} and
  * {@link NioOutboundPipeline} between {@link NioThread} instances.
  *
- * It measures number of events serviced by each handler in a given interval and if imbalance is detected then it
- * schedules handler migration to fix the situation. The exact migration strategy can be customized via
+ * It measures number of events serviced by each pipeline in a given interval and if imbalance is detected then it
+ * schedules pipeline migration to fix the situation. The exact migration strategy can be customized via
  * {@link com.hazelcast.internal.networking.nio.iobalancer.MigrationStrategy}.
  *
  * Measuring interval can be customized via {@link GroupProperty#IO_BALANCER_INTERVAL_SECONDS}
@@ -99,7 +99,7 @@ public class IOBalancer {
         return outLoadTracker;
     }
 
-    public void channelAdded(MigratableHandler readHandler, MigratableHandler writeHandler) {
+    public void channelAdded(MigratablePipeline readHandler, MigratablePipeline writeHandler) {
         // if not enabled, then don't schedule tasks that will not get processed.
         // See https://github.com/hazelcast/hazelcast/issues/11501
         if (!enabled) {
@@ -110,7 +110,7 @@ public class IOBalancer {
         outLoadTracker.notifyHandlerAdded(writeHandler);
     }
 
-    public void channelRemoved(MigratableHandler readHandler, MigratableHandler writeHandler) {
+    public void channelRemoved(MigratablePipeline readHandler, MigratablePipeline writeHandler) {
         // if not enabled, then don't schedule tasks that will not get processed.
         // See https://github.com/hazelcast/hazelcast/issues/11501
         if (!enabled) {
@@ -152,7 +152,7 @@ public class IOBalancer {
                 long min = loadImbalance.minimumEvents;
                 long max = loadImbalance.maximumEvents;
                 if (max == Long.MIN_VALUE) {
-                    logger.finest("There is at most 1 handler associated with each thread. "
+                    logger.finest("There is at most 1 pipeline associated with each thread. "
                             + "There is nothing to balance");
                 } else {
                     logger.finest("No imbalance has been detected. Max. events: " + max + " Min events: " + min + ".");
@@ -193,8 +193,8 @@ public class IOBalancer {
     }
 
     private void tryMigrate(LoadImbalance loadImbalance) {
-        MigratableHandler handler = strategy.findHandlerToMigrate(loadImbalance);
-        if (handler == null) {
+        MigratablePipeline pipeline = strategy.findPipelineToMigrate(loadImbalance);
+        if (pipeline == null) {
             logger.finest("I/O imbalance is detected, but no suitable migration candidate is found.");
             return;
         }
@@ -202,10 +202,10 @@ public class IOBalancer {
         NioThread destinationSelector = loadImbalance.destinationSelector;
         if (logger.isFinestEnabled()) {
             NioThread sourceSelector = loadImbalance.sourceSelector;
-            logger.finest("Scheduling migration of handler " + handler
+            logger.finest("Scheduling migration of pipeline " + pipeline
                     + " from selector thread " + sourceSelector + " to " + destinationSelector);
         }
-        handler.requestMigration(destinationSelector);
+        pipeline.requestMigration(destinationSelector);
     }
 
     public void signalMigrationComplete() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioPipeline;
-import com.hazelcast.internal.networking.nio.MigratableHandler;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.util.ItemCounter;
 
@@ -40,11 +40,11 @@ class LoadImbalance {
     //least busy NioThread
     NioThread destinationSelector;
 
-    private final Map<NioThread, Set<MigratableHandler>> selectorToHandlers;
-    private final ItemCounter<MigratableHandler> handlerLoadCounter;
+    private final Map<NioThread, Set<MigratablePipeline>> selectorToHandlers;
+    private final ItemCounter<MigratablePipeline> handlerLoadCounter;
 
-    LoadImbalance(Map<NioThread, Set<MigratableHandler>> selectorToHandlers,
-                  ItemCounter<MigratableHandler> handlerLoadCounter) {
+    LoadImbalance(Map<NioThread, Set<MigratablePipeline>> selectorToHandlers,
+                  ItemCounter<MigratablePipeline> handlerLoadCounter) {
         this.selectorToHandlers = selectorToHandlers;
         this.handlerLoadCounter = handlerLoadCounter;
     }
@@ -53,15 +53,15 @@ class LoadImbalance {
      * @param selector
      * @return A set of Handlers owned by the selector
      */
-    Set<MigratableHandler> getHandlersOwnerBy(NioThread selector) {
+    Set<MigratablePipeline> getPipelinesOwnerBy(NioThread selector) {
         return selectorToHandlers.get(selector);
     }
 
     /**
-     * @param handler
-     * @return number of events recorded by the handler
+     * @param pipeline
+     * @return load recorded by the pipeline
      */
-    long getLoad(MigratableHandler handler) {
-        return handlerLoadCounter.get(handler);
+    long getLoad(MigratablePipeline pipeline) {
+        return handlerLoadCounter.get(pipeline);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.ItemCounter;
@@ -35,8 +35,8 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
  * Tracks the load of of NioThread(s) and creates a mapping between NioThread -> Handler.
  * <p/>
  * This class is not thread-safe with the exception of
- * {@link #addHandler(MigratableHandler)}   and
- * {@link #removeHandler(MigratableHandler)}
+ * {@link #addPipeline(MigratablePipeline)}   and
+ * {@link #removePipeline(MigratablePipeline)}
  */
 class LoadTracker {
     final Queue<Runnable> tasks = new LinkedBlockingQueue<Runnable>();
@@ -45,18 +45,18 @@ class LoadTracker {
 
     //all known IO ioThreads. we assume no. of ioThreads is constant during a lifespan of a member
     private final NioThread[] ioThreads;
-    private final Map<NioThread, Set<MigratableHandler>> selectorToHandlers;
+    private final Map<NioThread, Set<MigratablePipeline>> selectorToHandlers;
 
-    //no. of events per handler since an instance started
-    private final ItemCounter<MigratableHandler> lastEventCounter = new ItemCounter<MigratableHandler>();
+    //no. of events per pipeline since an instance started
+    private final ItemCounter<MigratablePipeline> lastEventCounter = new ItemCounter<MigratablePipeline>();
 
     //no. of events per NioThread since last calculation
     private final ItemCounter<NioThread> selectorEvents = new ItemCounter<NioThread>();
-    //no. of events per handler since last calculation
-    private final ItemCounter<MigratableHandler> handlerEventsCounter = new ItemCounter<MigratableHandler>();
+    //no. of events per pipeline since last calculation
+    private final ItemCounter<MigratablePipeline> handlerEventsCounter = new ItemCounter<MigratablePipeline>();
 
-    //contains all known handlers
-    private final Set<MigratableHandler> handlers = new HashSet<MigratableHandler>();
+    //contains all known pipelines
+    private final Set<MigratablePipeline> pipelines = new HashSet<MigratablePipeline>();
 
     private final LoadImbalance imbalance;
 
@@ -68,7 +68,7 @@ class LoadTracker {
 
         this.selectorToHandlers = createHashMap(ioThreads.length);
         for (NioThread selector : ioThreads) {
-            selectorToHandlers.put(selector, new HashSet<MigratableHandler>());
+            selectorToHandlers.put(selector, new HashSet<MigratablePipeline>());
         }
         this.imbalance = new LoadImbalance(selectorToHandlers, handlerEventsCounter);
     }
@@ -98,17 +98,17 @@ class LoadTracker {
     }
 
     // just for testing
-    Set<MigratableHandler> getHandlers() {
-        return handlers;
+    Set<MigratablePipeline> getPipelines() {
+        return pipelines;
     }
 
     // just for testing
-    ItemCounter<MigratableHandler> getLastEventCounter() {
+    ItemCounter<MigratablePipeline> getLastEventCounter() {
         return lastEventCounter;
     }
 
     // just for testing
-    ItemCounter<MigratableHandler> getHandlerEventsCounter() {
+    ItemCounter<MigratablePipeline> getHandlerEventsCounter() {
         return handlerEventsCounter;
     }
 
@@ -123,7 +123,7 @@ class LoadTracker {
 
             if (eventCount > imbalance.maximumEvents && handlerCount > 1) {
                 // if a selector has only 1 handle, there is no point in making it a source selector since
-                // there is no handler that can be migrated anyway. In that case it is better to move on to
+                // there is no pipeline that can be migrated anyway. In that case it is better to move on to
                 // the next selector.
                 imbalance.maximumEvents = eventCount;
                 imbalance.sourceSelector = selector;
@@ -136,54 +136,54 @@ class LoadTracker {
         }
     }
 
-    public void notifyHandlerAdded(MigratableHandler handler) {
-        AddHandlerTask addHandlerTask = new AddHandlerTask(handler);
-        tasks.offer(addHandlerTask);
+    public void notifyHandlerAdded(MigratablePipeline pipeline) {
+        AddPipelineTask addPipelineTask = new AddPipelineTask(pipeline);
+        tasks.offer(addPipelineTask);
     }
 
-    public void notifyHandlerRemoved(MigratableHandler handler) {
-        RemoveHandlerTask removeHandlerTask = new RemoveHandlerTask(handler);
-        tasks.offer(removeHandlerTask);
+    public void notifyHandlerRemoved(MigratablePipeline pipeline) {
+        RemovePipelineTask removePipelineTask = new RemovePipelineTask(pipeline);
+        tasks.offer(removePipelineTask);
     }
 
 
     private void updateNewWorkingImbalance() {
-        for (MigratableHandler handler : handlers) {
-            updateHandlerState(handler);
+        for (MigratablePipeline pipeline : pipelines) {
+            updateHandlerState(pipeline);
         }
     }
 
-    private void updateHandlerState(MigratableHandler handler) {
-        long handlerEventCount = getEventCountSinceLastCheck(handler);
-        handlerEventsCounter.set(handler, handlerEventCount);
-        NioThread owner = handler.getOwner();
-        selectorEvents.add(owner, handlerEventCount);
-        Set<MigratableHandler> handlersOwnedBy = selectorToHandlers.get(owner);
-        handlersOwnedBy.add(handler);
+    private void updateHandlerState(MigratablePipeline pipeline) {
+        long pipelineEventCount = getEventCountSinceLastCheck(pipeline);
+        handlerEventsCounter.set(pipeline, pipelineEventCount);
+        NioThread owner = pipeline.getOwner();
+        selectorEvents.add(owner, pipelineEventCount);
+        Set<MigratablePipeline> handlersOwnedBy = selectorToHandlers.get(owner);
+        handlersOwnedBy.add(pipeline);
     }
 
-    private long getEventCountSinceLastCheck(MigratableHandler handler) {
-        long eventCount = handler.getLoad();
-        Long lastEventCount = lastEventCounter.getAndSet(handler, eventCount);
+    private long getEventCountSinceLastCheck(MigratablePipeline pipeline) {
+        long eventCount = pipeline.getLoad();
+        Long lastEventCount = lastEventCounter.getAndSet(pipeline, eventCount);
         return eventCount - lastEventCount;
     }
 
     private void clearWorkingImbalance() {
         handlerEventsCounter.reset();
         selectorEvents.reset();
-        for (Set<MigratableHandler> handlerSet : selectorToHandlers.values()) {
+        for (Set<MigratablePipeline> handlerSet : selectorToHandlers.values()) {
             handlerSet.clear();
         }
     }
 
-    void addHandler(MigratableHandler handler) {
-        handlers.add(handler);
+    void addPipeline(MigratablePipeline pipeline) {
+        pipelines.add(pipeline);
     }
 
-    void removeHandler(MigratableHandler handler) {
-        handlers.remove(handler);
-        handlerEventsCounter.remove(handler);
-        lastEventCounter.remove(handler);
+    void removePipeline(MigratablePipeline pipeline) {
+        pipelines.remove(pipeline);
+        handlerEventsCounter.remove(pipeline);
+        lastEventCounter.remove(pipeline);
     }
 
     private void printDebugTable() {
@@ -206,7 +206,7 @@ class LoadTracker {
                 .append(" received ")
                 .append(eventCountPerSelector)
                 .append(" events. ");
-        sb.append("It contains following handlers: ").
+        sb.append("It contains following pipelines: ").
                 append(LINE_SEPARATOR);
         appendSelectorInfo(minThread, selectorToHandlers, sb);
 
@@ -216,7 +216,7 @@ class LoadTracker {
                 .append(" received ")
                 .append(eventCountPerSelector)
                 .append(" events. ");
-        sb.append("It contains following handlers: ")
+        sb.append("It contains following pipelines: ")
                 .append(LINE_SEPARATOR);
         appendSelectorInfo(maxThread, selectorToHandlers, sb);
 
@@ -230,7 +230,7 @@ class LoadTracker {
                         .append(selector)
                         .append(" contains ")
                         .append(eventCountPerSelector)
-                        .append(" and has these handlers: ")
+                        .append(" and has these pipelines: ")
                         .append(LINE_SEPARATOR);
                 appendSelectorInfo(selector, selectorToHandlers, sb);
             }
@@ -242,10 +242,10 @@ class LoadTracker {
 
     private void appendSelectorInfo(
             NioThread minThread,
-            Map<NioThread, Set<MigratableHandler>> threadHandlers,
+            Map<NioThread, Set<MigratablePipeline>> threadHandlers,
             StringBuilder sb) {
-        Set<MigratableHandler> handlerSet = threadHandlers.get(minThread);
-        for (MigratableHandler selectionHandler : handlerSet) {
+        Set<MigratablePipeline> handlerSet = threadHandlers.get(minThread);
+        for (MigratablePipeline selectionHandler : handlerSet) {
             Long eventCountPerHandler = handlerEventsCounter.get(selectionHandler);
             sb.append(selectionHandler)
                     .append(":  ")
@@ -255,41 +255,39 @@ class LoadTracker {
         sb.append(LINE_SEPARATOR);
     }
 
-    class RemoveHandlerTask implements Runnable {
+    class RemovePipelineTask implements Runnable {
 
-        private final MigratableHandler handler;
+        private final MigratablePipeline pipeline;
 
-        public RemoveHandlerTask(MigratableHandler handler) {
-            this.handler = handler;
+        public RemovePipelineTask(MigratablePipeline pipeline) {
+            this.pipeline = pipeline;
         }
 
         @Override
         public void run() {
-
             if (logger.isFinestEnabled()) {
-                logger.finest("Removing handler: " + handler);
+                logger.finest("Removing pipeline: " + pipeline);
             }
 
-            removeHandler(handler);
+            removePipeline(pipeline);
         }
     }
 
-    class AddHandlerTask implements Runnable {
+    class AddPipelineTask implements Runnable {
 
-        private final MigratableHandler handler;
+        private final MigratablePipeline pipeline;
 
-        public AddHandlerTask(MigratableHandler handler) {
-            this.handler = handler;
+        public AddPipelineTask(MigratablePipeline pipeline) {
+            this.pipeline = pipeline;
         }
 
         @Override
         public void run() {
-
             if (logger.isFinestEnabled()) {
-                logger.finest("Adding handler: " + handler);
+                logger.finest("Adding pipeline: " + pipeline);
             }
 
-            addHandler(handler);
+            addPipeline(pipeline);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MigrationStrategy.java
@@ -16,19 +16,19 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 
 /**
- * Decides if a {@link MigratableHandler handler} migration should be attempted
- * and which handler to choose.
+ * Decides if a {@link MigratablePipeline pipeline} migration should be attempted
+ * and which pipeline to choose.
  *
  * @see IOBalancer
  */
 interface MigrationStrategy {
 
     /**
-     * Looks for imbalance in {@link MigratableHandler handler} to {@link NioThread ioThread}
+     * Looks for imbalance in {@link MigratablePipeline pipeline} to {@link NioThread ioThread}
      * mapping.
      *
      * @param imbalance
@@ -37,10 +37,10 @@ interface MigrationStrategy {
     boolean imbalanceDetected(LoadImbalance imbalance);
 
     /**
-     * Finds a {@link MigratableHandler handler} to migrate
+     * Finds a {@link MigratablePipeline pipeline} to migrate
      *
      * @param imbalance
      * @return Handler to migrate or <code>null</code> if no suitable candidate is found
      */
-    MigratableHandler findHandlerToMigrate(LoadImbalance imbalance);
+    MigratablePipeline findPipelineToMigrate(LoadImbalance imbalance);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/MonkeyMigrationStrategy.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 
 import java.util.Iterator;
 import java.util.Random;
@@ -24,9 +24,9 @@ import java.util.Set;
 
 /**
  * IOBalancer Migration Strategy intended to be used by stress tests only. It always tries to
- * select a random {@link MigratableHandler handler} to be migrated.
+ * select a random {@link MigratablePipeline pipeline} to be migrated.
  *
- * It stresses the handler migration mechanism increasing a chance to reveal possible race-conditions.
+ * It stresses the pipeline migration mechanism increasing a chance to reveal possible race-conditions.
  */
 class MonkeyMigrationStrategy implements MigrationStrategy {
 
@@ -34,17 +34,17 @@ class MonkeyMigrationStrategy implements MigrationStrategy {
 
     @Override
     public boolean imbalanceDetected(LoadImbalance imbalance) {
-        Set<? extends MigratableHandler> candidates = imbalance.getHandlersOwnerBy(imbalance.sourceSelector);
-        //only attempts to migrate if at least 1 handler exists
+        Set<? extends MigratablePipeline> candidates = imbalance.getPipelinesOwnerBy(imbalance.sourceSelector);
+        //only attempts to migrate if at least 1 pipeline exists
         return (candidates.size() > 0);
     }
 
     @Override
-    public MigratableHandler findHandlerToMigrate(LoadImbalance imbalance) {
-        Set<? extends MigratableHandler> candidates = imbalance.getHandlersOwnerBy(imbalance.sourceSelector);
+    public MigratablePipeline findPipelineToMigrate(LoadImbalance imbalance) {
+        Set<? extends MigratablePipeline> candidates = imbalance.getPipelinesOwnerBy(imbalance.sourceSelector);
         int handlerCount = candidates.size();
         int selected = random.nextInt(handlerCount);
-        Iterator<? extends MigratableHandler> iterator = candidates.iterator();
+        Iterator<? extends MigratablePipeline> iterator = candidates.iterator();
         for (int i = 0; i < selected; i++) {
             iterator.next();
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
@@ -102,7 +102,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                verify(handler).handle();
+                verify(handler).process();
             }
         });
         assertEquals(1, thread.getEventCount());
@@ -134,7 +134,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
         SelectionKey selectionKey = mock(SelectionKey.class);
         selectionKey.attach(handler);
         when(selectionKey.isValid()).thenReturn(true);
-        doThrow(new ExpectedRuntimeException()).when(handler).handle();
+        doThrow(new ExpectedRuntimeException()).when(handler).process();
 
         selector.scheduleSelectAction(selectionKey);
 
@@ -191,7 +191,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                verify(handler).handle();
+                verify(handler).process();
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/EventCountBasicMigrationStrategyTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -43,16 +43,16 @@ import static org.mockito.Mockito.mock;
 @Category({QuickTest.class, ParallelTest.class})
 public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
 
-    private Map<NioThread, Set<MigratableHandler>> selectorToHandlers;
-    private ItemCounter<MigratableHandler> handlerEventsCounter;
+    private Map<NioThread, Set<MigratablePipeline>> selectorToHandlers;
+    private ItemCounter<MigratablePipeline> handlerEventsCounter;
     private LoadImbalance imbalance;
 
     private EventCountBasicMigrationStrategy strategy;
 
     @Before
     public void setUp() {
-        selectorToHandlers = new HashMap<NioThread, Set<MigratableHandler>>();
-        handlerEventsCounter = new ItemCounter<MigratableHandler>();
+        selectorToHandlers = new HashMap<NioThread, Set<MigratablePipeline>>();
+        handlerEventsCounter = new ItemCounter<MigratablePipeline>();
         imbalance = new LoadImbalance(selectorToHandlers, handlerEventsCounter);
         strategy = new EventCountBasicMigrationStrategy();
     }
@@ -99,18 +99,18 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
         imbalance.destinationSelector = destinationSelector;
 
         imbalance.minimumEvents = 100;
-        MigratableHandler handler1 = mock(MigratableHandler.class);
+        MigratablePipeline handler1 = mock(MigratablePipeline.class);
         handlerEventsCounter.set(handler1, 100L);
         selectorToHandlers.put(destinationSelector, singleton(handler1));
 
         imbalance.maximumEvents = 300;
-        MigratableHandler handler2 = mock(MigratableHandler.class);
-        MigratableHandler handler3 = mock(MigratableHandler.class);
+        MigratablePipeline handler2 = mock(MigratablePipeline.class);
+        MigratablePipeline handler3 = mock(MigratablePipeline.class);
         handlerEventsCounter.set(handler2, 200L);
         handlerEventsCounter.set(handler3, 100L);
         selectorToHandlers.put(sourceSelector, setOf(handler2, handler3));
 
-        MigratableHandler handlerToMigrate = strategy.findHandlerToMigrate(imbalance);
+        MigratablePipeline handlerToMigrate = strategy.findPipelineToMigrate(imbalance);
         assertEquals(handler3, handlerToMigrate);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerMemoryLeakTest.java
@@ -68,8 +68,8 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                int inHandlerSize = ioBalancer.getInLoadTracker().getHandlers().size();
-                int outHandlerSize = ioBalancer.getOutLoadTracker().getHandlers().size();
+                int inHandlerSize = ioBalancer.getInLoadTracker().getPipelines().size();
+                int outHandlerSize = ioBalancer.getOutLoadTracker().getPipelines().size();
                 assertEquals(0, inHandlerSize);
                 assertEquals(0, outHandlerSize);
             }
@@ -117,8 +117,8 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
             public void run() throws Exception {
                 LoadTracker inLoadTracker = ioBalancer.getInLoadTracker();
                 LoadTracker outLoadTracker = ioBalancer.getOutLoadTracker();
-                int inHandlerSize = inLoadTracker.getHandlers().size();
-                int outHandlerSize = outLoadTracker.getHandlers().size();
+                int inHandlerSize = inLoadTracker.getPipelines().size();
+                int outHandlerSize = outLoadTracker.getPipelines().size();
                 int inHandlerEventsCount = inLoadTracker.getHandlerEventsCounter().keySet().size();
                 int outHandlerEventsCount = outLoadTracker.getHandlerEventsCounter().keySet().size();
                 int inLastEventsCount = inLoadTracker.getLastEventCounter().keySet().size();

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioChannel;
 import com.hazelcast.internal.networking.nio.NioEventLoopGroup;
 import com.hazelcast.internal.networking.nio.NioInboundPipeline;
@@ -83,12 +83,12 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
     private void assertBalanced(HazelcastInstance hz) {
         TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(hz);
 
-        Map<NioThread, Set<MigratableHandler>> handlersPerSelector = getHandlersPerSelector(connectionManager);
+        Map<NioThread, Set<MigratablePipeline>> handlersPerSelector = getHandlersPerSelector(connectionManager);
 
         try {
-            for (Map.Entry<NioThread, Set<MigratableHandler>> entry : handlersPerSelector.entrySet()) {
+            for (Map.Entry<NioThread, Set<MigratablePipeline>> entry : handlersPerSelector.entrySet()) {
                 NioThread selector = entry.getKey();
-                Set<MigratableHandler> handlers = entry.getValue();
+                Set<MigratablePipeline> handlers = entry.getValue();
                 assertBalanced(selector, handlers);
             }
         } catch (AssertionError e) {
@@ -98,8 +98,8 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         }
     }
 
-    private Map<NioThread, Set<MigratableHandler>> getHandlersPerSelector(TcpIpConnectionManager connectionManager) {
-        Map<NioThread, Set<MigratableHandler>> handlersPerSelector = new HashMap<NioThread, Set<MigratableHandler>>();
+    private Map<NioThread, Set<MigratablePipeline>> getHandlersPerSelector(TcpIpConnectionManager connectionManager) {
+        Map<NioThread, Set<MigratablePipeline>> handlersPerSelector = new HashMap<NioThread, Set<MigratablePipeline>>();
         for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
             NioChannel channel = (NioChannel) connection.getChannel();
             add(handlersPerSelector, channel.getInboundPipeline());
@@ -108,10 +108,10 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         return handlersPerSelector;
     }
 
-    private void add(Map<NioThread, Set<MigratableHandler>> handlersPerSelector, MigratableHandler handler) {
-        Set<MigratableHandler> handlers = handlersPerSelector.get(handler.getOwner());
+    private void add(Map<NioThread, Set<MigratablePipeline>> handlersPerSelector, MigratablePipeline handler) {
+        Set<MigratablePipeline> handlers = handlersPerSelector.get(handler.getOwner());
         if (handlers == null) {
-            handlers = new HashSet<MigratableHandler>();
+            handlers = new HashSet<MigratablePipeline>();
             handlersPerSelector.put(handler.getOwner(), handlers);
         }
         handlers.add(handler);
@@ -124,16 +124,16 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
      * <li>potentially 1 dead handler (duplicate connection), so event count should be low</li>
      * </ul>
      */
-    private void assertBalanced(NioThread selector, Set<MigratableHandler> handlers) {
+    private void assertBalanced(NioThread selector, Set<MigratablePipeline> handlers) {
         assertTrue("no handlers were found for selector:" + selector, handlers.size() > 0);
         assertTrue("too many handlers were found for selector:" + selector, handlers.size() <= 2);
 
-        Iterator<MigratableHandler> iterator = handlers.iterator();
-        MigratableHandler activeHandler = iterator.next();
+        Iterator<MigratablePipeline> iterator = handlers.iterator();
+        MigratablePipeline activeHandler = iterator.next();
         if (handlers.size() == 2) {
-            MigratableHandler deadHandler = iterator.next();
+            MigratablePipeline deadHandler = iterator.next();
             if (activeHandler.getLoad() < deadHandler.getLoad()) {
-                MigratableHandler tmp = deadHandler;
+                MigratablePipeline tmp = deadHandler;
                 deadHandler = activeHandler;
                 activeHandler = tmp;
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.networking.nio.iobalancer;
 
 import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.LoggingServiceImpl;
@@ -40,8 +40,8 @@ public class IOBalancerTest {
     @Test
     public void whenChannelAdded_andDisabled_thenSkipTaskCreation() {
         IOBalancer ioBalancer = new IOBalancer(new NioThread[1], new NioThread[1], "foo", 1, loggingService);
-        MigratableHandler readHandler = mock(MigratableHandler.class);
-        MigratableHandler writeHandler = mock(MigratableHandler.class);
+        MigratablePipeline readHandler = mock(MigratablePipeline.class);
+        MigratablePipeline writeHandler = mock(MigratablePipeline.class);
 
         ioBalancer.channelAdded(readHandler, writeHandler);
 
@@ -53,8 +53,8 @@ public class IOBalancerTest {
     @Test
     public void whenChannelRemoved_andDisabled_thenSkipTaskCreation() {
         IOBalancer ioBalancer = new IOBalancer(new NioThread[1], new NioThread[1], "foo", 1, loggingService);
-        MigratableHandler readHandler = mock(MigratableHandler.class);
-        MigratableHandler writeHandler = mock(MigratableHandler.class);
+        MigratablePipeline readHandler = mock(MigratablePipeline.class);
+        MigratablePipeline writeHandler = mock(MigratablePipeline.class);
 
         ioBalancer.channelRemoved(readHandler, writeHandler);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking.nio.iobalancer;
 
-import com.hazelcast.internal.networking.nio.MigratableHandler;
+import com.hazelcast.internal.networking.nio.MigratablePipeline;
 import com.hazelcast.internal.networking.nio.NioThread;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -55,28 +55,28 @@ public class LoadTrackerTest {
 
     @Test
     public void testUpdateImbalance() throws Exception {
-        MigratableHandler selector1Handler1 = mock(MigratableHandler.class);
+        MigratablePipeline selector1Handler1 = mock(MigratablePipeline.class);
         when(selector1Handler1.getLoad()).thenReturn(0L)
                 .thenReturn(100L);
         when(selector1Handler1.getOwner())
                 .thenReturn(selector1);
-        loadTracker.addHandler(selector1Handler1);
+        loadTracker.addPipeline(selector1Handler1);
 
-        MigratableHandler selector2Handler1 = mock(MigratableHandler.class);
+        MigratablePipeline selector2Handler1 = mock(MigratablePipeline.class);
         when(selector2Handler1.getLoad())
                 .thenReturn(0L)
                 .thenReturn(200L);
         when(selector2Handler1.getOwner())
                 .thenReturn(selector2);
-        loadTracker.addHandler(selector2Handler1);
+        loadTracker.addPipeline(selector2Handler1);
 
-        MigratableHandler selector2Handler3 = mock(MigratableHandler.class);
+        MigratablePipeline selector2Handler3 = mock(MigratablePipeline.class);
         when(selector2Handler3.getLoad())
                 .thenReturn(0L)
                 .thenReturn(100L);
         when(selector2Handler3.getOwner())
                 .thenReturn(selector2);
-        loadTracker.addHandler(selector2Handler3);
+        loadTracker.addPipeline(selector2Handler3);
 
         LoadImbalance loadImbalance = loadTracker.updateImbalance();
         assertEquals(0, loadImbalance.minimumEvents);
@@ -92,21 +92,21 @@ public class LoadTrackerTest {
     // there is no point in selecting a selector with a single handler as source.
     @Test
     public void testUpdateImbalance_notUsingSingleHandlerSelectorAsSource() throws Exception {
-        MigratableHandler selector1Handler1 = mock(MigratableHandler.class);
+        MigratablePipeline selector1Handler1 = mock(MigratablePipeline.class);
         // the first selector has a handler with a large number of events
         when(selector1Handler1.getLoad()).thenReturn(10000L);
         when(selector1Handler1.getOwner()).thenReturn(selector1);
-        loadTracker.addHandler(selector1Handler1);
+        loadTracker.addPipeline(selector1Handler1);
 
-        MigratableHandler selector2Handler = mock(MigratableHandler.class);
+        MigratablePipeline selector2Handler = mock(MigratablePipeline.class);
         when(selector2Handler.getLoad()).thenReturn(200L);
         when(selector2Handler.getOwner()).thenReturn(selector2);
-        loadTracker.addHandler(selector2Handler);
+        loadTracker.addPipeline(selector2Handler);
 
-        MigratableHandler selector2Handler2 = mock(MigratableHandler.class);
+        MigratablePipeline selector2Handler2 = mock(MigratablePipeline.class);
         when(selector2Handler2.getLoad()).thenReturn(200L);
         when(selector2Handler2.getOwner()).thenReturn(selector2);
-        loadTracker.addHandler(selector2Handler2);
+        loadTracker.addPipeline(selector2Handler2);
 
         LoadImbalance loadImbalance = loadTracker.updateImbalance();
 


### PR DESCRIPTION
Also the NioPipeline.handle method has been renamed to process.