### PR TITLE
AbstractChannel caches local/remote socketAddress

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/NioChannelFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/NioChannelFactoryTest.java
@@ -27,9 +27,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.net.Socket;
 import java.nio.channels.SocketChannel;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -45,6 +47,8 @@ public class NioChannelFactoryTest extends HazelcastTestSupport {
     @Test
     public void wrapSocketChannel() throws Exception {
         SocketChannel socketChannel = mock(SocketChannel.class);
+        Socket socket = mock(Socket.class);
+        when(socketChannel.socket()).thenReturn(socket);
         Channel wrapper = factory.create(socketChannel, false, false);
 
         assertInstanceOf(NioChannel.class, wrapper);


### PR DESCRIPTION
Instead of getting them from the socket (which also creates a new object), they are
now cached when the AbstractChannel is created.

This should prevent ending up with null addresses in toStrings and other debug
information.