### PR TITLE
Pipeline has now own error handler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioEventLoopGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioEventLoopGroup.java
@@ -233,6 +233,7 @@ public class NioEventLoopGroup implements EventLoopGroup {
         return new NioOutboundPipeline(
                 channel,
                 threads[index],
+                errorHandler,
                 loggingService.getLogger(NioOutboundPipeline.class),
                 ioBalancer,
                 channelInitializer);
@@ -248,6 +249,7 @@ public class NioEventLoopGroup implements EventLoopGroup {
         return new NioInboundPipeline(
                 channel,
                 threads[index],
+                errorHandler,
                 loggingService.getLogger(NioInboundPipeline.class),
                 ioBalancer,
                 channelInitializer);

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.InitResult;
@@ -60,10 +61,11 @@ public final class NioInboundPipeline extends NioPipeline {
     public NioInboundPipeline(
             NioChannel channel,
             NioThread ioThread,
+            ChannelErrorHandler errorHandler,
             ILogger logger,
             IOBalancer balancer,
             ChannelInitializer initializer) {
-        super(channel, ioThread, OP_READ, logger, balancer);
+        super(channel, ioThread, errorHandler, OP_READ, logger, balancer);
         this.initializer = initializer;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.ChannelOutboundHandler;
 import com.hazelcast.internal.networking.InitResult;
@@ -79,10 +80,11 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
 
     public NioOutboundPipeline(NioChannel channel,
                                NioThread ioThread,
+                               ChannelErrorHandler errorHandler,
                                ILogger logger,
                                IOBalancer balancer,
                                ChannelInitializer initializer) {
-        super(channel, ioThread, OP_WRITE, logger, balancer);
+        super(channel, ioThread, errorHandler, OP_WRITE, logger, balancer);
         this.initializer = initializer;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -164,10 +164,6 @@ public class NioThread extends Thread implements OperationHostileThread {
         return selector;
     }
 
-    public ChannelErrorHandler getErrorHandler() {
-        return errorHandler;
-    }
-
     /**
      * Returns the total number of selection-key events that have been processed by this thread.
      *


### PR DESCRIPTION
Instead of needing to borrow it from the NioThread.