### PR TITLE
Improved split-brain SPI design

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientManagedContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientManagedContext.java
@@ -16,17 +16,17 @@
 
 package com.hazelcast.client.impl;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.spi.serialization.SerializationServiceAware;
 
 final class HazelcastClientManagedContext implements ManagedContext {
 
-    private final HazelcastInstance instance;
+    private final HazelcastClientInstanceImpl instance;
     private final ManagedContext externalContext;
     private final boolean hasExternalContext;
 
-    public HazelcastClientManagedContext(final HazelcastInstance instance, final ManagedContext externalContext) {
+    public HazelcastClientManagedContext(HazelcastClientInstanceImpl instance, ManagedContext externalContext) {
         this.instance = instance;
         this.externalContext = externalContext;
         this.hasExternalContext = externalContext != null;
@@ -37,6 +37,9 @@ final class HazelcastClientManagedContext implements ManagedContext {
         Object object = obj;
         if (object instanceof HazelcastInstanceAware) {
             ((HazelcastInstanceAware) object).setHazelcastInstance(instance);
+        }
+        if (object instanceof SerializationServiceAware) {
+            ((SerializationServiceAware) object).setSerializationService(instance.getSerializationService());
         }
 
         if (hasExternalContext) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.serialization.SerializationService;
 
 public final class ClientTestUtil {
 
@@ -30,4 +31,7 @@ public final class ClientTestUtil {
         return impl;
     }
 
+    public static SerializationService getClientSerializationService(HazelcastInstance hz) {
+        return getHazelcastClientInstanceImpl(hz).getSerializationService();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1451,8 +1451,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         final long now = Clock.currentTimeMillis();
         final long start = isStatisticsEnabled() ? System.nanoTime() : 0;
 
+        injectDependencies(mergingEntry);
         injectDependencies(mergePolicy);
-        mergingEntry.setSerializationService(nodeEngine.getSerializationService());
 
         boolean merged = false;
         Data key = mergingEntry.getKey();
@@ -1469,8 +1469,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             }
         } else {
             Data oldValue = nodeEngine.getSerializationService().toData(record.getValue());
-            MergingEntryHolder<Data, Data> existingEntry = createMergeHolder(key, oldValue, record);
-            existingEntry.setSerializationService(nodeEngine.getSerializationService());
+            MergingEntryHolder<Data, Data> existingEntry = createMergeHolder(nodeEngine.getSerializationService(), key, oldValue,
+                    record);
             Data newValue = mergePolicy.merge(mergingEntry, existingEntry);
             if (newValue != null && newValue != oldValue) {
                 merged = updateRecordWithExpiry(key, newValue, record, expiryTime, now, true, IGNORE_COMPLETION);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.impl.AbstractMergeRunnable;
+import com.hazelcast.spi.impl.merge.AbstractMergeRunnable;
 import com.hazelcast.spi.merge.MergingEntryHolder;
 import com.hazelcast.util.function.BiConsumer;
 
@@ -65,7 +65,7 @@ class CacheMergeRunnable extends AbstractMergeRunnable<ICacheRecordStore, Mergin
             CacheRecord record = entry.getValue();
             Data dataValue = toData(record.getValue());
 
-            consumer.accept(partitionId, createMergeHolder(key, dataValue, record));
+            consumer.accept(partitionId, createMergeHolder(getSerializationService(), key, dataValue, record));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -19,7 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.impl.merge.policy.CacheMergePolicyProvider;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.impl.AbstractSplitBrainHandlerService;
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainHandlerService;
 
 import java.util.Collection;
 import java.util.Iterator;

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/MergeOperation.java
@@ -21,6 +21,8 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.MergingEntryHolder;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 
@@ -51,7 +53,9 @@ public class MergeOperation
 
     @Override
     public void run() throws Exception {
-        backupValue = getCardinalityEstimatorContainer().merge(createMergeHolder(name, value), mergePolicy);
+        SerializationService serializationService = getNodeEngine().getSerializationService();
+        MergingEntryHolder<String, HyperLogLog> mergingEntry = createMergeHolder(serializationService, name, value);
+        backupValue = getCardinalityEstimatorContainer().merge(mergingEntry, mergePolicy, serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -352,8 +352,8 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
      */
     public CollectionItem merge(MergingValueHolder<Data> mergingValue, SplitBrainMergePolicy mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
+        serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingValue.setSerializationService(serializationService);
 
         // try to find an existing item with the same value
         CollectionItem existingItem = null;
@@ -374,8 +374,7 @@ public abstract class CollectionContainer implements IdentifiedDataSerializable 
                 }
             }
         } else {
-            MergingValueHolder<Data> existingValue = createMergeHolder(existingItem);
-            existingValue.setSerializationService(serializationService);
+            MergingValueHolder<Data> existingValue = createMergeHolder(serializationService, existingItem);
             Data newValue = mergePolicy.merge(mergingValue, existingValue);
             if (newValue != null && !newValue.equals(existingValue.getValue())) {
                 existingItem.setValue(newValue);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -280,7 +280,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
                     mergingValues = new ArrayList<MergingValueHolder<Data>>();
                     for (CollectionItem item : itemList) {
-                        MergingValueHolder<Data> mergingValue = createMergeHolder(item);
+                        MergingValueHolder<Data> mergingValue = createMergeHolder(serializationService, item);
                         mergingValues.add(mergingValue);
                         itemCount++;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -1104,8 +1104,8 @@ public class QueueContainer implements IdentifiedDataSerializable {
      */
     public QueueItem merge(MergingValueHolder<Data> mergingValue, SplitBrainMergePolicy mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
+        serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingValue.setSerializationService(serializationService);
         // try to find an existing item with the same value
         QueueItem existingItem = null;
         for (QueueItem item : getItemQueue()) {
@@ -1125,8 +1125,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
                 }
             }
         } else {
-            MergingValueHolder<Data> existingValue = createMergeHolder(existingItem);
-            existingValue.setSerializationService(serializationService);
+            MergingValueHolder<Data> existingValue = createMergeHolder(serializationService, existingItem);
             Data newValue = mergePolicy.merge(mergingValue, existingValue);
             if (newValue != null && !newValue.equals(existingValue.getValue())) {
                 existingItem.setData(newValue);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -475,7 +475,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
                     mergingValues = new ArrayList<MergingValueHolder<Data>>(batchSize);
                     for (QueueItem item : itemList) {
-                        MergingValueHolder<Data> mergingValue = createMergeHolder(item);
+                        MergingValueHolder<Data> mergingValue = createMergeHolder(serializationService, item);
                         mergingValues.add(mergingValue);
                         itemCount++;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
@@ -87,12 +87,11 @@ public class AtomicLongContainer {
      * @return the new value if merge is applied, otherwise {@code null}
      */
     public Long merge(MergingValueHolder<Long> mergingValue, SplitBrainMergePolicy mergePolicy, boolean isExistingContainer) {
+        serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingValue.setSerializationService(serializationService);
 
         if (isExistingContainer) {
-            MergingValueHolder<Long> existingValue = createMergeHolder(value);
-            existingValue.setSerializationService(serializationService);
+            MergingValueHolder<Long> existingValue = createMergeHolder(serializationService, value);
             Long newValue = mergePolicy.merge(mergingValue, existingValue);
             if (newValue != null && !newValue.equals(value)) {
                 value = newValue;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
@@ -54,8 +54,8 @@ public class MergeOperation extends AtomicLongBackupAwareOperation {
         AtomicLongService service = getService();
         boolean isExistingContainer = service.containsAtomicLong(name);
 
-        MergingValueHolder<Long> mergingValue = createMergeHolder(this.mergingValue);
-        backupValue = getLongContainer().merge(mergingValue, mergePolicy, isExistingContainer);
+        MergingValueHolder<Long> mergeHolder = createMergeHolder(getNodeEngine().getSerializationService(), mergingValue);
+        backupValue = getLongContainer().merge(mergeHolder, mergePolicy, isExistingContainer);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
@@ -88,12 +88,11 @@ public class AtomicReferenceContainer {
      * @return the new value if merge is applied, otherwise {@code null}
      */
     public Data merge(MergingValueHolder<Data> mergingValue, SplitBrainMergePolicy mergePolicy, boolean isExistingContainer) {
+        serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingValue.setSerializationService(serializationService);
 
         if (isExistingContainer) {
-            MergingValueHolder<Data> existingValue = createMergeHolder(value);
-            existingValue.setSerializationService(serializationService);
+            MergingValueHolder<Data> existingValue = createMergeHolder(serializationService, value);
             Data newValue = mergePolicy.merge(mergingValue, existingValue);
             if (newValue != null && !newValue.equals(value)) {
                 value = newValue;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeOperation.java
@@ -55,8 +55,8 @@ public class MergeOperation extends AtomicReferenceBackupAwareOperation {
         AtomicReferenceService service = getService();
         boolean isExistingContainer = service.containsReferenceContainer(name);
 
-        MergingValueHolder<Data> mergingValue = createMergeHolder(this.mergingValue);
-        backupValue = getReferenceContainer().merge(mergingValue, mergePolicy, isExistingContainer);
+        MergingValueHolder<Data> mergeHolder = createMergeHolder(getNodeEngine().getSerializationService(), mergingValue);
+        backupValue = getReferenceContainer().merge(mergeHolder, mergePolicy, isExistingContainer);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastManagedContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastManagedContext.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.spi.NodeAware;
 import com.hazelcast.spi.annotation.PrivateApi;
+import com.hazelcast.spi.serialization.SerializationServiceAware;
 
 @PrivateApi
 public final class HazelcastManagedContext implements ManagedContext {
@@ -28,7 +29,7 @@ public final class HazelcastManagedContext implements ManagedContext {
     private final ManagedContext externalContext;
     private final boolean hasExternalContext;
 
-    public HazelcastManagedContext(final HazelcastInstanceImpl instance, final ManagedContext externalContext) {
+    public HazelcastManagedContext(HazelcastInstanceImpl instance, ManagedContext externalContext) {
         this.instance = instance;
         this.externalContext = externalContext;
         this.hasExternalContext = externalContext != null;
@@ -37,12 +38,13 @@ public final class HazelcastManagedContext implements ManagedContext {
     @Override
     public Object initialize(Object obj) {
         if (obj instanceof HazelcastInstanceAware) {
-            HazelcastInstanceAware hazelcastInstanceAware = (HazelcastInstanceAware) obj;
-            hazelcastInstanceAware.setHazelcastInstance(instance);
+            ((HazelcastInstanceAware) obj).setHazelcastInstance(instance);
         }
         if (obj instanceof NodeAware) {
-            NodeAware nodeAware = (NodeAware) obj;
-            nodeAware.setNode(instance.node);
+            ((NodeAware) obj).setNode(instance.node);
+        }
+        if (obj instanceof SerializationServiceAware) {
+            ((SerializationServiceAware) obj).setSerializationService(instance.node.getSerializationService());
         }
 
         if (hasExternalContext) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
@@ -28,7 +28,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.impl.AbstractMergeRunnable;
+import com.hazelcast.spi.impl.merge.AbstractMergeRunnable;
 import com.hazelcast.spi.merge.MergingEntryHolder;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.function.BiConsumer;
@@ -67,7 +67,7 @@ class MapMergeRunnable extends AbstractMergeRunnable<RecordStore, MergingEntryHo
             Record record = iterator.next();
 
             Data dataValue = toData(record.getValue());
-            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(record, dataValue);
+            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(getSerializationService(), record, dataValue);
             consumer.accept(partitionId, mergingEntry);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -78,7 +78,8 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
 
         MapOperation operation;
         if (mergePolicy instanceof SplitBrainMergePolicy) {
-            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(replicationUpdate.getEntryView());
+            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(nodeEngine.getSerializationService(),
+                    replicationUpdate.getEntryView());
             operation = operationProvider.createMergeOperation(mapName, mergingEntry, (SplitBrainMergePolicy) mergePolicy, true);
         } else {
             EntryView<Data, Data> entryView = replicationUpdate.getEntryView();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -22,7 +22,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.impl.AbstractSplitBrainHandlerService;
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainHandlerService;
 
 import java.util.Collection;
 import java.util.Iterator;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -728,8 +728,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         checkIfLoaded();
         long now = getNow();
 
+        serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingEntry.setSerializationService(serializationService);
 
         Data key = mergingEntry.getKey();
         Record record = getRecordOrNull(key, now, false);
@@ -748,8 +748,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                     key, null, record.getValue());
         } else {
             oldValue = record.getValue();
-            MergingEntryHolder<Data, Object> existingEntry = createMergeHolder(record);
-            existingEntry.setSerializationService(serializationService);
+            MergingEntryHolder<Data, Object> existingEntry = createMergeHolder(serializationService, record);
             newValue = mergePolicy.merge(mergingEntry, existingEntry);
             // existing entry will be removed
             if (newValue == null) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -228,8 +228,8 @@ public class MultiMapContainer extends MultiMapContainerSupport {
      */
     public MultiMapValue merge(MergingEntryHolder<Data, MultiMapMergeContainer> mergingEntry, SplitBrainMergePolicy mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
+        serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingEntry.setSerializationService(serializationService);
 
         Data key = mergingEntry.getKey();
         MultiMapMergeContainer mergingContainer = mergingEntry.getValue();
@@ -247,7 +247,8 @@ public class MultiMapContainer extends MultiMapContainerSupport {
 
         MultiMapValue mergedValue = null;
         for (MultiMapRecord mergeRecord : mergingContainer.getRecords()) {
-            MergingEntryHolder<Data, Object> mergingEntry = createMergeHolder(mergingContainer, mergeRecord);
+            MergingEntryHolder<Data, Object> mergingEntry = createMergeHolder(nodeEngine.getSerializationService(),
+                    mergingContainer, mergeRecord);
             Object newValue = mergePolicy.merge(mergingEntry, null);
             if (newValue != null) {
                 MultiMapRecord newRecord = new MultiMapRecord(nextId(), isBinary ? newValue : ss.toObject(newValue));
@@ -268,13 +269,13 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         Collection<MultiMapRecord> existingRecords = existingValue.getCollection(false);
         int existingHits = existingValue.getHits();
         for (MultiMapRecord mergeRecord : mergingContainer.getRecords()) {
-            MergingEntryHolder<Data, Object> mergingEntry = createMergeHolder(mergingContainer, mergeRecord);
+            MergingEntryHolder<Data, Object> mergingEntry = createMergeHolder(nodeEngine.getSerializationService(),
+                    mergingContainer, mergeRecord);
             MergingEntryHolder<Data, Object> existingEntry = null;
             MultiMapRecord existingRecord = null;
             for (MultiMapRecord record : existingRecords) {
                 if (record.getObject().equals(mergeRecord.getObject())) {
-                    existingEntry = createMergeHolder(this, key, record, existingHits);
-                    existingEntry.setSerializationService(ss);
+                    existingEntry = createMergeHolder(nodeEngine.getSerializationService(), this, key, record, existingHits);
                     existingRecord = record;
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeOperation.java
@@ -72,7 +72,8 @@ public class MergeOperation extends MultiMapOperation implements BackupAwareOper
                 continue;
             }
 
-            MergingEntryHolder<Data, MultiMapMergeContainer> dataHolder = createMergeHolder(key, mergeContainer);
+            MergingEntryHolder<Data, MultiMapMergeContainer> dataHolder
+                    = createMergeHolder(getNodeEngine().getSerializationService(), key, mergeContainer);
             MultiMapValue result = container.merge(dataHolder, mergePolicy);
             if (result != null) {
                 resultMap.put(key, result.getCollection(false));

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapSplitBrainHandlerService.java
@@ -180,7 +180,7 @@ class ReplicatedMapSplitBrainHandlerService implements SplitBrainHandlerService 
                     entriesPerPartition[partitionId] = entries;
                 }
 
-                MergingEntryHolder<Object, Object> mergingEntry = createMergeHolder(record);
+                MergingEntryHolder<Object, Object> mergingEntry = createMergeHolder(serializationService, record);
                 entries.add(mergingEntry);
 
                 long currentSize = ++counterPerMember[partitionId].value;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -343,8 +343,8 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     @Override
     @SuppressWarnings("unchecked")
     public boolean merge(MergingEntryHolder<Object, Object> mergingEntry, SplitBrainMergePolicy mergePolicy) {
+        serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingEntry.setSerializationService(serializationService);
 
         K marshalledKey = (K) marshall(mergingEntry.getKey());
         InternalReplicatedMapStorage<K, V> storage = getStorage();
@@ -362,8 +362,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
             VersionResponsePair responsePair = new VersionResponsePair(mergingEntry.getValue(), getVersion());
             sendReplicationOperation(false, name, dataKey, dataValue, record.getTtlMillis(), responsePair);
         } else {
-            MergingEntryHolder<Object, Object> existingEntry = createMergeHolder(record);
-            existingEntry.setSerializationService(serializationService);
+            MergingEntryHolder<Object, Object> existingEntry = createMergeHolder(serializationService, record);
             V newValue = (V) mergePolicy.merge(mergingEntry, existingEntry);
             if (newValue == null) {
                 storage.remove(marshalledKey, record);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -160,8 +160,8 @@ public class ArrayRingbuffer<E> implements Ringbuffer<E> {
 
     @Override
     public long merge(MergingValueHolder<E> mergingValue, SplitBrainMergePolicy mergePolicy, long remainingCapacity) {
+        serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingValue.setSerializationService(serializationService);
 
         // try to find an existing item with the same value
         E existingItem = null;
@@ -186,8 +186,7 @@ public class ArrayRingbuffer<E> implements Ringbuffer<E> {
                 return add(newValue);
             }
         } else {
-            MergingValueHolder<E> existingValue = createMergeHolder(existingSequence, existingItem);
-            existingValue.setSerializationService(serializationService);
+            MergingValueHolder<E> existingValue = createMergeHolder(serializationService, existingSequence, existingItem);
             E newValue = mergePolicy.merge(mergingValue, existingValue);
             if (newValue != null && !newValue.equals(existingItem)) {
                 set(existingSequence, newValue);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -442,7 +442,7 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
                     mergingValues = new ArrayList<MergingValueHolder<Object>>(batchSize);
                     for (long sequence = ringbuffer.headSequence(); sequence <= ringbuffer.tailSequence(); sequence++) {
                         Object item = ringbuffer.read(sequence);
-                        MergingValueHolder<Object> mergingValue = createMergeHolder(sequence, item);
+                        MergingValueHolder<Object> mergingValue = createMergeHolder(serializationService, sequence, item);
                         mergingValues.add(mergingValue);
                         itemCount++;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -410,7 +410,8 @@ public class DistributedScheduledExecutorService
 
                         mergingEntries = new ArrayList<MergingEntryHolder<String, ScheduledTaskDescriptor>>();
                         for (ScheduledTaskDescriptor descriptor : tasks) {
-                            MergingEntryHolder<String, ScheduledTaskDescriptor> mergingEntry = createMergeHolder(descriptor);
+                            MergingEntryHolder<String, ScheduledTaskDescriptor> mergingEntry
+                                    = createMergeHolder(nodeEngine.getSerializationService(), descriptor);
                             mergingEntries.add(mergingEntry);
                             size++;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -243,8 +243,8 @@ public class ScheduledExecutorContainer {
     public ScheduledTaskDescriptor merge(MergingValueHolder<ScheduledTaskDescriptor> mergingValue,
                                          SplitBrainMergePolicy mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
+        serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
-        mergingValue.setSerializationService(serializationService);
 
         // try to find an existing item with the same value
         ScheduledTaskDescriptor match = null;
@@ -264,8 +264,7 @@ public class ScheduledExecutorContainer {
             }
         } else {
             // Found a match -> real merge
-            MergingValueHolder<ScheduledTaskDescriptor> existingValue = createMergeHolder(match);
-            existingValue.setSerializationService(serializationService);
+            MergingValueHolder<ScheduledTaskDescriptor> existingValue = createMergeHolder(serializationService, match);
             merged = mergePolicy.merge(mergingValue, existingValue);
             if (merged != null && !merged.equals(match)) {
                 // Cancel matched one, before replacing it

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractSplitBrainHandlerService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.merge;
 
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.SplitBrainHandlerService;
@@ -30,10 +30,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Contains common functionality to implement a {@link SplitBrainHandlerService}
+ * Contains common functionality to implement a {@link SplitBrainHandlerService}.
  *
  * @param <Store> store of a partition
  */
+@SuppressWarnings("WeakerAccess")
 public abstract class AbstractSplitBrainHandlerService<Store> implements SplitBrainHandlerService {
 
     private final int partitionCount;
@@ -68,7 +69,6 @@ public abstract class AbstractSplitBrainHandlerService<Store> implements SplitBr
                         Object mergePolicy = getMergePolicy(dataStructureName);
 
                         if (!isDiscardPolicy(mergePolicy)) {
-
                             if (mergePolicy instanceof SplitBrainMergePolicy) {
                                 copyToCollectedStores(store, collectedStores);
                             } else {
@@ -99,11 +99,12 @@ public abstract class AbstractSplitBrainHandlerService<Store> implements SplitBr
         // NOP intentionally, implementations can override this method
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     protected boolean isDiscardPolicy(Object mergePolicy) {
         return mergePolicy instanceof DiscardMergePolicy;
     }
 
-    // overridden on ee
+    // overridden on EE
     public void destroyStores(Collection<Store> recordStores) {
         Iterator<Store> iterator = recordStores.iterator();
         while (iterator.hasNext()) {
@@ -128,7 +129,7 @@ public abstract class AbstractSplitBrainHandlerService<Store> implements SplitBr
     }
 
     /**
-     * Destroys provided store
+     * Destroys the provided store.
      */
     protected abstract void destroyStore(Store store);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractSplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractSplitBrainMergePolicy.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.merge;
+package com.hazelcast.spi.impl.merge;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
+import com.hazelcast.spi.merge.MergingValueHolder;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/FullMergingEntryHolderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/FullMergingEntryHolderImpl.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.merge.MergingValueHolder;
 import com.hazelcast.spi.merge.TtlHolder;
 import com.hazelcast.spi.merge.VersionHolder;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.spi.serialization.SerializationServiceAware;
 
 import java.io.IOException;
 
@@ -45,7 +46,7 @@ import java.io.IOException;
 @SuppressWarnings("checkstyle:methodcount")
 public class FullMergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V>, CostHolder, CreationTimeHolder,
         ExpirationTimeHolder, HitsHolder, LastAccessTimeHolder, LastStoredTimeHolder, LastUpdateTimeHolder, VersionHolder,
-        TtlHolder, IdentifiedDataSerializable {
+        TtlHolder, SerializationServiceAware, IdentifiedDataSerializable {
 
     private V value;
     private K key;
@@ -61,7 +62,11 @@ public class FullMergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V
 
     private transient SerializationService serializationService;
 
-    FullMergingEntryHolderImpl() {
+    public FullMergingEntryHolderImpl() {
+    }
+
+    public FullMergingEntryHolderImpl(SerializationService serializationService) {
+        this.serializationService = serializationService;
     }
 
     @Override
@@ -72,11 +77,6 @@ public class FullMergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V
     @Override
     public Object getDeserializedValue() {
         return serializationService.toObject(value);
-    }
-
-    @Override
-    public void setSerializationService(SerializationService serializationService) {
-        this.serializationService = serializationService;
     }
 
     public FullMergingEntryHolderImpl<K, V> setValue(V value) {
@@ -190,6 +190,11 @@ public class FullMergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V
     }
 
     @Override
+    public void setSerializationService(SerializationService serializationService) {
+        this.serializationService = serializationService;
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         IOUtil.writeObject(out, key);
         IOUtil.writeObject(out, value);
@@ -291,7 +296,7 @@ public class FullMergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V
 
     @Override
     public String toString() {
-        return "MergeDataHolder{"
+        return "MergingEntryHolder{"
                 + "key=" + key
                 + ", value=" + value
                 + ", cost=" + cost

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingEntryHolderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingEntryHolderImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.merge.CreationTimeHolder;
 import com.hazelcast.spi.merge.MergingEntryHolder;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.spi.serialization.SerializationServiceAware;
 
 import java.io.IOException;
 
@@ -33,13 +34,21 @@ import java.io.IOException;
  * @param <V> the type of value
  * @since 3.10
  */
-public class MergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V>, CreationTimeHolder, IdentifiedDataSerializable {
+public class MergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V>, CreationTimeHolder, SerializationServiceAware,
+        IdentifiedDataSerializable {
 
     private K key;
     private V value;
     private long creationTime;
 
     private transient SerializationService serializationService;
+
+    public MergingEntryHolderImpl() {
+    }
+
+    public MergingEntryHolderImpl(SerializationService serializationService) {
+        this.serializationService = serializationService;
+    }
 
     @Override
     public K getKey() {
@@ -66,11 +75,6 @@ public class MergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V>, C
         return serializationService.toObject(value);
     }
 
-    @Override
-    public void setSerializationService(SerializationService serializationService) {
-        this.serializationService = serializationService;
-    }
-
     public MergingEntryHolderImpl<K, V> setValue(V value) {
         this.value = value;
         return this;
@@ -84,6 +88,11 @@ public class MergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V>, C
     public MergingEntryHolderImpl<K, V> setCreationTime(long creationTime) {
         this.creationTime = creationTime;
         return this;
+    }
+
+    @Override
+    public void setSerializationService(SerializationService serializationService) {
+        this.serializationService = serializationService;
     }
 
     @Override
@@ -139,7 +148,7 @@ public class MergingEntryHolderImpl<K, V> implements MergingEntryHolder<K, V>, C
 
     @Override
     public String toString() {
-        return "MergeDataHolder{"
+        return "MergingEntryHolder{"
                 + "key=" + key
                 + ", value=" + value
                 + ", creationTime=" + creationTime

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingHolders.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingHolders.java
@@ -31,6 +31,7 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskDescriptor;
 import com.hazelcast.spi.merge.MergingEntryHolder;
 import com.hazelcast.spi.merge.MergingValueHolder;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 
 /**
@@ -43,20 +44,21 @@ public final class MergingHolders {
     private MergingHolders() {
     }
 
-    public static <V> MergingValueHolder<V> createMergeHolder(V value) {
-        return new MergingValueHolderImpl<V>()
+    public static <V> MergingValueHolder<V> createMergeHolder(SerializationService serializationService, V value) {
+        return new MergingValueHolderImpl<V>(serializationService)
                 .setValue(value);
     }
 
-    public static <K, V> MergingEntryHolder<K, V> createMergeHolder(K key, V value) {
-        return new MergingEntryHolderImpl<K, V>()
+    public static <K, V> MergingEntryHolder<K, V> createMergeHolder(SerializationService serializationService, K key, V value) {
+        return new MergingEntryHolderImpl<K, V>(serializationService)
                 .setKey(key)
                 .setValue(value)
                 .setCreationTime(Clock.currentTimeMillis());
     }
 
-    public static <K, V> MergingEntryHolder<K, V> createMergeHolder(EntryView<K, V> entryView) {
-        return new FullMergingEntryHolderImpl<K, V>()
+    public static <K, V> MergingEntryHolder<K, V> createMergeHolder(SerializationService serializationService,
+                                                                    EntryView<K, V> entryView) {
+        return new FullMergingEntryHolderImpl<K, V>(serializationService)
                 .setKey(entryView.getKey())
                 .setValue(entryView.getValue())
                 .setCreationTime(entryView.getCreationTime())
@@ -69,8 +71,9 @@ public final class MergingHolders {
                 .setCost(entryView.getCost());
     }
 
-    public static <K, V> MergingEntryHolder<K, V> createMergeHolder(CacheEntryView<K, V> entryView) {
-        return new FullMergingEntryHolderImpl<K, V>()
+    public static <K, V> MergingEntryHolder<K, V> createMergeHolder(SerializationService serializationService,
+                                                                    CacheEntryView<K, V> entryView) {
+        return new FullMergingEntryHolderImpl<K, V>(serializationService)
                 .setKey(entryView.getKey())
                 .setValue(entryView.getValue())
                 .setCreationTime(entryView.getCreationTime())
@@ -79,19 +82,20 @@ public final class MergingHolders {
                 .setHits(entryView.getAccessHit());
     }
 
-    public static MergingValueHolder<Data> createMergeHolder(CollectionItem item) {
-        return new MergingValueHolderImpl<Data>()
+    public static MergingValueHolder<Data> createMergeHolder(SerializationService serializationService, CollectionItem item) {
+        return new MergingValueHolderImpl<Data>(serializationService)
                 .setValue(item.getValue());
     }
 
-    public static MergingValueHolder<Data> createMergeHolder(QueueItem item) {
-        return new MergingValueHolderImpl<Data>()
+    public static MergingValueHolder<Data> createMergeHolder(SerializationService serializationService, QueueItem item) {
+        return new MergingValueHolderImpl<Data>(serializationService)
                 .setValue(item.getData());
     }
 
-    public static MergingEntryHolder<Data, Object> createMergeHolder(MultiMapMergeContainer container,
+    public static MergingEntryHolder<Data, Object> createMergeHolder(SerializationService serializationService,
+                                                                     MultiMapMergeContainer container,
                                                                      MultiMapRecord record) {
-        return new FullMergingEntryHolderImpl<Data, Object>()
+        return new FullMergingEntryHolderImpl<Data, Object>(serializationService)
                 .setKey(container.getKey())
                 .setValue(record.getObject())
                 .setCreationTime(container.getCreationTime())
@@ -100,9 +104,10 @@ public final class MergingHolders {
                 .setHits(container.getHits());
     }
 
-    public static MergingEntryHolder<Data, Object> createMergeHolder(MultiMapContainer container, Data key,
+    public static MergingEntryHolder<Data, Object> createMergeHolder(SerializationService serializationService,
+                                                                     MultiMapContainer container, Data key,
                                                                      MultiMapRecord record, int hits) {
-        return new FullMergingEntryHolderImpl<Data, Object>()
+        return new FullMergingEntryHolderImpl<Data, Object>(serializationService)
                 .setKey(key)
                 .setValue(record.getObject())
                 .setCreationTime(container.getCreationTime())
@@ -111,8 +116,9 @@ public final class MergingHolders {
                 .setHits(hits);
     }
 
-    public static MergingEntryHolder<Data, Data> createMergeHolder(Record record, Data dataValue) {
-        return new FullMergingEntryHolderImpl<Data, Data>()
+    public static MergingEntryHolder<Data, Data> createMergeHolder(SerializationService serializationService,
+                                                                   Record record, Data dataValue) {
+        return new FullMergingEntryHolderImpl<Data, Data>(serializationService)
                 .setKey(record.getKey())
                 .setValue(dataValue)
                 .setCreationTime(record.getCreationTime())
@@ -125,8 +131,8 @@ public final class MergingHolders {
                 .setTtl(record.getTtl());
     }
 
-    public static MergingEntryHolder<Data, Object> createMergeHolder(Record record) {
-        return new FullMergingEntryHolderImpl<Data, Object>()
+    public static MergingEntryHolder<Data, Object> createMergeHolder(SerializationService serializationService, Record record) {
+        return new FullMergingEntryHolderImpl<Data, Object>(serializationService)
                 .setKey(record.getKey())
                 .setValue(record.getValue())
                 .setCreationTime(record.getCreationTime())
@@ -139,8 +145,9 @@ public final class MergingHolders {
                 .setTtl(record.getTtl());
     }
 
-    public static <R extends CacheRecord> MergingEntryHolder<Data, Data> createMergeHolder(Data key, Data value, R record) {
-        return new FullMergingEntryHolderImpl<Data, Data>()
+    public static <R extends CacheRecord> MergingEntryHolder<Data, Data> createMergeHolder(
+            SerializationService serializationService, Data key, Data value, R record) {
+        return new FullMergingEntryHolderImpl<Data, Data>(serializationService)
                 .setKey(key)
                 .setValue(value)
                 .setCreationTime(record.getCreationTime())
@@ -149,8 +156,9 @@ public final class MergingHolders {
                 .setLastAccessTime(record.getLastAccessTime());
     }
 
-    public static MergingEntryHolder<Object, Object> createMergeHolder(ReplicatedRecord record) {
-        return new FullMergingEntryHolderImpl<Object, Object>()
+    public static MergingEntryHolder<Object, Object> createMergeHolder(SerializationService serializationService,
+                                                                       ReplicatedRecord record) {
+        return new FullMergingEntryHolderImpl<Object, Object>(serializationService)
                 .setKey(record.getKeyInternal())
                 .setValue(record.getValueInternal())
                 .setCreationTime(record.getCreationTime())
@@ -160,15 +168,17 @@ public final class MergingHolders {
                 .setTtl(record.getTtlMillis());
     }
 
-    public static MergingEntryHolder<String, HyperLogLog> createMergeHolder(String name, HyperLogLog item) {
-        return new MergingEntryHolderImpl<String, HyperLogLog>()
+    public static MergingEntryHolder<String, HyperLogLog> createMergeHolder(SerializationService serializationService,
+                                                                            String name, HyperLogLog item) {
+        return new MergingEntryHolderImpl<String, HyperLogLog>(serializationService)
                 .setKey(name)
                 .setValue(item)
                 .setCreationTime(Clock.currentTimeMillis());
     }
 
-    public static MergingEntryHolder<String, ScheduledTaskDescriptor> createMergeHolder(ScheduledTaskDescriptor task) {
-        return new MergingEntryHolderImpl<String, ScheduledTaskDescriptor>()
+    public static MergingEntryHolder<String, ScheduledTaskDescriptor> createMergeHolder(SerializationService serializationService,
+                                                                                        ScheduledTaskDescriptor task) {
+        return new MergingEntryHolderImpl<String, ScheduledTaskDescriptor>(serializationService)
                 .setKey(task.getDefinition().getName())
                 .setValue(task)
                 .setCreationTime(Clock.currentTimeMillis());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueHolderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueHolderImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.merge.MergingValueHolder;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.spi.serialization.SerializationServiceAware;
 
 import java.io.IOException;
 
@@ -31,11 +32,19 @@ import java.io.IOException;
  * @param <V> the type of value
  * @since 3.10
  */
-public class MergingValueHolderImpl<V> implements MergingValueHolder<V>, IdentifiedDataSerializable {
+public class MergingValueHolderImpl<V> implements MergingValueHolder<V>, SerializationServiceAware,
+        IdentifiedDataSerializable {
 
     private V value;
 
     private transient SerializationService serializationService;
+
+    public MergingValueHolderImpl() {
+    }
+
+    public MergingValueHolderImpl(SerializationService serializationService) {
+        this.serializationService = serializationService;
+    }
 
     @Override
     public V getValue() {
@@ -97,7 +106,7 @@ public class MergingValueHolderImpl<V> implements MergingValueHolder<V>, Identif
 
     @Override
     public String toString() {
-        return "MergeDataHolder{"
+        return "MergingValueHolder{"
                 + "value=" + value
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/CostHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/CostHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view of memory costs for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface CostHolder extends DataSerializable {
+public interface CostHolder {
 
     /**
      * Returns the memory cost of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HitsHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HitsHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view access hits for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface HitsHolder extends DataSerializable {
+public interface HitsHolder {
 
     /**
      * Returns the access hits of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.merge;
 
 import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 
 import static com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook.HYPER_LOG_LOG;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LastAccessTimeHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LastAccessTimeHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view of a last access time for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface LastAccessTimeHolder extends DataSerializable {
+public interface LastAccessTimeHolder {
 
     /**
      * Returns the last access time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LastStoredTimeHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LastStoredTimeHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view of a last stored time for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface LastStoredTimeHolder extends DataSerializable {
+public interface LastStoredTimeHolder {
 
     /**
      * Returns the last stored time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LastUpdateTimeHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LastUpdateTimeHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view of a last update time for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface LastUpdateTimeHolder extends DataSerializable {
+public interface LastUpdateTimeHolder {
 
     /**
      * Returns the last update time of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValueHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValueHolder.java
@@ -16,16 +16,13 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.spi.serialization.SerializationService;
-
 /**
  * Represents a read-only view of a data structure value for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
-public interface MergingValueHolder<V> extends DataSerializable {
+public interface MergingValueHolder<V> {
 
     /**
      * Returns the merging value in the in-memory format of the backing data structure.
@@ -40,11 +37,4 @@ public interface MergingValueHolder<V> extends DataSerializable {
      * @return the deserialized merging value
      */
     Object getDeserializedValue();
-
-    /**
-     * Sets the {@link SerializationService} to deserialize the value on demand.
-     *
-     * @param serializationService the serialization service
-     */
-    void setSerializationService(SerializationService serializationService);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/TtlHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/TtlHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view of a TTL for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface TtlHolder extends DataSerializable {
+public interface TtlHolder {
 
     /**
      * Returns the TTL of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/VersionHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/VersionHolder.java
@@ -16,14 +16,12 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.DataSerializable;
-
 /**
  * Represents a read-only view of a version for the merging process after a split-brain.
  *
  * @since 3.10
  */
-public interface VersionHolder extends DataSerializable {
+public interface VersionHolder {
 
     /**
      * Returns the version of the merge data.

--- a/hazelcast/src/main/java/com/hazelcast/spi/serialization/SerializationServiceAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/serialization/SerializationServiceAware.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.merge;
+package com.hazelcast.spi.serialization;
 
 /**
- * Represents a read-only view a creation time for the merging process after a split-brain.
- *
- * @since 3.10
+ * Used to get a {@link SerializationService} reference injected.
  */
-public interface CreationTimeHolder {
+public interface SerializationServiceAware {
 
     /**
-     * Returns the creation time of the merge data.
+     * Gets the SerializationService reference injected.
      *
-     * @return the creation time of the merge data
+     * @param serializationService the SerializationService reference
      */
-    long getCreationTime();
+    void setSerializationService(SerializationService serializationService);
 }

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
@@ -283,7 +283,7 @@ public class WanReplicationTest extends HazelcastTestSupport {
             op = operationProvider.createLegacyMergeOperation(mapName, entryView, new PassThroughMergePolicy(),
                     !enableWANReplicationEvent);
         } else {
-            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(entryView);
+            MergingEntryHolder<Data, Data> mergingEntry = createMergeHolder(serializationService, entryView);
             SplitBrainMergePolicy mergePolicy = new com.hazelcast.spi.merge.PassThroughMergePolicy();
             op = operationProvider.createMergeOperation(mapName, mergingEntry, mergePolicy, !enableWANReplicationEvent);
         }


### PR DESCRIPTION
* added `SerializationServiceAware` to SPI and `ManagedContext`
* removed `setSerializationService()` from `MergingValueHolder` interface
* removed `DataSerializable` dependency from other holder interfaces
* moved `AbstractSplitBrainMergePolicy` to `spi.impl.merge` package
* moved `AbstractMergeRunnable` to `spi.impl.merge` package
* moved `AbstractSplitBrainHandlerService` to `spi.impl.merge` package

![screenshot from 2018-02-28 10-23-10](https://user-images.githubusercontent.com/4196298/36779791-6dd3e8fe-1c71-11e8-8bd8-288e2043634c.png)

![screenshot from 2018-02-28 15-09-13](https://user-images.githubusercontent.com/4196298/36791933-607e410e-1c99-11e8-88e8-c840de6a58fb.png)
