### PR TITLE
Fix partition listener in IScheduledFutureProxy

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
@@ -67,7 +67,13 @@ public class ClientScheduledExecutorServiceBasicTest extends ScheduledExecutorSe
     @Test
     @Ignore("Never supported feature")
     @Override
-    public void schedule_testPartitionLostEvent() {
+    public void schedule_testPartitionLostEvent_withDurabilityCount() {
+    }
+
+    @Test
+    @Ignore("Never supported feature")
+    @Override
+    public void schedule_testPartitionLostEvent_withMaxBackupCount() {
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -21,14 +21,15 @@ import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.core.MembershipAdapter;
-import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.partition.PartitionLostEvent;
 import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.scheduledexecutor.impl.operations.MergeOperation;
 import com.hazelcast.spi.ManagedService;
+import com.hazelcast.spi.MemberAttributeServiceEvent;
+import com.hazelcast.spi.MembershipAwareService;
+import com.hazelcast.spi.MembershipServiceEvent;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -71,7 +72,8 @@ import static java.util.Collections.synchronizedSet;
  * Scheduled executor service, middle-man responsible for managing Scheduled Executor containers.
  */
 public class DistributedScheduledExecutorService
-        implements ManagedService, RemoteService, MigrationAwareService, QuorumAwareService, SplitBrainHandlerService {
+        implements ManagedService, RemoteService, MigrationAwareService, QuorumAwareService, SplitBrainHandlerService,
+                   MembershipAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:scheduledExecutorService";
 
@@ -107,8 +109,6 @@ public class DistributedScheduledExecutorService
         }
     };
 
-    private String membershipListenerRegistration;
-
     public DistributedScheduledExecutorService() {
     }
 
@@ -143,12 +143,9 @@ public class DistributedScheduledExecutorService
 
         memberBin = new ScheduledExecutorMemberBin(nodeEngine);
 
+        // Keep using the public API due to the benefit of getting events on all partitions and not just local
         if (partitionLostRegistration == null) {
             registerPartitionListener();
-        }
-
-        if (membershipListenerRegistration == null) {
-            registerMembershipListener();
         }
 
         for (int partitionId = 0; partitionId < partitions.length; partitionId++) {
@@ -170,7 +167,6 @@ public class DistributedScheduledExecutorService
         lossListeners.clear();
 
         unRegisterPartitionListenerIfExists();
-        unRegisterMembershipListenerIfExists();
 
         for (int partitionId = 0; partitionId < partitions.length; partitionId++) {
             if (partitions[partitionId] != null) {
@@ -281,9 +277,9 @@ public class DistributedScheduledExecutorService
         this.partitionLostRegistration =
                 getNodeEngine().getPartitionService().addPartitionLostListener(new PartitionLostListener() {
                     @Override
-                    public void partitionLost(PartitionLostEvent event) {
+                    public void partitionLost(final PartitionLostEvent event) {
                         // use toArray before iteration since it is done under mutex
-                        ScheduledFutureProxy[] futures = lossListeners.toArray(new ScheduledFutureProxy[lossListeners.size()]);
+                        ScheduledFutureProxy[] futures = lossListeners.toArray(new ScheduledFutureProxy[0]);
                         for (ScheduledFutureProxy future : futures) {
                             future.notifyPartitionLost(event);
                         }
@@ -307,33 +303,23 @@ public class DistributedScheduledExecutorService
         this.partitionLostRegistration = null;
     }
 
-    private void registerMembershipListener() {
-        this.membershipListenerRegistration = getNodeEngine().getClusterService().addMembershipListener(new MembershipAdapter() {
-            @Override
-            public void memberRemoved(MembershipEvent event) {
-                // use toArray before iteration since it is done under mutex
-                ScheduledFutureProxy[] futures = lossListeners.toArray(new ScheduledFutureProxy[lossListeners.size()]);
-                for (ScheduledFutureProxy future : futures) {
-                    future.notifyMemberLost(event);
-                }
-            }
-        });
+    @Override
+    public void memberAdded(MembershipServiceEvent event) {
+       // ignore
     }
 
-    private void unRegisterMembershipListenerIfExists() {
-        if (this.membershipListenerRegistration == null) {
-            return;
+    @Override
+    public void memberRemoved(MembershipServiceEvent event) {
+        // use toArray before iteration since it is done under mutex
+        ScheduledFutureProxy[] futures = lossListeners.toArray(new ScheduledFutureProxy[0]);
+        for (ScheduledFutureProxy future : futures) {
+            future.notifyMemberLost(event);
         }
+    }
 
-        try {
-            getNodeEngine().getClusterService().removeMembershipListener(membershipListenerRegistration);
-        } catch (Exception ex) {
-            if (peel(ex, HazelcastInstanceNotActiveException.class, null) instanceof HazelcastInstanceNotActiveException) {
-                throw rethrow(ex);
-            }
-        }
-
-        this.membershipListenerRegistration = null;
+    @Override
+    public void memberAttributeChanged(MemberAttributeServiceEvent event) {
+        // ignore
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
@@ -182,7 +182,8 @@ public final class ScheduledFutureProxy<V>
             return;
         }
 
-        if (handler.isAssignedToMember() && handler.getAddress().equals(event.getMember().getAddress())) {
+        if (handler.isAssignedToMember()
+                && handler.getAddress().equals(event.getMember().getAddress())) {
             this.memberLost.set(true);
         }
     }
@@ -196,8 +197,9 @@ public final class ScheduledFutureProxy<V>
 
         int durability = instance.getConfig().getScheduledExecutorConfig(handler.getSchedulerName()).getDurability();
 
-        if (handler.isAssignedToPartition() && handler.getPartitionId() == event.getPartitionId()
-                && event.getLostBackupCount() == durability) {
+        if (handler.isAssignedToPartition()
+                && handler.getPartitionId() == event.getPartitionId()
+                && event.getLostBackupCount() >= durability) {
             this.partitionLost.set(true);
         }
     }
@@ -205,11 +207,13 @@ public final class ScheduledFutureProxy<V>
     private void checkAccessibleOwner() {
         if (handler.isAssignedToPartition()) {
             if (partitionLost.get()) {
-                throw new IllegalStateException("Partition holding this Scheduled task was lost along with all backups.");
+                throw new IllegalStateException("Partition " + handler.getPartitionId() + ", holding this scheduled task"
+                        + " was lost along with all backups.");
             }
         } else {
             if (memberLost.get()) {
-                throw new IllegalStateException("Member holding this Scheduled task was removed from the cluster.");
+                throw new IllegalStateException("Member with address: " + handler.getAddress() +  ",  holding this scheduled task"
+                        + " is not part of this cluster.");
             }
         }
     }


### PR DESCRIPTION
There were a couple of different issues associated with the split-brain test. 
The first, as found by https://github.com/hazelcast/hazelcast/issues/12424 was a missing exception in the try-catch block due to the inconsistent thrown exception for stale tasks. (Since we can't fix it for minor releases, the only approach here, was to add an extra catch).

The more complicated issue was about spurious `java.lang.IllegalStateException: Partition holding this Scheduled task was lost along with all backups.` exceptions, coming from *any* of the scheduled tasks upon verification (after merge assertion phase). This turned out to be a race condition between the lost-partition event handling and scheduling of new tasks (see. https://github.com/hazelcast/hazelcast/pull/12431/files#diff-9565c99a790fa2c2395ef6f1efe9a27aR120)

A few extra fixes, to handle wrong replica index assertion upon partition loss event. It was using the equal operator, where it should be using the greater than, operator, to account for total loss with MAX_BACKUP_COUNT value.

Fixes https://github.com/hazelcast/hazelcast/issues/12424