### PR TITLE
IO migration threading simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -71,7 +71,7 @@ public class NioChannel extends AbstractChannel {
 
     @Override
     public void flush() {
-        outboundPipeline.flush();
+        outboundPipeline.wakeup();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -100,23 +100,8 @@ public final class NioInboundPipeline extends NioPipeline {
         return lastReadTime;
     }
 
-    /**
-     * Migrates this Pipeline to a new NioThread.
-     * The migration logic is rather simple:
-     * <p><ul>
-     * <li>Submit a de-registration task to a current NioThread</li>
-     * <li>The de-registration task submits a registration task to the new NioThread</li>
-     * </ul></p>
-     *
-     * @param newOwner target NioThread this pipeline migrates to
-     */
     @Override
-    public void requestMigration(NioThread newOwner) {
-        owner.addTaskAndWakeup(new StartMigrationTask(newOwner));
-    }
-
-    @Override
-    public void process() throws Exception {
+    void process() throws Exception {
         processCount.inc();
         // we are going to set the timestamp even if the channel is going to fail reading. In that case
         // the connection is going to be closed anyway.
@@ -160,11 +145,13 @@ public final class NioInboundPipeline extends NioPipeline {
     }
 
     @Override
-    public void publishMetrics() {
+    void publishMetrics() {
         if (Thread.currentThread() != owner) {
             return;
         }
 
+        // since this is executed by the owner, the owner field can't change while
+        // this method is executed.
         owner.bytesTransceived += bytesRead.get() - bytesReadLastPublish;
         owner.framesTransceived += normalFramesRead.get() - normalFramesReadLastPublish;
         owner.priorityFramesTransceived += priorityFramesRead.get() - priorityFramesReadLastPublish;
@@ -178,17 +165,9 @@ public final class NioInboundPipeline extends NioPipeline {
 
     @Override
     public void close() {
-        owner.addTaskAndWakeup(new Runnable() {
+        addTaskAndWakeup(new NioPipelineTask(this) {
             @Override
-            public void run() {
-                if (owner != Thread.currentThread()) {
-                    // the NioInboundPipeline has migrated to a different IOThread after the close got called.
-                    // so we need to send the task to the right owner. Otherwise multiple ioThreads could be accessing
-                    // the same channel.
-                    owner.addTaskAndWakeup(this);
-                    return;
-                }
-
+            public void run0() {
                 try {
                     channel.closeInbound();
                 } catch (IOException e) {
@@ -203,27 +182,4 @@ public final class NioInboundPipeline extends NioPipeline {
         return channel + ".inboundPipeline";
     }
 
-    private class StartMigrationTask implements Runnable {
-        private final NioThread newOwner;
-
-        StartMigrationTask(NioThread newOwner) {
-            this.newOwner = newOwner;
-        }
-
-        @Override
-        public void run() {
-            // if there is no change, we are done
-            if (owner == newOwner) {
-                return;
-            }
-
-            publishMetrics();
-
-            try {
-                startMigration(newOwner);
-            } catch (Throwable t) {
-                onFailure(t);
-            }
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -39,10 +39,11 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.IOUtil.compactOrClear;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
+import static java.lang.Thread.currentThread;
 import static java.nio.channels.SelectionKey.OP_WRITE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public final class NioOutboundPipeline extends NioPipeline implements Runnable {
+public final class NioOutboundPipeline extends NioPipeline {
 
     private static final long TIMEOUT = 3;
 
@@ -67,11 +68,6 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
 
     private OutboundFrame currentFrame;
     private volatile long lastWriteTime;
-
-    // this field will be accessed by the NioThread or
-    // it is accessed by any other thread but only that thread managed to cas the scheduled flag to true.
-    // This prevents running into an NioThread that is migrating.
-    private NioThread newOwner;
 
     private long bytesReadLastPublish;
     private long normalFramesReadLastPublish;
@@ -140,10 +136,6 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
         return scheduled.get() ? 1 : 0;
     }
 
-    public void flush() {
-        owner.addTaskAndWakeup(this);
-    }
-
     public void write(OutboundFrame frame) {
         if (frame.isUrgent()) {
             urgentWriteQueue.offer(frame);
@@ -155,26 +147,18 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
     }
 
     private OutboundFrame poll() {
-        for (; ; ) {
-            OutboundFrame frame = urgentWriteQueue.poll();
+        OutboundFrame frame = urgentWriteQueue.poll();
+        if (frame == null) {
+            frame = writeQueue.poll();
             if (frame == null) {
-                frame = writeQueue.poll();
-                if (frame == null) {
-                    return null;
-                }
-                normalFramesWritten.inc();
-            } else {
-                priorityFramesWritten.inc();
+                return null;
             }
-
-            if (frame.getClass() == TaskFrame.class) {
-                TaskFrame taskFrame = (TaskFrame) frame;
-                taskFrame.task.run();
-                continue;
-            }
-
-            return frame;
+            normalFramesWritten.inc();
+        } else {
+            priorityFramesWritten.inc();
         }
+
+        return frame;
     }
 
     /**
@@ -199,7 +183,8 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
 
         // We managed to schedule this ChannelOutboundHandler. This means we need to add a task to
         // the owner and give it a kick so that it processes our frames.
-        owner.addTaskAndWakeup(this);
+
+        wakeup();
     }
 
     /**
@@ -214,7 +199,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
      * If the outputBuffer is not dirty, then it will unregister itself from an OP_WRITE since it isn't interested
      * in space in the socket outputBuffer.
      * <p/>
-     * This call is only made by the IO thread.
+     * This call is only made by the owning IO thread.
      */
     private void unschedule() throws IOException {
         if (dirtyOutputBuffer() || currentFrame != null) {
@@ -247,12 +232,14 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
         // We managed to reschedule. So lets add ourselves to the owner so we are processed again.
         // We don't need to call wakeup because the current thread is the IO-thread and the selectionQueue will be processed
         // till it is empty. So it will also pick up tasks that are added while it is processing the selectionQueue.
+
+        // since this is executed from the owning io thread, owner will always be set to the correct value.
         owner.addTask(this);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public void process() throws Exception {
+    void process() throws Exception {
         processCount.inc();
         lastWriteTime = currentTimeMillis();
 
@@ -266,11 +253,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
             writeOutputBufferToSocket();
         }
 
-        if (newOwner == null) {
-            unschedule();
-        } else {
-            startMigration();
-        }
+        unschedule();
     }
 
     /**
@@ -291,12 +274,6 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
         this.outboundHandler = init.getHandler();
         registerOp(OP_WRITE);
         return true;
-    }
-
-    private void startMigration() throws IOException {
-        NioThread newOwner = this.newOwner;
-        this.newOwner = null;
-        startMigration(newOwner);
     }
 
     /**
@@ -344,27 +321,13 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
     }
 
     @Override
-    public void run() {
-        try {
-            process();
-        } catch (Throwable t) {
-            onFailure(t);
-        }
-    }
-
-    @Override
     public void close() {
         writeQueue.clear();
         urgentWriteQueue.clear();
 
         CloseTask closeTask = new CloseTask();
-        write(new TaskFrame(closeTask));
+        addTaskAndWakeup(closeTask);
         closeTask.awaitCompletion();
-    }
-
-    @Override
-    public void requestMigration(NioThread newOwner) {
-        write(new TaskFrame(new StartMigrationTask(newOwner)));
     }
 
     @Override
@@ -372,56 +335,14 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
         return channel + ".outboundPipeline";
     }
 
-    /**
-     * The TaskFrame is not really a Frame. It is a way to put a task on one of the frame-queues. Using this approach we
-     * can lift on top of the Frame scheduling mechanism and we can prevent having:
-     * - multiple NioThread-tasks for a NioOutboundPipeline on multiple NioThread
-     * - multiple NioThread-tasks for a NioOutboundPipeline on the same NioThread.
-     */
-    private static final class TaskFrame implements OutboundFrame {
-
-        private final Runnable task;
-
-        private TaskFrame(Runnable task) {
-            this.task = task;
-        }
-
-        @Override
-        public boolean isUrgent() {
-            return true;
-        }
-    }
-
-    /**
-     * Triggers the migration when executed by setting the NioOutboundPipeline.newOwner field. When the handle method completes,
-     * it checks if this field if set, if so, the migration starts.
-     *
-     * If the current owner is the same as 'theNewOwner' then the call is ignored.
-     */
-    private final class StartMigrationTask implements Runnable {
-        // field is called 'theNewOwner' to prevent any ambiguity problems with the outboundHandler.newOwner.
-        // Else you get a lot of ugly ChannelOutboundHandler.this.newOwner is...
-        private final NioThread theNewOwner;
-
-        StartMigrationTask(NioThread theNewOwner) {
-            this.theNewOwner = theNewOwner;
-        }
-
-        @Override
-        public void run() {
-            assert newOwner == null : "No migration can be in progress";
-
-            if (owner == theNewOwner) {
-                // if there is no change, we are done
-                return;
-            }
-
-            newOwner = theNewOwner;
-        }
-    }
-
     @Override
-    protected void publishMetrics() {
+    void publishMetrics() {
+        if (currentThread() != owner) {
+            return;
+        }
+
+        // since this is executed by the owner, the owner field can't change while
+        // this method is executed.
         owner.bytesTransceived += bytesWritten.get() - bytesReadLastPublish;
         owner.framesTransceived += normalFramesWritten.get() - normalFramesReadLastPublish;
         owner.priorityFramesTransceived += priorityFramesWritten.get() - priorityFramesReadLastPublish;
@@ -433,11 +354,15 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
         processCountLastPublish = processCount.get();
     }
 
-    private class CloseTask implements Runnable {
+    private class CloseTask extends NioPipelineTask {
         private final CountDownLatch latch = new CountDownLatch(1);
 
+        CloseTask() {
+            super(NioOutboundPipeline.this);
+        }
+
         @Override
-        public void run() {
+        public void run0() {
             try {
                 channel.closeOutbound();
             } catch (IOException e) {
@@ -451,7 +376,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
             try {
                 latch.await(TIMEOUT, SECONDS);
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                currentThread().interrupt();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -26,12 +26,15 @@ import com.hazelcast.logging.ILogger;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static java.lang.Thread.currentThread;
 
-public abstract class NioPipeline implements MigratablePipeline, Closeable {
+public abstract class NioPipeline implements MigratablePipeline, Closeable, Runnable {
 
     protected static final int LOAD_BALANCING_HANDLE = 0;
     protected static final int LOAD_BALANCING_BYTE = 1;
@@ -41,25 +44,24 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
     protected static final int LOAD_TYPE = Integer.getInteger("hazelcast.io.load", LOAD_BALANCING_BYTE);
 
     @Probe
-    protected final SwCounter processCount = newSwCounter();
-    @Probe
-    protected final SwCounter completedMigrations = newSwCounter();
-    protected final ILogger logger;
-    protected final Channel channel;
-    protected NioThread owner;
-    protected SelectionKey selectionKey;
-    private final ChannelErrorHandler errorHandler;
+    final SwCounter processCount = newSwCounter();
+    final ILogger logger;
+    final Channel channel;
+
+    volatile NioThread owner;
+    private SelectionKey selectionKey;
     private final SocketChannel socketChannel;
     private final int initialOps;
     private final IOBalancer ioBalancer;
-
-    // shows the ID of the owner that is currently owning the handler
+    private final ChannelErrorHandler errorHandler;
+    private final AtomicReference<TaskNode> delayedTaskStack = new AtomicReference<TaskNode>();
     @Probe
     private volatile int ownerId;
-
-    // counts the number of migrations that have happened so far.
+    // counts the number of migrations that have happened so far
     @Probe
-    private final SwCounter migrationCount = newSwCounter();
+    private final SwCounter startedMigrations = newSwCounter();
+    @Probe
+    private final SwCounter completedMigrations = newSwCounter();
 
     NioPipeline(NioChannel channel,
                 NioThread owner,
@@ -69,13 +71,12 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
                 IOBalancer ioBalancer) {
         this.channel = channel;
         this.socketChannel = channel.socketChannel();
-        this.errorHandler = errorHandler;
-        this.ownerId = owner.id;
         this.owner = owner;
         this.ownerId = owner.id;
         this.logger = logger;
         this.initialOps = initialOps;
         this.ioBalancer = ioBalancer;
+        this.errorHandler = errorHandler;
     }
 
     public Channel getChannel() {
@@ -96,13 +97,13 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
 
     @Override
     public NioThread owner() {
-            return owner;
+        return owner;
     }
 
-    public void start() {
-        owner.addTaskAndWakeup(new Runnable() {
+    void start() {
+        addTaskAndWakeup(new NioPipelineTask(this) {
             @Override
-            public void run() {
+            protected void run0() {
                 try {
                     getSelectionKey();
                 } catch (Throwable t) {
@@ -112,7 +113,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
         });
     }
 
-    SelectionKey getSelectionKey() throws IOException {
+    private SelectionKey getSelectionKey() throws IOException {
         if (selectionKey == null) {
             selectionKey = socketChannel.register(owner.getSelector(), initialOps, this);
         }
@@ -136,36 +137,127 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
         }
     }
 
-    protected abstract void publishMetrics();
+    abstract void publishMetrics();
 
     /**
-     * Called when there are bytes available for reading, or space available to write.
+     * Called when there are bytes available for reading, or space available to
+     * write.
      *
-     * Any exception that leads to a termination of the connection like an IOException should not be handled in the handle method
-     * but should be propagated. The reason behind this is that the handle logic already is complicated enough and by pulling it
-     * out the flow will be easier to understand.
+     * Any exception that leads to a termination of the connection like an
+     * IOException should not be dealt with in the handle method but should
+     * be propagated. The reason behind this is that the handle logic already
+     * is complicated enough and by pulling it out the flow will be easier to
+     * understand.
      *
      * @throws Exception
      */
-    public abstract void process() throws Exception;
+    abstract void process() throws Exception;
+
+    /**
+     * Forces this NioPipeline to wakeup by scheduling this on the owner using
+     * {@link NioThread#addTaskAndWakeup(Runnable)}
+     *
+     * This method can be called by any thread. It is a pretty expensive method
+     * because it will cause the {@link Selector#wakeup()} method to be called.
+     *
+     * This call can safely be made during the migration of the pipeline.
+     */
+    final void wakeup() {
+        addTaskAndWakeup(this);
+    }
+
+    /**
+     * Adds a task to be executed on the {@link NioThread owner}.
+     *
+     * This task is scheduled on the task queue of the owning {@link NioThread}.
+     *
+     * If the pipeline is currently migrating, this method will make sure the
+     * task ends up at the new owner.
+     *
+     * It is extremely important that this task takes very little time because
+     * otherwise it could cause a lot of problems in the IOSystem.
+     *
+     * This method can be called by any thread. It is a pretty expensive method
+     * because it will cause the {@link Selector#wakeup()} method to be called.
+     *
+     * @param task the task to add.
+     */
+    final void addTaskAndWakeup(Runnable task) {
+        // in this loop we are going to either send the task to the owner
+        // or store the delayed task to be picked up as soon as the migration
+        // completes
+        for (; ; ) {
+            NioThread localOwner = owner;
+            if (localOwner != null) {
+                // there is an owner, lets send the task.
+                localOwner.addTaskAndWakeup(task);
+                return;
+            }
+
+            // there is no owner, so we put the task on the delayedTaskStack
+            TaskNode old = delayedTaskStack.get();
+            TaskNode update = new TaskNode(task, old);
+            if (delayedTaskStack.compareAndSet(old, update)) {
+                break;
+            }
+        }
+
+        NioThread localOwner = owner;
+        if (localOwner != null) {
+            // an owner was set, but we have no guarantee that he has seen our task.
+            // So lets try to reschedule the delayed tasks to make sure they get executed.
+            restoreTasks(localOwner, delayedTaskStack.getAndSet(null), true);
+        }
+    }
+
+    private void restoreTasks(NioThread owner, TaskNode node, boolean wakeup) {
+        if (node == null) {
+            return;
+        }
+
+        // we restore in the opposite order so that we get fifo.
+        restoreTasks(owner, node.next, false);
+        if (wakeup) {
+            owner.addTaskAndWakeup(node.task);
+        } else {
+            owner.addTask(node.task);
+        }
+    }
+
+    @Override
+    public final void run() {
+        if (owner == currentThread()) {
+            try {
+                process();
+            } catch (Throwable t) {
+                onFailure(t);
+            }
+        } else {
+            // the pipeline is executed on the wrong IOThread, so send the
+            // pipeline to the right IO Thread to be executed.
+            addTaskAndWakeup(this);
+        }
+    }
 
     /**
      * Is called when the {@link #process()} throws an exception.
      *
-     * The idiom to use a pipeline is:
+     * This method should only be called by the current {@link NioThread owner}.
+     *
+     * The idiom to use a handler is:
      * <code>
-     *     try{
-     *         pipeline.handle();
-     *     } catch(Throwable t) {
-     *         pipeline.onFailure(t);
-     *     }
+     * try{
+     * handler.handle();
+     * } catch(Throwable t) {
+     * handler.onFailure(t);
+     * }
      * </code>
      *
      * @param e
      */
     public void onFailure(Throwable e) {
         if (e instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
+            currentThread().interrupt();
         }
 
         if (selectionKey != null) {
@@ -175,47 +267,105 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
         errorHandler.onError(channel, e);
     }
 
-    // This method run on the oldOwner NioThread
-    void startMigration(final NioThread newOwner) throws IOException {
-        assert owner == Thread.currentThread() : "startMigration can only run on the owning NioThread";
-        assert owner != newOwner : "newOwner can't be the same as the existing owner";
-
-        if (!socketChannel.isOpen()) {
-            // if the channel is closed, we are done.
-            return;
-        }
-
-        migrationCount.inc();
-
-        unregisterOp(initialOps);
-        owner = newOwner;
-        ownerId = owner.id;
-        selectionKey.cancel();
-        selectionKey = null;
-
-        newOwner.addTaskAndWakeup(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    completeMigration(newOwner);
-                } catch (Throwable t) {
-                    onFailure(t);
-                }
-            }
-        });
+    /**
+     * Migrates this pipeline to a different owner.
+     * The migration logic is rather simple:
+     * <p><ul>
+     * <li>Submit a de-registration task to a current NioThread</li>
+     * <li>The de-registration task submits a registration task to the new NioThread</li>
+     * </ul></p>
+     *
+     * @param newOwner target NioThread this handler migrates to
+     */
+    @Override
+    public final void requestMigration(NioThread newOwner) {
+        // todo: what happens when owner null.
+        owner.addTaskAndWakeup(new StartMigrationTask(newOwner));
     }
 
-    private void completeMigration(NioThread newOwner) throws IOException {
-        assert owner == newOwner;
+    private class StartMigrationTask implements Runnable {
+        private final NioThread newOwner;
 
-        completedMigrations.inc();
-        ioBalancer.signalMigrationComplete();
-
-        if (!socketChannel.isOpen()) {
-            return;
+        StartMigrationTask(NioThread newOwner) {
+            this.newOwner = newOwner;
         }
 
-        selectionKey = getSelectionKey();
-        registerOp(initialOps);
+        @Override
+        public void run() {
+            // if there is no change, we are done
+            if (owner == newOwner) {
+                return;
+            }
+
+            publishMetrics();
+
+            try {
+                startMigration(newOwner);
+            } catch (Throwable t) {
+                onFailure(t);
+            }
+        }
+
+        // This method run on the owning NioThread
+        private void startMigration(final NioThread newOwner) throws IOException {
+            assert owner == currentThread() : "startMigration can only run on the owning NioThread";
+            assert owner != newOwner : "newOwner can't be the same as the existing owner";
+
+            if (!socketChannel.isOpen()) {
+                // if the channel is closed, we are done.
+                return;
+            }
+
+            startedMigrations.inc();
+
+            unregisterOp(initialOps);
+            selectionKey.cancel();
+            selectionKey = null;
+            owner = null;
+            ownerId = -1;
+
+            newOwner.addTaskAndWakeup(new CompleteMigrationTask(newOwner));
+        }
+    }
+
+    private class CompleteMigrationTask implements Runnable {
+        private final NioThread newOwner;
+
+        CompleteMigrationTask(NioThread newOwner) {
+            this.newOwner = newOwner;
+        }
+
+        @Override
+        public void run() {
+            try {
+                assert owner == null;
+                owner = newOwner;
+
+                // we don't need to wakeup since the io thread will see the delayed tasks.
+                restoreTasks(owner, delayedTaskStack.getAndSet(null), false);
+
+                completedMigrations.inc();
+                ioBalancer.signalMigrationComplete();
+
+                if (!socketChannel.isOpen()) {
+                    return;
+                }
+
+                selectionKey = getSelectionKey();
+                registerOp(initialOps);
+            } catch (Throwable t) {
+                onFailure(t);
+            }
+        }
+    }
+
+    private static class TaskNode {
+        private final Runnable task;
+        private final TaskNode next;
+
+        TaskNode(Runnable task, TaskNode next) {
+            this.task = task;
+            this.next = next;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipelineTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipelineTask.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import static java.lang.Thread.currentThread;
+
+/**
+ * A {@link Runnable} that gets executed on the {@link NioThread} owning the pipeline.
+ *
+ * Normally this is a pretty simple task, just schedule the runnable on the owner
+ * using {@link NioThread#addTaskAndWakeup(Runnable)}.
+ *
+ * The problem however is that pipeline migration can cause a task to end up at a
+ * NioThread that doesn't own the pipeline any longer. Therefor this task does a
+ * check when it is executed if the owner of the pipeline is the same as the
+ * current thread. If it is, then the {@link #run0()} is called. If it isn't, the
+ * task is send to the {@link NioPipeline#addTaskAndWakeup(Runnable)} which will
+ * make sure the task is send to the right NioThread.
+ */
+abstract class NioPipelineTask implements Runnable {
+
+    private final NioPipeline pipeline;
+
+    NioPipelineTask(NioPipeline pipeline) {
+        this.pipeline = pipeline;
+    }
+
+    @Override
+    public final void run() {
+        if (pipeline.owner() == currentThread()) {
+            // the task is picked by the proper thread
+            run0();
+        } else {
+            // the pipeline is migrating or already has migrated
+            // lets lets reschedule this task on the pipeline so
+            // it will be picked up by the new owner.
+            pipeline.addTaskAndWakeup(this);
+        }
+    }
+
+    protected abstract void run0();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -333,29 +333,11 @@ public class NioThread extends Thread implements OperationHostileThread {
             if (task == null) {
                 break;
             }
-            executeTask(task);
+            task.run();
+            completedTaskCount.inc();
             tasksProcessed = true;
         }
         return tasksProcessed;
-    }
-
-    private void executeTask(Runnable task) {
-        completedTaskCount.inc();
-
-        NioThread target = getTargetIOThread(task);
-        if (target == this) {
-            task.run();
-        } else {
-            target.addTaskAndWakeup(task);
-        }
-    }
-
-    private NioThread getTargetIOThread(Runnable task) {
-        if (task instanceof MigratablePipeline) {
-            return ((MigratablePipeline) task).owner();
-        } else {
-            return this;
-        }
     }
 
     private void handleSelectionKeys() {
@@ -364,7 +346,6 @@ public class NioThread extends Thread implements OperationHostileThread {
         while (it.hasNext()) {
             SelectionKey sk = it.next();
             it.remove();
-
             handleSelectionKey(sk);
         }
     }


### PR DESCRIPTION
The thread migration logic is pulled into the common superclass of the inbound/outbound pipeline: NioPipeline

Also introduced the NioPipelineTask that always gets executed on the thread that truly owns the pipeline (this can change due to migration).

This is a prerequisite to the new IO pipeline.